### PR TITLE
Rename various types (including Nat) to adhere to capitalization rule

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -722,7 +722,7 @@ argument in question.  One way to avoid this is to instead use a
 `Fixpoint` definition, or the tactic `fix`, along with `destruct`.
 There is a tactic `simple_induction` defined in `Overture` whose
 interface is almost the same as `induction` but does this internally,
-although it only works for induction over `nat` and `trunc_index`.
+although it only works for induction over `Nat` and `trunc_index`.
 
 If you apply the `symmetry` tactic when constructing an equivalence to
 reverse the direction of the goal, then rather than applying
@@ -740,10 +740,10 @@ described above; another is to call the instance(s) you need
 explicitly, rather than relying on typeclass inference to find them.
 
 Sometimes binders without type annotations, like `forall n, foo n`
-where `foo : nat -> Type0`, will produce a fresh universe for
+where `foo : Nat -> Type0`, will produce a fresh universe for
 the variable's type, eg `forall n : (? : Type@{fresh}), foo n`,
 which will remain in the definition as a phantom type:
-`fresh |= forall n : nat, foo n`. Annotating the binder will get rid of it.
+`fresh |= forall n : Nat, foo n`. Annotating the binder will get rid of it.
 See also [bug #4868](https://coq.inria.fr/bugs/show_bug.cgi?id=4868).
 
 ### 1.6.4. Lifting and lowering ###
@@ -1383,7 +1383,7 @@ End Coq.
 ```
 
 and then replace all `Require Import`s in the pasted files with simply
-`Import`, remove the definition of `nat` (because there's no way to
+`Import`, remove the definition of `Nat` (because there's no way to
 get special syntax for it), and possibly remove dependent choice.  You
 can then run the bug-finder on this file again to remove the parts of
 the pasted stdlib that aren't needed, telling it to use the unmodified

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -166,22 +166,22 @@ End Book_1_5.
 (* ================================================== ex:nat-semiring *)
 (** Exercise 1.8 *)
 
-Fixpoint rec_nat' (C : Type) c0 cs (n : nat) : C :=
+Fixpoint rec_nat' (C : Type) c0 cs (n : Nat) : C :=
   match n with
     O => c0
   | S m => cs m (rec_nat' C c0 cs m)
   end.
 
-Definition add : nat -> nat -> nat :=
-  rec_nat' (nat -> nat) (fun m => m) (fun n g m => (S (g m))).
+Definition add : Nat -> Nat -> Nat :=
+  rec_nat' (Nat -> Nat) (fun m => m) (fun n g m => (S (g m))).
 
-Definition mult : nat -> nat -> nat  :=
-  rec_nat' (nat -> nat) (fun m => 0) (fun n g m => add m (g m)).
+Definition mult : Nat -> Nat -> Nat  :=
+  rec_nat' (Nat -> Nat) (fun m => 0) (fun n g m => add m (g m)).
 
 (* rec_nat' gives back a function with the wrong argument order, so we flip the
    order of the arguments p and q *)
-Definition exp : nat -> nat -> nat  :=
-  fun p q => (rec_nat' (nat -> nat) (fun m => (S 0)) (fun n g m => mult m (g m))) q p.
+Definition exp : Nat -> Nat -> Nat  :=
+  fun p q => (rec_nat' (Nat -> Nat) (fun m => (S 0)) (fun n g m => mult m (g m))) q p.
 
 Example add_example: add 32 17 = 49. Proof. reflexivity. Defined.
 Example mult_example: mult 20 5 = 100. Proof. reflexivity. Defined.
@@ -197,10 +197,10 @@ Example exp_example: exp 2 10 = 1024. Proof. reflexivity. Defined.
 (* ================================================== ex:ackermann *)
 (** Exercise 1.10 *)
 
-Fixpoint ack (n m : nat) : nat :=
+Fixpoint ack (n m : Nat) : Nat :=
   match n with
   | O => S m
-  | S p => let fix ackn (m : nat) :=
+  | S p => let fix ackn (m : Nat) :=
                match m with
                  | O => ack p 1
                  | S q => ack p (ackn q)
@@ -355,8 +355,8 @@ Defined.
 (* ================================================== ex:npaths *)
 (** Exercise 2.4 *)
 
-Definition Book_2_4_npath : nat -> Type -> Type
-  := nat_ind (fun (n : nat) => Type -> Type)
+Definition Book_2_4_npath : Nat -> Type -> Type
+  := Nat_ind (fun (n : Nat) => Type -> Type)
              (* 0-dimensional paths are elements *)
              (fun A => A)
              (* (n+1)-dimensional paths are paths between n-dimimensional paths *)
@@ -364,7 +364,7 @@ Definition Book_2_4_npath : nat -> Type -> Type
 
 (* This is the intuition behind definition of nboundary:
    As we've defined them, every (n+1)-path is a path between two n-paths. *)
-Lemma npath_as_sig : forall {n : nat} {A : Type},
+Lemma npath_as_sig : forall {n : Nat} {A : Type},
     (Book_2_4_npath (S n) A) = (exists (p1 p2 : Book_2_4_npath n A), p1 = p2).
 Proof.
   reflexivity.
@@ -381,7 +381,7 @@ Eval compute in (Book_2_4_npath 2 A). (* and so on... *)
 
 (* Given an (n+1)-path, we simply project to a pair of n-paths. *)
 Definition Book_2_4_nboundary
-  : forall {n : nat} {A : Type}, Book_2_4_npath (S n) A ->
+  : forall {n : Nat} {A : Type}, Book_2_4_npath (S n) A ->
                           (Book_2_4_npath n A * Book_2_4_npath n A)
   := fun {n} {A} p => (pr1 p, pr1 (pr2 p)).
 
@@ -1266,9 +1266,9 @@ Defined.
 Section Book_5_2.
   (** Here is one example of functions which are propositionally equal but not judgmentally equal.  They satisfy the same reucrrence propositionally. *)
   Let ez : Bool := true.
-  Let es : nat -> Bool -> Bool := fun _ => idmap.
-  Definition Book_5_2_i : nat -> Bool := nat_ind (fun _ => Bool) ez es.
-  Definition Book_5_2_ii : nat -> Bool := fun _ => true.
+  Let es : Nat -> Bool -> Bool := fun _ => idmap.
+  Definition Book_5_2_i : Nat -> Bool := Nat_ind (fun _ => Bool) ez es.
+  Definition Book_5_2_ii : Nat -> Bool := fun _ => true.
   Fail Definition Book_5_2_not_defn_eq : Book_5_2_i = Book_5_2_ii := idpath.
   Lemma Book_5_2_i_prop_eq : forall n, Book_5_2_i n = Book_5_2_ii n.
   Proof.
@@ -1279,10 +1279,10 @@ End Book_5_2.
 Section Book_5_2'.
   Local Open Scope nat_scope.
   (** Here's another example where two functions are not (currently) definitionally equal, but satisfy the same reucrrence judgmentally.  This example is a bit less robust; it fails in CoqMT. *)
-  Let ez : nat := 1.
-  Let es : nat -> nat -> nat := fun _ => S.
-  Definition Book_5_2'_i : nat -> nat := fun n => n + 1.
-  Definition Book_5_2'_ii : nat -> nat := fun n => 1 + n.
+  Let ez : Nat := 1.
+  Let es : Nat -> Nat -> Nat := fun _ => S.
+  Definition Book_5_2'_i : Nat -> Nat := fun n => n + 1.
+  Definition Book_5_2'_ii : Nat -> Nat := fun n => 1 + n.
   Fail Definition Book_5_2'_not_defn_eq : Book_5_2'_i = Book_5_2'_ii := idpath.
   Definition Book_5_2'_i_eq_ez : Book_5_2'_i 0 = ez := idpath.
   Definition Book_5_2'_ii_eq_ez : Book_5_2'_ii 0 = ez := idpath.
@@ -1295,10 +1295,10 @@ End Book_5_2'.
 
 Section Book_5_3.
   Let ez : Bool := true.
-  Let es : nat -> Bool -> Bool := fun _ => idmap.
+  Let es : Nat -> Bool -> Bool := fun _ => idmap.
   Let ez' : Bool := true.
-  Let es' : nat -> Bool -> Bool := fun _ _ => true.
-  Definition Book_5_3 : nat -> Bool := fun _ => true.
+  Let es' : Nat -> Bool -> Bool := fun _ _ => true.
+  Definition Book_5_3 : Nat -> Bool := fun _ => true.
   Definition Book_5_3_satisfies_ez : Book_5_3 0 = ez := idpath.
   Definition Book_5_3_satisfies_ez' : Book_5_3 0 = ez' := idpath.
   Definition Book_5_3_satisfies_es n : Book_5_3 (S n) = es n (Book_5_3 n) := idpath.
@@ -1316,17 +1316,17 @@ Definition Book_5_4 := @HoTT.Types.Bool.equiv_bool_forall_prod.
 (** Exercise 5.5 *)
 
 Section Book_5_5.
-  Let ind_nat (P : nat -> Type) := fun x => @nat_ind P (fst x) (snd x).
+  Let ind_nat (P : Nat -> Type) := fun x => @Nat_ind P (fst x) (snd x).
 
-  Lemma Book_5_5 `{fs : Funext} : ~forall P : nat -> Type,
+  Lemma Book_5_5 `{fs : Funext} : ~forall P : Nat -> Type,
                                      IsEquiv (@ind_nat P).
   Proof.
     intro H.
     specialize (H (fun _ => Bool)).
     pose proof (eissect (@ind_nat (fun _ => Bool)) (true, (fun _ _ => true))) as H1.
     pose proof (eissect (@ind_nat (fun _ => Bool)) (true, (fun _ => idmap))) as H2.
-    cut (ind_nat (fun _ : nat => Bool) (true, fun (_ : nat) (_ : Bool) => true)
-         = (ind_nat (fun _ : nat => Bool) (true, fun _ : nat => idmap))).
+    cut (ind_nat (fun _ : Nat => Bool) (true, fun (_ : Nat) (_ : Bool) => true)
+         = (ind_nat (fun _ : Nat => Bool) (true, fun _ : Nat => idmap))).
     - intro H'.
       apply true_ne_false.
       exact (ap10 (apD10 (ap snd (H1^ @ ap _ H' @ H2)) 0) false).

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -93,7 +93,7 @@ End Book_1_2_sig.
 (** The propositional uniqueness principles are named with an
     'eta' postfix in the HoTT library. *)
 
-Definition Book_1_3_prod_lib := @HoTT.Types.Prod.prod_ind.
+Definition Book_1_3_prod_lib := @HoTT.Types.Prod.Prod_ind.
 Section Book_1_3_prod.
   Variable A B : Type.
 
@@ -488,9 +488,9 @@ Definition coprod_ump1 {A B X} : (A + B -> X) -> (A -> X) * (B -> X) :=
 
 (* To create a function on the direct sum from functions on the summands, work
    by cases *)
-Check prod_rect.
+Check Prod_rect.
 Definition coprod_ump2 {A B X} : (A -> X) * (B -> X) -> (A + B -> X) :=
-  prod_rect (fun _ => A + B -> X) (fun f g => Sum_rect (fun _ => X) f g).
+  Prod_rect (fun _ => A + B -> X) (fun f g => Sum_rect (fun _ => X) f g).
 
 Definition Book_2_9 {A B X} `{Funext} : (A -> X) * (B -> X) <~> (A + B -> X).
   apply (equiv_adjointify coprod_ump2 coprod_ump1).

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -490,7 +490,7 @@ Definition coprod_ump1 {A B X} : (A + B -> X) -> (A -> X) * (B -> X) :=
    by cases *)
 Check prod_rect.
 Definition coprod_ump2 {A B X} : (A -> X) * (B -> X) -> (A + B -> X) :=
-  prod_rect (fun _ => A + B -> X) (fun f g => sum_rect (fun _ => X) f g).
+  prod_rect (fun _ => A + B -> X) (fun f g => Sum_rect (fun _ => X) f g).
 
 Definition Book_2_9 {A B X} `{Funext} : (A -> X) * (B -> X) <~> (A + B -> X).
   apply (equiv_adjointify coprod_ump2 coprod_ump1).

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -16,7 +16,7 @@ Section Reduction.
   Context (A : Type).
 
   (** We define words (with inverses) on A to be lists of marked elements of A *)
-  Local Definition Words : Type := list (A + A).
+  Local Definition Words : Type := List (A + A).
 
   (** Given a marked element of A we can change its mark *)
   Local Definition change_sign : A + A -> A + A

--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -35,7 +35,7 @@ Section FreeProduct.
   Context (G H K : Group)
     (f : GroupHomomorphism G H) (g : GroupHomomorphism G K).
 
-  Local Definition Words : Type := list (H + K).
+  Local Definition Words : Type := List (H + K).
 
   Local Notation "[ x ]" := (cons x nil).
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -463,7 +463,7 @@ End GroupMovement.
 
 (** Power operation *)
 
-Fixpoint grp_pow {G : Group} (g : G) (n : nat) : G :=
+Fixpoint grp_pow {G : Group} (g : G) (n : Nat) : G :=
   match n with
   | 0%nat => mon_unit
   | m.+1%nat => g * grp_pow g m

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -12,7 +12,7 @@ Local Open Scope nat_scope.
 
 Definition subgroup_index {U : Univalence} (G : Group) (H : Subgroup G)
   (fin_G : Finite G) (fin_H : Finite H)
-  : nat.
+  : Nat.
 Proof.
   refine (fcard (Quotient (in_cosetL H))).
   nrapply finite_quotient.

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -404,14 +404,14 @@ Defined.
 (** *** More Ring laws *)
 
 (** Powers of ring elements *)
-Fixpoint rng_power {R : CRing} (x : R) (n : nat) : R :=
+Fixpoint rng_power {R : CRing} (x : R) (n : Nat) : R :=
   match n with
   | 0%nat => cring_one
   | n.+1%nat => x * rng_power x n
   end.
 
 (** Power laws *)
-Lemma rng_power_mult_law {R : CRing} (x : R) (n m : nat)
+Lemma rng_power_mult_law {R : CRing} (x : R) (n m : Nat)
   : (rng_power x n) * (rng_power x m) = rng_power x (n + m).
 Proof.
   revert m.
@@ -424,7 +424,7 @@ Proof.
 Defined.
 
 (** Powers commute with multiplication *)
-Lemma rng_power_mult {R : CRing} (x y : R) (n : nat)
+Lemma rng_power_mult {R : CRing} (x y : R) (n : Nat)
   : rng_power (x * y) n = rng_power x n * rng_power y n.
 Proof.
   induction n.

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -210,7 +210,7 @@ Proof.
 Defined.
 
 (** Finitely generated ideal *)
-Definition ideal_generated_finite {R : CRing} {n : nat} (X : Fin n -> R) : Ideal R.
+Definition ideal_generated_finite {R : CRing} {n : Nat} (X : Fin n -> R) : Ideal R.
 Proof.
   apply ideal_generated.
   intros r.

--- a/theories/Algebra/Universal/Operation.v
+++ b/theories/Algebra/Universal/Operation.v
@@ -19,7 +19,7 @@ Local Open Scope nat_scope.
 (** Functions [head_dom'] and [head_dom] are used to get the first
     element of a nonempty operation domain [a : forall i, A (ss i)]. *)
 
-Monomorphic Definition head_dom' {σ} (A : Carriers σ) (n : nat)
+Monomorphic Definition head_dom' {σ} (A : Carriers σ) (n : Nat)
   : forall (N : n > 0) (ss : FinSeq n (Sort σ)) (a : forall i, A (ss i)),
     A (fshead' n N ss)
   := match n with
@@ -27,7 +27,7 @@ Monomorphic Definition head_dom' {σ} (A : Carriers σ) (n : nat)
      | n'.+1 => fun N ss a => a fin_zero
      end.
 
-Monomorphic Definition head_dom {σ} (A : Carriers σ) {n : nat}
+Monomorphic Definition head_dom {σ} (A : Carriers σ) {n : Nat}
   (ss : FinSeq n.+1 (Sort σ)) (a : forall i, A (ss i))
   : A (fshead ss)
   := head_dom' A n.+1 _ ss a.
@@ -35,7 +35,7 @@ Monomorphic Definition head_dom {σ} (A : Carriers σ) {n : nat}
 (** Functions [tail_dom'] and [tail_dom] are used to obtain the tail
     of an operation domain [a : forall i, A (ss i)]. *)
 
-Monomorphic Definition tail_dom' {σ} (A : Carriers σ) (n : nat)
+Monomorphic Definition tail_dom' {σ} (A : Carriers σ) (n : Nat)
   : forall (ss : FinSeq n (Sort σ)) (a : forall i, A (ss i)) (i : Fin (pred n)),
     A (fstail' n ss i)
   := match n with
@@ -43,7 +43,7 @@ Monomorphic Definition tail_dom' {σ} (A : Carriers σ) (n : nat)
      | n'.+1 => fun ss a i => a (fsucc i)
      end.
 
-Monomorphic Definition tail_dom {σ} (A : Carriers σ) {n : nat}
+Monomorphic Definition tail_dom {σ} (A : Carriers σ) {n : Nat}
   (ss : FinSeq n.+1 (Sort σ)) (a : forall i, A (ss i))
   : forall i, A (fstail ss i)
   := tail_dom' A n.+1 ss a.
@@ -51,7 +51,7 @@ Monomorphic Definition tail_dom {σ} (A : Carriers σ) {n : nat}
 (** Functions [cons_dom'] and [cons_dom] to add an element to
     the front of a given domain [a : forall i, A (ss i)]. *)
 
-Monomorphic Definition cons_dom' {σ} (A : Carriers σ) {n : nat}
+Monomorphic Definition cons_dom' {σ} (A : Carriers σ) {n : Nat}
   : forall (i : Fin n) (ss : FinSeq n (Sort σ)) (N : n > 0),
     A (fshead' n N ss) -> (forall i, A (fstail' n ss i)) -> A (ss i)
   := fin_ind
@@ -62,7 +62,7 @@ Monomorphic Definition cons_dom' {σ} (A : Carriers σ) {n : nat}
       (fun n' i' _ => fun _ _ _ xs => xs i').
 
 Definition cons_dom {σ} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n.+1 (Sort σ))
+  {n : Nat} (ss : FinSeq n.+1 (Sort σ))
   (x : A (fshead ss)) (xs : forall i, A (fstail ss i))
   : forall i : Fin n.+1, A (ss i)
   := fun i => cons_dom' A i ss _ x xs.
@@ -76,7 +76,7 @@ Definition nil_dom {σ} (A : Carriers σ) (ss : FinSeq 0 (Sort σ))
 (** A specialization of [Operation] to finite [Fin n] arity. *)
 
 Definition FiniteOperation {σ : Signature} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n (Sort σ)) (t : Sort σ) : Type
+  {n : Nat} (ss : FinSeq n (Sort σ)) (t : Sort σ) : Type
   := Operation A {| Arity := Fin n; sorts_dom := ss; sort_cod := t |}.
 
 (** A type of curried operations
@@ -84,7 +84,7 @@ Definition FiniteOperation {σ : Signature} (A : Carriers σ)
 CurriedOperation A [s1, ..., sn] t := A s1 -> ... -> A sn -> A t.
 >> *)
 
-Fixpoint CurriedOperation {σ} (A : Carriers σ) {n : nat}
+Fixpoint CurriedOperation {σ} (A : Carriers σ) {n : Nat}
   : (FinSeq n (Sort σ)) -> Sort σ -> Type
   := match n with
      | 0 => fun ss t => A t
@@ -100,7 +100,7 @@ operation_uncurry A [s1, ..., sn] t (op : CurriedOperation A [s1, ..., sn] t)
 >>
 See [equiv_operation_curry] below. *)
 
-Fixpoint operation_uncurry {σ} (A : Carriers σ) {n : nat}
+Fixpoint operation_uncurry {σ} (A : Carriers σ) {n : Nat}
   : forall (ss : FinSeq n (Sort σ)) (t : Sort σ),
     CurriedOperation A ss t -> FiniteOperation A ss t
   := match n with
@@ -112,7 +112,7 @@ Fixpoint operation_uncurry {σ} (A : Carriers σ) {n : nat}
 
 Local Example computation_example_operation_uncurry
   : forall
-      (σ : Signature) (A : Carriers σ) (n : nat) (s1 s2 t : Sort σ)
+      (σ : Signature) (A : Carriers σ) (n : Nat) (s1 s2 t : Sort σ)
       (ss := (fscons s1 (fscons s2 fsnil)))
       (op : CurriedOperation A ss t) (a : forall i, A (ss i)),
     operation_uncurry A ss t op
@@ -129,7 +129,7 @@ operation_curry A [s1, ..., sn] t (op : FiniteOperation A [s1, ..., sn] t)
 >>
 See [equiv_operation_curry] below. *)
 
-Fixpoint operation_curry {σ} (A : Carriers σ) {n : nat} 
+Fixpoint operation_curry {σ} (A : Carriers σ) {n : Nat} 
   : forall (ss : FinSeq n (Sort σ)) (t : Sort σ),
     FiniteOperation A ss t -> CurriedOperation A ss t
   := match n with
@@ -141,7 +141,7 @@ Fixpoint operation_curry {σ} (A : Carriers σ) {n : nat}
 
 Local Example computation_example_operation_curry
   : forall
-      (σ : Signature) (A : Carriers σ) (n : nat) (s1 s2 t : Sort σ)
+      (σ : Signature) (A : Carriers σ) (n : Nat) (s1 s2 t : Sort σ)
       (ss := (fscons s1 (fscons s2 fsnil)))
       (op : FiniteOperation A ss t)
       (x1 : A s1) (x2 : A s2),
@@ -151,7 +151,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma expand_cons_dom' {σ} (A : Carriers σ) (n : nat)
+Lemma expand_cons_dom' {σ} (A : Carriers σ) (n : Nat)
   : forall (i : Fin n) (ss : FinSeq n (Sort σ)) (N : n > 0)
            (a : forall i, A (ss i)),
     cons_dom' A i ss N (head_dom' A n N ss a) (tail_dom' A n ss a) = a i.
@@ -166,7 +166,7 @@ Proof.
 Qed.
 
 Lemma expand_cons_dom `{Funext} {σ} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n.+1 (Sort σ)) (a : forall i, A (ss i))
+  {n : Nat} (ss : FinSeq n.+1 (Sort σ)) (a : forall i, A (ss i))
   : cons_dom A ss (head_dom A ss a) (tail_dom A ss a) = a.
 Proof.
   funext i.
@@ -174,7 +174,7 @@ Proof.
 Defined.
 
 Lemma path_operation_curry_to_cunurry `{Funext} {σ} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
+  {n : Nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
   : operation_uncurry A ss t o operation_curry A ss t == idmap.
 Proof.
   intro a.
@@ -187,7 +187,7 @@ Proof.
 Qed.
 
 Lemma path_operation_uncurry_to_curry `{Funext} {σ} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
+  {n : Nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
   : operation_curry A ss t o operation_uncurry A ss t == idmap.
 Proof.
   intro a.
@@ -205,7 +205,7 @@ Proof.
 Qed.
 
 Global Instance isequiv_operation_curry `{Funext} {σ} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
+  {n : Nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
   : IsEquiv (operation_curry A ss t).
 Proof.
   srapply isequiv_adjointify.
@@ -215,7 +215,7 @@ Proof.
 Defined.
 
 Definition equiv_operation_curry `{Funext} {σ} (A : Carriers σ)
-  {n : nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
+  {n : Nat} (ss : FinSeq n (Sort σ)) (t : Sort σ)
   : FiniteOperation A ss t <~> CurriedOperation A ss t
   := Build_Equiv _ _ (operation_curry A ss t) _.
 

--- a/theories/Analysis/Locator.v
+++ b/theories/Analysis/Locator.v
@@ -471,7 +471,7 @@ Section locator.
     Local Definition P (qeps' : Q * Qpos Q) : Type :=
       match qeps' with
       | (q' , eps') =>
-        (prod
+        (Prod
            (locates_left l (ltQnegQ q' eps'))
            (locates_right m (ltQposQ q' eps')))
       end.

--- a/theories/Analysis/Locator.v
+++ b/theories/Analysis/Locator.v
@@ -53,8 +53,8 @@ Section locator.
   Context `{Funext} `{Univalence}.
 
   (* Assume we have enumerations of the rationals, and of pairs of ordered rationals. *)
-  Context (Q_eq : nat <~> Q).
-  Context (QQpos_eq : nat <~> Q * Qpos Q).
+  Context (Q_eq : Nat <~> Q).
+  Context (QQpos_eq : Nat <~> Q * Qpos Q).
 
   Instance qinc : Cast Q F := rationals_to_field Q F.
   (* TODO The following two instances should probably come from the `Rationals` instance. *)
@@ -311,9 +311,9 @@ Section locator.
       - assumption.
     Qed.
 
-    Instance inc_N_Q : Cast nat Q := naturals_to_semiring nat Q.
+    Instance inc_N_Q : Cast Nat Q := naturals_to_semiring Nat Q.
 
-    Instance inc_fin_N {n} : Cast (Fin n) nat := fin_to_nat.
+    Instance inc_fin_N {n} : Cast (Fin n) Nat := fin_to_nat.
 
     Lemma tight_bound (epsilon : Qpos Q) : {u : Q | ' u < x < ' (u + ' epsilon)}.
     Proof.
@@ -394,7 +394,7 @@ Section locator.
         unfold grid.
         change (' fsucc fin_zero) with (fin_to_nat (@fsucc (S n) fin_zero)).
         rewrite path_nat_fsucc, path_nat_fin_zero.
-        rewrite (@preserves_1 nat Q _ _ _ _ _ _ _ _ _ _).
+        rewrite (@preserves_1 Nat Q _ _ _ _ _ _ _ _ _ _).
         rewrite plus_negate_r.
         rewrite mult_0_l.
         rewrite plus_0_r.
@@ -408,7 +408,7 @@ Section locator.
         rewrite path_nat_fin_incl, path_nat_fin_last.
         rewrite S_nat_plus_1.
         rewrite (preserves_plus n 1).
-        rewrite (@preserves_1 nat Q _ _ _ _ _ _ _ _ _ _).
+        rewrite (@preserves_1 Nat Q _ _ _ _ _ _ _ _ _ _).
         rewrite <- (associativity (' n) 1 (-1)).
         rewrite plus_negate_r.
         rewrite plus_0_r.
@@ -755,7 +755,7 @@ Section locator.
 
   Section limit.
 
-    Context {xs : nat -> F}.
+    Context {xs : Nat -> F}.
     Context {M} {M_ismod : CauchyModulus Q F xs M}.
     Context (ls : forall n, locator (xs n)).
 

--- a/theories/Basics/Datatypes.v
+++ b/theories/Basics/Datatypes.v
@@ -85,22 +85,22 @@ Notation "A <-> B" := (Iff A B) : type_scope.
 
 (** Polymorphic lists and some operations *)
 
-Inductive list (A : Type) : Type :=
- | nil : list A
- | cons : A -> list A -> list A.
+Inductive List (A : Type) : Type :=
+| nil : List A
+| cons : A -> List A -> List A.
 
-Scheme list_rect := Induction for list Sort Type.
+Scheme List_rect := Induction for List Sort Type.
 
 Arguments nil {A}.
 Declare Scope list_scope.
 Infix "::" := cons : list_scope.
 Delimit Scope list_scope with list.
-Bind Scope list_scope with list.
+Bind Scope list_scope with List.
 
 Local Open Scope list_scope.
 (** Concatenation of two lists *)
 
-Definition app (A : Type) : list A -> list A -> list A :=
+Definition app (A : Type) : List A -> List A -> List A :=
   fix app l m :=
   match l with
    | nil => m

--- a/theories/Basics/Datatypes.v
+++ b/theories/Basics/Datatypes.v
@@ -33,21 +33,21 @@ Arguments none {A}.
 
 Register Option as core.option.type.
 
-(** [sum A B], written [A + B], is the disjoint sum of [A] and [B] *)
+(** [Sum A B], written [A + B], is the disjoint sum of [A] and [B] *)
 
-Inductive sum (A B : Type) : Type :=
-| inl : A -> sum A B
-| inr : B -> sum A B.
+Inductive Sum (A B : Type) : Type :=
+| inl : A -> Sum A B
+| inr : B -> Sum A B.
 
-Scheme sum_rect := Induction for sum Sort Type.
+Scheme Sum_rect := Induction for Sum Sort Type.
 
-Notation "x + y" := (sum x y) : type_scope.
+Notation "x + y" := (Sum x y) : type_scope.
 
 Arguments inl {A B} _ , [A] B _.
 Arguments inr {A B} _ , A [B] _.
 
 (* A notation for coproduct that's less overloaded than [+] *)
-Notation "x |_| y" := (sum x y) (only parsing) : type_scope.
+Notation "x |_| y" := (Sum x y) (only parsing) : type_scope.
 
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)

--- a/theories/Basics/Datatypes.v
+++ b/theories/Basics/Datatypes.v
@@ -52,30 +52,30 @@ Notation "x |_| y" := (Sum x y) (only parsing) : type_scope.
 (** [prod A B], written [A * B], is the product of [A] and [B];
     the pair [pair A B a b] of [a] and [b] is abbreviated [(a,b)] *)
 
-Record prod (A B : Type) := pair { fst : A ; snd : B }.
+Record Prod (A B : Type) := pair { fst : A ; snd : B }.
 
-Scheme prod_rect := Induction for prod Sort Type.
+Scheme Prod_rect := Induction for Prod Sort Type.
 
 Arguments pair {A B} _ _.
 Arguments fst {A B} _ / .
 Arguments snd {A B} _ / .
 
-Add Printing Let prod.
+Add Printing Let Prod.
 
-Notation "x * y" := (prod x y) : type_scope.
+Notation "x * y" := (Prod x y) : type_scope.
 Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : core_scope.
-Notation "A /\ B" := (prod A B) (only parsing) : type_scope.
-Notation and := prod (only parsing).
+Notation "A /\ B" := (Prod A B) (only parsing) : type_scope.
+Notation and := Prod (only parsing).
 Notation conj := pair (only parsing).
 
 #[export] Hint Resolve pair inl inr : core.
 
 Definition prod_curry (A B C : Type) (f : A -> B -> C)
-  (p : prod A B) : C := f (fst p) (snd p).
+  (p : Prod A B) : C := f (fst p) (snd p).
 
 (** [iff A B], written [A <-> B], expresses the equivalence of [A] and [B] *)
 
-Definition iff (A B : Type) := prod (A -> B) (B -> A).
+Definition iff (A B : Type) := Prod (A -> B) (B -> A).
 
 Notation "A <-> B" := (iff A B) : type_scope.
 

--- a/theories/Basics/Datatypes.v
+++ b/theories/Basics/Datatypes.v
@@ -73,11 +73,11 @@ Notation conj := pair (only parsing).
 Definition prod_curry (A B C : Type) (f : A -> B -> C)
   (p : Prod A B) : C := f (fst p) (snd p).
 
-(** [iff A B], written [A <-> B], expresses the equivalence of [A] and [B] *)
+(** [Iff A B], written [A <-> B], expresses the equivalence of [A] and [B] *)
 
-Definition iff (A B : Type) := Prod (A -> B) (B -> A).
+Definition Iff (A B : Type) := Prod (A -> B) (B -> A).
 
-Notation "A <-> B" := (iff A B) : type_scope.
+Notation "A <-> B" := (Iff A B) : type_scope.
 
 (** Another way of interpreting booleans as propositions *)
 

--- a/theories/Basics/Datatypes.v
+++ b/theories/Basics/Datatypes.v
@@ -20,24 +20,24 @@ Global Set Primitive Projections.
 Global Set Nonrecursive Elimination Schemes.
 Local Unset Elimination Schemes.
 
-(** [option A] is the extension of [A] with an extra element [None] *)
+(** [Option A] is the extension of [A] with an extra element none] *)
 
-Inductive option (A : Type) : Type :=
-  | Some : A -> option A
-  | None : option A.
+Inductive Option (A : Type) : Type :=
+| some : A -> Option A
+| none : Option A.
 
-Scheme option_rect := Induction for option Sort Type.
+Scheme Option_rect := Induction for Option Sort Type.
 
-Arguments Some {A} a.
-Arguments None {A}.
+Arguments some {A} a.
+Arguments none {A}.
 
-Register option as core.option.type.
+Register Option as core.option.type.
 
 (** [sum A B], written [A + B], is the disjoint sum of [A] and [B] *)
 
 Inductive sum (A B : Type) : Type :=
-  | inl : A -> sum A B
-  | inr : B -> sum A B.
+| inl : A -> sum A B
+| inr : B -> sum A B.
 
 Scheme sum_rect := Induction for sum Sort Type.
 

--- a/theories/Basics/Nat.v
+++ b/theories/Basics/Nat.v
@@ -88,19 +88,19 @@ Definition to_uint n :=
 
 Definition to_num_uint n := Numeral.UIntDec (to_uint n).
 
-Definition of_int (d:Decimal.int) : option nat :=
+Definition of_int (d:Decimal.int) : Option nat :=
   match Decimal.norm d with
-    | Decimal.Pos u => Some (of_uint u)
-    | _ => None
+    | Decimal.Pos u => some (of_uint u)
+    | _ => none
   end.
 
-Definition of_hex_int (d:Hexadecimal.int) : option nat :=
+Definition of_hex_int (d:Hexadecimal.int) : Option nat :=
   match Hexadecimal.norm d with
-    | Hexadecimal.Pos u => Some (of_hex_uint u)
-    | _ => None
+    | Hexadecimal.Pos u => some (of_hex_uint u)
+    | _ => none
   end.
 
-Definition of_num_int (d:Numeral.int) : option nat :=
+Definition of_num_int (d:Numeral.int) : Option nat :=
   match d with
   | Numeral.IntDec d => of_int d
   | Numeral.IntHex d => of_hex_int d

--- a/theories/Basics/Nat.v
+++ b/theories/Basics/Nat.v
@@ -29,7 +29,7 @@ Definition tail_mul n m := tail_addmul O n m.
 
 Local Notation ten := (S (S (S (S (S (S (S (S (S (S O)))))))))).
 
-Fixpoint of_uint_acc (d:Decimal.uint)(acc:nat) :=
+Fixpoint of_uint_acc (d:Decimal.uint)(acc:Nat) :=
   match d with
   | Decimal.Nil => acc
   | Decimal.D0 d => of_uint_acc d (tail_mul ten acc)
@@ -48,7 +48,7 @@ Definition of_uint (d:Decimal.uint) := of_uint_acc d O.
 
 Local Notation sixteen := (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S (S O)))))))))))))))).
 
-Fixpoint of_hex_uint_acc (d:Hexadecimal.uint)(acc:nat) :=
+Fixpoint of_hex_uint_acc (d:Hexadecimal.uint)(acc:Nat) :=
   match d with
   | Hexadecimal.Nil => acc
   | Hexadecimal.D0 d => of_hex_uint_acc d (tail_mul sixteen acc)
@@ -88,19 +88,19 @@ Definition to_uint n :=
 
 Definition to_num_uint n := Numeral.UIntDec (to_uint n).
 
-Definition of_int (d:Decimal.int) : Option nat :=
+Definition of_int (d:Decimal.int) : Option Nat :=
   match Decimal.norm d with
     | Decimal.Pos u => some (of_uint u)
     | _ => none
   end.
 
-Definition of_hex_int (d:Hexadecimal.int) : Option nat :=
+Definition of_hex_int (d:Hexadecimal.int) : Option Nat :=
   match Hexadecimal.norm d with
     | Hexadecimal.Pos u => some (of_hex_uint u)
     | _ => none
   end.
 
-Definition of_num_int (d:Numeral.int) : Option nat :=
+Definition of_num_int (d:Numeral.int) : Option Nat :=
   match d with
   | Numeral.IntDec d => of_int d
   | Numeral.IntHex d => of_hex_int d
@@ -113,7 +113,7 @@ Definition to_num_int n := Numeral.IntDec (to_int n).
 Arguments of_uint d%dec_uint_scope.
 Arguments of_int d%dec_int_scope.
 
-(* Parsing / printing of [nat] numbers *)
-Number Notation nat of_num_uint to_num_uint (abstract after 5001) : nat_scope.
+(* Parsing / printing of [Nat] numbers *)
+Number Notation Nat of_num_uint to_num_uint (abstract after 5001) : nat_scope.
 
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -209,17 +209,17 @@ Notation "g 'o' f" := (compose g%function f%function) : function_scope.
 Definition Compose {A B C : Type} (g : B -> C) (f : A -> B) : A -> C := compose g f.
 
 (** Composition of logical equivalences *)
-Global Instance iff_compose : Transitive iff | 1
+Global Instance iff_compose : Transitive Iff | 1
   := fun A B C f g => (fst g o fst f , snd f o snd g).
 Arguments iff_compose {A B C} f g : rename.
 
 (** While we're at it, inverses of logical equivalences *)
-Global Instance iff_inverse : Symmetric iff | 1
+Global Instance iff_inverse : Symmetric Iff | 1
   := fun A B f => (snd f , fst f).
 Arguments iff_inverse {A B} f : rename.
 
 (** And reflexivity of them *)
-Global Instance iff_reflexive : Reflexive iff | 1
+Global Instance iff_reflexive : Reflexive Iff | 1
   := fun A => (idmap , idmap).
 
 (** Dependent composition of functions. *)

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -27,7 +27,7 @@ Global Set Keyed Unification.
 (** This command makes it so that you don't have to declare universes explicitly when mentioning them in the type.  (Without this command, if you want to say [Definition foo := Type@{i}.], you must instead say [Definition foo@{i} := Type@{i}.]. *)
 Global Unset Strict Universe Declaration.
 
-(** This command makes it so that when we say something like [IsHSet nat] we get [IsHSet@{i} nat] instead of [IsHSet@{Set} nat]. *)
+(** This command makes it so that when we say something like [IsHSet Nat] we get [IsHSet@{i} Nat] instead of [IsHSet@{Set} Nat]. *)
 Global Unset Universe Minimization ToSet.
 
 (** Force to use bullets in proofs. *)
@@ -569,7 +569,7 @@ Definition trunc_index_rect := trunc_index_ind.
 Bind Scope trunc_scope with trunc_index.
 Arguments trunc_S _%trunc_scope.
 
-(** Include the basic numerals, so we don't need to go through the coercion from [nat], and so that we get the right binding with [trunc_scope]. *)
+(** Include the basic numerals, so we don't need to go through the coercion from [Nat], and so that we get the right binding with [trunc_scope]. *)
 (** Note that putting the negative numbers at level 0 allows us to override the [- _] notation for negative numbers. *)
 Notation "n .+1" := (trunc_S n) : trunc_scope.
 Notation "n .+2" := (n.+1.+1)%trunc : trunc_scope.
@@ -637,7 +637,7 @@ Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_inst
 
 (** *** Simple induction *)
 
-(** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [nat] or a [trunc_index].  The difference is that it produces proof terms involving [match] and [fix] explicitly rather than [nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. *)
+(** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [Nat] or a [trunc_index].  The difference is that it produces proof terms involving [match] and [fix] explicitly rather than [Nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. *)
 
 Ltac simple_induction n n' IH :=
   generalize dependent n;
@@ -694,22 +694,22 @@ Ltac path_via mid :=
 Local Set Elimination Schemes.
 
 (**  Natural numbers. *)
-Inductive nat : Type :=
-| O : nat
-| S : nat -> nat.
+Inductive Nat : Type :=
+| O : Nat
+| S : Nat -> Nat.
 
 Local Unset Elimination Schemes.
 
 (** These schemes are therefore defined in Spaces.Nat *)
 (*
-Scheme nat_ind := Induction for nat Sort Type.
-Scheme nat_rect := Induction for nat Sort Type.
-Scheme nat_rec := Minimality for nat Sort Type.
+Scheme Nat_ind := Induction for Nat Sort Type.
+Scheme Nat_rect := Induction for Nat Sort Type.
+Scheme Nat_rec := Minimality for Nat Sort Type.
  *)
 
 Declare Scope nat_scope.
 Delimit Scope nat_scope with nat.
-Bind Scope nat_scope with nat.
+Bind Scope nat_scope with Nat.
 Arguments S _%nat.
 
 (** We put [Empty] here, instead of in [Empty.v], because [Ltac done] uses it. *)

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -2,7 +2,7 @@ Require Import Basics.Overture Basics.Nat.
 
 
 (** TODO: Clean up *)
-(** This module implements various tactics used to simplify the goals produced by Program,
+(** This module implements various tactics used to simplify the goals Produced by Program,
    which are also generally useful. *)
 
 (** Debugging tactics to show the goal during evaluation. *)
@@ -43,7 +43,7 @@ Ltac on_last_hyp tac :=
 
 Ltac destruct_one_pair :=
  match goal with
-   | [H : prod _ _ |- _] => destruct H
+   | [H : Prod _ _ |- _] => destruct H
  end.
 
 (** Repeateadly destruct pairs. *)
@@ -401,7 +401,7 @@ Tactic Notation "nrefine" uconstr(term) := notypeclasses refine term; global_axi
 (** A shorter name for [simple notypeclasses refine]; also handles global axioms. *)
 Tactic Notation "snrefine" uconstr(term) := simple notypeclasses refine term; global_axiom.
 
-(** Note that the Coq standard library has a [rapply], but it is like our [rapply'] with many-holes first.  We prefer fewer-holes first, for instance so that a theorem producing an equivalence will by preference be used to produce an equivalence rather than to apply the coercion of that equivalence to a function. *)
+(** Note that the Coq standard library has a [rapply], but it is like our [rapply'] with many-holes first.  We prefer fewer-holes first, for instance so that a theorem Producing an equivalence will by preference be used to Produce an equivalence rather than to apply the coercion of that equivalence to a function. *)
 Tactic Notation "rapply" uconstr(term)
   := do_with_holes ltac:(fun x => refine x) term.
 Tactic Notation "rapply'" uconstr(term)
@@ -446,7 +446,7 @@ Ltac by_extensionality x :=
   match goal with
   | [ |- ?f = ?g ] => eapply path_forall; intro x;
       match goal with
-        | [ |- forall (_ : prod _ _), _ ] => intros [? ?]
+        | [ |- forall (_ : Prod _ _), _ ] => intros [? ?]
         | [ |- forall (_ : sig _ _), _ ] => intros [? ?]
         | _ => intros
     end;

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -26,7 +26,7 @@ Ltac show_hyps :=
         | [ H : ?T |- _ ] => show_hyp H ; fail
       end.
 
-(** The [do] tactic but using a Coq-side nat. *)
+(** The [do] tactic but using a Coq-side Nat. *)
 
 Ltac do_nat n tac :=
   match n with

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -55,21 +55,21 @@ Definition nat_to_trunc_index (n : nat) : trunc_index
 
 Coercion nat_to_trunc_index : nat >-> trunc_index.
 
-Definition int_to_trunc_index (v : Decimal.int) : option trunc_index
+Definition int_to_trunc_index (v : Decimal.int) : Option trunc_index
   := match v with
-     | Decimal.Pos d => Some (nat_to_trunc_index (Nat.of_uint d))
+     | Decimal.Pos d => some (nat_to_trunc_index (Nat.of_uint d))
      | Decimal.Neg d => match Nat.of_uint d with
-                        | 2%nat => Some minus_two
-                        | 1%nat => Some (minus_two.+1)
-                        | 0%nat => Some (minus_two.+2)
-                        | _ => None
+                        | 2%nat => some minus_two
+                        | 1%nat => some (minus_two.+1)
+                        | 0%nat => some (minus_two.+2)
+                        | _ => none
                         end
      end.
 
-Definition num_int_to_trunc_index (v : Numeral.int) : option trunc_index :=
+Definition num_int_to_trunc_index (v : Numeral.int) : Option trunc_index :=
   match v with
   | Numeral.IntDec v => int_to_trunc_index v
-  | Numeral.IntHex _ => None
+  | Numeral.IntHex _ => none
   end.
 
 Fixpoint trunc_index_to_little_uint n acc :=

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -16,7 +16,7 @@ Generalizable Variables A B m n f.
 Open Scope trunc_scope.
 
 (* Increase a truncation index by a natural number. *)
-Fixpoint trunc_index_inc (k : trunc_index) (n : nat)
+Fixpoint trunc_index_inc (k : trunc_index) (n : Nat)
   : trunc_index
   := match n with
       | O => k
@@ -25,14 +25,14 @@ Fixpoint trunc_index_inc (k : trunc_index) (n : nat)
 
 (* This is a variation that inserts the successor operations in
    the other order.  This is sometimes convenient. *)
-Fixpoint trunc_index_inc' (k : trunc_index) (n : nat)
+Fixpoint trunc_index_inc' (k : trunc_index) (n : Nat)
   : trunc_index
   := match n with
       | O => k
       | S m => (trunc_index_inc' k.+1 m)
     end.
 
-Definition trunc_index_inc'_succ (n : nat) (k : trunc_index)
+Definition trunc_index_inc'_succ (n : Nat) (k : trunc_index)
   : trunc_index_inc' k.+1 n = (trunc_index_inc' k n).+1.
 Proof.
   revert k; induction n; intro k.
@@ -40,7 +40,7 @@ Proof.
   - apply (IHn k.+1).
 Defined.
 
-Definition trunc_index_inc_agree (k : trunc_index) (n : nat)
+Definition trunc_index_inc_agree (k : trunc_index) (n : Nat)
   : trunc_index_inc k n = trunc_index_inc' k n.
 Proof.
   induction n.
@@ -50,10 +50,10 @@ Proof.
     symmetry; apply trunc_index_inc'_succ.
 Defined.
 
-Definition nat_to_trunc_index (n : nat) : trunc_index
+Definition nat_to_trunc_index (n : Nat) : trunc_index
   := (trunc_index_inc minus_two n).+2.
 
-Coercion nat_to_trunc_index : nat >-> trunc_index.
+Coercion nat_to_trunc_index : Nat >-> trunc_index.
 
 Definition int_to_trunc_index (v : Decimal.int) : Option trunc_index
   := match v with

--- a/theories/Basics/UniverseLevel.v
+++ b/theories/Basics/UniverseLevel.v
@@ -134,5 +134,5 @@ Global Existing Instance lower'_isequiv. (* work around https://coq.inria.fr/bug
 Definition lower'_equiv@{i j i' j'} {A : Type@{i}} {B : Type@{j}} (e : Equiv (Lift'@{i j} A) (Lift'@{i' j'} B)) : Equiv A B
   := @Build_Equiv A B (lower'2 e) _.
 
-(*Fail Check Lift nat : Type0.
-Check 1 : Lift nat.*)
+(*Fail Check Lift Nat : Type0.
+Check 1 : Lift Nat.*)

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -6,7 +6,7 @@ Require Import HoTT.Spaces.Nat.
 Section bounded_search.
 
   Context `{Funext}.
-  Context (P : nat -> Type)
+  Context (P : Nat -> Type)
           {P_hprop : forall n, IsHProp (P n)}
           (P_dec : forall n, Decidable (P n))
           (P_inhab : hexists (fun n => P n)).
@@ -15,12 +15,12 @@ Section bounded_search.
   Local Open Scope nat_scope.
   Local Open Scope type_scope.
   
-  Local Definition minimal (n : nat) : Type := forall m : nat, P m -> n <= m.
-  Local Definition ishprop_minimal (n : nat) : IsHProp (minimal n).
+  Local Definition minimal (n : Nat) : Type := forall m : Nat, P m -> n <= m.
+  Local Definition ishprop_minimal (n : Nat) : IsHProp (minimal n).
   Proof.
     apply _.
   Qed.
-  Local Definition min_n_Type : Type := { n : nat & ((P n) * (minimal n))%type}.
+  Local Definition min_n_Type : Type := { n : Nat & ((P n) * (minimal n))%type}.
 
   Local Definition ishpropmin_n : IsHProp min_n_Type.
   Proof.
@@ -33,9 +33,9 @@ Section bounded_search.
 
   (* Local Definition min_n : hProp := hProppair min_n_UU isapropmin_n. *)
 
-  Local Definition smaller (n : nat) := { l : nat & (P l * minimal l * (l <= n))%type}.
+  Local Definition smaller (n : Nat) := { l : Nat & (P l * minimal l * (l <= n))%type}.
 
-  Local Definition smaller_S (n : nat) (k : smaller n) : smaller (S n).
+  Local Definition smaller_S (n : Nat) (k : smaller n) : smaller (S n).
   Proof.
     induction k as [l [[p m] z]].
     exists l.
@@ -43,7 +43,7 @@ Section bounded_search.
     exact _.
   Qed.
 
-  Local Definition bounded_search (n : nat) : smaller n + forall l : nat, (l <= n) -> not (P l).
+  Local Definition bounded_search (n : Nat) : smaller n + forall l : Nat, (l <= n) -> not (P l).
   Proof.
     induction n as [|n IHn].
     - assert (P 0 + not (P 0)) as X; [apply P_dec |].
@@ -77,7 +77,7 @@ Section bounded_search.
              rewrite eqlSn; assumption.
   Qed.
 
-  Local Definition n_to_min_n (n : nat) (Pn : P n) : min_n_Type.
+  Local Definition n_to_min_n (n : Nat) (Pn : P n) : min_n_Type.
   Proof.
     assert (smaller n + forall l, (l <= n) -> not (P l)) as X by apply bounded_search.
     induction X as [[l [[Pl ml] leqln]]|none].
@@ -92,7 +92,7 @@ Section bounded_search.
     - induction 1 as [n Pn]. exact (n_to_min_n n Pn).
   Defined.
 
-  Definition minimal_n : { n : nat & P n }.
+  Definition minimal_n : { n : Nat & P n }.
   Proof.
     induction prop_n_to_min_n as [n pl]. induction pl as [p _].
     exact (n;p).
@@ -103,7 +103,7 @@ End bounded_search.
 Section bounded_search_alt_type.
   Context `{Funext}.
   Context (X : Type)
-          (e : nat <~> X)
+          (e : Nat <~> X)
           (P : X -> Type)
           {P_hprop : forall x, IsHProp (P x)}
           (P_dec : forall x, Decidable (P x))

--- a/theories/Categories/ChainCategory.v
+++ b/theories/Categories/ChainCategory.v
@@ -30,7 +30,7 @@ Module Export Core.
   (** *** [[ω]], the linear order on ℕ *)
   Definition omega : PreCategory
     := @Build_PreCategory
-         nat
+         Nat
          leq
          leq_refl
          (fun x y z p q => leq_trans q p)
@@ -43,7 +43,7 @@ Module Export Core.
   (** Using [n + 1] elements allows us to agree with the common
       definition of an [n]-simplex, where a 0-simplex is a point, and
       a 1-simplex has two end-points, etc. *)
-  Definition chain (n : nat) : PreCategory
+  Definition chain (n : Nat) : PreCategory
     := { m : omega | m <= n }%category.
 
   (** TODO: Possibly generalize this to arbitrary sets with arbitrary

--- a/theories/Categories/Comma/ProjectionFunctors.v
+++ b/theories/Categories/Comma/ProjectionFunctors.v
@@ -64,7 +64,7 @@ Section comma.
               (center _)
               _).
     simpl.
-    destruct_head_hnf Datatypes.prod.
+    destruct_head_hnf Datatypes.Prod.
     path_functor.
   Defined.
 
@@ -74,7 +74,7 @@ Section comma.
     rewrite !transport_forall_constant;
     transport_path_forall_hammer;
     simpl;
-    destruct_head Datatypes.prod;
+    destruct_head Datatypes.Prod;
     simpl in *;
     apply CommaCategory.path_morphism;
     simpl;

--- a/theories/Categories/ExponentialLaws/Tactics.v
+++ b/theories/Categories/ExponentialLaws/Tactics.v
@@ -27,7 +27,7 @@ Ltac exp_laws_simplify_types' :=
     | [ H : (_ * _)%type |- _ ] => destruct H
     | [ |- _ = _ :> Functor _ _ ] => progress path_functor
     | [ |- _ = _ :> NaturalTransformation _ _ ] => progress path_natural_transformation
-    | [ |- _ = _ :> prod _ _ ] => apply path_prod
+    | [ |- _ = _ :> Prod _ _ ] => apply path_prod
   end.
 
 (** Do some simplifications of contractible types *)

--- a/theories/Categories/Functor/Prod/Universal.v
+++ b/theories/Categories/Functor/Prod/Universal.v
@@ -12,7 +12,7 @@ Set Asymmetric Patterns.
 Local Notation fst_type := Basics.Datatypes.fst.
 Local Notation snd_type := Basics.Datatypes.snd.
 Local Notation pair_type := Basics.Datatypes.pair.
-Local Notation prod_type := Basics.Datatypes.prod.
+Local Notation prod_type := Basics.Datatypes.Prod.
 
 Local Open Scope morphism_scope.
 Local Open Scope functor_scope.

--- a/theories/Categories/NatCategory.v
+++ b/theories/Categories/NatCategory.v
@@ -14,17 +14,17 @@ Module Export Core.
   (** We use [Empty] for [0] and [Unit] for [1] so that we get nice judgmental behavior.
       TODO: this should be unified with [Spaces.Finite.Fin].
    *)
-  Fixpoint CardinalityRepresentative (n : nat) : Type0 :=
+  Fixpoint CardinalityRepresentative (n : Nat) : Type0 :=
     match n with
       | 0 => Empty
       | 1 => Unit
       | S n' => (CardinalityRepresentative n' + Unit)%type
     end.
 
-  Coercion CardinalityRepresentative : nat >-> Sortclass.
+  Coercion CardinalityRepresentative : Nat >-> Sortclass.
 
   (** ** [Fin n] is an hSet *)
-  Global Instance trunc_cardinality_representative (n : nat)
+  Global Instance trunc_cardinality_representative (n : Nat)
   : IsHSet (CardinalityRepresentative n).
   Proof.
     induction n; [ typeclasses eauto |].
@@ -34,7 +34,7 @@ Module Export Core.
   Qed.
 
   (** ** Define the categories [n] *)
-  Definition nat_category (n : nat) :=
+  Definition nat_category (n : Nat) :=
     match n with
       | 0 => indiscrete_category 0
       | 1 => indiscrete_category 1

--- a/theories/Categories/ProductLaws.v
+++ b/theories/Categories/ProductLaws.v
@@ -11,7 +11,7 @@ Set Asymmetric Patterns.
 Local Open Scope category_scope.
 Local Open Scope functor_scope.
 
-Local Notation prod_type := Basics.Datatypes.prod.
+Local Notation prod_type := Basics.Datatypes.Prod.
 Local Notation fst_type := Basics.Datatypes.fst.
 Local Notation snd_type := Basics.Datatypes.snd.
 Local Notation pair_type := Basics.Datatypes.pair.

--- a/theories/Categories/SimplicialSets.v
+++ b/theories/Categories/SimplicialSets.v
@@ -24,17 +24,17 @@ Module Export Core.
     (** We say that the objects of Δ are natural numbers, where a
         number [n] is morally considered as the canonical [n]-simplex,
         a finite linear order on [n + 1] elements.  By declaring
-        [chain] to be a local coercion from [nat] to [PreCategory], we
+        [chain] to be a local coercion from [Nat] to [PreCategory], we
         can rely on on-the-fly eta-expansion to make this moral
         consideration a reality, telling Coq that it can unify, for
-        example, [nat -> nat -> Type] with [PreCategory -> PreCategory
+        example, [Nat -> Nat -> Type] with [PreCategory -> PreCategory
         -> Type] by silently inserting [chain]. *)
 
-    Local Coercion chain : nat >-> PreCategory.
+    Local Coercion chain : Nat >-> PreCategory.
 
     Definition simplex_category
       := @Build_PreCategory
-           nat
+           Nat
            Functor
            identity
            compose

--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -39,17 +39,17 @@ Section basics.
     | double2 n' => double2 (Succ (double n'))
     end.
 
-  Fixpoint Double (n : nat) : nat :=
+  Fixpoint Double (n : Nat) : Nat :=
     match n with
     | O    => O
     | S n' => S (S (Double n'))
     end.
 
-  Definition Double1 (n : nat) : nat := S (Double n).
+  Definition Double1 (n : Nat) : Nat := S (Double n).
 
-  Definition Double2 (n : nat) : nat := S (S (Double n)).
+  Definition Double2 (n : Nat) : Nat := S (S (Double n)).
 
-  Fixpoint binary (n : nat) : binnat :=
+  Fixpoint binary (n : Nat) : binnat :=
     match n with
     | O    => bzero
     | S n' => Succ (binary n')
@@ -59,7 +59,7 @@ End basics.
 
 Section binary_equiv.
 
-  Local Fixpoint unary' (n : binnat) : nat :=
+  Local Fixpoint unary' (n : binnat) : Nat :=
     match n with
     | bzero      => O
     | double1 n' => Double1 (unary' n')
@@ -81,7 +81,7 @@ Section binary_equiv.
     - simpl. rewrite succunary. apply ap. exact IHn.
   Qed.
 
-  Definition double1binary (n : nat) : binary (Double1 n) = double1 (binary n).
+  Definition double1binary (n : Nat) : binary (Double1 n) = double1 (binary n).
   Proof.
     induction n.
     - reflexivity.
@@ -89,7 +89,7 @@ Section binary_equiv.
       rewrite IHn. reflexivity.
   Qed.
 
-  Definition double2binary (n : nat) : binary (Double2 n) = double2 (binary n).
+  Definition double2binary (n : Nat) : binary (Double2 n) = double2 (binary n).
   Proof.
     induction n.
     - reflexivity.
@@ -108,7 +108,7 @@ Section binary_equiv.
   Global Instance isequiv_binary : IsEquiv binary :=
     isequiv_adjointify binary unary' binaryunary unarybinary.
 
-  Definition equiv_binary : nat <~> binnat :=
+  Definition equiv_binary : Nat <~> binnat :=
     Build_Equiv _ _  binary isequiv_binary.
 
 End binary_equiv.
@@ -150,7 +150,7 @@ End semiring_struct.
 
 Section semiring_laws.
 
-  Definition binarysucc (n : nat) : binary n.+1 = Succ (binary n).
+  Definition binarysucc (n : Nat) : binary n.+1 = Succ (binary n).
   Proof.
     reflexivity.
   Qed.
@@ -168,7 +168,7 @@ Section semiring_laws.
     induction m; induction n; try reflexivity; simpl; rewrite <- IHm; done.
   Qed.
 
-  Definition binaryplus (m n : nat) : binary m + binary n = binary (m + n).
+  Definition binaryplus (m n : Nat) : binary m + binary n = binary (m + n).
   Proof.
     induction m; induction n; try reflexivity.
     - simpl. rewrite binnatplussucc. apply ap. done.
@@ -222,7 +222,7 @@ Section semiring_laws.
       done.
   Qed.
 
-  Definition binarymult (m n : nat) : binary m * binary n = binary (m * n).
+  Definition binarymult (m n : Nat) : binary m * binary n = binary (m * n).
   Proof.
     induction m; induction n; try reflexivity; rewrite binnatmultsucc, IHm, binaryplus; done.
   Qed.
@@ -276,7 +276,7 @@ Section semiring_laws.
 
   Global Instance binnat_set : IsHSet binnat.
   Proof.
-    apply (istrunc_isequiv_istrunc nat binary).
+    apply (istrunc_isequiv_istrunc Nat binary).
   Qed.
 
   Global Instance binnat_semiring : IsSemiRing binnat.
@@ -358,8 +358,8 @@ Section naturals.
       | double1 n' => 2 * (f n') + 1
       | double2 n' => 2 * (f n') + 2 end.
 
-  Definition nat_to_semiring_helper : NaturalsToSemiRing nat :=
-    fun _ _ _ _ _ _ => fix f (n: nat) :=
+  Definition nat_to_semiring_helper : NaturalsToSemiRing Nat :=
+    fun _ _ _ _ _ _ => fix f (n: Nat) :=
       match n with
       | 0%nat => 0
       | S n' => 1 + f n'
@@ -370,7 +370,7 @@ Section naturals.
     Context {R:Type} `{IsSemiRing R}.
 
     Notation toR := (naturals_to_semiring binnat R).
-    Notation toR_fromnat := (naturals_to_semiring nat R).
+    Notation toR_fromnat := (naturals_to_semiring Nat R).
     Notation toR_vianat := (toR_fromnat ∘ unary).
 
     Definition f_suc (m : binnat) : toR (Succ m) = (toR m)+1.
@@ -723,7 +723,7 @@ Section minus.
       rewrite IHm. reflexivity.
   Qed.
 
-  Let binaryminus (x y : nat) : binary x ∸ binary y = binary (x ∸ y).
+  Let binaryminus (x y : Nat) : binary x ∸ binary y = binary (x ∸ y).
   Proof.
     revert y; induction x; intros y; induction y; try reflexivity.
     - apply binnat_zero_minus.

--- a/theories/Classes/implementations/family_prod.v
+++ b/theories/Classes/implementations/family_prod.v
@@ -18,7 +18,7 @@ Section family_prod.
       It is convenient to have the [Unit] in the end.
   *)
 
-  Definition FamilyProd (F : I → Type) : list I → Type
+  Definition FamilyProd (F : I → Type) : List I → Type
     := fold_right (λ (i:I) (A:Type), F i * A) Unit.
 
   (** Map function for [FamilyProd F ℓ],
@@ -28,7 +28,7 @@ Section family_prod.
         = (f x1, f x2, ..., f xn, tt)
       >> *)
 
-  Fixpoint map_family_prod {F G : I → Type} {ℓ : list I}
+  Fixpoint map_family_prod {F G : I → Type} {ℓ : List I}
       (f : ∀ i, F i → G i)
       : FamilyProd F ℓ → FamilyProd G ℓ :=
     match ℓ with
@@ -39,7 +39,7 @@ Section family_prod.
   (** [for_all_family_prod F P (x1, ..., xn, tt) = True] if
       [P i1 x1 ∧ P i2 x2 ∧ ... ∧ P in xn] holds. *)
 
-  Fixpoint for_all_family_prod (F : I → Type) {ℓ : list I}
+  Fixpoint for_all_family_prod (F : I → Type) {ℓ : List I}
       (P : ∀ i, F i -> Type) : FamilyProd F ℓ → Type :=
     match ℓ with
     | nil => λ _, True
@@ -49,7 +49,7 @@ Section family_prod.
   (** [for_all_2_family_prod F G R (x1,...,xn,tt) (y1,...,yn,tt) = True]
       if [R i1 x1 y1 ∧ R i2 x2 y2 ∧ ... ∧ P in xn yn] holds. *)
 
-  Fixpoint for_all_2_family_prod (F G : I → Type) {ℓ : list I}
+  Fixpoint for_all_2_family_prod (F G : I → Type) {ℓ : List I}
       (R : ∀ i, F i -> G i -> Type)
       : FamilyProd F ℓ → FamilyProd G ℓ → Type :=
     match ℓ with
@@ -67,7 +67,7 @@ Section family_prod.
       holds. *)
   Lemma reflexive_for_all_2_family_prod (F : I → Type)
     (R : ∀ i, Relation (F i)) `{!∀ i, Reflexive (R i)}
-    {ℓ : list I} (s : FamilyProd F ℓ)
+    {ℓ : List I} (s : FamilyProd F ℓ)
     : for_all_2_family_prod F F R s s.
   Proof with try reflexivity.
     induction ℓ...

--- a/theories/Classes/implementations/list.v
+++ b/theories/Classes/implementations/list.v
@@ -17,25 +17,25 @@ End ListNotations.
 
 Import ListNotations.
 
-Fixpoint length {A} (l : list A) := match l with
+Fixpoint length {A} (l : List A) := match l with
   | [] => O
   | _ :: l => S (length l)
   end.
 
-Fixpoint fold_left {A B} (f : A -> B -> A) (acc : A) (l : list B) :=
+Fixpoint fold_left {A B} (f : A -> B -> A) (acc : A) (l : List B) :=
   match l with
   | [] => acc
   | x :: l => fold_left f (f acc x) l
   end.
 
-Fixpoint map {A B} (f : A -> B) (l : list A) :=
+Fixpoint map {A B} (f : A -> B) (l : List A) :=
   match l with
   | [] => []
   | x :: l => (f x) :: (map f l)
   end.
 
 Fixpoint map2 `(f : A -> B -> C)
-  (def_l : list A -> list C) (def_r : list B -> list C)
+  (def_l : List A -> List C) (def_r : List B -> List C)
   l1 l2 :=
   match l1, l2 with
   | [], [] => []
@@ -50,14 +50,14 @@ Proof.
 reflexivity.
 Qed.
 
-Lemma map_id `(f : A -> A) (Hf : forall x, f x = x) (l : list A) : map f l = l.
+Lemma map_id `(f : A -> A) (Hf : forall x, f x = x) (l : List A) : map f l = l.
 Proof.
 induction l as [|x l IHl].
 - reflexivity.
 - simpl. rewrite Hf,IHl. reflexivity.
 Qed.
 
-Global Instance sg_op_app A : SgOp (list A) := @app A.
+Global Instance sg_op_app A : SgOp (List A) := @app A.
 
 Global Instance app_assoc A : Associative (@app A).
 Proof.
@@ -120,21 +120,21 @@ intros l;induction l as [|x l IHl];simpl.
 Qed.
 
 (* Copy pasted from the Coq library. *)
-Definition tl {A} (l:list A) : list A :=
+Definition tl {A} (l:List A) : List A :=
   match l with
     | [] => nil
     | a :: m => m
   end.
 
 (* Modified copy from the Coq library. *)
-(** The "In list" predicate *)
-Fixpoint InList {A} (a:A) (l:list A) : Type0 :=
+(** The "In List" predicate *)
+Fixpoint InList {A} (a:A) (l:List A) : Type0 :=
   match l with
     | [] => False
     | b :: m => b = a |_| InList a m
   end.
 
-Fixpoint fold_right {A} {B} (f : B -> A -> A) (x : A) (l : list B) : A :=
+Fixpoint fold_right {A} {B} (f : B -> A -> A) (x : A) (l : List B) : A :=
   match l with
     | nil => x
     | cons b t => f b (fold_right f x t)

--- a/theories/Classes/implementations/ne_list.v
+++ b/theories/Classes/implementations/ne_list.v
@@ -72,13 +72,13 @@ Section with_type.
 
   Definition last: ne_list → T := foldr1 (fun x y => y).
 
-  Fixpoint replicate_Sn (x: T) (n: nat): ne_list :=
+  Fixpoint replicate_Sn (x: T) (n: Nat): ne_list :=
     match n with
     | 0 => one x
     | S n' => cons x (replicate_Sn x n')
     end.
 
-  Fixpoint take (n: nat) (l: ne_list): ne_list :=
+  Fixpoint take (n: Nat) (l: ne_list): ne_list :=
     match l, n with
     | cons x xs, S n' => take n' xs
     | _, _ => one (head l)

--- a/theories/Classes/implementations/ne_list.v
+++ b/theories/Classes/implementations/ne_list.v
@@ -47,19 +47,19 @@ Section with_type.
   Definition head (l: ne_list): T
     := match l with one x => x | cons x _ => x end.
 
-  Fixpoint to_list (l: ne_list): list T :=
+  Fixpoint to_list (l: ne_list): List T :=
     match l with
     | one x => x :: nil
     | cons x xs => x :: to_list xs
     end.
 
-  Fixpoint from_list (x: T) (xs: list T): ne_list :=
+  Fixpoint from_list (x: T) (xs: List T): ne_list :=
     match xs with
     | nil => one x
     | Datatypes.cons h t => cons x (from_list h t)
     end.
 
-  Definition tail (l: ne_list): list T
+  Definition tail (l: ne_list): List T
     := match l with one _ => nil | cons _ x => to_list x end.
 
   Lemma decomp_eq (l: ne_list): l = from_list (head l) (tail l).
@@ -84,7 +84,7 @@ Section with_type.
     | _, _ => one (head l)
     end.
 
-  Fixpoint front (l: ne_list) : list T :=
+  Fixpoint front (l: ne_list) : List T :=
     match l with
     | one _ => nil
     | cons x xs => x :: front xs
@@ -177,4 +177,4 @@ Fixpoint zip {A B: Type} (l: ne_list A) (m: ne_list B)
 
 End ne_list.
 
-Global Coercion ne_list.to_list : ne_list.ne_list >-> list.
+Global Coercion ne_list.to_list : ne_list.ne_list >-> List.

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -249,7 +249,7 @@ induction k.
 Qed.
 
 Lemma le_exists : forall n m : nat,
-  iff@{N N N} (n <= m) (sig@{N N} (fun k => m =N= k + n)).
+  Iff@{N N N} (n <= m) (sig@{N N} (fun k => m =N= k + n)).
 Proof.
 intros n m;split.
 - intros E;induction E as [|m E IH].
@@ -265,7 +265,7 @@ Proof.
 induction a;constructor;auto.
 Qed.
 
-Lemma le_S_S : forall a b : nat, iff@{N N N} (a <= b) (S a <= S b).
+Lemma le_S_S : forall a b : nat, Iff@{N N N} (a <= b) (S a <= S b).
 Proof.
 intros. etransitivity;[apply le_exists|].
 etransitivity;[|apply symmetry,le_exists].

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -18,37 +18,37 @@ Section nat_lift.
 
 Universe N.
 
-Let natpaths := @paths@{N} nat.
+Let natpaths := @paths@{N} Nat.
 Infix "=N=" := natpaths.
 Let natpaths_symm : Symmetric@{N N} natpaths.
 Proof. unfold natpaths;apply _. Qed.
 
-Global Instance nat_0: Zero@{N} nat := 0%nat.
-Global Instance nat_1: One@{N} nat := 1%nat.
+Global Instance nat_0: Zero@{N} Nat := 0%nat.
+Global Instance nat_1: One@{N} Nat := 1%nat.
 
-Global Instance nat_plus: Plus@{N} nat := Nat.add.
+Global Instance nat_plus: Plus@{N} Nat := Nat.add.
 
 Notation mul := Nat.mul.
 
-Global Instance nat_mult: Mult@{N} nat := Nat.mul.
+Global Instance nat_mult: Mult@{N} Nat := Nat.mul.
 
 Ltac simpl_nat :=
-  change (@plus nat _) with Nat.add;
-  change (@mult nat _) with Nat.mul;
+  change (@plus Nat _) with Nat.add;
+  change (@mult Nat _) with Nat.mul;
   simpl;
-  change Nat.add with (@plus nat Nat.add);
-  change Nat.mul with (@mult nat Nat.mul).
+  change Nat.add with (@plus Nat Nat.add);
+  change Nat.mul with (@mult Nat Nat.mul).
 
-Local Instance add_assoc : Associative@{N} (plus : Plus nat).
+Local Instance add_assoc : Associative@{N} (plus : Plus Nat).
 Proof.
-hnf. apply (nat_rect@{N} (fun a => forall b c, _));[|intros a IH];
+hnf. apply (Nat_rect@{N} (fun a => forall b c, _));[|intros a IH];
 intros b c.
 + reflexivity.
 + change (S (a + (b + c)) = S (a + b + c)).
   apply ap,IH.
 Qed.
 
-Lemma add_0_r : forall x:nat, x + 0 =N= x.
+Lemma add_0_r : forall x:Nat, x + 0 =N= x.
 Proof.
 intros a;induction a as [|a IH].
 + reflexivity.
@@ -68,9 +68,9 @@ Proof. exact idpath. Qed.
 Lemma add_0_l a : 0 + a =N= a.
 Proof. exact idpath. Qed.
 
-Local Instance add_comm : Commutative@{N N} (plus : Plus nat).
+Local Instance add_comm : Commutative@{N N} (plus : Plus Nat).
 Proof.
-hnf. apply (nat_rect@{N} (fun a => forall b, _));[|intros a IHa];
+hnf. apply (Nat_rect@{N} (fun a => forall b, _));[|intros a IHa];
 intros b;induction b as [|b IHb].
 - reflexivity.
 - change (S b = S (b + 0)). apply ap,IHb.
@@ -80,9 +80,9 @@ intros b;induction b as [|b IHb].
 Qed.
 
 Local Instance add_mul_distr_l : LeftDistribute@{N}
-  (mult :Mult nat) (plus:Plus nat).
+  (mult :Mult Nat) (plus:Plus Nat).
 Proof.
-hnf. apply (nat_rect@{N} (fun a => forall b c, _));[|intros a IHa];
+hnf. apply (Nat_rect@{N} (fun a => forall b c, _));[|intros a IHa];
 simpl_nat.
 - intros _ _;reflexivity.
 - intros. rewrite IHa.
@@ -91,15 +91,15 @@ simpl_nat.
   reflexivity.
 Qed.
 
-Lemma mul_0_r : forall a : nat, a * 0 =N= 0.
+Lemma mul_0_r : forall a : Nat, a * 0 =N= 0.
 Proof.
 induction a;simpl_nat;trivial.
 reflexivity.
 Qed.
 
-Lemma mul_S_r : forall a b : nat, a * S b =N= a + a * b.
+Lemma mul_S_r : forall a b : Nat, a * S b =N= a + a * b.
 Proof.
-apply (nat_rect@{N} (fun a => forall b, _));[|intros a IHa];intros b;simpl_nat.
+apply (Nat_rect@{N} (fun a => forall b, _));[|intros a IHa];intros b;simpl_nat.
 - reflexivity.
 - simpl_nat. rewrite IHa.
   rewrite (simple_associativity b a).
@@ -108,16 +108,16 @@ apply (nat_rect@{N} (fun a => forall b, _));[|intros a IHa];intros b;simpl_nat.
   reflexivity.
 Qed.
 
-Local Instance mul_comm : Commutative@{N N} (mult : Mult nat).
+Local Instance mul_comm : Commutative@{N N} (mult : Mult Nat).
 Proof.
-hnf. apply (nat_rect@{N} (fun a => forall b, _));[|intros a IHa];simpl_nat.
+hnf. apply (Nat_rect@{N} (fun a => forall b, _));[|intros a IHa];simpl_nat.
 - intros;apply symmetry,mul_0_r.
 - intros b;rewrite IHa. rewrite mul_S_r,<-IHa. reflexivity.
 Qed.
 
-Local Instance mul_assoc : Associative@{N} (mult : Mult nat).
+Local Instance mul_assoc : Associative@{N} (mult : Mult Nat).
 Proof.
-hnf. apply (nat_rect@{N} (fun a => forall b c, _));[|intros a IHa].
+hnf. apply (Nat_rect@{N} (fun a => forall b c, _));[|intros a IHa].
 - intros;reflexivity.
 - unfold mult;simpl;change nat_mult with mult.
   intros b c.
@@ -141,10 +141,10 @@ Definition pred x := match x with | 0%nat => 0 | S k => k end.
 Global Instance S_inj : IsInjective@{N N} S
   := { injective := fun a b E => ap pred E }.
 
-Global Instance nat_dec: DecidablePaths@{N} nat.
+Global Instance nat_dec: DecidablePaths@{N} Nat.
 Proof.
 hnf.
-apply (nat_rect@{N} (fun x => forall y, _)).
+apply (Nat_rect@{N} (fun x => forall y, _)).
 - intros [|b].
   + left;reflexivity.
   + right;apply symmetric_neq,S_neq_0.
@@ -155,12 +155,12 @@ apply (nat_rect@{N} (fun x => forall y, _)).
     * right;intros E. apply (injective S) in E. auto.
 Defined.
 
-Global Instance nat_set : IsTrunc@{N} 0 nat.
+Global Instance nat_set : IsTrunc@{N} 0 Nat.
 Proof.
 apply hset_pathcoll, pathcoll_decpaths, nat_dec.
 Qed.
 
-Instance nat_semiring : IsSemiRing@{N} nat.
+Instance nat_semiring : IsSemiRing@{N} Nat.
 Proof.
 repeat (split; try apply _);
 first [change sg_op with plus; change mon_unit with 0
@@ -171,7 +171,7 @@ first [change sg_op with plus; change mon_unit with 0
   rewrite mul_S_r,mul_0_r. apply add_0_r.
 Qed.
 
-(* Add Ring nat: (rings.stdlib_semiring_theory nat). *)
+(* Add Ring Nat: (rings.stdlib_semiring_theory Nat). *)
 
 (* Close Scope nat_scope. *)
 
@@ -186,18 +186,18 @@ Qed.
 Lemma S_nat_1_plus x : S x =N= 1 + x.
 Proof. reflexivity. Qed.
 
-Lemma nat_induction (P : nat -> Type) :
+Lemma nat_induction (P : Nat -> Type) :
   P 0 -> (forall n, P n -> P (1 + n)) -> forall n, P n.
-Proof. apply nat_rect. Qed.
+Proof. apply Nat_rect. Qed.
 
-Lemma plus_eq_zero : forall a b : nat, a + b =N= 0 -> a =N= 0 /\ b =N= 0.
+Lemma plus_eq_zero : forall a b : Nat, a + b =N= 0 -> a =N= 0 /\ b =N= 0.
 Proof.
 intros [|a];[intros [|b];auto|].
 - intros E. destruct (S_neq_0 _ E).
 - intros ? E. destruct (S_neq_0 _ E).
 Qed.
 
-Lemma mult_eq_zero : forall a b : nat, a * b =N= 0 -> a =N= 0 |_| b =N= 0.
+Lemma mult_eq_zero : forall a b : Nat, a * b =N= 0 -> a =N= 0 |_| b =N= 0.
 Proof.
 intros [|a] [|b];auto.
 - intros _;right;reflexivity.
@@ -206,14 +206,14 @@ intros [|a] [|b];auto.
   destruct (S_neq_0 _ E).
 Defined.
 
-Instance nat_zero_divisors : NoZeroDivisors nat.
+Instance nat_zero_divisors : NoZeroDivisors Nat.
 Proof.
 intros x [Ex [y [Ey1 Ey2]]].
 apply mult_eq_zero in Ey2.
 destruct Ey2;auto.
 Qed.
 
-Instance nat_plus_cancel_l : forall z:nat, LeftCancellation@{N} plus z.
+Instance nat_plus_cancel_l : forall z:Nat, LeftCancellation@{N} plus z.
 Proof.
 red. intros a;induction a as [|a IHa];simpl_nat;intros b c E.
 - trivial.
@@ -221,7 +221,7 @@ red. intros a;induction a as [|a IHa];simpl_nat;intros b c E.
 Qed.
 
 Instance nat_mult_cancel_l
-  : forall z : nat, PropHolds (~ (z =N= 0)) -> LeftCancellation@{N} (.*.) z.
+  : forall z : Nat, PropHolds (~ (z =N= 0)) -> LeftCancellation@{N} (.*.) z.
 Proof.
 unfold PropHolds. unfold LeftCancellation.
 intros a Ea b c E;revert b c a Ea E.
@@ -238,8 +238,8 @@ induction b as [|b IHb];intros [|c];simpl_nat;intros a Ea E.
 Qed.
 
 (* Order *)
-Global Instance nat_le: Le@{N N} nat := Nat.leq.
-Global Instance nat_lt: Lt@{N N} nat := Nat.lt.
+Global Instance nat_le: Le@{N N} Nat := Nat.leq.
+Global Instance nat_lt: Lt@{N N} Nat := Nat.lt.
 
 Lemma le_plus : forall n k, n <= k + n.
 Proof.
@@ -248,7 +248,7 @@ induction k.
 - simpl_nat. constructor. assumption.
 Qed.
 
-Lemma le_exists : forall n m : nat,
+Lemma le_exists : forall n m : Nat,
   Iff@{N N N} (n <= m) (sig@{N N} (fun k => m =N= k + n)).
 Proof.
 intros n m;split.
@@ -265,7 +265,7 @@ Proof.
 induction a;constructor;auto.
 Qed.
 
-Lemma le_S_S : forall a b : nat, Iff@{N N N} (a <= b) (S a <= S b).
+Lemma le_S_S : forall a b : Nat, Iff@{N N N} (a <= b) (S a <= S b).
 Proof.
 intros. etransitivity;[apply le_exists|].
 etransitivity;[|apply symmetry,le_exists].
@@ -274,7 +274,7 @@ split;intros [k E];exists k.
 - rewrite add_S_r in E;apply (injective _) in E. trivial.
 Qed.
 
-Lemma lt_0_S : forall a : nat, 0 < S a.
+Lemma lt_0_S : forall a : Nat, 0 < S a.
 Proof.
 intros. apply le_S_S. apply zero_least.
 Qed.
@@ -287,7 +287,7 @@ intros [|a] b.
   left. apply le_S_S. trivial.
 Defined.
 
-Lemma le_lt_dec : forall a b : nat, a <= b |_| b < a.
+Lemma le_lt_dec : forall a b : Nat, a <= b |_| b < a.
 Proof.
 induction a as [|a IHa].
 - intros;left;apply zero_least.
@@ -314,7 +314,7 @@ destruct b.
 - constructor. apply le_S_S. trivial.
 Qed.
 
-Local Instance nat_le_total : TotalRelation@{N N} (_:Le nat).
+Local Instance nat_le_total : TotalRelation@{N N} (_:Le Nat).
 Proof.
 hnf. intros a b.
 destruct (le_lt_dec a b);[left|right].
@@ -322,7 +322,7 @@ destruct (le_lt_dec a b);[left|right].
 - apply lt_le;trivial.
 Qed.
 
-Local Instance nat_lt_irrefl : Irreflexive@{N N} (_:Lt nat).
+Local Instance nat_lt_irrefl : Irreflexive@{N N} (_:Lt Nat).
 Proof.
 hnf. intros x E.
 apply le_exists in E.
@@ -334,12 +334,12 @@ rewrite add_0_r, add_S_r,<-add_S_l.
 rewrite add_comm. apply natpaths_symm,E.
 Qed.
 
-Local Instance nat_le_hprop : is_mere_relation nat le.
+Local Instance nat_le_hprop : is_mere_relation Nat le.
 Proof.
 intros m n;apply Trunc.hprop_allpath.
 generalize (idpath (S n) : S n =N= S n).
 generalize n at 2 3 4 5.
-change (forall n0 : nat,
+change (forall n0 : Nat,
 S n =N= S n0 -> forall le_mn1 le_mn2 : m <= n0, le_mn1 = le_mn2).
 induction (S n) as [|n0 IHn0].
 - intros ? E;destruct (S_neq_0 _ (natpaths_symm _ _ E)).
@@ -390,7 +390,7 @@ repeat split.
     trivial.
 Qed.
 
-Local Instance nat_strict : StrictOrder (_:Lt nat).
+Local Instance nat_strict : StrictOrder (_:Lt Nat).
 Proof.
 split.
 - cbv; exact _.
@@ -405,7 +405,7 @@ split.
   reflexivity.
 Qed.
 
-Instance nat_trichotomy : Trichotomy@{N N i} (lt:Lt nat).
+Instance nat_trichotomy : Trichotomy@{N N i} (lt:Lt Nat).
 Proof.
 hnf. fold natpaths.
 intros a b. destruct (le_lt_dec a b) as [[|]|E];auto.
@@ -413,9 +413,9 @@ intros a b. destruct (le_lt_dec a b) as [[|]|E];auto.
 - left. apply le_S_S. trivial.
 Qed.
 
-Global Instance nat_apart : Apart@{N N} nat := fun n m => n < m |_| m < n.
+Global Instance nat_apart : Apart@{N N} Nat := fun n m => n < m |_| m < n.
 
-Instance nat_apart_mere : is_mere_relation nat nat_apart.
+Instance nat_apart_mere : is_mere_relation Nat nat_apart.
 Proof.
 intros;apply ishprop_sum;try apply _.
 intros E1 E2. apply (irreflexivity nat_lt x).
@@ -427,7 +427,7 @@ Proof.
   rapply decidable_sum; apply Nat.decidable_lt.
 Defined.
 
-Global Instance nat_trivial_apart : TrivialApart nat.
+Global Instance nat_trivial_apart : TrivialApart Nat.
 Proof.
 split.
 - apply _.
@@ -445,7 +445,7 @@ destruct (le_lt_dec b a);auto.
 destruct E;auto.
 Qed.
 
-Lemma nat_lt_not_le : forall a b : nat, a < b -> ~ (b <= a).
+Lemma nat_lt_not_le : forall a b : Nat, a < b -> ~ (b <= a).
 Proof.
 intros a b E1 E2.
 apply le_exists in E1;apply le_exists in E2.
@@ -460,7 +460,7 @@ rewrite (add_assoc k1), (add_comm k1), <-(add_assoc k2).
 apply natpaths_symm,E2.
 Qed.
 
-Global Instance nat_le_dec: forall x y : nat, Decidable (x ≤ y).
+Global Instance nat_le_dec: forall x y : Nat, Decidable (x ≤ y).
 Proof.
 intros a b. destruct (le_lt_dec a b).
 - left;trivial.
@@ -479,7 +479,7 @@ intros [|a] E.
 - apply S_gt_0.
 Qed.
 
-Lemma nat_le_lt_trans : forall a b c : nat, a <= b -> b < c -> a < c.
+Lemma nat_le_lt_trans : forall a b c : Nat, a <= b -> b < c -> a < c.
 Proof.
 intros a b c E1 E2.
 apply le_exists in E1;apply le_exists in E2.
@@ -487,7 +487,7 @@ destruct E1 as [k1 E1],E2 as [k2 E2];rewrite E2,E1.
 rewrite add_S_r,add_assoc. apply le_S_S,le_plus.
 Qed.
 
-Lemma lt_strong_cotrans : forall a b : nat, a < b -> forall c, a < c |_| c < b.
+Lemma lt_strong_cotrans : forall a b : Nat, a < b -> forall c, a < c |_| c < b.
 Proof.
 intros a b E1 c.
 destruct (le_lt_dec c a) as [E2|E2].
@@ -572,15 +572,15 @@ Proof.
 split;apply _.
 Qed.
 
-Global Instance nat_naturals_to_semiring : NaturalsToSemiRing@{N i} nat :=
-  fun _ _ _ _ _ _ => fix f (n: nat) := match n with 0%nat => 0 | 1%nat => 1 |
+Global Instance nat_naturals_to_semiring : NaturalsToSemiRing@{N i} Nat :=
+  fun _ _ _ _ _ _ => fix f (n: Nat) := match n with 0%nat => 0 | 1%nat => 1 |
    S n' => 1 + f n' end.
 
 Section for_another_semiring.
   Universe U.
   Context {R:Type@{U} } `{IsSemiRing@{U} R}.
 
-  Notation toR := (naturals_to_semiring nat R).
+  Notation toR := (naturals_to_semiring Nat R).
 
 (*   Add Ring R: (rings.stdlib_semiring_theory R). *)
 
@@ -620,31 +620,31 @@ Section for_another_semiring.
   Qed.
 
   Global Instance nat_to_sr_morphism
-    : IsSemiRingPreserving (naturals_to_semiring nat R).
+    : IsSemiRingPreserving (naturals_to_semiring Nat R).
   Proof.
   repeat (split;try apply _);trivial.
   Defined.
 
-  Lemma toR_unique (h : nat -> R) `{!IsSemiRingPreserving h} x :
-    naturals_to_semiring nat R x = h x.
+  Lemma toR_unique (h : Nat -> R) `{!IsSemiRingPreserving h} x :
+    naturals_to_semiring Nat R x = h x.
   Proof.
   induction x as [|n E].
   + change (0 = h 0).
     apply symmetry,preserves_0.
-  + rewrite f_S. change (1 + naturals_to_semiring nat R n = h (1+n)).
+  + rewrite f_S. change (1 + naturals_to_semiring Nat R n = h (1+n)).
     rewrite (preserves_plus (f:=h)).
     rewrite E. apply ap10,ap,symmetry,preserves_1.
   Qed.
 End for_another_semiring.
 
-Lemma nat_naturals : Naturals@{N N N N N N N i} nat.
+Lemma nat_naturals : Naturals@{N N N N N N N i} Nat.
 Proof.
 split;try apply _.
 intros;apply toR_unique, _.
 Qed.
 Global Existing Instance nat_naturals.
 
-Global Instance nat_cut_minus: CutMinus@{N} nat := Nat.sub.
+Global Instance nat_cut_minus: CutMinus@{N} Nat := Nat.sub.
 
 Lemma plus_minus : forall a b, cut_minus (a + b) b =N= a.
 Proof.
@@ -659,7 +659,7 @@ intros a b;revert a;induction b as [|b IH].
     rewrite add_S_r,<-add_S_l;apply IH.
 Qed.
 
-Lemma le_plus_minus : forall n m : nat, n <= m -> m =N= (n + (cut_minus m  n)).
+Lemma le_plus_minus : forall n m : Nat, n <= m -> m =N= (n + (cut_minus m  n)).
 Proof.
 intros n m E. apply le_exists in E.
 destruct E as [k E];rewrite E.
@@ -676,7 +676,7 @@ intros a b;revert a;induction b as [|b IH];intros [|a];simpl.
 - intros E. apply IH;apply le_S_S,E.
 Qed.
 
-Global Instance nat_cut_minus_spec : CutMinusSpec@{N N} nat nat_cut_minus.
+Global Instance nat_cut_minus_spec : CutMinusSpec@{N N} Nat nat_cut_minus.
 Proof.
 split.
 - intros x y E. rewrite add_comm.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -148,9 +148,9 @@ Section upper_classes.
     ; dec_recip_0 : /0 = 0
     ; dec_recip_inverse : forall x, x <> 0 -> x / x = 1 }.
 
-  Class FieldCharacteristic@{j} {Aap : Apart@{i j} A} (k : nat) : Type@{j}
-    := field_characteristic : forall n : nat, Nat.lt@{i} 0 n ->
-      Iff@{j j j} (forall m : nat, not@{j j} (paths@{Set} n (Nat.mul k m)))
+  Class FieldCharacteristic@{j} {Aap : Apart@{i j} A} (k : Nat) : Type@{j}
+    := field_characteristic : forall n : Nat, Nat.lt@{i} 0 n ->
+      Iff@{j j j} (forall m : Nat, not@{j j} (paths@{Set} n (Nat.mul k m)))
         (@apart A Aap (Nat.nat_iter n (1 +) 0) 0).
 
 End upper_classes.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -150,7 +150,7 @@ Section upper_classes.
 
   Class FieldCharacteristic@{j} {Aap : Apart@{i j} A} (k : nat) : Type@{j}
     := field_characteristic : forall n : nat, Nat.lt@{i} 0 n ->
-      iff@{j j j} (forall m : nat, not@{j j} (paths@{Set} n (Nat.mul k m)))
+      Iff@{j j j} (forall m : nat, not@{j j} (paths@{Set} n (Nat.mul k m)))
         (@apart A Aap (Nat.nat_iter n (1 +) 0) 0).
 
 End upper_classes.

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -405,7 +405,7 @@ Class Return (M : Type -> Type) := ret : forall {A}, A -> M A.
 Class Bind (M : Type -> Type) := bind : forall {A B}, M A -> (A -> M B) -> M B.
 
 Class Enumerable@{i} (A : Type@{i}) :=
-  { enumerator : nat -> A
+  { enumerator : Nat -> A
   ; enumerator_issurj :>
     IsConnMap@{i} (trunc_S minus_two) enumerator }.
 Arguments enumerator A {_} _.

--- a/theories/Classes/interfaces/cauchy.v
+++ b/theories/Classes/interfaces/cauchy.v
@@ -26,24 +26,24 @@ Section cauchy.
   Existing Instance qinc_strong_presving.
 
   Section sequence.
-    Context (x : nat -> F).
+    Context (x : Nat -> F).
 
-    Class CauchyModulus (M : Qpos Q -> nat) :=
+    Class CauchyModulus (M : Qpos Q -> Nat) :=
       cauchy_convergence : forall epsilon : Qpos Q, forall m n,
             M epsilon <= m -> M epsilon <= n ->
             - ' (' epsilon) < (x m) - (x n) < ' (' epsilon).
 
     Class IsLimit (l : F) := is_limit
       : forall epsilon : Qpos Q,
-          hexists (fun N : nat => forall n : nat, N <= n ->
+          hexists (fun N : Nat => forall n : Nat, N <= n ->
             - ' (' epsilon) < l - x n < ' (' epsilon)).
   End sequence.
 
   Class IsComplete := is_complete
-    : forall x : nat -> F, forall M , CauchyModulus x M -> exists l, IsLimit x l.
+    : forall x : Nat -> F, forall M , CauchyModulus x M -> exists l, IsLimit x l.
 
   Section theory.
-    Context (x : nat -> F) {M} `{CauchyModulus x M}.
+    Context (x : Nat -> F) {M} `{CauchyModulus x M}.
 
     Lemma modulus_close_limit
           {l}

--- a/theories/Classes/interfaces/round.v
+++ b/theories/Classes/interfaces/round.v
@@ -7,7 +7,7 @@ Require Import
 Section round_up.
 
   Class RoundUpStrict A `{IsSemiRing A} `{StrictSemiRingOrder A}
-    := round_up_strict : forall a : A, {n : nat & a < naturals_to_semiring nat A n}.
+    := round_up_strict : forall a : A, {n : Nat & a < naturals_to_semiring Nat A n}.
   Global Arguments round_up_strict A {_ _ _ _ _ _ _ _ _ _ _ _} _.
 
 End round_up.

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -45,7 +45,7 @@ Global Coercion symbol_types : Signature >-> Funclass.
 
 (** A single sorted [Signature] is a signature with [Sort = Unit]. *)
 
-Definition BuildSingleSortedSignature (sym : Type) (arities : sym → nat)
+Definition BuildSingleSortedSignature (sym : Type) (arities : sym → Nat)
   : Signature
   := BuildSignature Unit sym (ne_list.replicate_Sn tt o arities).
 
@@ -68,10 +68,10 @@ Definition dom_symboltype {σ} : SymbolType σ → List (Sort σ)
   := ne_list.front.
 
 (** For [s : SymbolType σ], [cod_symboltype σ] is the arity of the
-    symbol type [s]. That is the number [n:nat] of arguments of the
+    symbol type [s]. That is the number [n:Nat] of arguments of the
     [SymbolType σ]. *)
 
-Definition arity_symboltype {σ} : SymbolType σ → nat
+Definition arity_symboltype {σ} : SymbolType σ → Nat
   := length o dom_symboltype.
 
 (** An [Algebra] must provide a family of [Carriers σ] indexed by

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -64,7 +64,7 @@ Definition cod_symboltype {σ} : SymbolType σ → Sort σ
 (** For [s : SymbolType σ], [cod_symboltype σ] is the domain of the
     symbol type [s]. *)
 
-Definition dom_symboltype {σ} : SymbolType σ → list (Sort σ)
+Definition dom_symboltype {σ} : SymbolType σ → List (Sort σ)
   := ne_list.front.
 
 (** For [s : SymbolType σ], [cod_symboltype σ] is the arity of the

--- a/theories/Classes/orders/integers.v
+++ b/theories/Classes/orders/integers.v
@@ -24,7 +24,7 @@ Context `{Funext} `{Univalence}.
 Context `{Integers Z} `{!TrivialApart Z}.
 
 (* Add Ring Z : (rings.stdlib_ring_theory Z). *)
-(* Add Ring nat : (rings.stdlib_semiring_theory nat). *)
+(* Add Ring Nat : (rings.stdlib_semiring_theory Nat). *)
 
 Lemma induction
   (P: Z -> Type):
@@ -32,7 +32,7 @@ Lemma induction
   forall n, P n.
 Proof.
 intros P0 Psuc1 Psuc2 n.
-destruct (int_abs_sig Z nat n) as [[a A]|[a A]].
+destruct (int_abs_sig Z Nat n) as [[a A]|[a A]].
 - rewrite <-A. clear A. revert a.
   apply naturals.induction.
   + rewrite rings.preserves_0. trivial.
@@ -86,8 +86,8 @@ intros x y.
 (* otherwise Z_le gets defined using peano.nat_ring
    but we only know order_reflecting when using naturals.nat_ring *)
 pose (naturals_ring) as E0.
-destruct (dec (integers_to_ring _ (NatPair.Z nat) x ≤
-    integers_to_ring _ (NatPair.Z nat) y)) as [E|E].
+destruct (dec (integers_to_ring _ (NatPair.Z Nat) x ≤
+    integers_to_ring _ (NatPair.Z Nat) y)) as [E|E].
 - left. apply (order_reflecting _) in E. trivial.
 - right. intro;apply E;apply (order_preserving _);trivial.
 Qed.

--- a/theories/Classes/orders/naturals.v
+++ b/theories/Classes/orders/naturals.v
@@ -72,10 +72,10 @@ Qed.
 Global Instance slow_nat_le_dec: forall x y: N, Decidable (x ≤ y) | 10.
 Proof.
 intros x y.
-destruct (nat_le_dec (naturals_to_semiring _ nat x) (naturals_to_semiring _ nat y))
+destruct (nat_le_dec (naturals_to_semiring _ Nat x) (naturals_to_semiring _ Nat y))
 as [E | E].
 - left.
-  apply (order_reflecting (naturals_to_semiring N nat)). exact E.
+  apply (order_reflecting (naturals_to_semiring N Nat)). exact E.
 - right. intros E'. apply E.
   apply order_preserving;trivial. apply _.
 Qed.

--- a/theories/Classes/tactics/ring_quote.v
+++ b/theories/Classes/tactics/ring_quote.v
@@ -66,7 +66,7 @@ Proof. intros []. Defined.
 
 Definition singleton x : Vars Unit := fun _ => x.
 
-Definition merge {A B:Type0 } (va:Vars A) (vb:Vars B) : Vars (sum@{Set Set} A B)
+Definition merge {A B:Type0 } (va:Vars A) (vb:Vars B) : Vars (Sum@{Set Set} A B)
   := fun i => match i with inl i => va i | inr i => vb i end.
 
 Section Lookup.

--- a/theories/Classes/tactics/ring_tac.v
+++ b/theories/Classes/tactics/ring_tac.v
@@ -112,7 +112,7 @@ Ltac ring_with_nat :=
   match goal with
   |- @paths ?R _ _ =>
     ((pose proof (_ : IsSemiRing R)) || fail "target equality not on a semiring");
-    apply (by_quoting (naturals_to_semiring nat R));
+    apply (by_quoting (naturals_to_semiring Nat R));
     compute;reflexivity
   end.
 

--- a/theories/Classes/tests/ring_tac.v
+++ b/theories/Classes/tests/ring_tac.v
@@ -22,7 +22,7 @@ Lemma test2 `{IsSemiRing R}
   : forall x y : R, x + (y * x) = x * (y + 1).
 Proof.
 intros.
-apply (by_quoting (naturals_to_semiring nat R)).
+apply (by_quoting (naturals_to_semiring Nat R)).
 compute. reflexivity.
 Qed.
 
@@ -32,7 +32,7 @@ Lemma test3 `{IsSemiRing R}
 = pa * pb * pc.
 Proof.
 intros.
-apply (by_quoting (naturals_to_semiring nat R)). compute.
+apply (by_quoting (naturals_to_semiring Nat R)). compute.
 reflexivity.
 Qed.
 
@@ -41,11 +41,11 @@ Lemma test4 `{IsSemiRing R}
   : a * b = b * a.
 Proof.
 apply (ring_quote.Quoting.eval_eqquote R).
-apply (prove_prequoted (naturals_to_semiring nat R)).
+apply (prove_prequoted (naturals_to_semiring Nat R)).
 reflexivity.
 Qed.
 
-Lemma test5 : forall x y : nat, x + (y * x) = x * (y + 1).
+Lemma test5 : forall x y : Nat, x + (y * x) = x * (y + 1).
 Proof.
 intros;ring_with_nat.
 Qed.

--- a/theories/Classes/theory/additional_operations.v
+++ b/theories/Classes/theory/additional_operations.v
@@ -8,7 +8,7 @@ Global Instance decide_eqb `{DecidablePaths A} : Eqb A
   := fun a b => if decide_rel paths a b then true else false.
 
 Lemma decide_eqb_ok@{i} {A:Type@{i} } `{DecidablePaths A} :
-  forall a b, iff@{Set i i} (eqb a b = true) (a = b).
+  forall a b, Iff@{Set i i} (eqb a b = true) (a = b).
 Proof.
 unfold eqb,decide_eqb.
 intros a b;destruct (decide_rel paths a b) as [E1|E1];split;intros E2;auto.

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -143,8 +143,8 @@ Qed.
 
 Global Instance int_dec : DecidablePaths Z | 10.
 Proof.
-apply decidablepaths_equiv with (NatPair.Z nat)
-  (integers_to_ring (NatPair.Z nat) Z);apply _.
+apply decidablepaths_equiv with (NatPair.Z Nat)
+  (integers_to_ring (NatPair.Z Nat) Z);apply _.
 Qed.
 
 Global Instance slow_int_abs `{Naturals N} : IntAbs Z N | 10.
@@ -162,21 +162,21 @@ Qed.
 Instance int_nontrivial : PropHolds ((1:Z) <>0).
 Proof.
 intros E.
-apply (rings.is_ne_0 (1:nat)).
-apply (injective (naturals_to_semiring nat Z)).
-exact E. (* because [naturals_to_semiring nat] plays nice with 1 *)
+apply (rings.is_ne_0 (1:Nat)).
+apply (injective (naturals_to_semiring Nat Z)).
+exact E. (* because [naturals_to_semiring Nat] plays nice with 1 *)
 Qed.
 
 Global Instance int_zero_product : ZeroProduct Z.
 Proof.
 intros x y E.
-destruct (zero_product (integers_to_ring Z (NatPair.Z nat) x)
-  (integers_to_ring Z (NatPair.Z nat) y)).
+destruct (zero_product (integers_to_ring Z (NatPair.Z Nat) x)
+  (integers_to_ring Z (NatPair.Z Nat) y)).
 - rewrite <-(rings.preserves_mult (A:=Z)), E, (rings.preserves_0 (A:=Z)).
   trivial.
-- left. apply (injective (integers_to_ring Z (NatPair.Z nat))).
+- left. apply (injective (integers_to_ring Z (NatPair.Z Nat))).
   rewrite rings.preserves_0. trivial.
-- right. apply (injective (integers_to_ring Z (NatPair.Z nat))).
+- right. apply (injective (integers_to_ring Z (NatPair.Z Nat))).
   rewrite rings.preserves_0. trivial.
 Qed.
 

--- a/theories/Classes/theory/nat_distance.v
+++ b/theories/Classes/theory/nat_distance.v
@@ -51,18 +51,18 @@ Defined.
 
 (* Using the preceding instance we can make an instance
    for arbitrary models of the naturals
-   by translation into [nat] on which we already have a [CutMinus] instance. *)
+   by translation into [Nat] on which we already have a [CutMinus] instance. *)
 Global Instance natdistance_default `{Naturals N} : NatDistance N | 10.
 Proof.
 intros x y.
-destruct (nat_distance_sig (naturals_to_semiring N nat x)
-  (naturals_to_semiring N nat y)) as [[n E]|[n E]].
-- left. exists (naturals_to_semiring nat N n).
-  rewrite <-(naturals.to_semiring_involutive N nat y), <-E.
-  rewrite (rings.preserves_plus (A:=nat)), (naturals.to_semiring_involutive _ _).
+destruct (nat_distance_sig (naturals_to_semiring N Nat x)
+  (naturals_to_semiring N Nat y)) as [[n E]|[n E]].
+- left. exists (naturals_to_semiring Nat N n).
+  rewrite <-(naturals.to_semiring_involutive N Nat y), <-E.
+  rewrite (rings.preserves_plus (A:=Nat)), (naturals.to_semiring_involutive _ _).
   split.
-- right. exists (naturals_to_semiring nat N n).
-  rewrite <-(naturals.to_semiring_involutive N nat x), <-E.
-  rewrite (rings.preserves_plus (A:=nat)), (naturals.to_semiring_involutive _ _).
+- right. exists (naturals_to_semiring Nat N n).
+  rewrite <-(naturals.to_semiring_involutive N Nat x), <-E.
+  rewrite (rings.preserves_plus (A:=Nat)), (naturals.to_semiring_involutive _ _).
   split.
 Defined.

--- a/theories/Classes/theory/naturals.v
+++ b/theories/Classes/theory/naturals.v
@@ -133,7 +133,7 @@ Section borrowed_from_nat.
   pose (Q := fun s : SemiRings.Operations =>
     forall P : s -> Type, P 0 -> (forall n, P n -> P (1 + n)) -> forall n, P n).
   change (Q (SemiRings.BuildOperations N)).
-  apply (from_nat_stmt nat).
+  apply (from_nat_stmt Nat).
   unfold Q;clear Q.
   simpl.
   exact nat_induction.
@@ -141,7 +141,7 @@ Section borrowed_from_nat.
 
   Lemma case : forall x : N, x = 0 |_| exists y : N, (x = 1 + y)%mc.
   Proof.
-  refine (from_nat_stmt nat
+  refine (from_nat_stmt Nat
     (fun s => forall x : s, x = 0 |_| exists y : s, (x = 1 + y)%mc) _).
   simpl. intros [|x];eauto.
   Qed.
@@ -156,7 +156,7 @@ Section borrowed_from_nat.
   Global Instance nat_plus_cancel_l : forall z : N, LeftCancellation (+) z.
   Proof.
   refine (from_nat_stmt@{i U}
-    nat (fun s => forall z : s, LeftCancellation plus z) _).
+    Nat (fun s => forall z : s, LeftCancellation plus z) _).
   simpl. first [exact nat_plus_cancel_l@{U i}|exact nat_plus_cancel_l@{U}].
   Qed.
 
@@ -165,7 +165,7 @@ Section borrowed_from_nat.
 
   Global Instance: forall z : N, PropHolds (z <> 0) -> LeftCancellation (.*.) z.
   Proof.
-  refine (from_nat_stmt nat (fun s =>
+  refine (from_nat_stmt Nat (fun s =>
     forall z : s, PropHolds (z <> 0) -> LeftCancellation mult z) _).
   simpl. apply nat_mult_cancel_l.
   Qed.
@@ -175,7 +175,7 @@ Section borrowed_from_nat.
 
   Instance nat_nontrivial: PropHolds ((1:N) <> 0).
   Proof.
-  refine (from_nat_stmt nat (fun s => PropHolds ((1:s) <> 0)) _).
+  refine (from_nat_stmt Nat (fun s => PropHolds ((1:s) <> 0)) _).
   apply _.
   Qed.
 
@@ -185,14 +185,14 @@ Section borrowed_from_nat.
 
   Lemma zero_sum : forall (x y : N), x + y = 0 -> x = 0 /\ y = 0.
   Proof.
-  refine (from_nat_stmt nat
+  refine (from_nat_stmt Nat
     (fun s => forall x y : s, x + y = 0 -> x = 0 /\ y = 0) _).
   simpl. apply plus_eq_zero.
   Qed.
 
   Lemma one_sum : forall (x y : N), x + y = 1 -> (x = 1 /\ y = 0) |_| (x = 0 /\ y = 1).
   Proof.
-  refine (from_nat_stmt nat (fun s =>
+  refine (from_nat_stmt Nat (fun s =>
     forall (x y : s), x + y = 1 -> (x = 1 /\ y = 0) |_| (x = 0 /\ y = 1)) _).
   simpl.
   intros [|x] [|y];auto.
@@ -206,7 +206,7 @@ Section borrowed_from_nat.
 
   Global Instance: ZeroProduct N.
   Proof.
-  refine (from_nat_stmt nat (fun s => ZeroProduct s) _).
+  refine (from_nat_stmt Nat (fun s => ZeroProduct s) _).
   simpl. red. apply mult_eq_zero.
   Qed.
 End borrowed_from_nat.
@@ -218,7 +218,7 @@ Qed.
 
 Global Instance slow_naturals_dec : DecidablePaths N.
 Proof.
-apply decidablepaths_equiv with nat (naturals_to_semiring nat N);apply _.
+apply decidablepaths_equiv with Nat (naturals_to_semiring Nat N);apply _.
 Qed.
 
 Section with_a_ring.

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -40,7 +40,7 @@ Class Triangular A `{Closeness A}
   close (e+d) u w.
 
 Class Rounded@{i j} (A:Type@{i}) `{Closeness A}
-  := rounded : forall e u v, iff@{i j j} (close e u v)
+  := rounded : forall e u v, Iff@{i j j} (close e u v)
     (merely@{j} (sig@{UQ j} (fun d => sig@{UQ j} (fun d' =>
       e = d + d' /\ close d u v)))).
 

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -740,13 +740,13 @@ split.
   rewrite negate_swap_r,!involutive in E2.
   pose proof (plus_lt_compat _ _ _ _ E1' E2) as E.
   assert (Hrw : s - r = q - r + (s - q))
-    by abstract ring_tac.ring_with_integers (NatPair.Z nat).
+    by abstract ring_tac.ring_with_integers (NatPair.Z Nat).
   rewrite Hrw;trivial.
 - apply flip_lt_negate in E1.
   rewrite negate_swap_r,!involutive in E1.
   pose proof (plus_lt_compat _ _ _ _ E1 E2') as E.
   assert (Hrw : r - s = r - q + (q - s))
-    by abstract ring_tac.ring_with_integers (NatPair.Z nat).
+    by abstract ring_tac.ring_with_integers (NatPair.Z Nat).
   rewrite Hrw;trivial.
 Qed.
 
@@ -820,7 +820,7 @@ Global Instance Qplus_nonexpanding_l@{} : forall s : Q, NonExpanding (+ s).
 Proof.
 red. unfold close,Q_close;simpl. intros s e q r E.
 assert (Hrw : q + s - (r + s) = q - r)
-  by abstract ring_tac.ring_with_integers (NatPair.Z nat).
+  by abstract ring_tac.ring_with_integers (NatPair.Z Nat).
 rewrite Hrw;trivial.
 Qed.
 
@@ -828,7 +828,7 @@ Global Instance Qplus_nonexpanding_r@{} : forall s : Q, NonExpanding (s +).
 Proof.
 red;unfold close,Q_close;simpl. intros s e q r E.
 assert (Hrw : s + q - (s + r) = q - r)
-  by abstract ring_tac.ring_with_integers (NatPair.Z nat).
+  by abstract ring_tac.ring_with_integers (NatPair.Z Nat).
 rewrite Hrw;trivial.
 Qed.
 
@@ -942,7 +942,7 @@ rewrite !(plus_mult_distr_l (Aplus:=Qplus)).
 rewrite dec_recip_inverse by (apply irrefl_neq,symmetric_neq in E;trivial).
 rewrite mult_1_r.
 assert (Hrw :  (r ⊔ ' e) * ((q ⊔ ' e) * - / (r ⊔ ' e)) = - Y * (X / X))
-  by ring_tac.ring_with_integers (NatPair.Z nat).
+  by ring_tac.ring_with_integers (NatPair.Z Nat).
 rewrite Hrw;clear Hrw.
 rewrite dec_recip_inverse by (apply irrefl_neq,symmetric_neq in E';trivial).
 rewrite mult_1_r. unfold X, Y.

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -104,15 +104,15 @@ apply pos_dec_recip_compat.
 solve_propholds.
 Defined.
 
-Global Instance pos_of_nat@{} : Cast nat Q+.
+Global Instance pos_of_nat@{} : Cast Nat Q+.
 Proof.
 intros n. destruct n as [|k].
 - exists 1;apply lt_0_1.
-- exists (naturals_to_semiring nat Q (S k)).
+- exists (naturals_to_semiring Nat Q (S k)).
   induction k as [|k Ik].
   + change (0 < 1). apply lt_0_1.
-  + change (0 < 1 + naturals_to_semiring nat Q (S k)).
-    set (K := naturals_to_semiring nat Q (S k)) in *;clearbody K.
+  + change (0 < 1 + naturals_to_semiring Nat Q (S k)).
+    set (K := naturals_to_semiring Nat Q (S k)) in *;clearbody K.
     apply pos_plus_compat.
     * apply lt_0_1.
     * trivial.
@@ -257,7 +257,7 @@ simple refine (exist _ _ _);simpl.
   + apply pos_eq. unfold cast at 2;simpl.
     unfold cast at 3;simpl.
     set (a':=a/2);rewrite (pos_split2 a);unfold a';clear a'.
-    ring_tac.ring_with_integers (NatPair.Z nat).
+    ring_tac.ring_with_integers (NatPair.Z Nat).
 Qed.
 
 Lemma Qpos_lt_min@{} : forall a b : Q+, exists c ca cb : Q+,
@@ -279,7 +279,7 @@ Defined.
 Lemma Qpos_diff_pr@{} : forall q r E, r = q + ' (Qpos_diff q r E).
 Proof.
 intros q r E. change (r = q + (r - q)).
-abstract ring_tac.ring_with_integers (NatPair.Z nat).
+abstract ring_tac.ring_with_integers (NatPair.Z Nat).
 Qed.
 
 
@@ -388,7 +388,7 @@ split.
     { rewrite dec_recip_inverse;[|solve_propholds].
       rewrite mult_1_l;trivial.
     }
-    ring_tac.ring_with_integers (NatPair.Z nat).
+    ring_tac.ring_with_integers (NatPair.Z Nat).
   }
   apply pos_mult_compat;[|apply _].
   red. apply (snd (flip_pos_minus _ _)). trivial.
@@ -398,7 +398,7 @@ split.
     { rewrite dec_recip_inverse;[|solve_propholds].
       rewrite mult_1_l;trivial.
     }
-    ring_tac.ring_with_integers (NatPair.Z nat).
+    ring_tac.ring_with_integers (NatPair.Z Nat).
   }
   apply pos_mult_compat;[|apply _].
   red. apply (snd (flip_pos_minus _ _)). trivial.
@@ -460,7 +460,7 @@ assert (Haux : forall a b : Q, a <= b -> forall e, a < ' e -> b < ' e ->
   - apply le_lt_trans with (join b 0);trivial. apply join_ub_l.
   - apply pos_eq. unfold cast at 2;simpl. unfold cast at 2;simpl.
     unfold cast at 3;simpl.
-    abstract ring_tac.ring_with_integers (NatPair.Z nat).
+    abstract ring_tac.ring_with_integers (NatPair.Z Nat).
 }
 intros a b e E1 E2. destruct (total le a b) as [E|E];auto.
 destruct (Haux _ _ E e) as [d [d' [E3 [E4 E5]]]];trivial.
@@ -492,11 +492,11 @@ Proof.
 intros q r.
 apply (order_reflecting (+ (abs r))).
 assert (Hrw : abs q - abs r + abs r = abs q)
-  by ring_tac.ring_with_integers (NatPair.Z nat);
+  by ring_tac.ring_with_integers (NatPair.Z Nat);
 rewrite Hrw;clear Hrw.
 etransitivity;[|apply Q_triangle_le].
 assert (Hrw : q - r + r = q)
-  by ring_tac.ring_with_integers (NatPair.Z nat);
+  by ring_tac.ring_with_integers (NatPair.Z Nat);
 rewrite Hrw;clear Hrw.
 reflexivity.
 Qed.
@@ -586,7 +586,7 @@ Qed.
 Section enumerable.
 Context `{Enumerable Q}.
 
-Definition Qpos_enumerator : nat -> Q+.
+Definition Qpos_enumerator : Nat -> Q+.
 Proof.
 intros n.
 destruct (le_or_lt (enumerator Q n) 0) as [E|E].

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -31,7 +31,7 @@ Section quotient_algebra.
     that [P (class_of _ x1, ..., class_of _ xn, tt)] holds for all
     [(x1, ..., xn, tt) : FamilyProd A w]. *)
 
-  Fixpoint quotient_ind_prop_family_prod {w : list (Sort σ)}
+  Fixpoint quotient_ind_prop_family_prod {w : List (Sort σ)}
     : ∀ (P : FamilyProd carriers_quotient_algebra w → Type)
         `{!∀ a, IsHProp (P a)}
         (dclass : ∀ x, P (map_family_prod (λ s, class_of (Φ s)) x))

--- a/theories/Classes/theory/ua_third_isomorphism.v
+++ b/theories/Classes/theory/ua_third_isomorphism.v
@@ -45,7 +45,7 @@ Section cong_quotient.
       + exact (D x2 y2 (EquivRel_Reflexive x2) Q).
   Defined.
 
-  Lemma for_all_relation_quotient {w : list (Sort σ)} (a b : FamilyProd A w)
+  Lemma for_all_relation_quotient {w : List (Sort σ)} (a b : FamilyProd A w)
     : for_all_2_family_prod (A/Ψ) (A/Ψ) (cong_quotient subrel)
         (map_family_prod (λ s, class_of (Ψ s)) a)
         (map_family_prod (λ s, class_of (Ψ s)) b) →

--- a/theories/Colimits/Sequential.v
+++ b/theories/Colimits/Sequential.v
@@ -80,7 +80,7 @@ Proof.
   destruct x as [n a]; exact (n.+1; a^+).
 Defined.
 
-Definition seq_pair_shift_by {A : Sequence} (x : sig A) (k : nat) : sig A.
+Definition seq_pair_shift_by {A : Sequence} (x : sig A) (k : Nat) : sig A.
 Proof.
   induction k as [ | k y].
   - exact x.
@@ -90,7 +90,7 @@ Defined.
 Notation "x ^++" := (seq_pair_shift x).
 Notation "x ^++ k" := (seq_pair_shift_by x k).
 
-Definition seq_pair_shift_assoc {A : Sequence} (x : sig A) (k : nat)
+Definition seq_pair_shift_assoc {A : Sequence} (x : sig A) (k : Nat)
   : (x^++)^++k = x^++(k.+1).
 Proof.
   induction k as [ | k q].

--- a/theories/Diagrams/Sequence.v
+++ b/theories/Diagrams/Sequence.v
@@ -10,16 +10,13 @@ Local Open Scope path_scope.
 
 (** A Sequence is a sequence of maps from [X(n)] to [X(n+1)]. *)
 
-Definition sequence_graph : Graph.
-Proof.
-  srapply (Build_Graph nat).
-  intros n m; exact (S n = m).
-Defined.
+Definition sequence_graph : Graph :=
+  Build_Graph Nat (fun n m => S n = m).
 
 Definition Sequence := Diagram sequence_graph.
 
 Definition Build_Sequence
-  (X : nat -> Type)
+  (X : Nat -> Type)
   (f : forall n, X n -> X n.+1)
   : Sequence.
 Proof.

--- a/theories/Equiv/PathSplit.v
+++ b/theories/Equiv/PathSplit.v
@@ -14,14 +14,14 @@ Context `{Funext}.
 
 A map is n-path-split if its induced maps on the first n iterated path-spaces are split surjections.  Thus every map is 0-path-split, the 1-path-split maps are the split surjections, and so on.  It turns out that for n>1, being n-path-split is the same as being an equivalence. *)
 
-Fixpoint PathSplit (n : nat) `(f : A -> B) : Type
+Fixpoint PathSplit (n : Nat) `(f : A -> B) : Type
   := match n with
        | 0 => Unit
        | S n => (forall a, hfiber f a) *
                 forall (x y : A), PathSplit n (@ap _ _ f x y)
      end.
 
-Definition isequiv_pathsplit (n : nat) `{f : A -> B}
+Definition isequiv_pathsplit (n : Nat) `{f : A -> B}
 : PathSplit n.+2 f -> IsEquiv f.
 Proof.
   intros [g k].
@@ -43,7 +43,7 @@ Proof.
 Defined.
 
 Global Instance contr_pathsplit_isequiv
-           (n : nat) `(f : A -> B) `{IsEquiv _ _ f}
+           (n : Nat) `(f : A -> B) `{IsEquiv _ _ f}
 : Contr (PathSplit n f).
 Proof.
   generalize dependent B; revert A.
@@ -52,7 +52,7 @@ Proof.
   - apply contr_prod.
 Defined.
 
-Global Instance ishprop_pathsplit (n : nat) `(f : A -> B)
+Global Instance ishprop_pathsplit (n : Nat) `(f : A -> B)
 : IsHProp (PathSplit n.+2 f).
 Proof.
   apply hprop_inhabited_contr; intros ps.
@@ -60,7 +60,7 @@ Proof.
   exact _.
 Defined.
 
-Definition equiv_pathsplit_isequiv (n : nat) `(f : A -> B)
+Definition equiv_pathsplit_isequiv (n : Nat) `(f : A -> B)
 : PathSplit n.+2 f <~> IsEquiv f.
 Proof.
   refine (equiv_iff_hprop _ _).
@@ -69,7 +69,7 @@ Proof.
 Defined.
 
 (** Path-splitness transfers across commutative squares of equivalences. *)
-Lemma equiv_functor_pathsplit (n : nat) {A B C D}
+Lemma equiv_functor_pathsplit (n : Nat) {A B C D}
       (f : A -> B) (g : C -> D) (h : A <~> C) (k : B <~> D)
       (p : g o h == k o f)
 : PathSplit n f <~> PathSplit n g.

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -87,7 +87,7 @@ Section Extensions.
   (** Here is the iterated version. *)
 
   Fixpoint ExtendableAlong@{i j k l}
-           (n : nat) {A : Type@{i}} {B : Type@{j}}
+           (n : Nat) {A : Type@{i}} {B : Type@{j}}
            (f : A -> B) (C : B -> Type@{k}) : Type@{l}
     := match n with
          | 0 => Unit
@@ -106,7 +106,7 @@ Section Extensions.
 
   (** We can modify the universes, as with [ExtensionAlong]. *)
   Definition lift_extendablealong@{a1 a2 amin b1 b2 bmin p1 p2 pmin m1 m2}
-             (n : nat) {A : Type@{amin}} {B : Type@{bmin}}
+             (n : Nat) {A : Type@{amin}} {B : Type@{bmin}}
              (f : A -> B) (P : B -> Type@{pmin})
   : ExtendableAlong@{a1 b1 p1 m1} n f P -> ExtendableAlong@{a2 b2 p2 m2} n f P.
   Proof.
@@ -120,7 +120,7 @@ Section Extensions.
         exact (IH P' (snd ext h k)).
   Defined.
 
-  Definition equiv_extendable_pathsplit `{Funext} (n : nat)
+  Definition equiv_extendable_pathsplit `{Funext} (n : Nat)
              {A B : Type} (C : B -> Type) (f : A -> B)
   : ExtendableAlong n f C
     <~> PathSplit n (fun (g : forall b, C b) => g oD f).
@@ -140,20 +140,20 @@ Section Extensions.
       intros []; reflexivity.
   Defined.
 
-  Definition isequiv_extendable `{Funext} (n : nat)
+  Definition isequiv_extendable `{Funext} (n : Nat)
              {A B : Type} {C : B -> Type} {f : A -> B}
   : ExtendableAlong n.+2 f C
     -> IsEquiv (fun g => g oD f)
     := isequiv_pathsplit n o (equiv_extendable_pathsplit n.+2 C f).
 
-  Global Instance ishprop_extendable `{Funext} (n : nat)
+  Global Instance ishprop_extendable `{Funext} (n : Nat)
          {A B : Type} (C : B -> Type) (f : A -> B)
   : IsHProp (ExtendableAlong n.+2 f C).
   Proof.
     exact (istrunc_equiv_istrunc _ (equiv_extendable_pathsplit n.+2 C f)^-1).
   Defined.
 
-  Definition equiv_extendable_isequiv `{Funext} (n : nat)
+  Definition equiv_extendable_isequiv `{Funext} (n : Nat)
              {A B : Type} (C : B -> Type) (f : A -> B)
   : ExtendableAlong n.+2 f C
     <~> IsEquiv (fun (g : forall b, C b) => g oD f).
@@ -178,7 +178,7 @@ Section Extensions.
   Defined.
 
   (** Postcomposition with a known equivalence.  Note that this does not require funext to define, although showing that it is an equivalence would require funext. *)
-  Definition extendable_postcompose' (n : nat)
+  Definition extendable_postcompose' (n : Nat)
              {A B : Type} (C D : B -> Type) (f : A -> B)
              (g : forall b, C b <~> D b)
   : ExtendableAlong n f C -> ExtendableAlong n f D.
@@ -202,14 +202,14 @@ Section Extensions.
       apply equiv_inverse, equiv_ap; exact _.
   Defined.
 
-  Definition extendable_postcompose (n : nat)
+  Definition extendable_postcompose (n : Nat)
              {A B : Type} (C D : B -> Type) (f : A -> B)
              (g : forall b, C b -> D b) `{forall b, IsEquiv (g b)}
   : ExtendableAlong n f C -> ExtendableAlong n f D
     := extendable_postcompose' n C D f (fun b => Build_Equiv _ _ (g b) _).
 
   (** Composition of the maps we extend along.  This also does not require funext. *)
-  Definition extendable_compose (n : nat)
+  Definition extendable_compose (n : Nat)
              {A B C : Type} (P : C -> Type) (f : A -> B) (g : B -> C)
   : ExtendableAlong n g P -> ExtendableAlong n f (fun b => P (g b)) -> ExtendableAlong n (g o f) P.
   Proof.
@@ -225,7 +225,7 @@ Section Extensions.
   Defined.
 
   (** And cancellation *)
-  Definition cancelL_extendable (n : nat)
+  Definition cancelL_extendable (n : Nat)
              {A B C : Type} (P : C -> Type) (f : A -> B) (g : B -> C)
   : ExtendableAlong n g P -> ExtendableAlong n (g o f) P -> ExtendableAlong n f (fun b => P (g b)).
   Proof.
@@ -242,7 +242,7 @@ Section Extensions.
       + apply (IHn (fun c => h' c = k' c) (snd extg h' k') (snd extgf h' k')).
   Defined.
 
-  Definition cancelR_extendable (n : nat)
+  Definition cancelR_extendable (n : Nat)
              {A B C : Type} (P : C -> Type) (f : A -> B) (g : B -> C)
   : ExtendableAlong n.+1 f (fun b => P (g b)) -> ExtendableAlong n (g o f) P -> ExtendableAlong n g P.
   Proof.
@@ -258,7 +258,7 @@ Section Extensions.
   Defined.
 
   (** And transfer across homotopies *)
-  Definition extendable_homotopic (n : nat)
+  Definition extendable_homotopic (n : Nat)
              {A B : Type} (C : B -> Type) (f : A -> B) {g : A -> B} (p : f == g)
   : ExtendableAlong n f C -> ExtendableAlong n g C.
   Proof.
@@ -273,7 +273,7 @@ Section Extensions.
   Defined.
 
   (** We can extend along equivalences *)
-  Definition extendable_equiv (n : nat)
+  Definition extendable_equiv (n : Nat)
              {A B : Type} (C : B -> Type) (f : A -> B) `{IsEquiv _ _ f}
   : ExtendableAlong n f C.
   Proof.
@@ -288,7 +288,7 @@ Section Extensions.
   Defined.
 
   (** And into contractible types *)
-  Definition extendable_contr (n : nat)
+  Definition extendable_contr (n : Nat)
              {A B : Type} (C : B -> Type) (f : A -> B)
              `{forall b, Contr (C b)}
   : ExtendableAlong n f C.
@@ -303,7 +303,7 @@ Section Extensions.
   Defined.
 
   (** This is inherited by types of homotopies. *)
-  Definition extendable_homotopy (n : nat)
+  Definition extendable_homotopy (n : Nat)
              {A B : Type} (C : B -> Type) (f : A -> B)
              (h k : forall b, C b)
   : ExtendableAlong n.+1 f C -> ExtendableAlong n f (fun b => h b = k b).
@@ -321,7 +321,7 @@ Section Extensions.
   Definition ooExtendableAlong@{i j k l}
              {A : Type@{i}} {B : Type@{j}}
              (f : A -> B) (C : B -> Type@{k}) : Type@{l}
-    := forall n : nat, ExtendableAlong@{i j k l} n f C.
+    := forall n : Nat, ExtendableAlong@{i j k l} n f C.
   (** Universe parameters are the same as for [ExtendableAlong]. *)
 
   Global Arguments ooExtendableAlong {A B}%type_scope (f C)%function_scope.
@@ -430,7 +430,7 @@ Section Extensions.
       apply ooextendable_homotopy, orth.
   Defined.
 
-End Extensions.
+End Extensions. 
 
 (** ** Extendability along cofibrations *)
 
@@ -446,7 +446,7 @@ Proof.
   + reflexivity. (** The point is that this equality is now definitional. *)
 Defined.
 
-Definition cyl_extendable (n : nat)
+Definition cyl_extendable (n : Nat)
            {A B} (f : A -> B) (C : Cyl f -> Type)
            (ext : ExtendableAlong n cyl C)
   : ExtendableAlong n cyl C.
@@ -476,7 +476,7 @@ Proof.
   intros x; apply ext.2.
 Defined.
 
-Definition cyl_extendable' (n : nat)
+Definition cyl_extendable' (n : Nat)
            {A B} (f : A -> B) (C : B -> Type)
            (ext : ExtendableAlong n f C)
   : ExtendableAlong n cyl (C o (pr_cyl' f)).
@@ -515,7 +515,7 @@ Proof.
     exact ((fst (ef (g b)) _).2 a).
 Defined.
 
-Definition extendable_functor_prod (n : nat)
+Definition extendable_functor_prod (n : Nat)
            {A B A' B'} (f : A -> A') (g : B -> B')
            (P : A' * B' -> Type)
            (ef : forall b', ExtendableAlong n f (fun a' => P (a',b')))
@@ -585,7 +585,7 @@ Definition HomotopyExtensionAlong {A B} {Q : B -> Type}
            (p : forall (a:A) (v:Q (f a)), C (f a;v))
   := { q : forall (b:B) (v:Q b), C (b;v) & forall a v, q (f a) v = p a v }.
 
-Fixpoint HomotopyExtendableAlong (n : nat)
+Fixpoint HomotopyExtendableAlong (n : Nat)
          {A B} {Q : B -> Type} (f : A -> B) (C : sig Q -> Type) : Type
   := match n with
      | 0 => Unit
@@ -620,7 +620,7 @@ Proof.
     exact ((fst (eg a) _).2 u).
 Defined.
 
-Definition extendable_functor_sigma (n : nat)
+Definition extendable_functor_sigma (n : Nat)
            {A B} {P : A -> Type} {Q : B -> Type}
            (f : A -> B) (g : forall a, P a -> Q (f a))
            (C : sig Q -> Type)
@@ -664,7 +664,7 @@ Proof.
   + exact (fst eg (h o inr)).2.
 Defined.
 
-Definition extendable_functor_sum (n : nat)
+Definition extendable_functor_sum (n : Nat)
            {A B A' B'} (f : A -> A') (g : B -> B')
            (P : A' + B' -> Type)
            (ef : ExtendableAlong n f (P o inl))
@@ -757,7 +757,7 @@ Proof.
 Defined.
 
 (** Now we can easily iterate into higher extendability. *)
-Definition extendable_functor_coeq (n : nat)
+Definition extendable_functor_coeq (n : Nat)
            {B A f g B' A' f' g'}
            {h : B -> B'} {k : A -> A'}
            {p : k o f == f' o h} {q : k o g == g' o h}
@@ -788,7 +788,7 @@ Definition ooextendable_functor_coeq
   := fun n => extendable_functor_coeq n (ek n) (fun u v => eh u v n).
 
 (** Since extending at level [n.+1] into [C] implies extending at level [n] into path-types of [C], we get the following corollary. *)
-Definition extendable_functor_coeq' (n : nat)
+Definition extendable_functor_coeq' (n : Nat)
            {B A f g B' A' f' g'}
            {h : B -> B'} {k : A -> A'}
            {p : k o f == f' o h} {q : k o g == g' o h}

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -657,7 +657,7 @@ Definition extension_functor_sum
            (h : forall z, P (functor_sum f g z))
   : ExtensionAlong (functor_sum f g) P h.
 Proof.
-  srefine (sum_ind _ _ _ ; sum_ind _ _ _).
+  srefine (Sum_ind _ _ _ ; Sum_ind _ _ _).
   + exact (fst ef (h o inl)).1.
   + exact (fst eg (h o inr)).1.
   + exact (fst ef (h o inl)).2.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -198,7 +198,7 @@ End LicataFinsterLemma.
 Section EilenbergMacLane.
   Context `{Univalence}.
 
-  Fixpoint EilenbergMacLane (G : Group) (n : nat) : pType
+  Fixpoint EilenbergMacLane (G : Group) (n : Nat) : pType
     := match n with
         | 0    => Build_pType G _
         | 1    => pClassifyingSpace G
@@ -207,12 +207,12 @@ Section EilenbergMacLane.
 
   Notation "'K(' G , n )" := (EilenbergMacLane G n).
 
-  Global Instance istrunc_em {G : Group}  {n : nat} : IsTrunc n K(G, n).
+  Global Instance istrunc_em {G : Group}  {n : Nat} : IsTrunc n K(G, n).
   Proof.
     destruct n as [|[]]; exact _.
   Defined.
 
-  Global Instance isconnected_em {G : Group} (n : nat)
+  Global Instance isconnected_em {G : Group} (n : Nat)
     : IsConnected n K(G, n.+1).
   Proof.
     induction n; exact _.
@@ -221,7 +221,7 @@ Section EilenbergMacLane.
   Local Open Scope trunc_scope.
 
   (* This is a variant of [pequiv_ptr_loop_psusp] from pSusp.v. All we are really using is that [n.+2 <= n +2+ n], but because of the use of [isconnmap_pred_add], the proof is a bit more specific to this case. *)
-  Local Lemma pequiv_ptr_loop_psusp' (X : pType) (n : nat) `{IsConnected n.+1 X}
+  Local Lemma pequiv_ptr_loop_psusp' (X : pType) (n : Nat) `{IsConnected n.+1 X}
     : pTr n.+2 X <~>* pTr n.+2 (loops (psusp X)).
   Proof.
     snrapply Build_pEquiv.
@@ -232,7 +232,7 @@ Section EilenbergMacLane.
     rapply conn_map_loop_susp_unit.
   Defined.
 
-  Lemma pequiv_loops_em_em (G : AbGroup) (n : nat)
+  Lemma pequiv_loops_em_em (G : AbGroup) (n : Nat)
     : loops K(G, n.+1) <~>* K(G, n).
   Proof.
     destruct n.
@@ -246,7 +246,7 @@ Section EilenbergMacLane.
     symmetry; rapply pequiv_ptr_loop_psusp'.
   Defined.
 
-  Definition pequiv_loops_em_g (G : AbGroup) (n : nat)
+  Definition pequiv_loops_em_g (G : AbGroup) (n : Nat)
     : iterated_loops n K(G, n) <~>* G.
   Proof.
     induction n.
@@ -256,7 +256,7 @@ Section EilenbergMacLane.
   Defined.
 
   (* For positive indices, we in fact get a group isomorphism. *)
-  Definition equiv_g_pi_n_em (G : AbGroup) (n : nat)
+  Definition equiv_g_pi_n_em (G : AbGroup) (n : Nat)
     : GroupIsomorphism G (Pi n.+1 K(G, n.+1)).
   Proof.
     induction n.

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -63,7 +63,7 @@ Proof.
 Defined.
 
 Definition iscomplex_iterated_loops {F X Y : pType}
-  (i : F ->* X) (f : X ->* Y) (cx : IsComplex i f) (n : nat)
+  (i : F ->* X) (f : X ->* Y) (cx : IsComplex i f) (n : Nat)
   : IsComplex (fmap (iterated_loops n) i) (fmap (iterated_loops n) f).
 Proof.
   induction n as [|n IHn]; [ exact cx | ].
@@ -326,7 +326,7 @@ Proof.
 Defined.
 
 Global Instance isexact_iterated_loops {F X Y}
-  (i : F ->* X) (f : X ->* Y) `{IsExact purely F X Y i f} (n : nat)
+  (i : F ->* X) (f : X ->* Y) `{IsExact purely F X Y i f} (n : Nat)
   : IsExact purely (fmap (iterated_loops n) i) (fmap (iterated_loops n) f).
 Proof.
   induction n as [|n IHn]; [ assumption | apply isexact_loops; assumption ].

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -12,14 +12,14 @@ Local Open Scope pointed_scope.
 Local Open Scope path_scope.
 
 (** The type that the nth homotopy group will have. *)
-Definition HomotopyGroup_type (n : nat) : Type
+Definition HomotopyGroup_type (n : Nat) : Type
   := match n with
       | 0 => pType
       | n.+1 => Group
      end.
 
 (* Every homotopy group is, in particular, a pointed type. *)
-Definition HomotopyGroup_type_ptype (n : nat) : HomotopyGroup_type n -> pType
+Definition HomotopyGroup_type_ptype (n : Nat) : HomotopyGroup_type n -> pType
   := match n return HomotopyGroup_type n -> pType with
      | 0 => fun X => X
      (* This works because [ptype_group] is already a coercion. *)
@@ -29,15 +29,15 @@ Definition HomotopyGroup_type_ptype (n : nat) : HomotopyGroup_type n -> pType
 Coercion HomotopyGroup_type_ptype : HomotopyGroup_type >-> pType.
 
 (** We construct the wildcat structure on HomotopyGroup_type in the obvious way. *)
-Global Instance isgraph_homotopygroup_type (n : nat)
+Global Instance isgraph_homotopygroup_type (n : Nat)
   : IsGraph (HomotopyGroup_type n) := ltac:(destruct n; exact _).
-Global Instance is2graph_homotopygroup_type (n : nat)
+Global Instance is2graph_homotopygroup_type (n : Nat)
   : Is2Graph (HomotopyGroup_type n) := ltac:(destruct n; exact _).
-Global Instance is01cat_homotopygroup_type (n : nat)
+Global Instance is01cat_homotopygroup_type (n : Nat)
   : Is01Cat (HomotopyGroup_type n) := ltac:(destruct n; exact _).
-Global Instance is1cat_homotopygroup_type (n : nat)
+Global Instance is1cat_homotopygroup_type (n : Nat)
   : Is1Cat (HomotopyGroup_type n) := ltac:(destruct n; exact _).
-Global Instance is0functor_homotopygroup_type_ptype (n : nat)
+Global Instance is0functor_homotopygroup_type_ptype (n : Nat)
   : Is0Functor (HomotopyGroup_type_ptype n)
   := ltac:(destruct n; exact _).
 
@@ -87,7 +87,7 @@ Proof.
 Defined.
 
 (** Definition of the nth homotopy group *)
-Definition Pi (n : nat) (X : pType) : HomotopyGroup_type n.
+Definition Pi (n : Nat) (X : pType) : HomotopyGroup_type n.
 Proof.
   destruct n.
   1: exact (pTr 0 X).
@@ -104,7 +104,7 @@ Module PiUtf8.
 End PiUtf8.
 
 (** When n >= 2 we have that the nth homotopy group is an abelian group. Note that we don't actually define it as an abelian group but merely show that it is one. This would cause lots of complications with the typechecker. *)
-Global Instance isabgroup_pi (n : nat) (X : pType)
+Global Instance isabgroup_pi (n : Nat) (X : pType)
   : IsAbGroup (Pi n.+2 X).
 Proof.
   nrapply Build_IsAbGroup.
@@ -116,7 +116,7 @@ Proof.
 Defined.
 
 (** The nth homotopy group is in fact a functor. We now give the type this functor ought to have. For n = 0, this will simply be a pointed map, for n >= 1 this should be a group homomorphism. *)
-Definition pi_functor_type (n : nat) (X Y : pType) : Type
+Definition pi_functor_type (n : Nat) (X Y : pType) : Type
   := match n with
      | 0 => pTr 0 X ->* pTr 0 Y
      | n.+1 => GroupHomomorphism (Pi n.+1 X) (Pi n.+1 Y)
@@ -155,10 +155,10 @@ Proof.
   apply ap_pp.
 Defined.
 
-Global Instance is0functor_pi (n : nat) : Is0Functor (Pi n)
+Global Instance is0functor_pi (n : Nat) : Is0Functor (Pi n)
   := ltac:(destruct n; exact _).
 
-Definition fmap_pi_succ {X Y : pType} (f : X $-> Y) (n : nat)
+Definition fmap_pi_succ {X Y : pType} (f : X $-> Y) (n : Nat)
   : fmap (Pi n.+1) f $== fmap (Pi 1) (fmap (iterated_loops n) f).
 Proof.
   reflexivity.
@@ -174,10 +174,10 @@ Proof.
     | by rapply (fmap_comp _ (is1functor_F := is1f)) ].
 Defined.
 
-Global Instance is1functor_pi (n : nat) : Is1Functor (Pi n)
+Global Instance is1functor_pi (n : Nat) : Is1Functor (Pi n)
   := ltac:(destruct n; exact _).
 
-Definition groupiso_pi_functor (n : nat)
+Definition groupiso_pi_functor (n : Nat)
   {X Y : pType} (e : X <~>* Y)
   : Pi n.+1 X $<~> Pi n.+1 Y
   := emap (Pi n.+1) e.
@@ -196,7 +196,7 @@ Proof.
   rapply groupiso_pi_loops.
 Defined.
 
-Definition fmap_pi_loops (n : nat) {X Y : pType} (f : X ->* Y)
+Definition fmap_pi_loops (n : Nat) {X Y : pType} (f : X ->* Y)
   : (pi_loops n Y) o (fmap (Pi n.+1) f)
     == (fmap (HomotopyGroup_type_ptype n o Pi n o loops) f)
         o (pi_loops n X).
@@ -209,7 +209,7 @@ Proof.
 Defined.
 
 (** Homotopy groups preserve products *)
-Lemma pi_prod (X Y : pType) {n : nat}
+Lemma pi_prod (X Y : pType) {n : Nat}
   : GroupIsomorphism (Pi n.+1 (X * Y))
       (grp_prod (Pi n.+1 X) (Pi n.+1 Y)).
 Proof.
@@ -235,7 +235,7 @@ Proof.
 Defined.
 
 (** Can we make this reflexivity? *)
-Lemma pmap_pi_functor {X Y : pType} (f : X ->* Y) (n : nat) 
+Lemma pmap_pi_functor {X Y : pType} (f : X ->* Y) (n : Nat) 
   : fmap (Pi n.+1) f
     ==* fmap (pTr 0) (fmap (iterated_loops n.+1) f).
 Proof.

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -269,7 +269,7 @@ Defined.
 
 
 (** The joint of n.+1 copies of a type. *)
-Fixpoint Join_power (A : Type) (n : nat) : Type :=
+Fixpoint Join_power (A : Type) (n : Nat) : Type :=
   match n with
   | 0%nat => A
   | m.+1%nat => Join A (Join_power A m)

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -172,7 +172,7 @@ Section Smash.
     rapply Smash_ind_beta_gluel.
   Qed.
 
-  Definition smash_rec_beta_gluer {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
+  Definition Smash_rec_beta_gluer {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (b : Y)
     : ap (Smash_rec Psm Pl Pr Pgl Pgr) (gluer b) = Pgr b.
   Proof.
@@ -197,7 +197,7 @@ Section Smash.
     : ap (Smash_rec Psm Pl Pr Pgl Pgr) (gluer' a b) = Pgr a @ (Pgr b)^.
   Proof.
     rewrite ap_pp, ap_V.
-    by rewrite 2 smash_rec_beta_gluer.
+    by rewrite 2 Smash_rec_beta_gluer.
   Qed.
 
   Definition smash_rec_beta_glue {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -10,10 +10,10 @@ Local Open Scope dpath_scope.
 (* Definition of smash product *)
 
 Definition sum_to_prod (X Y : pType) : X + Y -> X * Y
-  := sum_ind _ (fun x => (x, point Y)) (fun y => (point X, y)).
+  := Sum_ind _ (fun x => (x, point Y)) (fun y => (point X, y)).
 
 Definition sum_to_bool X Y : X + Y -> Bool
-  := sum_ind _ (fun _ => false) (fun _ => true).
+  := Sum_ind _ (fun _ => false) (fun _ => true).
 
 Definition Smash (X Y : pType) : pType
   := Build_pType (Pushout (sum_to_prod X Y) (sum_to_bool X Y))
@@ -84,7 +84,7 @@ Section Smash.
     + intros [a b].
       apply Psm.
     + apply (Bool_ind _ Pr Pl).
-    + srapply sum_ind; intro; apply dp_path_transport^-1.
+    + srapply Sum_ind; intro; apply dp_path_transport^-1.
       - apply Pgl.
       - apply Pgr.
   Defined.
@@ -97,7 +97,7 @@ Section Smash.
   Proof.
     apply dp_apD_path_transport.
     refine (Pushout_ind_beta_pglue P _ _ _ (inl a) @ _).
-    unfold sum_ind.
+    unfold Sum_ind.
     by apply ap.
   Qed.
 
@@ -109,7 +109,7 @@ Section Smash.
   Proof.
     apply dp_apD_path_transport.
     refine (Pushout_ind_beta_pglue P _ _ _ (inr b) @ _).
-    unfold sum_ind.
+    unfold Sum_ind.
     by apply ap.
   Qed.
 

--- a/theories/Homotopy/SuccessorStructure.v
+++ b/theories/Homotopy/SuccessorStructure.v
@@ -25,7 +25,7 @@ Arguments ss_succ {_} _.
 Notation "x .+1" := (ss_succ x) : succ_scope.
 
 (** Successor structure of naturals *)
-Definition NatSucc : SuccStr := Build_SuccStr nat Nat.succ.
+Definition NatSucc : SuccStr := Build_SuccStr Nat Nat.succ.
 
 (** Successor structure of integers *)
 Definition IntSucc : SuccStr := Build_SuccStr Int int_succ.
@@ -35,9 +35,9 @@ Notation "'+Z'" := IntSucc : succ_scope.
 
 (** Stratified successor structures *)
 
-Definition StratifiedType (N : SuccStr) (n : nat) : Type := N * Fin n.
+Definition StratifiedType (N : SuccStr) (n : Nat) : Type := N * Fin n.
 
-Definition stratified_succ (N : SuccStr) (n : nat) (x : StratifiedType N n)
+Definition stratified_succ (N : SuccStr) (n : Nat) (x : StratifiedType N n)
   : StratifiedType N n.
 Proof.
   constructor.
@@ -49,11 +49,11 @@ Proof.
   + exact (fsucc_mod (snd x)).
 Defined.
 
-Definition Stratified (N : SuccStr) (n : nat) : SuccStr
+Definition Stratified (N : SuccStr) (n : Nat) : SuccStr
   := Build_SuccStr (StratifiedType N n) (stratified_succ N n).
 
 (** Addition in successor structures *)
-Fixpoint ss_add {N : SuccStr} (n : N) (k : nat) : N :=
+Fixpoint ss_add {N : SuccStr} (n : N) (k : Nat) : N :=
   match k with
   | O   => n
   | S k => (ss_add n k).+1
@@ -61,7 +61,7 @@ Fixpoint ss_add {N : SuccStr} (n : N) (k : nat) : N :=
 
 Infix "+" := ss_add : succ_scope.
 
-Definition ss_add_succ {N : SuccStr} (n : N) (k : nat)
+Definition ss_add_succ {N : SuccStr} (n : N) (k : Nat)
   : (n + k.+1) = n.+1 + k.
 Proof.
   induction k.

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -418,7 +418,7 @@ End UnivPropNat.
 
 (** Now we can iterate, deducing [n]-extendability. *)
 Definition extendable_iff_functor_susp
-           {X Y : Type} (f : X -> Y) (P : Susp Y -> Type) (n : nat)
+           {X Y : Type} (f : X -> Y) (P : Susp Y -> Type) (n : Nat)
   : (ExtendableAlong n (functor_susp f) P)
     <-> (forall NS, ExtendableAlong n f (fun x => DPath P (merid x) (fst NS) (snd NS))).
 Proof.

--- a/theories/Homotopy/WhiteheadsPrinciple.v
+++ b/theories/Homotopy/WhiteheadsPrinciple.v
@@ -76,7 +76,7 @@ Definition whiteheads_principle
            {ua : Univalence} {A B : Type} {f : A -> B}
            (n : trunc_index) {H0 : IsTrunc n A} {H1 : IsTrunc n B}
            {i  : IsEquiv (Trunc_functor 0 f)}
-           {ii : forall (x : A) (k : nat), IsEquiv (fmap (Pi k.+1) (pmap_from_point f x)) }
+           {ii : forall (x : A) (k : Nat), IsEquiv (fmap (Pi k.+1) (pmap_from_point f x)) }
   : IsEquiv f.
 Proof.
   revert A B H0 H1 f i ii.

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -365,9 +365,9 @@ Section Splitting.
 
   (** The splitting will be the sequential limit of the sequence [... -> X -> X -> X]. *)
   Definition split_idem : Type
-    := { a : nat -> X & forall n, f (a n.+1) = a n }.
+    := { a : Nat -> X & forall n, f (a n.+1) = a n }.
 
-  Definition split_idem_pr1 : split_idem -> (nat -> X)
+  Definition split_idem_pr1 : split_idem -> (Nat -> X)
     := pr1.
   Coercion split_idem_pr1 : split_idem >-> Funclass.
   Arguments split_idem_pr1 / .
@@ -448,7 +448,7 @@ Section Splitting.
 
   (** Now we're ready to prove the final condition.  We prove the two arguments of [path_split_idem] separately, in order to make the first one transparent and the second opaque. *)
 
-  Local Definition split_idem_issect_part1 (a : split_idem) (n : nat)
+  Local Definition split_idem_issect_part1 (a : split_idem) (n : Nat)
   : f (f (a n.+1)) = f (a 0).
   Proof.
     induction n as [|n IH].
@@ -456,7 +456,7 @@ Section Splitting.
     - exact (ap f (a.2 n.+1) @ (I (a n.+1))^ @ IH).
   Defined.
 
-  Local Definition split_idem_issect_part2 (a : split_idem) (n : nat)
+  Local Definition split_idem_issect_part2 (a : split_idem) (n : Nat)
   : ap f (ap f (a.2 n.+1)) @ split_idem_issect_part1 a n =
     ap f ((ap f (a.2 n.+1) @ (I (a.1 n.+1))^) @ split_idem_issect_part1 a n) @ I (a.1 0).
   Proof.

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -89,7 +89,7 @@ Module Import IsNull_Internal.
 End IsNull_Internal.
 
 (** A central fact: if a type [X] is null for all the fibers of a map [f], then it is [f]-local.  (NB: the converse is *not* generally true.)  TODO: Should this go in [Extensions]? *)
-Definition extendable_isnull_fibers (n : nat)
+Definition extendable_isnull_fibers (n : Nat)
            {A B} (f : A -> B) (C : B -> Type)
 : (forall b, ooExtendableAlong (@const (hfiber f b) Unit tt)
                                (fun _ => C b))

--- a/theories/Modalities/Accessible.v
+++ b/theories/Modalities/Accessible.v
@@ -35,8 +35,8 @@ Class IsAccRSU@{a i} (O : Subuniverse@{i}) :=
 {
   acc_lgen : LocalGenerators@{a} ;
   inO_iff_islocal : forall (X : Type@{i}),
-      (** We call [iff] explicitly to control the number of universe parameters. *)
-      iff@{i i i} (In O X) (IsLocal acc_lgen X) ;
+      (** We call [Iff] explicitly to control the number of universe parameters. *)
+      Iff@{i i i} (In O X) (IsLocal acc_lgen X) ;
 }.
 
 Arguments acc_lgen O {_}.
@@ -119,7 +119,7 @@ Class IsAccModality@{a i} (O : Subuniverse@{i}) :=
 {
   acc_ngen : NullGenerators@{a} ;
   inO_iff_isnull : forall (X : Type@{i}),
-      iff@{i i i} (In O X) (IsNull acc_ngen X) ;
+      Iff@{i i i} (In O X) (IsNull acc_ngen X) ;
 }.
 
 Arguments acc_ngen O {_}.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -419,7 +419,7 @@ Fixpoint nSep (n : trunc_index) (O : Subuniverse) : Subuniverse
      | n.+1 => Sep (nSep n O)
      end.
 
-(** The reason for indexing this notion by a [trunc_index] rather than a [nat] is that when O is lex, a type is n-O-separated if and only if its O-unit is an n-truncated map. *)
+(** The reason for indexing this notion by a [trunc_index] rather than a [Nat] is that when O is lex, a type is n-O-separated if and only if its O-unit is an n-truncated map. *)
 Definition nsep_iff_trunc_to_O (n : trunc_index) (O : Modality) `{Lex O} (A : Type)
   : In (nSep n O) A <-> IsTruncMap n (to O A).
 Proof.

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -46,7 +46,7 @@ Then, however, we have to express the hypotheses of the induction principle.  We
 (** ** Dependent extendability *)
 
 Fixpoint ExtendableAlong_Over@{a b c d m}
-         (n : nat) {A : Type@{a}} {B : Type@{b}} (f : A -> B)
+         (n : Nat) {A : Type@{a}} {B : Type@{b}} (f : A -> B)
          (C : B -> Type@{c})
          (D : forall b, C b -> Type@{d})
          (ext : ExtendableAlong@{a b c m} n f C)
@@ -72,7 +72,7 @@ Check ExtendableAlong_Over@{a b c d m}.
     - size of result (>= A,B,C,D) *)
 
 (** Like [ExtendableAlong], these can be postcomposed with known equivalences. *)
-Definition extendable_over_postcompose' (n : nat)
+Definition extendable_over_postcompose' (n : Nat)
            {A B : Type} (C : B -> Type) (f : A -> B)
            (ext : ExtendableAlong n f C)
            (D E : forall b, C b -> Type)
@@ -105,7 +105,7 @@ Proof.
     apply ap, symmetry, eisretr.
 Defined.
 
-Definition extendable_over_postcompose (n : nat)
+Definition extendable_over_postcompose (n : Nat)
            {A B : Type} (C : B -> Type) (f : A -> B)
            (ext : ExtendableAlong n f C)
            (D E : forall b, C b -> Type)
@@ -118,7 +118,7 @@ Definition extendable_over_postcompose (n : nat)
 
 (** And if the dependency is trivial, we obtain them from an ordinary [ExtendableAlong]. *)
 Definition extendable_over_const
-           (n : nat) {A B : Type} (C : B -> Type) (f : A -> B)
+           (n : Nat) {A B : Type} (C : B -> Type) (f : A -> B)
            (ext : ExtendableAlong n f C) (D : B -> Type)
 : ExtendableAlong n f D
   -> ExtendableAlong_Over n f C (fun b _ => D b) ext.
@@ -139,7 +139,7 @@ Proof.
 Defined.
 
 (** This lemma will be used in stating the computation rule for localization. *)
-Fixpoint apD_extendable_eq (n : nat) {A B : Type} (C : B -> Type) (f : A -> B)
+Fixpoint apD_extendable_eq (n : Nat) {A B : Type} (C : B -> Type) (f : A -> B)
          (ext : ExtendableAlong n f C) (D : forall b, C b -> Type)
          (g : forall b c, D b c)
          (ext' : ExtendableAlong_Over n f C D ext)
@@ -388,7 +388,7 @@ Section LocalTypes.
   : IsEquiv (fun g => g o f i)
   := isequiv_ooextendable (fun _ => X) (f i) (ooextendable_islocal i).
 
-  (** The non-dependent eliminator *)
+  (** The non-dependent elimiNator *)
   Definition Localize_rec {X Z : Type} `{IsLocal f Z} (g : X -> Z)
   : Localize f X -> Z.
   Proof.
@@ -467,7 +467,7 @@ Proof.
   exact B_inO1.
 Defined.
 
-(** Similarly, because localization is a HIT that has an elimination rule into types in *all* universes, for accessible reflective subuniverses we can show that containment implies connectedness properties with the universe containments in the other order. *)
+(** Similarly, because localization is a HIT that has an elimiNation rule into types in *all* universes, for accessible reflective subuniverses we can show that containment implies connectedness properties with the universe containments in the other order. *)
 Definition isconnected_O_leq'@{a i1 i2}
            (O1 : ReflectiveSubuniverse@{i1}) (O2 : ReflectiveSubuniverse@{i2}) `{IsAccRSU@{a i1} O1}
            (** Compared to [O_leq@{i1 i2 i1}] and [A : Type@{i1}] in [isconnected_O_leq], these two lines are what make [i2 <= i1] instead of vice versa. *)

--- a/theories/Modalities/Localization.v
+++ b/theories/Modalities/Localization.v
@@ -148,7 +148,7 @@ Fixpoint apD_extendable_eq (n : nat) {A B : Type} (C : B -> Type) (f : A -> B)
 Proof.
   destruct n.
   - exact Unit.
-  - apply prod.
+  - apply Prod.
     + exact (forall (h : forall a, C (f a)) (b : B),
                g b ((fst ext h).1 b) = (fst ext' h (fun a => g (f a) (h a))).1 b).
     + exact (forall h k, apD_extendable_eq

--- a/theories/Modalities/Nullification.v
+++ b/theories/Modalities/Nullification.v
@@ -13,7 +13,7 @@ Local Open Scope path_scope.
 
 (** The hypotheses of this lemma may look slightly odd (why are we bothering to talk about type families dependent over [Unit]?), but they seem to be the most convenient to make the induction go through.  *)
 
-Definition extendable_over_unit (n : nat)
+Definition extendable_over_unit (n : Nat)
   (A : Type@{a}) (C : Unit -> Type@{i}) (D : forall u, C u -> Type@{j})
   (ext : ExtendableAlong@{a a i k} n (@const A Unit tt) C)
   (ext' : forall (c : forall u, C u),

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1402,7 +1402,7 @@ Section ConnectedTypes.
   Defined.
 
   (** Here's another way of stating the universal property for mapping out of connected types into modal ones. *)
-  Definition extendable_const_isconnected_inO (n : nat)
+  Definition extendable_const_isconnected_inO (n : Nat)
              (A : Type) `{IsConnected O A}
              (C : Type) `{In O C}
   : ExtendableAlong n (@const A Unit tt) (fun _ => C).
@@ -1640,7 +1640,7 @@ Section ConnectedMaps.
     apply conn_map_comp.
   Defined.
 
-  Definition extendable_conn_map_inO (n : nat)
+  Definition extendable_conn_map_inO (n : Nat)
              {A B : Type} (f : A -> B) `{IsConnMap O _ _ f}
              (P : B -> Type) `{forall b:B, In O (P b)}
   : ExtendableAlong n f P.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -961,7 +961,7 @@ Section Reflective_Subuniverse.
       refine (inO_equiv_inO _ (issig_equiv@{i j k} A B)).
       refine (inO_equiv_inO _ (equiv_functor_sigma equiv_idmap@{k}
                                  (fun f => equiv_biinv_isequiv@{i j k} f))).
-      transparent assert (c : (prod@{k k} (A->B) (prod@{k k} (B->A) (B->A)) -> prod@{k k} (A -> A) (B -> B))).
+      transparent assert (c : (Prod@{k k} (A->B) (Prod@{k k} (B->A) (B->A)) -> Prod@{k k} (A -> A) (B -> B))).
       { intros [f [g h]]; exact (h o f, f o g). }
       pose (U := hfiber@{k k} c (idmap, idmap)).
       refine (inO_equiv_inO'@{k k k} U _). (** Introduces some extra copies of [k] by typeclass inference. *)

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -14,14 +14,14 @@ Global Instance ispointed_loops A (a : A) : IsPointed (a = a) := 1.
 Definition loops (A : pType) : pType
   := Build_pType (point A = point A) _.
 
-Fixpoint iterated_loops (n : nat) (A : pType) : pType
+Fixpoint iterated_loops (n : Nat) (A : pType) : pType
   := match n with
        | O => A
        | S p => loops (iterated_loops p A)
      end.
 
 (* Inner unfolding for iterated loops *)
-Lemma unfold_iterated_loops (n : nat) (X : pType)
+Lemma unfold_iterated_loops (n : Nat) (X : pType)
   : iterated_loops n.+1 X = iterated_loops n (loops X).
 Proof.
   induction n.
@@ -170,7 +170,7 @@ Proof.
 Defined.
 
 Definition isconnected_iterated_fmap_loops `{Univalence}
-  (k : nat) (A B : pType) (f : A ->* B)
+  (k : Nat) (A B : pType) (f : A ->* B)
   : forall n : trunc_index, IsConnMap (trunc_index_inc' n k) f
                        -> IsConnMap n (fmap (iterated_loops k) f).
 Proof.
@@ -216,7 +216,7 @@ Definition pequiv_fmap_loops {A B : pType}
   := emap loops.
 
 (** A version of [unfold_iterated_loops] that's an equivalence rather than an equality.  We could get this from the equality, but it's more useful to construct it explicitly since then we can reason about it.  *)
-Definition unfold_iterated_loops' (n : nat) (X : pType)
+Definition unfold_iterated_loops' (n : Nat) (X : pType)
   : iterated_loops n.+1 X <~>* iterated_loops n (loops X).
 Proof.
   induction n.
@@ -227,7 +227,7 @@ Proof.
 Defined.
 
 (** For instance, we can prove that it's natural. *)
-Definition unfold_iterated_fmap_loops {A B : pType} (n : nat) (f : A ->* B)
+Definition unfold_iterated_fmap_loops {A B : pType} (n : Nat) (f : A ->* B)
   : (unfold_iterated_loops' n B) o* (fmap (iterated_loops n.+1) f)
     ==* (fmap (iterated_loops n) (fmap loops f)) o* (unfold_iterated_loops' n A).
 Proof.
@@ -298,7 +298,7 @@ Proof.
 Defined.
 
 (* product and iterated loops commute *)
-Lemma iterated_loops_pproduct_commute `{Funext} (A : Type) (F : A -> pType) (n : nat)
+Lemma iterated_loops_pproduct_commute `{Funext} (A : Type) (F : A -> pType) (n : Nat)
   : iterated_loops n (pproduct F) <~>* pproduct (iterated_loops n o F).
 Proof.
   induction n.
@@ -309,7 +309,7 @@ Proof.
 Defined.
 
 (* Loops neutralise sigmas when truncated *)
-Lemma loops_psigma_trunc (n : nat) : forall (Aa : pType)
+Lemma loops_psigma_trunc (n : Nat) : forall (Aa : pType)
   (Pp : pFam Aa) (istrunc_Pp : IsTrunc_pFam (trunc_index_inc minus_two n) Pp),
   iterated_loops n (psigma Pp)
   <~>* iterated_loops n Aa.
@@ -341,7 +341,7 @@ Proof.
   reflexivity.
 Defined.
 
-Lemma local_global_looping `{Univalence} (A : Type@{i}) (n : nat)
+Lemma local_global_looping `{Univalence} (A : Type@{i}) (n : Nat)
   : iterated_loops@{j} n.+2 (Type@{i}, A)
     <~>* pproduct (fun a => iterated_loops@{j} n.+1 (A, a)).
 Proof.
@@ -366,7 +366,7 @@ Proof.
 Defined.
 
 (* 7.2.9, with [n] here meaning the same as [n-1] there. Note that [n.-1] in the statement is short for [trunc_index_pred (nat_to_trunc_index n)] which is definitionally equal to [(trunc_index_inc minus_two n).+1]. *)
-Theorem equiv_istrunc_contr_iterated_loops `{Univalence} (n : nat)
+Theorem equiv_istrunc_contr_iterated_loops `{Univalence} (n : Nat)
   : forall A, IsTrunc n.-1 A <~> forall a : A, Contr (iterated_loops n (A, a)).
 Proof.
   induction n; intro A.

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -59,7 +59,7 @@ Proof.
   - abstract (pointed_reduce_rewrite; reflexivity).
 Defined.
 
-Definition pfiber_fmap_iterated_loops {A B : pType} (n : nat) (f : A ->* B)
+Definition pfiber_fmap_iterated_loops {A B : pType} (n : Nat) (f : A ->* B)
   : pfiber (fmap (iterated_loops n) f) <~>* iterated_loops n (pfiber f).
 Proof.
   induction n.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -102,7 +102,7 @@ Proof.
 Defined.
 
 Definition ptr_iterated_loops `{Univalence} (n : trunc_index)
-  (k : nat) (A : pType)
+  (k : Nat) (A : pType)
   : pTr n (iterated_loops k A) <~>* iterated_loops k (pTr (trunc_index_inc' n k) A).
 Proof.
   revert A n.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -154,7 +154,7 @@ Section AssumeStuff.
                               f Ha Hb.
 
     Definition graph_unsucc_equiv_edge@{} (x y : vert A)
-      : iff@{s s s} (edge A x y) (edge B (graph_unsucc_equiv_vert x) (graph_unsucc_equiv_vert y)).
+      : Iff@{s s s} (edge A x y) (edge B (graph_unsucc_equiv_vert x) (graph_unsucc_equiv_vert y)).
     Proof.
       pose (h := e (inl x) (inl y)).
       rewrite <- (unfunctor_sum_l_beta f Ha x) in h.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -75,7 +75,7 @@ Section AssumeStuff.
 
   Definition graph_succ@{} (A : Graph) : Graph.
   Proof.
-    srefine (Build_Graph (sum@{s s} (vert A) Unit) _ _).
+    srefine (Build_Graph (Sum@{s s} (vert A) Unit) _ _).
     - intros [x|x] [y|y].
       + exact (edge A x y).
       + exact Unit.
@@ -698,7 +698,7 @@ Section AssumeStuff.
   Qed.
 
   Definition equiv_N_segment@{} (n : N)
-    : { m : N & m <= n } <~> (sum@{p p} {m : N & m < n} Unit).
+    : { m : N & m <= n } <~> (Sum@{p p} {m : N & m < n} Unit).
   Proof.
     srefine (equiv_adjointify _ _ _ _).
     - intros mH.
@@ -728,7 +728,7 @@ Section AssumeStuff.
   Defined.
 
   Definition equiv_N_segment_succ@{} (n : N)
-    : { m : N & m <= succ n } <~> @sum@{p p} {m : N & m <= n} Unit.
+    : { m : N & m <= succ n } <~> @Sum@{p p} {m : N & m <= n} Unit.
   Proof.
     refine (_ oE equiv_N_segment (succ n)).
     apply equiv_functor_sum_r.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -776,7 +776,7 @@ Section AssumeStuff.
     Local Definition partial_Nrec@{} (n : N) : Type@{nr}
       := sig@{nr nr}
             (fun f : ({ m : N & m <= n} -> X) =>
-               prod@{x nr} (f (zero_seg n) = x0)
+               Prod@{x nr} (f (zero_seg n) = x0)
                    (forall (mh : {m:N & m < n}),
                        f (succ_seg n mh) = xs (f ((equiv_N_segment n)^-1 (inl mh))))).
 
@@ -819,7 +819,7 @@ Section AssumeStuff.
     Local Existing Instance contr_partial_Nrec_zero.
 
     Local Definition equiv_N_segment_succ_maps@{} (n : N)
-      : Equiv@{nr nr} (prod@{nr x} ({ m : N & m <= n} -> X) X) ({ m : N & m <= succ n} -> X).
+      : Equiv@{nr nr} (Prod@{nr x} ({ m : N & m <= n} -> X) X) ({ m : N & m <= succ n} -> X).
     Proof.
       refine (_ oE @equiv_sum_ind@{x nr nr nr nr p p p}
                 _ {m:N&m<=n} Unit (fun _ => X) oE _).
@@ -999,7 +999,7 @@ Section AssumeStuff.
     we want to prove to be contractible. *)
     Definition NRec : Type@{nr}
       := sig@{nr nr} (fun f : N -> X =>
-                        prod@{x nr} (f zero = x0)
+                        Prod@{x nr} (f zero = x0)
                             (forall m:N, f (succ m) = xs (f m))).
 
     Local Definition nrec_partials@{} : NRec -> partials.

--- a/theories/Sets/GCH.v
+++ b/theories/Sets/GCH.v
@@ -116,14 +116,14 @@ Section LEM.
 
 End LEM.
 
-(* We can instantiate the previous lemma with nat to obtain GCH -> LEM. *)
+(* We can instantiate the previous lemma with Nat to obtain GCH -> LEM. *)
 
 Theorem GCH_LEM {PR : PropResizing} {UA : Univalence} :
   GCH -> (forall P : HProp, P \/ ~ P).
 Proof.
-  intros gch P. eapply (CH_LEM (Build_HSet nat)); try exact _. intros H1 H2 H3.
-  pose (sings := { p : nat -> HProp | sing (Build_HSet nat) p \/ (P + ~ P) }).
-  destruct (gch (Build_HSet nat) (Build_HSet sings)) as [H|H].
+  intros gch P. eapply (CH_LEM (Build_HSet Nat)); try exact _. intros H1 H2 H3.
+  pose (sings := { p : Nat -> HProp | sing (Build_HSet Nat) p \/ (P + ~ P) }).
+  destruct (gch (Build_HSet Nat) (Build_HSet sings)) as [H|H].
   - cbn. exists idmap. apply isinj_idmap.
   - apply tr. apply H1.
   - apply tr. apply H2.

--- a/theories/Sets/GCHtoAC.v
+++ b/theories/Sets/GCHtoAC.v
@@ -47,7 +47,7 @@ Proof.
 Qed.
 
 Lemma path_unit_nat :
-  Unit + nat = nat.
+  Unit + Nat = Nat.
 Proof.
   apply path_universe_uncurried. srapply equiv_adjointify.
   - exact (fun x => match x with inl _ => O | inr n => S n end).
@@ -258,7 +258,7 @@ Variable HN : HSet -> HSet.
 
 Hypothesis HN_ninject : forall X, ~ InjectsInto (HN X) X.
 
-Variable HN_bound : nat.
+Variable HN_bound : Nat.
 Hypothesis HN_inject : forall X, InjectsInto (HN X) (power_iterated X HN_bound).
 
 (* This section then concludes the intermediate result that abstractly,
@@ -309,9 +309,9 @@ Proof.
 Qed.
 
 Theorem GCH_injects (X : HSet) :
-  GCH -> InjectsInto X (HN (Build_HSet (Build_HSet (nat + X) -> HProp))).
+  GCH -> InjectsInto X (HN (Build_HSet (Build_HSet (Nat + X) -> HProp))).
 Proof.
-  intros gch. eapply InjectsInto_trans with (nat + X).
+  intros gch. eapply InjectsInto_trans with (Nat + X).
   - apply tr. exists inr. intros x y. apply path_sum_inr.
   - apply GCH_injects'; trivial. exists inl. intros x y. apply path_sum_inl.
 Qed.
@@ -324,7 +324,7 @@ Theorem GCH_AC {UA : Univalence} {PR : PropResizing} {LEM : ExcludedMiddle} :
   GCH -> Choice_type.
 Proof.
   intros gch.
-  apply WO_AC. intros X. apply tr. exists (hartogs_number (Build_HSet (Build_HSet (nat + X) -> HProp))).
+  apply WO_AC. intros X. apply tr. exists (hartogs_number (Build_HSet (Build_HSet (Nat + X) -> HProp))).
   unshelve eapply (@GCH_injects UA LEM PR hartogs_number _ 3 _ X gch).
   - intros Y. intros H. eapply merely_destruct; try apply H. apply hartogs_number_no_injection.
   - intros Y. apply tr. apply hartogs_number_injection.

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -136,16 +136,6 @@ Proof.
 Defined.
 
 
-Global Instance transitive_iff
-  : Transitive iff.
-Proof.
-  intros A B C A_B B_C.
-  split.
-  - intros a. apply B_C. apply A_B. exact a.
-  - intros c. apply A_B. apply B_C. exact c.
-Qed.
-
-
 Lemma transitive_Isomorphism
   : forall A B C,
     Isomorphism A B

--- a/theories/Spaces/Cantor.v
+++ b/theories/Spaces/Cantor.v
@@ -6,7 +6,7 @@ Local Open Scope path_scope.
 
 (** * Cantor space 2^N *)
 
-Definition Cantor : Type := nat -> Bool.
+Definition Cantor : Type := Nat -> Bool.
 
 Definition cantor_fold : Cantor + Cantor -> Cantor.
 Proof.

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -191,7 +191,7 @@ Qed.
 
 (** * Infinity *)
 
-(* We call a set infinite if nat embeds into it. *)
+(* We call a set infinite if Nat embeds into it. *)
 
 Definition infinite X :=
-  Injection nat X.
+  Injection Nat X.

--- a/theories/Spaces/Finite/Fin.v
+++ b/theories/Spaces/Finite/Fin.v
@@ -13,15 +13,15 @@ Local Open Scope nat_scope.
 
 (** ** Canonical finite sets *)
 
-(** A *finite set* is a type that is merely equivalent to the canonical finite set determined by some natural number.  There are many equivalent ways to define the canonical finite sets, such as [{ k : nat & k < n}]; we instead choose a recursive one. *)
+(** A *finite set* is a type that is merely equivalent to the canonical finite set determined by some natural number.  There are many equivalent ways to define the canonical finite sets, such as [{ k : Nat & k < n}]; we instead choose a recursive one. *)
 
-Fixpoint Fin (n : nat) : Type0
+Fixpoint Fin (n : Nat) : Type0
   := match n with
        | 0 => Empty
        | S n => Fin n + Unit
      end.
 
-Fixpoint fin_to_nat {n} : Fin n -> nat
+Fixpoint fin_to_nat {n} : Fin n -> Nat
   := match n with
      | 0 => Empty_rec
      | S n' =>
@@ -32,14 +32,14 @@ Fixpoint fin_to_nat {n} : Fin n -> nat
          end
      end.
 
-Global Instance decidable_fin (n : nat)
+Global Instance decidable_fin (n : Nat)
 : Decidable (Fin n).
 Proof.
   destruct n as [|n]; try exact _.
   exact (inl (inr tt)).
 Defined.
 
-Global Instance decidablepaths_fin (n : nat)
+Global Instance decidablepaths_fin (n : Nat)
 : DecidablePaths (Fin n).
 Proof.
   induction n as [|n IHn]; simpl; exact _.
@@ -50,27 +50,27 @@ Proof.
   refine (contr_equiv' Unit (sum_empty_l Unit)^-1).
 Defined.
 
-Definition fin_empty (n : nat) (f : Fin n -> Empty) : n = 0.
+Definition fin_empty (n : Nat) (f : Fin n -> Empty) : n = 0.
 Proof.
   destruct n; [ reflexivity | ].
   elim (f (inr tt)).
 Defined.
 
 (** The zeroth element of a non-empty finite set is the left most element. It also happens to be the biggest by termsize. *)
-Fixpoint fin_zero {n : nat} : Fin n.+1 :=
+Fixpoint fin_zero {n : Nat} : Fin n.+1 :=
   match n with
   | O => inr tt
   | S _ => inl fin_zero
   end.
 
 (** Where `fin_zero` computes the first element of Fin (S n), `fin_last` computes the last. *)
-Definition fin_last {n : nat} : Fin (S n) := inr tt.
+Definition fin_last {n : Nat} : Fin (S n) := inr tt.
 
 (** Injection Fin n -> Fin n.+1 mapping the kth element to the kth element. *)
-Definition fin_incl {n : nat} (k : Fin n) : Fin (S n) := inl k.
+Definition fin_incl {n : Nat} (k : Fin n) : Fin (S n) := inl k.
 
 (** There is an injection from Fin n -> Fin n.+1 that maps the kth element to the (k+1)th element. *)
-Fixpoint fsucc {n : nat} : Fin n -> Fin n.+1 :=
+Fixpoint fsucc {n : Nat} : Fin n -> Fin n.+1 :=
   match n with
   | O => Empty_rec
   | S n' =>
@@ -82,7 +82,7 @@ Fixpoint fsucc {n : nat} : Fin n -> Fin n.+1 :=
   end.
 
 (** This injection is an injection/embedding *)
-Lemma isembedding_fsucc {n : nat} : IsEmbedding (@fsucc n).
+Lemma isembedding_fsucc {n : Nat} : IsEmbedding (@fsucc n).
 Proof.
   apply isembedding_isinj_hset.
   induction n.
@@ -94,17 +94,17 @@ Proof.
     + destruct u, u0; reflexivity.
 Qed.
 
-Lemma path_fin_fsucc_incl {n : nat} : forall k : Fin n, fsucc (fin_incl k) = fin_incl (fsucc k).
+Lemma path_fin_fsucc_incl {n : Nat} : forall k : Fin n, fsucc (fin_incl k) = fin_incl (fsucc k).
 Proof.
   trivial.
 Qed.
 
-Lemma path_nat_fin_incl {n : nat} : forall k : Fin n, fin_to_nat (fin_incl k) = fin_to_nat k.
+Lemma path_nat_fin_incl {n : Nat} : forall k : Fin n, fin_to_nat (fin_incl k) = fin_to_nat k.
 Proof.
   reflexivity.
 Qed.
 
-Lemma path_nat_fsucc {n : nat} : forall k : Fin n, fin_to_nat (fsucc k) = S (fin_to_nat k).
+Lemma path_nat_fsucc {n : Nat} : forall k : Fin n, fin_to_nat (fsucc k) = S (fin_to_nat k).
 Proof.
   induction n as [|n' IHn].
   - intros [].
@@ -132,7 +132,7 @@ Qed.
 
 (** *** Swap the last two elements. *)
 
-Definition fin_transpose_last_two (n : nat)
+Definition fin_transpose_last_two (n : Nat)
 : Fin n.+2 <~> Fin n.+2
   := ((equiv_sum_assoc _ _ _)^-1)
        oE (1 +E (equiv_sum_symm _ _))
@@ -140,21 +140,21 @@ Definition fin_transpose_last_two (n : nat)
 
 Arguments fin_transpose_last_two : simpl nomatch.
 
-Definition fin_transpose_last_two_last (n : nat)
+Definition fin_transpose_last_two_last (n : Nat)
 : fin_transpose_last_two n (inr tt) = (inl (inr tt))
   := 1.
 
-Definition fin_transpose_last_two_nextlast (n : nat)
+Definition fin_transpose_last_two_nextlast (n : Nat)
 : fin_transpose_last_two n (inl (inr tt)) = (inr tt)
   := 1.
 
-Definition fin_transpose_last_two_rest (n : nat) (k : Fin n)
+Definition fin_transpose_last_two_rest (n : Nat) (k : Fin n)
 : fin_transpose_last_two n (inl (inl k)) = (inl (inl k))
   := 1.
 
 (** *** Swap the last element with [k]. *)
 
-Fixpoint fin_transpose_last_with (n : nat) (k : Fin n.+1)
+Fixpoint fin_transpose_last_with (n : Nat) (k : Fin n.+1)
 : Fin n.+1 <~> Fin n.+1.
 Proof.
   destruct k as [k|].
@@ -171,7 +171,7 @@ Defined.
 
 Arguments fin_transpose_last_with : simpl nomatch.
 
-Definition fin_transpose_last_with_last (n : nat) (k : Fin n.+1)
+Definition fin_transpose_last_with_last (n : Nat) (k : Fin n.+1)
 : fin_transpose_last_with n k (inr tt) = k.
 Proof.
   destruct k as [k|].
@@ -185,7 +185,7 @@ Proof.
     all:apply ap, path_contr.
 Qed.
 
-Definition fin_transpose_last_with_with (n : nat) (k : Fin n.+1)
+Definition fin_transpose_last_with_with (n : Nat) (k : Fin n.+1)
 : fin_transpose_last_with n k k = inr tt.
 Proof.
   destruct k as [k|].
@@ -198,7 +198,7 @@ Proof.
     all:apply ap, path_contr.
 Qed.
 
-Definition fin_transpose_last_with_rest (n : nat)
+Definition fin_transpose_last_with_rest (n : Nat)
            (k : Fin n.+1) (l : Fin n)
            (notk : k <> inl l)
 : fin_transpose_last_with n k (inl l) = (inl l).
@@ -218,13 +218,13 @@ Proof.
   - destruct n; reflexivity.
 Qed.
 
-Definition fin_transpose_last_with_last_other (n : nat) (k : Fin n.+1)
+Definition fin_transpose_last_with_last_other (n : Nat) (k : Fin n.+1)
 : fin_transpose_last_with n (inr tt) k = k.
 Proof.
   destruct n; reflexivity.
 Qed.
 
-Definition fin_transpose_last_with_invol (n : nat) (k : Fin n.+1)
+Definition fin_transpose_last_with_invol (n : Nat) (k : Fin n.+1)
 : fin_transpose_last_with n k o fin_transpose_last_with n k == idmap.
 Proof.
   intros l.
@@ -248,19 +248,19 @@ Qed.
 (** To give an equivalence [Fin n.+1 <~> Fin m.+1] is equivalent to giving an element of [Fin m.+1] (the image of the last element) together with an equivalence [Fin n <~> Fin m].  More specifically, any such equivalence can be decomposed uniquely as a last-element transposition followed by an equivalence fixing the last element.  *)
 
 (** Here is the uncurried map that constructs an equivalence [Fin n.+1 <~> Fin m.+1]. *)
-Definition fin_equiv (n m : nat)
+Definition fin_equiv (n m : Nat)
            (k : Fin m.+1) (e : Fin n <~> Fin m)
 : Fin n.+1 <~> Fin m.+1
   := (fin_transpose_last_with m k)
        oE (e +E 1).
 
 (** Here is the curried version that we will prove to be an equivalence. *)
-Definition fin_equiv' (n m : nat)
+Definition fin_equiv' (n m : Nat)
 : ((Fin m.+1) * (Fin n <~> Fin m)) -> (Fin n.+1 <~> Fin m.+1)
   := fun ke => fin_equiv n m (fst ke) (snd ke).
 
 (** We construct its inverse and the two homotopies first as versions using homotopies without funext (similar to [ExtendableAlong]), then apply funext at the end. *)
-Definition fin_equiv_hfiber (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
+Definition fin_equiv_hfiber (n m : Nat) (e : Fin n.+1 <~> Fin m.+1)
 : { kf : (Fin m.+1) * (Fin n <~> Fin m) & fin_equiv' n m kf == e }.
 Proof.
   simpl in e.
@@ -306,15 +306,15 @@ Proof.
       symmetry; apply p.
 Qed.
 
-Definition fin_equiv_inv (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
+Definition fin_equiv_inv (n m : Nat) (e : Fin n.+1 <~> Fin m.+1)
 : (Fin m.+1) * (Fin n <~> Fin m)
   := (fin_equiv_hfiber n m e).1.
 
-Definition fin_equiv_issect (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
+Definition fin_equiv_issect (n m : Nat) (e : Fin n.+1 <~> Fin m.+1)
 : fin_equiv' n m (fin_equiv_inv n m e) == e
   := (fin_equiv_hfiber n m e).2.
 
-Definition fin_equiv_inj_fst (n m : nat)
+Definition fin_equiv_inj_fst (n m : Nat)
            (k l : Fin m.+1) (e f : Fin n <~> Fin m)
 : (fin_equiv n m k e == fin_equiv n m l f) -> (k = l).
 Proof.
@@ -323,7 +323,7 @@ Proof.
   rewrite fin_transpose_last_with_last; reflexivity.
 Qed.
 
-Definition fin_equiv_inj_snd (n m : nat)
+Definition fin_equiv_inj_snd (n m : Nat)
            (k l : Fin m.+1) (e f : Fin n <~> Fin m)
 : (fin_equiv n m k e == fin_equiv n m l f) -> (e == f).
 Proof.
@@ -336,7 +336,7 @@ Proof.
 Qed.
 
 (** Now it's time for funext. *)
-Global Instance isequiv_fin_equiv `{Funext} (n m : nat)
+Global Instance isequiv_fin_equiv `{Funext} (n m : Nat)
 : IsEquiv (fin_equiv' n m).
 Proof.
   refine (isequiv_pathsplit 0 _); split.
@@ -353,12 +353,12 @@ Proof.
       refine (fin_equiv_inj_snd n m k l e f p).
 Qed.
 
-Definition equiv_fin_equiv `{Funext} (n m : nat)
+Definition equiv_fin_equiv `{Funext} (n m : Nat)
 : ((Fin m.+1) * (Fin n <~> Fin m)) <~> (Fin n.+1 <~> Fin m.+1)
   := Build_Equiv _ _ (fin_equiv' n m) _.
 
 (** In particular, this implies that if two canonical finite sets are equivalent, then their cardinalities are equal. *)
-Definition nat_eq_fin_equiv (n m : nat)
+Definition nat_eq_fin_equiv (n m : Nat)
 : (Fin n <~> Fin m) -> (n = m).
 Proof.
   revert m; induction n as [|n IHn]; induction m as [|m IHm]; intros e.
@@ -369,9 +369,9 @@ Proof.
     exact (snd (fin_equiv_inv n m e)).
 Qed.
 
-(** ** Initial segments of [nat] *)
+(** ** Initial segments of [Nat] *)
 
-Definition nat_fin (n : nat) (k : Fin n) : nat.
+Definition nat_fin (n : Nat) (k : Fin n) : Nat.
 Proof.
   induction n as [|n nf].
   - contradiction.
@@ -380,11 +380,11 @@ Proof.
     + exact n.
 Defined.
 
-Definition nat_fin_inl (n : nat) (k : Fin n)
+Definition nat_fin_inl (n : Nat) (k : Fin n)
 : nat_fin n.+1 (inl k) = nat_fin n k
   := 1.
 
-Definition nat_fin_compl (n : nat) (k : Fin n) : nat.
+Definition nat_fin_compl (n : Nat) (k : Fin n) : Nat.
 Proof.
   induction n as [|n nfc].
   - contradiction.
@@ -407,7 +407,7 @@ Proof.
 Qed.
 
 (** [fsucc_mod] is the successor function mod n *)
-Definition fsucc_mod {n : nat} : Fin n -> Fin n.
+Definition fsucc_mod {n : Nat} : Fin n -> Fin n.
 Proof.
   destruct n.
   1: exact idmap.
@@ -417,7 +417,7 @@ Proof.
 Defined.
 
 (** fsucc allows us to convert a natural number into an element of a finite set. This can be thought of as the modulo map. *)
-Fixpoint fin_nat {n : nat} (m : nat) : Fin n.+1
+Fixpoint fin_nat {n : Nat} (m : Nat) : Fin n.+1
   := match m with
       | 0 => fin_zero
       | S m => fsucc_mod (fin_nat m)

--- a/theories/Spaces/Finite/FinInduction.v
+++ b/theories/Spaces/Finite/FinInduction.v
@@ -8,10 +8,10 @@ Require Import
 
 Local Open Scope nat_scope.
 
-Definition fin_ind (P : forall n : nat, Fin n -> Type)
-  (z : forall n : nat, P n.+1 fin_zero)
-  (s : forall (n : nat) (k : Fin n), P n k -> P n.+1 (fsucc k))
-  {n : nat} (k : Fin n)
+Definition fin_ind (P : forall n : Nat, Fin n -> Type)
+  (z : forall n : Nat, P n.+1 fin_zero)
+  (s : forall (n : Nat) (k : Fin n), P n k -> P n.+1 (fsucc k))
+  {n : Nat} (k : Fin n)
   : P n k.
 Proof.
   refine (transport (P n) (path_fin_to_finnat_to_fin k) _).
@@ -22,9 +22,9 @@ Proof.
     by apply s.
 Defined.
 
-Lemma compute_fin_ind_fin_zero (P : forall n : nat, Fin n -> Type)
-  (z : forall n : nat, P n.+1 fin_zero)
-  (s : forall (n : nat) (k : Fin n), P n k -> P n.+1 (fsucc k)) (n : nat)
+Lemma compute_fin_ind_fin_zero (P : forall n : Nat, Fin n -> Type)
+  (z : forall n : Nat, P n.+1 fin_zero)
+  (s : forall (n : Nat) (k : Fin n), P n k -> P n.+1 (fsucc k)) (n : Nat)
   : fin_ind P z s fin_zero = z n.
 Proof.
   unfold fin_ind.
@@ -36,10 +36,10 @@ Proof.
   by destruct (hset_path2 1 (path_zero_finnat n leq_1_Sn)).
 Defined.
 
-Lemma compute_fin_ind_fsucc (P : forall n : nat, Fin n -> Type)
-  (z : forall n : nat, P n.+1 fin_zero)
-  (s : forall (n : nat) (k : Fin n), P n k -> P n.+1 (fsucc k))
-  {n : nat} (k : Fin n)
+Lemma compute_fin_ind_fsucc (P : forall n : Nat, Fin n -> Type)
+  (z : forall n : Nat, P n.+1 fin_zero)
+  (s : forall (n : Nat) (k : Fin n), P n k -> P n.+1 (fsucc k))
+  {n : Nat} (k : Fin n)
   : fin_ind P z s (fsucc k) = s n k (fin_ind P z s k).
 Proof.
   unfold fin_ind.
@@ -55,23 +55,23 @@ Proof.
   apply transport_pV.
 Defined.
 
-Definition fin_rec (B : nat -> Type)
-  : (forall n : nat, B n.+1) -> (forall (n : nat), Fin n -> B n -> B n.+1) ->
-    forall {n : nat}, Fin n -> B n
+Definition fin_rec (B : Nat -> Type)
+  : (forall n : Nat, B n.+1) -> (forall (n : Nat), Fin n -> B n -> B n.+1) ->
+    forall {n : Nat}, Fin n -> B n
   := fin_ind (fun n _ => B n).
 
-Lemma compute_fin_rec_fin_zero (B : nat -> Type)
-  (z : forall n : nat, B n.+1)
-  (s : forall (n : nat) (k : Fin n), B n -> B n.+1) (n : nat)
+Lemma compute_fin_rec_fin_zero (B : Nat -> Type)
+  (z : forall n : Nat, B n.+1)
+  (s : forall (n : Nat) (k : Fin n), B n -> B n.+1) (n : Nat)
   : fin_rec B z s fin_zero = z n.
 Proof.
   apply (compute_fin_ind_fin_zero (fun n _ => B n)).
 Defined.
 
-Lemma compute_fin_rec_fsucc (B : nat -> Type)
-  (z : forall n : nat, B n.+1)
-  (s : forall (n : nat) (k : Fin n), B n -> B n.+1)
-  {n : nat} (k : Fin n)
+Lemma compute_fin_rec_fsucc (B : Nat -> Type)
+  (z : forall n : Nat, B n.+1)
+  (s : forall (n : Nat) (k : Fin n), B n -> B n.+1)
+  {n : Nat} (k : Fin n)
   : fin_rec B z s (fsucc k) = s n k (fin_rec B z s k).
 Proof.
   apply (compute_fin_ind_fsucc (fun n _ => B n)).

--- a/theories/Spaces/Finite/FinNat.v
+++ b/theories/Spaces/Finite/FinNat.v
@@ -8,47 +8,47 @@ Require Import
 
 Local Open Scope nat_scope.
 
-Definition FinNat (n : nat) : Type := {x : nat | x < n}.
+Definition FinNat (n : Nat) : Type := {x : Nat | x < n}.
 
-Definition zero_finnat (n : nat) : FinNat n.+1
+Definition zero_finnat (n : Nat) : FinNat n.+1
   := (0; leq_1_Sn).
 
-Lemma path_zero_finnat (n : nat) (h : 0 < n.+1) : zero_finnat n = (0; h).
+Lemma path_zero_finnat (n : Nat) (h : 0 < n.+1) : zero_finnat n = (0; h).
 Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition succ_finnat {n : nat} (u : FinNat n) : FinNat n.+1
+Definition succ_finnat {n : Nat} (u : FinNat n) : FinNat n.+1
   := (u.1.+1; leq_S_n' u.1.+1 n u.2).
 
-Lemma path_succ_finnat {n : nat} (u : FinNat n) (h : u.1.+1 < n.+1)
+Lemma path_succ_finnat {n : Nat} (u : FinNat n) (h : u.1.+1 < n.+1)
   : succ_finnat u = (u.1.+1; h).
 Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition last_finnat (n : nat) : FinNat n.+1
+Definition last_finnat (n : Nat) : FinNat n.+1
   := exist (fun x => x < n.+1) n (leq_refl n.+1).
 
-Lemma path_last_finnat (n : nat) (h : n < n.+1)
+Lemma path_last_finnat (n : Nat) (h : n < n.+1)
   : last_finnat n = (n; h).
 Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition incl_finnat {n : nat} (u : FinNat n) : FinNat n.+1
+Definition incl_finnat {n : Nat} (u : FinNat n) : FinNat n.+1
   := (u.1; leq_trans u.2 (leq_S n n (leq_n n))).
 
-Lemma path_incl_finnat (n : nat) (u : FinNat n) (h : u.1 < n.+1)
+Lemma path_incl_finnat (n : Nat) (u : FinNat n) (h : u.1 < n.+1)
   : incl_finnat u = (u.1; h).
 Proof.
   by apply path_sigma_hprop.
 Defined.
 
-Definition finnat_ind (P : forall n : nat, FinNat n -> Type)
-  (z : forall n : nat, P n.+1 (zero_finnat n))
-  (s : forall (n : nat) (u : FinNat n), P n u -> P n.+1 (succ_finnat u))
-  {n : nat} (u : FinNat n)
+Definition finnat_ind (P : forall n : Nat, FinNat n -> Type)
+  (z : forall n : Nat, P n.+1 (zero_finnat n))
+  (s : forall (n : Nat) (u : FinNat n), P n u -> P n.+1 (succ_finnat u))
+  {n : Nat} (u : FinNat n)
   : P n u.
 Proof.
   induction n as [| n IHn].
@@ -60,20 +60,20 @@ Proof.
       apply s. apply IHn.
 Defined.
 
-Lemma compute_finnat_ind_zero (P : forall n : nat, FinNat n -> Type)
-  (z : forall n : nat, P n.+1 (zero_finnat n))
-  (s : forall (n : nat) (u : FinNat n), P n u -> P n.+1 (succ_finnat u))
-  (n : nat)
+Lemma compute_finnat_ind_zero (P : forall n : Nat, FinNat n -> Type)
+  (z : forall n : Nat, P n.+1 (zero_finnat n))
+  (s : forall (n : Nat) (u : FinNat n), P n u -> P n.+1 (succ_finnat u))
+  (n : Nat)
   : finnat_ind P z s (zero_finnat n) = z n.
 Proof.
   cbn. by induction (hset_path2 1 (path_zero_finnat n leq_1_Sn)).
 Defined.
 
-Lemma compute_finnat_ind_succ (P : forall n : nat, FinNat n -> Type)
-  (z : forall n : nat, P n.+1 (zero_finnat n))
-  (s : forall (n : nat) (u : FinNat n),
+Lemma compute_finnat_ind_succ (P : forall n : Nat, FinNat n -> Type)
+  (z : forall n : Nat, P n.+1 (zero_finnat n))
+  (s : forall (n : Nat) (u : FinNat n),
        P n u -> P n.+1 (succ_finnat u))
-  {n : nat} (u : FinNat n)
+  {n : Nat} (u : FinNat n)
   : finnat_ind P z s (succ_finnat u) = s n u (finnat_ind P z s u).
 Proof.
   refine
@@ -101,7 +101,7 @@ Defined.
 Monomorphic Definition fin_to_finnat {n} (k : Fin n) : FinNat n
   := (fin_to_nat k; is_bounded_fin_to_nat k).
 
-Monomorphic Fixpoint finnat_to_fin {n : nat} : FinNat n -> Fin n
+Monomorphic Fixpoint finnat_to_fin {n : Nat} : FinNat n -> Fin n
   := match n with
      | 0 => fun u => Empty_rec (not_lt_n_0 _ u.2)
      | n.+1 => fun u =>
@@ -111,45 +111,45 @@ Monomorphic Fixpoint finnat_to_fin {n : nat} : FinNat n -> Fin n
         end
      end.
 
-Lemma path_fin_to_finnat_fsucc {n : nat} (k : Fin n)
+Lemma path_fin_to_finnat_fsucc {n : Nat} (k : Fin n)
   : fin_to_finnat (fsucc k) = succ_finnat (fin_to_finnat k).
 Proof.
   apply path_sigma_hprop.
   apply path_nat_fsucc.
 Defined.
 
-Lemma path_fin_to_finnat_fin_zero (n : nat)
+Lemma path_fin_to_finnat_fin_zero (n : Nat)
   : fin_to_finnat (@fin_zero n) = zero_finnat n.
 Proof.
   apply path_sigma_hprop.
   apply path_nat_fin_zero.
 Defined.
 
-Lemma path_fin_to_finnat_fin_incl {n : nat} (k : Fin n)
+Lemma path_fin_to_finnat_fin_incl {n : Nat} (k : Fin n)
   : fin_to_finnat (fin_incl k) = incl_finnat (fin_to_finnat k).
 Proof.
   reflexivity.
 Defined.
 
-Lemma path_fin_to_finnat_fin_last (n : nat)
+Lemma path_fin_to_finnat_fin_last (n : Nat)
   : fin_to_finnat (@fin_last n) = last_finnat n.
 Proof.
   reflexivity.
 Defined.
 
-Lemma path_finnat_to_fin_succ {n : nat} (u : FinNat n)
+Lemma path_finnat_to_fin_succ {n : Nat} (u : FinNat n)
   : finnat_to_fin (succ_finnat u) = fsucc (finnat_to_fin u).
 Proof.
   cbn. do 2 f_ap. by apply path_sigma_hprop.
 Defined.
 
-Lemma path_finnat_to_fin_zero (n : nat)
+Lemma path_finnat_to_fin_zero (n : Nat)
   : finnat_to_fin (zero_finnat n) = fin_zero.
 Proof.
   reflexivity.
 Defined.
 
-Lemma path_finnat_to_fin_incl {n : nat} (u : FinNat n)
+Lemma path_finnat_to_fin_incl {n : Nat} (u : FinNat n)
   : finnat_to_fin (incl_finnat u) = fin_incl (finnat_to_fin u).
 Proof.
   induction n as [| n IHn].
@@ -161,7 +161,7 @@ Proof.
     by induction (path_finnat_to_fin_succ (incl_finnat (x; leq_S_n _ _ h))).
 Defined.
 
-Lemma path_finnat_to_fin_last (n : nat)
+Lemma path_finnat_to_fin_last (n : Nat)
   : finnat_to_fin (last_finnat n) = fin_last.
 Proof.
   induction n as [| n IHn].
@@ -169,7 +169,7 @@ Proof.
   - exact (ap fsucc IHn).
 Defined.
 
-Lemma path_finnat_to_fin_to_finnat {n : nat} (u : FinNat n)
+Lemma path_finnat_to_fin_to_finnat {n : Nat} (u : FinNat n)
   : fin_to_finnat (finnat_to_fin u) = u.
 Proof.
   induction n as [| n IHn].
@@ -182,7 +182,7 @@ Proof.
       exact (ap S (IHn (x; leq_S_n _ _ h))..1).
 Defined.
 
-Lemma path_fin_to_finnat_to_fin {n : nat} (k : Fin n)
+Lemma path_fin_to_finnat_to_fin {n : Nat} (k : Fin n)
   : finnat_to_fin (fin_to_finnat k) = k.
 Proof.
   induction n as [| n IHn].
@@ -194,7 +194,7 @@ Proof.
     + apply path_finnat_to_fin_last.
 Defined.
 
-Definition equiv_fin_finnat (n : nat) : Fin n <~> FinNat n
+Definition equiv_fin_finnat (n : Nat) : Fin n <~> FinNat n
   := equiv_adjointify fin_to_finnat finnat_to_fin
       path_finnat_to_fin_to_finnat
       path_fin_to_finnat_to_fin.

--- a/theories/Spaces/Finite/FinSeq.v
+++ b/theories/Spaces/Finite/FinSeq.v
@@ -15,7 +15,7 @@ Local Open Scope nat_scope.
 
     Note that the induction principle [finseq_]*)
 
-Definition FinSeq@{u} (n : nat) (A : Type@{u}) : Type@{u} := Fin n -> A.
+Definition FinSeq@{u} (n : Nat) (A : Type@{u}) : Type@{u} := Fin n -> A.
 
 (** The empty finite sequence. *)
 
@@ -28,24 +28,24 @@ Defined.
 
 (** Add an element in the end of a finite sequence, [fscons'] and [fscons]. *)
 
-Definition fscons' {A : Type} (n : nat) (a : A) (v : FinSeq (pred n) A)
+Definition fscons' {A : Type} (n : Nat) (a : A) (v : FinSeq (pred n) A)
   : FinSeq n A
   := fun i =>  fin_rec (fun n => FinSeq (pred n) A -> A)
                        (fun _ _ => a) (fun n' i _ v => v i) i v.
 
-Definition fscons {A : Type} {n : nat} : A -> FinSeq n A -> FinSeq n.+1 A
+Definition fscons {A : Type} {n : Nat} : A -> FinSeq n A -> FinSeq n.+1 A
   := fscons' n.+1.
 
 (** Take the first element of a non-empty finite sequence,
     [fshead'] and [fshead]. *)
 
-Definition fshead' {A} (n : nat) : 0 < n -> FinSeq n A -> A
+Definition fshead' {A} (n : Nat) : 0 < n -> FinSeq n A -> A
   := match n with
      | 0 => fun N _ => Empty_rec (not_lt_n_0 _ N)
      | n'.+1 => fun _ v => v fin_zero
      end.
 
-Definition fshead {A} {n : nat} : FinSeq n.+1 A -> A := fshead' n.+1 _.
+Definition fshead {A} {n : Nat} : FinSeq n.+1 A -> A := fshead' n.+1 _.
 
 Definition compute_fshead' {A} n (N : n > 0) (a : A) (v : FinSeq (pred n) A)
   : fshead' n N (fscons' n a v) = a.
@@ -62,7 +62,7 @@ Defined.
 
 (** If the sequence is non-empty, then remove the first element. *)
 
-Definition fstail' {A} (n : nat) : FinSeq n A -> FinSeq (pred n) A
+Definition fstail' {A} (n : Nat) : FinSeq n A -> FinSeq (pred n) A
   := match n with
      | 0 => fun _ => Empty_rec
      | n'.+1 => fun v i => v (fsucc i)
@@ -70,7 +70,7 @@ Definition fstail' {A} (n : nat) : FinSeq n A -> FinSeq (pred n) A
 
 (** Remove the first element from a non-empty sequence. *)
 
-Definition fstail {A} {n : nat} : FinSeq n.+1 A -> FinSeq n A := fstail' n.+1.
+Definition fstail {A} {n : Nat} : FinSeq n.+1 A -> FinSeq n A := fstail' n.+1.
 
 Definition compute_fstail' {A} n (a : A) (v : FinSeq (pred n) A)
   : fstail' n (fscons' n a v) == v.
@@ -90,7 +90,7 @@ Defined.
 (** A non-empty finite sequence is equal to [fscons] of head and tail,
     [path_expand_fscons'] and [path_expand_fscons]. *)
 
-Lemma path_expand_fscons' {A : Type} (n : nat)
+Lemma path_expand_fscons' {A : Type} (n : Nat)
   (i : Fin n) (N : n > 0) (v : FinSeq n A)
   : fscons' n (fshead' n N v) (fstail' n v) i = v i.
 Proof.
@@ -120,7 +120,7 @@ Proof.
     exact (compute_fstail' n.+1 a1 v1 i @ q i).
 Defined.
 
-Definition compute_path_fscons' {A} (n : nat)
+Definition compute_path_fscons' {A} (n : Nat)
     (a : A) (v : FinSeq (pred n) A) (i : Fin n)
     : path_fscons' n (idpath a) (fun j => idpath (v j)) i = idpath.
 Proof.
@@ -153,7 +153,7 @@ Defined.
     identify [path_expand_fscons'] with [path_fscons'] and
     [path_expand_fscons] with [path_fscons]. *)
 
-Lemma path_expand_fscons_fscons' {A : Type} (n : nat)
+Lemma path_expand_fscons_fscons' {A : Type} (n : Nat)
   (N : n > 0) (a : A) (v : FinSeq (pred n) A) (i : Fin n)
   : path_expand_fscons' n i N (fscons' n a v) =
     path_fscons' n (compute_fshead' n N a v) (compute_fstail' n a v) i.
@@ -170,7 +170,7 @@ Proof.
 Qed.
 
 Lemma path_expand_fscons_fscons `{Funext}
-  {A : Type} {n : nat} (a : A) (v : FinSeq n A)
+  {A : Type} {n : Nat} (a : A) (v : FinSeq n A)
   : path_expand_fscons (fscons a v) =
     path_fscons (compute_fshead a v) (compute_fstail a v).
 Proof.
@@ -186,7 +186,7 @@ Defined.
 
 Lemma finseq_ind `{Funext} {A : Type} (P : forall n, FinSeq n A -> Type)
   (z : P 0 fsnil) (s : forall n a (v : FinSeq n A), P n v -> P n.+1 (fscons a v))
-  {n : nat} (v : FinSeq n A)
+  {n : Nat} (v : FinSeq n A)
   : P n v.
 Proof.
   induction n.
@@ -197,7 +197,7 @@ Defined.
 
 Lemma compute_finseq_ind_fsnil `{Funext} {A : Type}
   (P : forall n, FinSeq n A -> Type) (z : P 0 fsnil)
-  (s : forall (n : nat) (a : A) (v : FinSeq n A), P n v -> P n.+1 (fscons a v))
+  (s : forall (n : Nat) (a : A) (v : FinSeq n A), P n v -> P n.+1 (fscons a v))
   : finseq_ind P z s fsnil = z.
 Proof.
   exact (ap (fun x => _ x z) (hset_path2 1 (path_fsnil fsnil)))^.
@@ -205,8 +205,8 @@ Defined.
 
 Lemma compute_finseq_ind_fscons `{Funext} {A : Type}
   (P : forall n, FinSeq n A -> Type) (z : P 0 fsnil)
-  (s : forall (n : nat) (a : A) (v : FinSeq n A), P n v -> P n.+1 (fscons a v))
-  {n : nat} (a : A) (v : FinSeq n A)
+  (s : forall (n : Nat) (a : A) (v : FinSeq n A), P n v -> P n.+1 (fscons a v))
+  {n : Nat} (a : A) (v : FinSeq n A)
   : finseq_ind P z s (fscons a v) = s n a v (finseq_ind P z s v).
 Proof.
   simpl.

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -19,14 +19,14 @@ Local Open Scope nat_scope.
 (** ** Definition of general finite sets *)
 
 Class Finite (X : Type) :=
-  { fcard : nat ;
+  { fcard : Nat ;
     merely_equiv_fin : merely (X <~> Fin fcard) }.
 
 Arguments fcard X {_}.
 Arguments merely_equiv_fin X {_}.
 
 Definition issig_finite X
-: { n : nat & merely (X <~> Fin n) } <~> Finite X.
+: { n : Nat & merely (X <~> Fin n) } <~> Finite X.
 Proof.
   issig.
 Defined.
@@ -230,7 +230,7 @@ Proof.
       exact (tr (Sum_ind P IH (Unit_ind e))).
 Defined.
 
-Corollary isprojective_fin_n (n : nat) : IsProjective (Fin n).
+Corollary isprojective_fin_n (n : Nat) : IsProjective (Fin n).
 Proof.
   apply (iff_isoprojective_hasochoice _ (Fin n)).
   rapply finite_choice.
@@ -421,7 +421,7 @@ Defined.
 
 (** Amusingly, this automatically gives us a way to add up a family of natural numbers indexed by any finite set.  (We could of course also define such an operation directly, probably using [merely_ind_hset].) *)
 
-Definition finadd {X} `{Finite X} (f : X -> nat) : nat
+Definition finadd {X} `{Finite X} (f : X -> Nat) : Nat
   := fcard { x:X & Fin (f x) }.
 
 Definition fcard_sigma {X} (Y : X -> Type)
@@ -473,7 +473,7 @@ Defined.
 
 (** Similarly, closure of finite sets under [forall] automatically gives us a way to multiply a family of natural numbers indexed by any finite set.  Of course, if we defined this explicitly, it wouldn't need funext. *)
 
-Definition finmult `{Funext} {X} `{Finite X} (f : X -> nat) : nat
+Definition finmult `{Funext} {X} `{Finite X} (f : X -> Nat) : Nat
   := fcard (forall x:X, Fin (f x)).
 
 Definition fcard_forall `{Funext} {X} (Y : X -> Type)
@@ -686,16 +686,16 @@ Qed.
 
 (** ** Enumerations *)
 
-(** A function from [nat] to a finite set must repeat itself eventually. *)
+(** A function from [Nat] to a finite set must repeat itself eventually. *)
 Section Enumeration.
-  Context `{Funext} {X} `{Finite@{_ Set _} X} (e : nat -> X).
+  Context `{Funext} {X} `{Finite@{_ Set _} X} (e : Nat -> X).
 
-  Let er (n : nat) : Fin n -> X
+  Let er (n : Nat) : Fin n -> X
     := fun k => e (nat_fin n k).
 
-  Lemma finite_enumeration_stage (n : nat)
+  Lemma finite_enumeration_stage (n : Nat)
   : IsEmbedding (er n)
-    + { n : nat & { k : nat & e n = e (n + k).+1 }}.
+    + { n : Nat & { k : Nat & e n = e (n + k).+1 }}.
   Proof.
     induction n as [|n [IH|IH]].
     - left. intros x.
@@ -728,7 +728,7 @@ Section Enumeration.
   Defined.
 
   Definition finite_enumeration_repeats
-  : { n : nat & { k : nat & e n = e (n + k).+1 }}.
+  : { n : Nat & { k : Nat & e n = e (n + k).+1 }}.
   Proof.
     destruct (finite_enumeration_stage (fcard X).+1) as [p|?].
     - assert (q := leq_inj_finite (er (fcard X).+1) p); simpl in q.

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -227,7 +227,7 @@ Proof.
     + specialize (IH (P o inl) (f o inl)).
       assert (e := f (inr tt)).
       strip_truncations.
-      exact (tr (sum_ind P IH (Unit_ind e))).
+      exact (tr (Sum_ind P IH (Unit_ind e))).
 Defined.
 
 Corollary isprojective_fin_n (n : nat) : IsProjective (Fin n).
@@ -585,7 +585,7 @@ Section DecidableQuotients.
           apply qglue; unfold R''.
           exact (related_quotient_paths R' (inl u) (inl v) q). }
       { refine (finite_equiv' (Quotient R'' + Unit) _ _).
-        refine (Build_Equiv _ _ (sum_ind (fun _ => Quotient R')
+        refine (Build_Equiv _ _ (Sum_ind (fun _ => Quotient R')
                                         (Quotient_functor R'' R' inl inlresp)
                                         (fun _ => class_of R' (inr tt))) _).
         apply isequiv_surj_emb.
@@ -595,9 +595,9 @@ Section DecidableQuotients.
           + exists (inl (class_of R'' y)); reflexivity.
           + exists (inr tt); reflexivity.
         - apply isembedding_isinj_hset; intros u.
-          refine (sum_ind _ _ _).
+          refine (Sum_ind _ _ _).
           + refine (Quotient_ind_hprop R'' _ _); intros v.
-            revert u; refine (sum_ind _ _ _).
+            revert u; refine (Sum_ind _ _ _).
             * refine (Quotient_ind_hprop R'' _ _); intros u.
               simpl; intros q.
               apply ap, qglue; unfold R''.

--- a/theories/Spaces/Int/Core.v
+++ b/theories/Spaces/Int/Core.v
@@ -90,8 +90,8 @@ Definition int_of_decimal_int (d : Decimal.int) : Int :=
 
 Definition int_of_number_int (d:Numeral.int) :=
   match d with
-  | Numeral.IntDec d => Some (int_of_decimal_int d)
-  | Numeral.IntHex _ => None
+  | Numeral.IntDec d => some (int_of_decimal_int d)
+  | Numeral.IntHex _ => none
   end.
 
 Number Notation Int int_of_number_int int_to_number_int : int_scope.

--- a/theories/Spaces/List.v
+++ b/theories/Spaces/List.v
@@ -10,13 +10,13 @@ Section Fold_Left_Recursor.
   Variables (A : Type) (B : Type).
   Variable f : A -> B -> A.
 
-  Fixpoint fold_left (l : list B) (a0 : A) : A :=
+  Fixpoint fold_left (l : List B) (a0 : A) : A :=
     match l with
       | nil => a0
       | cons b t => fold_left t (f a0 b)
     end.
 
-  Lemma fold_left_app : forall (l l' : list B) (i : A),
+  Lemma fold_left_app : forall (l l' : List B) (i : A),
     fold_left (l ++ l') i = fold_left l' (fold_left l i).
   Proof.
     induction l; simpl; auto.
@@ -28,7 +28,7 @@ Section Fold_Right_Recursor.
   Variables (A : Type) (B : Type).
   Variable f : B -> A -> A.
 
-  Fixpoint fold_right (a0 : A) (l : list B) : A :=
+  Fixpoint fold_right (a0 : A) (l : List B) : A :=
     match l with
       | nil => a0
       | cons b t => f b (fold_right a0 t)

--- a/theories/Spaces/Nat.v
+++ b/theories/Spaces/Nat.v
@@ -6,9 +6,9 @@ Require Export HoTT.DProp.
 
 Local Unset Elimination Schemes.
 
-Scheme nat_ind := Induction for nat Sort Type.
-Scheme nat_rect := Induction for nat Sort Type.
-Scheme nat_rec := Minimality for nat Sort Type.
+Scheme Nat_ind := Induction for Nat Sort Type.
+Scheme Nat_rect := Induction for Nat Sort Type.
+Scheme Nat_rec := Minimality for Nat Sort Type.
 
 (** * Theorems about the natural numbers *)
 
@@ -24,14 +24,14 @@ Local Open Scope nat_scope.
 Notation succ := S (only parsing).
 
 (** The predecessor of a natural number. *)
-Definition pred n : nat :=
+Definition pred n : Nat :=
   match n with
   | 0 => n
   | S n' => n'
   end.
 
 (** Addition of natural numbers *)
-Fixpoint add n m : nat :=
+Fixpoint add n m : Nat :=
   match n with
   | 0 => m
   | S n' => S (add n' m)
@@ -39,9 +39,9 @@ Fixpoint add n m : nat :=
 
 Notation "n + m" := (add n m) : nat_scope.
 
-Definition double n : nat := n + n.
+Definition double n : Nat := n + n.
 
-Fixpoint mul n m : nat :=
+Fixpoint mul n m : Nat :=
   match n with
   | 0 => 0
   | S n' => m + (mul n' m)
@@ -50,7 +50,7 @@ Fixpoint mul n m : nat :=
 Notation "n * m" := (mul n m) : nat_scope.
 
 (** Truncated subtraction: [n - m] is [0] if [n <= m] *)
-Fixpoint sub n m : nat :=
+Fixpoint sub n m : Nat :=
   match n, m with
   | S n' , S m' => sub n' m'
   | _ , _ => n
@@ -86,7 +86,7 @@ Fixpoint pow n m :=
 
 (** This division is linear and tail-recursive. In [divmod], [y] is the predecessor of the actual divisor, and [u] is [y] sub the real remainder. *)
 
-Fixpoint divmod x y q u : nat * nat :=
+Fixpoint divmod x y q u : Nat * Nat :=
   match x with
   | 0 => (q , u)
   | S x' =>
@@ -96,13 +96,13 @@ Fixpoint divmod x y q u : nat * nat :=
     end
   end.
 
-Definition div x y : nat :=
+Definition div x y : Nat :=
   match y with
     | 0 => y
     | S y' => fst (divmod x y' 0 y')
   end.
 
-Definition modulo x y : nat :=
+Definition modulo x y : Nat :=
   match y with
     | 0 => y
     | S y' => y' - snd (divmod x y' 0 y')
@@ -123,7 +123,7 @@ Fixpoint gcd a b :=
 
 (** ** Square *)
 
-Definition square n : nat := n * n.
+Definition square n : Nat := n * n.
 
 (** ** Square root *)
 
@@ -140,7 +140,7 @@ Definition square n : nat := n * n.
   in n, hence the square root of n is p.
 *)
 
-Fixpoint sqrt_iter k p q r : nat :=
+Fixpoint sqrt_iter k p q r : Nat :=
   match k with
   | O => p
   | S k' =>
@@ -150,7 +150,7 @@ Fixpoint sqrt_iter k p q r : nat :=
     end
   end.
 
-Definition sqrt n : nat := sqrt_iter n 0 0 0.
+Definition sqrt n : Nat := sqrt_iter n 0 0 0.
 
 (** ** Log2 *)
 
@@ -185,7 +185,7 @@ Definition sqrt n : nat := sqrt_iter n 0 0 0.
   [k+q] is invariant), and [p] its logarithm.
 *)
 
-Fixpoint log2_iter k p q r : nat :=
+Fixpoint log2_iter k p q r : Nat :=
   match k with
   | O    => p
   | S k' =>
@@ -195,19 +195,19 @@ Fixpoint log2_iter k p q r : nat :=
     end
   end.
 
-Definition log2 n : nat := log2_iter (pred n) 0 1 0.
+Definition log2 n : Nat := log2_iter (pred n) 0 1 0.
 
 (** ** Iterator on natural numbers *)
 
-Definition iter (n : nat) {A} (f : A -> A) (x : A) : A :=
-  nat_rec A x (fun _ => f) n.
+Definition iter (n : Nat) {A} (f : A -> A) (x : A) : A :=
+  Nat_rec A x (fun _ => f) n.
 
 Local Definition ap_S := @ap _ _ S.
-Local Definition ap_nat := @ap nat.
+Local Definition ap_nat := @ap Nat.
 #[export] Hint Resolve ap_S : core.
 #[export] Hint Resolve ap_nat : core.
 
-Theorem pred_Sn : forall n:nat, n = pred (S n).
+Theorem pred_Sn : forall n:Nat, n = pred (S n).
 Proof.
   auto.
 Defined.
@@ -217,14 +217,14 @@ Defined.
 Definition path_nat_S n m (H : S n = S m) : n = m := ap pred H.
 #[export] Hint Immediate path_nat_S : core.
 
-Theorem not_eq_S : forall n m:nat, n <> m -> S n <> S m.
+Theorem not_eq_S : forall n m:Nat, n <> m -> S n <> S m.
 Proof.
   auto.
 Defined.
 #[export] Hint Resolve not_eq_S : core.
 
 (** TODO: keep or remove? *)
-Definition IsSucc (n: nat) : Type :=
+Definition IsSucc (n: Nat) : Type :=
   match n with
   | O => False
   | S p => True
@@ -232,41 +232,41 @@ Definition IsSucc (n: nat) : Type :=
 
 (** Zero is not the successor of a number *)
 
-Theorem not_eq_O_S : forall n:nat, 0 <> S n.
+Theorem not_eq_O_S : forall n:Nat, 0 <> S n.
 Proof.
   discriminate.
 Defined.
 #[export] Hint Resolve not_eq_O_S : core.
 
-Theorem not_eq_n_Sn : forall n:nat, n <> S n.
+Theorem not_eq_n_Sn : forall n:Nat, n <> S n.
 Proof.
   induction n; auto.
 Defined.
 #[export] Hint Resolve not_eq_n_Sn : core.
 
 Local Definition ap011_add := @ap011 _ _ _ add.
-Local Definition ap011_nat := @ap011 nat nat.
+Local Definition ap011_nat := @ap011 Nat Nat.
 #[export] Hint Resolve ap011_add : core.
 #[export] Hint Resolve ap011_nat : core.
 
-Lemma add_n_O : forall (n : nat), n = n + 0.
+Lemma add_n_O : forall (n : Nat), n = n + 0.
 Proof.
   induction n; simpl; auto.
 Defined.
 #[export] Hint Resolve add_n_O : core.
 
-Lemma add_O_n : forall (n : nat), 0 + n = n.
+Lemma add_O_n : forall (n : Nat), 0 + n = n.
 Proof.
   auto.
 Defined.
 
-Lemma add_n_Sm : forall n m:nat, S (n + m) = n + S m.
+Lemma add_n_Sm : forall n m:Nat, S (n + m) = n + S m.
 Proof.
   intros n m; induction n; simpl; auto.
 Defined.
 #[export] Hint Resolve add_n_Sm: core.
 
-Lemma add_Sn_m : forall n m:nat, S n + m = S (n + m).
+Lemma add_Sn_m : forall n m:Nat, S n + m = S (n + m).
 Proof.
   auto.
 Defined.
@@ -276,13 +276,13 @@ Defined.
 Local Definition ap011_mul := @ap011 _ _ _  mul.
 #[export] Hint Resolve ap011_mul : core.
 
-Lemma mul_n_O : forall n:nat, 0 = n * 0.
+Lemma mul_n_O : forall n:Nat, 0 = n * 0.
 Proof.
   induction n; simpl; auto.
 Defined.
 #[export] Hint Resolve mul_n_O : core.
 
-Lemma mul_n_Sm : forall n m:nat, n * m + n = n * S m.
+Lemma mul_n_Sm : forall n m:Nat, n * m + n = n * S m.
 Proof.
   intros; induction n as [| p H]; simpl; auto.
   destruct H; rewrite <- add_n_Sm; apply ap.
@@ -299,7 +299,7 @@ Notation mul_succ_r_reverse := mul_n_Sm (only parsing).
 
 (** *** Boolean equality and its properties *)
 
-Fixpoint code_nat (m n : nat) {struct m} : DHProp :=
+Fixpoint code_nat (m n : Nat) {struct m} : DHProp :=
   match m, n with
   | 0, 0 => True
   | m'.+1, n'.+1 => code_nat m' n'
@@ -336,16 +336,16 @@ Defined.
 Definition equiv_path_nat {n m} : (n =n m) <~> (n = m)
   := Build_Equiv _ _ (@path_nat n m) _.
 
-(** Thus [nat] has decidable paths *)
-Global Instance decidable_paths_nat : DecidablePaths nat
+(** Thus [Nat] has decidable paths *)
+Global Instance decidable_paths_nat : DecidablePaths Nat
   := fun n m => decidable_equiv _ (@path_nat n m) _.
 
 (** And is therefore a HSet *)
-Global Instance hset_nat : IsHSet nat := _.
+Global Instance hset_nat : IsHSet Nat := _.
 
 (** ** Inequality of natural numbers *)
 
-Inductive leq (n : nat) : nat -> Type :=
+Inductive leq (n : Nat) : Nat -> Type :=
 | leq_n : leq n n
 | leq_S : forall m, leq n m -> leq n (S m).
 
@@ -559,10 +559,10 @@ Notation "x < y <= z"  := (x < y  /\ y <= z) : nat_scope.
 
 (** Principle of double induction *)
 
-Theorem nat_double_ind (R : nat -> nat -> Type)
+Theorem nat_double_ind (R : Nat -> Nat -> Type)
   (H1 : forall n, R 0 n) (H2 : forall n, R (S n) 0)
   (H3 : forall n m, R n m -> R (S n) (S m))
-  : forall n m:nat, R n m.
+  : forall n m:Nat, R n m.
 Proof.
   induction n; auto.
   destruct m; auto.
@@ -607,7 +607,7 @@ Proof.
   cbn; by apply ap_S, IHm, leq_S_n.
 Defined.
 
-Theorem max_r : forall n m : nat, n <= m -> max n m = m.
+Theorem max_r : forall n m : Nat, n <= m -> max n m = m.
 Proof.
   intros; rewrite max_comm; by apply max_l.
 Defined.
@@ -617,7 +617,7 @@ Proof.
   induction n; destruct m; cbn; auto.
 Defined. 
 
-Theorem min_l : forall n m : nat, n <= m -> min n m = n.
+Theorem min_l : forall n m : Nat, n <= m -> min n m = n.
 Proof.
   intros n m; revert m; induction n; auto.
   intros [] p.
@@ -625,14 +625,14 @@ Proof.
   cbn; by apply ap_S, IHn, leq_S_n.
 Defined.
 
-Theorem min_r : forall n m : nat, m <= n -> min n m = m.
+Theorem min_r : forall n m : Nat, m <= n -> min n m = m.
 Proof.
   intros; rewrite min_comm; by apply min_l.
 Defined.
 
 (** [n]th iteration of the function [f] *)
 
-Fixpoint nat_iter (n:nat) {A} (f:A->A) (x:A) : A :=
+Fixpoint nat_iter (n:Nat) {A} (f:A->A) (x:A) : A :=
   match n with
     | O => x
     | S n' => f (nat_iter n' f x)
@@ -645,7 +645,7 @@ Proof.
 Defined.
 
 Theorem nat_iter_add :
-  forall (n m:nat) {A} (f:A -> A) (x:A),
+  forall (n m:Nat) {A} (f:A -> A) (x:A),
     nat_iter (n + m) f x = nat_iter n f (nat_iter m f x).
 Proof.
   induction n; intros; simpl; rewrite ?IHn; trivial.
@@ -653,7 +653,7 @@ Defined.
 
 (** Preservation of invariants : if [f : A -> A] preserves the invariant [Inv], then the iterates of [f] also preserve it. *)
 
-Theorem nat_iter_invariant (n : nat) {A} (f : A -> A) (P : A -> Type)
+Theorem nat_iter_invariant (n : Nat) {A} (f : A -> A) (P : A -> Type)
   : (forall x, P x -> P (f x)) -> forall x, P x -> P (nat_iter n f x).
 Proof.
   revert n A f P.
@@ -664,21 +664,21 @@ Defined.
 
 (** ** Arithmetic *)
 
-Lemma nat_add_n_O : forall n:nat, n = n + 0.
+Lemma nat_add_n_O : forall n:Nat, n = n + 0.
 Proof.
   induction n.
   - reflexivity.
   - simpl; apply ap; assumption.
 Defined.
 
-Lemma nat_add_n_Sm : forall n m:nat, (n + m).+1 = n + m.+1.
+Lemma nat_add_n_Sm : forall n m:Nat, (n + m).+1 = n + m.+1.
 Proof.
   intros n m; induction n; simpl.
   - reflexivity.
   - apply ap; assumption.
 Defined.
 
-Definition nat_add_comm (n m : nat) : n + m = m + n.
+Definition nat_add_comm (n m : Nat) : n + m = m + n.
 Proof.
   revert m; induction n as [|n IH]; intros m; simpl.
   - refine (nat_add_n_O m).
@@ -689,7 +689,7 @@ Defined.
 
 (** ** Exponentiation *)
 
-Fixpoint nat_exp (n m : nat) : nat
+Fixpoint nat_exp (n m : Nat) : Nat
   := match m with
        | 0 => 1
        | S m => nat_exp n m * n
@@ -697,7 +697,7 @@ Fixpoint nat_exp (n m : nat) : nat
 
 (** ** Factorials *)
 
-Fixpoint factorial (n : nat) : nat
+Fixpoint factorial (n : Nat) : Nat
   := match n with
        | 0 => 1
        | S n => S n * factorial n

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -22,7 +22,7 @@ Global Instance hasaddition_maxsort : HasAddition MaxSort
 
 Global Instance hasaddition_ordsort : HasAddition OrdSort
   := { empty_options := idmap ;
-       sum_options := fun _ _ _ _ f g => sum_ind _ f g }.
+       sum_options := fun _ _ _ _ f g => Sum_ind _ f g }.
 
 Global Instance hasaddition_decsort : HasAddition DecSort.
 Proof.
@@ -67,11 +67,11 @@ Section Addition.
                 _ _ _ _ _).
       - intros L' R' ? yL yR ycut x_plus_yL x_plus_yR x_plus_yL_lt_yR.
         pose (L'' := L + L').  pose (R'' := R + R').
-        pose (zL := sum_ind (fun _ => No)
+        pose (zL := Sum_ind (fun _ => No)
                             (fun l => (xL_plus l).1 {{ yL | yR // ycut }})
                             (fun l => (x_plus_yL l).1)
                     : L'' -> No).
-        pose (zR := sum_ind (fun _ => No)
+        pose (zR := Sum_ind (fun _ => No)
                             (fun r => (xR_plus r).1 {{ yL | yR // ycut }})
                             (fun r => (x_plus_yR r).1)
                     : R'' -> No).
@@ -133,11 +133,11 @@ Section Addition.
                (ycut : forall (l : L') (r : R'), yL l < yR r)
     : let L'' := L + L' in
       let R'' := R + R' in
-      let zL := sum_ind (fun _ => No)
+      let zL := Sum_ind (fun _ => No)
                         (fun l => (xL_plus l).1 {{ yL | yR // ycut }})
                         (fun l => (plus_inner.1 (yL l)).1)
                 : L'' -> No in
-      let zR := sum_ind (fun _ => No)
+      let zR := Sum_ind (fun _ => No)
                         (fun r => (xR_plus r).1 {{ yL | yR // ycut }})
                         (fun r => (plus_inner.1 (yR r)).1)
                 : R'' -> No in
@@ -262,10 +262,10 @@ Section Addition.
     let R'' := (R + R')%type in
     let x := {{ xL | xR // xcut }} in
     let y := {{ yL | yR // ycut }} in
-    let zL := sum_ind (fun _ => No)
+    let zL := Sum_ind (fun _ => No)
                       (fun l => (xL l) + y) (fun l => x + (yL l))
               : L'' -> No in
-    let zR := sum_ind (fun _ => No)
+    let zR := Sum_ind (fun _ => No)
                       (fun r => (xR r) + y) (fun r => x + (yR r))
               : R'' -> No in
     let Sz := sum_options L R L' R' _ _ in
@@ -309,7 +309,7 @@ Section Addition.
              let ef' := (eval hnf in ef) in
              progress change ef with ef'
            end;
-    repeat cbn [sum_ind];
+    repeat cbn [Sum_ind];
     (* rewrite with induction hypotheses from [repeat_No_ind_hprop] and [do_plus_cut] *)
     repeat match goal with
            | [ |- ?x = ?x ] => reflexivity
@@ -362,14 +362,14 @@ Section Addition.
     rewrite p; clear p;
     do_plus_cut.
     apply path_No.
-    - apply le_lr; [ intros [l|r]; cbn [sum_ind] | intros [] ].
+    - apply le_lr; [ intros [l|r]; cbn [Sum_ind] | intros [] ].
       + unfold zero in IHL; rewrite <- (IHL l); clear IHL.
         apply plus_lt_r.
         refine (lt_ropt _ _ _ l).
       + unfold zero in IHR; rewrite <- (IHR r); clear IHR.
         apply plus_lt_l.
         refine (lt_ropt _ _ _ r).
-    - apply le_lr; [ intros [] | intros [r|l] ]; cbn [sum_ind].
+    - apply le_lr; [ intros [] | intros [r|l] ]; cbn [Sum_ind].
       + unfold zero in IHR; rewrite <- (IHR r); clear IHR.
         apply plus_lt_r.
         refine (lt_lopt _ _ _ r).

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1103,17 +1103,17 @@ Proof.
   intros L R s xL xR xcut IHL IHR.
   pose (uLR := Unit + (L + R)).
   assert (Decidable uLR) by exact (inl (inl tt)).
-  pose (xLR := sum_ind _ (fun _ => zero) (sum_ind (fun _ => DecNo) (fun l => (IHL l).1) (fun r => (IHR r).1)) : uLR -> DecNo).
+  pose (xLR := Sum_ind _ (fun _ => zero) (Sum_ind (fun _ => DecNo) (fun l => (IHL l).1) (fun r => (IHR r).1)) : uLR -> DecNo).
   pose (z := {{ xLR | Empty_rec // rempty_cut }}).
   pose (z' := {{ unit_name z | Empty_rec // rempty_cut }}).
   pose (y := {{ Empty_rec | xLR // lempty_cut }}).
   pose (y' := {{ Empty_rec | unit_name y // lempty_cut }} ).
   pose (L' := Unit + L).
   assert (Decidable L') by exact (inl (inl tt)).
-  pose (wL := sum_ind _ (fun _ => y') (fun l => (IHL l).1) : L' -> DecNo).
+  pose (wL := Sum_ind _ (fun _ => y') (fun l => (IHL l).1) : L' -> DecNo).
   pose (R' := Unit + R).
   assert (Decidable R') by exact (inl (inl tt)).
-  pose (wR := sum_ind _ (fun _ => z') (fun r => (IHR r).1) : R' -> DecNo).
+  pose (wR := Sum_ind _ (fun _ => z') (fun r => (IHR r).1) : R' -> DecNo).
   assert (wcut : forall l r, wL l < wR r).
   { intros [[]|l] [[]|r]; cbn.
     - transitivity y.

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -370,31 +370,31 @@ Fixpoint pos_of_uint_acc (d : Decimal.uint) (acc : Pos) :=
   | Decimal.D9 l => pos_of_uint_acc l (pos_add 1~0~0~1 (pos_mul ten acc))
   end.
 
-Fixpoint pos_of_uint (d : Decimal.uint) : option Pos :=
+Fixpoint pos_of_uint (d : Decimal.uint) : Option Pos :=
   match d with
-    | Decimal.Nil => None
+    | Decimal.Nil => none
     | Decimal.D0 l => pos_of_uint l
-    | Decimal.D1 l => Some (pos_of_uint_acc l 1)
-    | Decimal.D2 l => Some (pos_of_uint_acc l 1~0)
-    | Decimal.D3 l => Some (pos_of_uint_acc l 1~1)
-    | Decimal.D4 l => Some (pos_of_uint_acc l 1~0~0)
-    | Decimal.D5 l => Some (pos_of_uint_acc l 1~0~1)
-    | Decimal.D6 l => Some (pos_of_uint_acc l 1~1~0)
-    | Decimal.D7 l => Some (pos_of_uint_acc l 1~1~1)
-    | Decimal.D8 l => Some (pos_of_uint_acc l 1~0~0~0)
-    | Decimal.D9 l => Some (pos_of_uint_acc l 1~0~0~1)
+    | Decimal.D1 l => some (pos_of_uint_acc l 1)
+    | Decimal.D2 l => some (pos_of_uint_acc l 1~0)
+    | Decimal.D3 l => some (pos_of_uint_acc l 1~1)
+    | Decimal.D4 l => some (pos_of_uint_acc l 1~0~0)
+    | Decimal.D5 l => some (pos_of_uint_acc l 1~0~1)
+    | Decimal.D6 l => some (pos_of_uint_acc l 1~1~0)
+    | Decimal.D7 l => some (pos_of_uint_acc l 1~1~1)
+    | Decimal.D8 l => some (pos_of_uint_acc l 1~0~0~0)
+    | Decimal.D9 l => some (pos_of_uint_acc l 1~0~0~1)
   end.
 
-Definition pos_of_decimal_int (d:Decimal.int) : option Pos :=
+Definition pos_of_decimal_int (d:Decimal.int) : Option Pos :=
   match d with
   | Decimal.Pos d => pos_of_uint d
-  | Decimal.Neg _ => None
+  | Decimal.Neg _ => none
   end.
 
-Definition pos_of_number_uint (d:Numeral.int) : option Pos :=
+Definition pos_of_number_uint (d:Numeral.int) : Option Pos :=
   match d with
   | Numeral.IntDec d => pos_of_decimal_int d
-  | Numeral.IntHex _ => None
+  | Numeral.IntHex _ => none
   end.
 
 Fixpoint pos_to_little_uint p :=

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -306,7 +306,7 @@ Definition pos_div2_up p :=
 
 (** ** Number of digits in a positive number *)
 
-Fixpoint nat_pos_size p : nat :=
+Fixpoint nat_pos_size p : Nat :=
   match p with
     | 1 => S O
     | p~1 => S (nat_pos_size p)
@@ -336,7 +336,7 @@ Definition pos_iter_op {A} (op : A -> A -> A)
 
 (** A version preserving positive numbers, and sending 0 to 1. *)
 
-Fixpoint pos_of_nat (n : nat) : Pos :=
+Fixpoint pos_of_nat (n : Nat) : Pos :=
  match n with
    | O => 1
    | S O => 1
@@ -345,7 +345,7 @@ Fixpoint pos_of_nat (n : nat) : Pos :=
 
 (* Another version that converts [n] into [n+1] *)
 
-Fixpoint pos_of_succ_nat (n : nat) : Pos :=
+Fixpoint pos_of_succ_nat (n : Nat) : Pos :=
   match n with
     | O => 1
     | S x => pos_succ (pos_of_succ_nat x)

--- a/theories/Spaces/Spheres.v
+++ b/theories/Spaces/Spheres.v
@@ -25,7 +25,7 @@ Fixpoint Sphere (n : trunc_index)
      end.
 
 (** ** Pointed sphere for non-negative dimensions *)
-Fixpoint psphere (n : nat) : pType
+Fixpoint psphere (n : Nat) : pType
   := match n with
       | O => Build_pType (Susp Empty) North
       | S n' => psusp (psphere n')

--- a/theories/Spaces/Torus/TorusEquivCircles.v
+++ b/theories/Spaces/Torus/TorusEquivCircles.v
@@ -148,7 +148,7 @@ Section TorusEquivCircle.
   (* We now prove t2c is a retraction of c2t *)
   Definition c2t2c : t2c o c2t == idmap.
   Proof.
-    rapply prod_ind.
+    rapply Prod_ind.
     (* Start with double circle induction *)
     srefine (Circle_ind_dp _ (Circle_ind_dp _ 1 _) _).
     (* Change the second loop case into a square and shelve *)

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -14,7 +14,7 @@ Local Open Scope pointed_scope.
 (** ** Basic Definitions of Spectra *)
 
 Record Prespectrum :=
-  { deloop :> nat -> pType
+  { deloop :> Nat -> pType
     ; glue : forall n, deloop n ->* loops (deloop (n .+1)) }.
 
 Class IsSpectrum (E : Prespectrum) :=

--- a/theories/Tactics/EquivalenceInduction.v
+++ b/theories/Tactics/EquivalenceInduction.v
@@ -94,7 +94,7 @@ Section prod.
                   idpath)).
   Defined.
 
-  Global Instance: @respects_equivalence_db _ _ (@prod) (@prod_respects_equivalenceL) := tt.
+  Global Instance: @respects_equivalence_db _ _ (@Prod) (@prod_respects_equivalenceL) := tt.
 End prod.
 
 (** A tactic to solve the identity-preservation part of equivalence-respectfulness. *)

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -1,7 +1,7 @@
 Require Import HoTT.
 
 Fail Check Type0 : Type0.
-Check Susp nat : Type0.
+Check Susp Nat : Type0.
 Fail Check Susp Type0 : Type0.
 
 Fail Check (fun (P : interval -> Type) (a : P Interval.zero) (b : P Interval.one)
@@ -9,8 +9,8 @@ Fail Check (fun (P : interval -> Type) (a : P Interval.zero) (b : P Interval.one
             => idpath : interval_ind P a b p = interval_rect P a b p').
 
 Local Open Scope nat_scope.
-Fail Check Lift nat : Type0.
-Check 1 : Lift nat.
+Fail Check Lift Nat : Type0.
+Check 1 : Lift Nat.
 
 Check lift'@{i j}.
 Check lower'@{i j}.
@@ -26,10 +26,10 @@ Check ({ l : Unit & { n : Unit & Unit }}).
 
 (** Test 1 from issue #754 *)
 Module Issue754_1.
-  Inductive nat : Type1 :=
-  | O : nat
-  | S : nat -> nat.
-  Fixpoint code_nat (m n : nat) {struct m} : DProp.DHProp :=
+  Inductive Nat : Type1 :=
+  | O : Nat
+  | S : Nat -> Nat.
+  Fixpoint code_nat (m n : Nat) {struct m} : DProp.DHProp :=
     match m with
       | O => match n with
                | O => DProp.True
@@ -44,12 +44,12 @@ Module Issue754_1.
   Local Set Warnings Append "-notation-overridden".
   Notation "x =n y" := (code_nat x y) : nat_scope.
   Local Set Warnings Append "notation-overridden".
-  Bind Scope nat_scope with nat.
+  Bind Scope nat_scope with Nat.
   Axiom equiv_path_nat :
-    forall n m : nat,
+    forall n m : Nat,
       Trunc.trunctype_type (DProp.dhprop_hprop (n =n m)) <~> n = m.
 
-  Definition nat_discr `{Funext} {n: nat}: O <> S n.
+  Definition nat_discr `{Funext} {n: Nat}: O <> S n.
   Proof.
     intro H'.
     equiv_induction (@equiv_path_nat O (S n)).
@@ -77,12 +77,12 @@ End Issue_1358.
 
 Module Issue_973.
 
-  Inductive vec (A : Type) : nat -> Type :=
+  Inductive vec (A : Type) : Nat -> Type :=
   | nil : vec A 0
-  | cons : forall n : nat, A -> vec A n -> vec A (S n).
+  | cons : forall n : Nat, A -> vec A n -> vec A (S n).
 (*   Arguments nil [A]. *)
 
-  Definition hd (A : Type) (n : nat) (v : vec A (S n)) : A :=
+  Definition hd (A : Type) (n : Nat) (v : vec A (S n)) : A :=
   match v in (vec _ (S n)) return A with
   | cons _ h _ => h
   end.
@@ -106,12 +106,12 @@ Module PR_1382.
   Goal O = S O -> Unit.
   intros H. Ltac g x := discriminate x. g H. Qed.
 
-  Goal (forall x y : nat, x = y -> x = S y) -> Unit.
+  Goal (forall x y : Nat, x = y -> x = S y) -> Unit.
   intros.
   try discriminate (H O) || exact tt.
   Qed.
 
-  Goal (forall x y : nat, x = y -> x = S y) -> Unit.
+  Goal (forall x y : Nat, x = y -> x = S y) -> Unit.
   intros H. ediscriminate (H O). instantiate (1:=O). Abort.
 
   (* Check discriminate on types with local definitions *)

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -7,8 +7,8 @@ Local Open Scope path_scope.
 
 Generalizable Variables X A B f g n.
 
-Scheme prod_ind := Induction for prod Sort Type.
-Arguments prod_ind {A B} P f p.
+Scheme Prod_ind := Induction for Prod Sort Type.
+Arguments Prod_ind {A B} P f p.
 
 (** ** Unpacking *)
 
@@ -315,10 +315,10 @@ Defined.
 
 (* First the positive universal property. *)
 Global Instance isequiv_prod_ind `(P : A * B -> Type)
-: IsEquiv (prod_ind P) | 0
+: IsEquiv (Prod_ind P) | 0
   := Build_IsEquiv
        _ _
-       (prod_ind P)
+       (Prod_ind P)
        (fun f x y => f (x, y))
        (fun _ => 1)
        (fun _ => 1)
@@ -326,7 +326,7 @@ Global Instance isequiv_prod_ind `(P : A * B -> Type)
 
 Definition equiv_prod_ind `(P : A * B -> Type)
   : (forall (a : A) (b : B), P (a, b)) <~> (forall p : A * B, P p)
-  := Build_Equiv _ _ (prod_ind P) _.
+  := Build_Equiv _ _ (Prod_ind P) _.
 
 (* The non-dependent version, which is a special case, is the currying equivalence. *)
 Definition equiv_uncurry (A B C : Type)

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -11,8 +11,8 @@ Local Open Scope path_scope.
 
 Generalizable Variables X A B f g n.
 
-Scheme sum_ind := Induction for sum Sort Type.
-Arguments sum_ind {A B} P f g s : rename.
+Scheme Sum_ind := Induction for Sum Sort Type.
+Arguments Sum_ind {A B} P f g s : rename.
 
 (** ** CoUnpacking *)
 
@@ -784,7 +784,7 @@ Definition decompose_r {A B C} (f : C -> A + B) : Type
 Definition equiv_decompose {A B C} (f : C -> A + B)
 : decompose_l f + decompose_r f <~> C.
 Proof.
-  simple refine (equiv_adjointify (sum_ind (fun _ => C) pr1 pr1) _ _ _).
+  simple refine (equiv_adjointify (Sum_ind (fun _ => C) pr1 pr1) _ _ _).
   - intros c; destruct (is_inl_or_is_inr (f c));
     [ left | right ]; exists c; assumption.
   - intros c; destruct (is_inl_or_is_inr (f c)); reflexivity.
@@ -887,7 +887,7 @@ Definition equiv_unfunctor_sum_contr_ll {A A' B B' : Type}
 Definition sum_ind_uncurried {A B} (P : A + B -> Type)
            (fg : (forall a, P (inl a)) * (forall b, P (inr b)))
 : forall s, P s
-  := @sum_ind A B P (fst fg) (snd fg).
+  := @Sum_ind A B P (fst fg) (snd fg).
 
 (* First the positive universal property.
    Doing this sort of thing without adjointifying will require very careful use of funext. *)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -170,7 +170,7 @@ Defined.
 
 (** [ap (prod A)] behaves like [equiv_functor_prod_l]. *)
 Definition ap_prod_l_path_universe `{Funext} A {B C} (f : B <~> C)
-  : equiv_path (A * B) (A * C) (ap (prod A) (path_universe f))
+  : equiv_path (A * B) (A * C) (ap (Prod A) (path_universe f))
     = equiv_functor_prod_l f.
 Proof.
   revert f. equiv_intro (equiv_path B C) f.


### PR DESCRIPTION
I've renamed the following:
 - `option` -> `Option`
 - `sum` -> `Sum`
 - `prod` -> `Prod`
 - `iff` -> `Iff`
 - `list` -> `List`
 - `nat` -> `Nat`
 
Together with their corresponding induction principles.

I've also fixed a typo in `Smash.v`.

These are all in separate commits so we can undo any we don't wish to do. I believe these are all worth doing. Notably, Dan raised concerns that `Nat` related lemmas may be harder to find, but this renaming doesn't affect the lemmas.

Fixes #1470