### PR TITLE
Fine-grained Require commands

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -1081,7 +1081,7 @@ Definition Book_7_2_2 := @HoTT.HSet.ishset_hrel_subpaths.
 (* ================================================== thm:path-truncation *)
 (** Theorem 7.3.12 *)
 
-Definition Book_7_3_12 := @HoTT.Truncations.Core.equiv_path_Tr.
+Definition Book_7_3_12 := @HoTT.Truncations.SeparatedTrunc.equiv_path_Tr.
 
 (* ================================================== lem:truncation-le *)
 (** Lemma 7.3.15 *)

--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -57,7 +57,8 @@
 
 *)
 
-From HoTT Require Import HoTT.
+From HoTT Require Import Basics Truncations Idempotents Spaces.Spheres Spaces.No
+     HIT.V HIT.Flattening Homotopy.WhiteheadsPrinciple.
 From HoTT Require Categories.
 From HoTT Require Import
   Metatheory.IntervalImpliesFunext

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -23,11 +23,10 @@
 
 *)
 
-From HoTT Require Import HoTT.
-From HoTT Require Import Spaces.Nat.
-From HoTT Require Import
-  Metatheory.Core
-  Metatheory.FunextVarieties.
+From HoTT Require Import Basics Types HProp HSet Projective
+     TruncType Truncations Modalities.Notnot Modalities.Open Modalities.Closed
+     BoundedSearch Equiv.BiInv Spaces.Nat Spaces.Torus.TorusEquivCircles
+     Metatheory.Core Metatheory.FunextVarieties.
 
 Local Open Scope nat_scope.
 Local Open Scope type_scope.

--- a/theories/Algebra/AbGroups.v
+++ b/theories/Algebra/AbGroups.v
@@ -1,5 +1,7 @@
 (** Theory *)
 
+Require Export HoTT.Algebra.Groups.
+
 Require Export HoTT.Algebra.AbGroups.AbelianGroup.
 Require Export HoTT.Algebra.AbGroups.Abelianization.
 Require Export HoTT.Algebra.AbGroups.AbPullback.

--- a/theories/Algebra/AbGroups.v
+++ b/theories/Algebra/AbGroups.v
@@ -4,9 +4,10 @@ Require Export HoTT.Algebra.AbGroups.AbelianGroup.
 Require Export HoTT.Algebra.AbGroups.Abelianization.
 Require Export HoTT.Algebra.AbGroups.AbPullback.
 Require Export HoTT.Algebra.AbGroups.AbPushout.
-Require Export HoTT.Algebra.AbGroups.AbSES.
 Require Export HoTT.Algebra.AbGroups.Biproduct.
 Require Export HoTT.Algebra.AbGroups.AbHom.
+
+(* We do not export AbGroups.AbSES here, to allow the build to be more parallel. *)
 
 (** Examples *)
 

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -1,4 +1,6 @@
 Require Import Limits.Pullback Cubical.PathSquare.
+Require Import Classes.interfaces.abstract_algebra.
+Require Export Algebra.Groups.GrpPullback.
 Require Import Algebra.AbGroups.AbelianGroup.
 Require Import WildCat.
 

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -1,4 +1,5 @@
 Require Import WildCat HSet.
+Require Export Algebra.Groups.Image Algebra.Groups.QuotientGroup.
 Require Import AbGroups.AbelianGroup AbGroups.Biproduct.
 
 Local Open Scope mc_scope.

--- a/theories/Algebra/AbGroups/AbSES/Core.v
+++ b/theories/Algebra/AbGroups/AbSES/Core.v
@@ -1,4 +1,5 @@
 Require Import HSet WildCat.
+Require Import Groups.Kernel Groups.Image Groups.QuotientGroup Groups.ShortExactSequence.
 Require Import AbGroups.AbelianGroup AbGroups.Biproduct AbGroups.AbHom.
 Require Import Homotopy.ExactSequence Pointed.
 

--- a/theories/Algebra/AbGroups/AbSES/PullbackFiberSequence.v
+++ b/theories/Algebra/AbGroups/AbSES/PullbackFiberSequence.v
@@ -1,6 +1,7 @@
 Require Import Basics HSet HFiber Limits.Pullback.
 Require Import WildCat Pointed Homotopy.ExactSequence.
-Require Import AbGroups.AbelianGroup AbGroups.Biproduct.
+Require Import Groups.QuotientGroup.
+Require Import AbGroups.AbelianGroup AbGroups.AbPullback AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.Pullback. 
 Require Import Modalities.Identity.
 

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -1,4 +1,6 @@
-Require Export Algebra.Groups.
+Require Export Algebra.Groups.Group.
+Require Export Algebra.Groups.Subgroup.
+Require Import Algebra.Groups.QuotientGroup.
 Require Import WildCat.
 
 Local Set Polymorphic Inductive Cumulativity.

--- a/theories/Basics.v
+++ b/theories/Basics.v
@@ -1,4 +1,3 @@
-Require Export Basics.Notations.
 Require Export Basics.Overture.
 Require Export Basics.UniverseLevel.
 Require Export Basics.PathGroupoids.
@@ -7,6 +6,7 @@ Require Export Basics.Equivalences.
 Require Export Basics.Trunc.
 Require Export Basics.Decidable.
 Require Export Basics.Utf8.
+Require Export Basics.Notations.
 Require Export Basics.Tactics.
 
 Require Export Basics.Nat.

--- a/theories/Basics/Utf8.v
+++ b/theories/Basics/Utf8.v
@@ -1,5 +1,3 @@
-Require Export Basics.Notations.
-
 Reserved Notation "'∀'  x .. y , P"
   (at level 200, x binder, y binder, right associativity).
 Reserved Notation "'∃'  x .. y , P"

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -1,5 +1,5 @@
 Require Import HoTT.Basics HoTT.Types.
-Require Import HoTT.Truncations.
+Require Import HoTT.Truncations.Core.
 Require Import HoTT.Spaces.Nat.
 
 Section bounded_search.

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids.
 
 (** * Quotient of a graph *)
 

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -3,7 +3,7 @@ Require Import Types.
 Require Import HSet.
 Require Import TruncType.
 Require Import Colimits.GraphQuotient.
-Require Import Truncations.
+Require Import Truncations.Core Truncations.Connectedness.
 
 Local Open Scope path_scope.
 

--- a/theories/Constant.v
+++ b/theories/Constant.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import Extensions Factorization.
-Require Import HoTT.Truncations.
+Require Import Truncations.Core Modalities.Modality.
 
 Local Open Scope path_scope.
 Local Open Scope trunc_scope.

--- a/theories/DProp.v
+++ b/theories/DProp.v
@@ -4,7 +4,7 @@
 
 Require Import HoTT.Basics HoTT.Types.
 Require Import TruncType HProp.
-Require Import HoTT.Truncations.
+Require Import Truncations.Core Modalities.ReflectiveSubuniverse.
 
 Local Open Scope path_scope.
 

--- a/theories/Diagrams/CommutativeSquares.v
+++ b/theories/Diagrams/CommutativeSquares.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.PathGroupoids.
 
 (** * Comutative squares *)
 

--- a/theories/Diagrams/Graph.v
+++ b/theories/Diagrams/Graph.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture.
 
 (** * Graphs *)
 

--- a/theories/HIT/Interval.v
+++ b/theories/HIT/Interval.v
@@ -2,8 +2,9 @@
 
 (** * Theorems about the homotopical interval. *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.PathGroupoids.
 Require Import Types.Paths.
+
 Local Open Scope path_scope.
 
 

--- a/theories/HIT/SetCone.v
+++ b/theories/HIT/SetCone.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics.
 Require Import Colimits.Pushout.
-Require Import HoTT.Truncations.
+Require Import Truncations.Core.
 
 (** * Cones of HSets *)
 

--- a/theories/HIT/epi.v
+++ b/theories/HIT/epi.v
@@ -1,7 +1,7 @@
 Require Import Basics.
 Require Import Types.
 Require Import TruncType.
-Require Import Colimits.Pushout Truncations HIT.SetCone.
+Require Import Colimits.Pushout Truncations.Core Modalities.Modality HIT.SetCone.
 
 Local Open Scope path_scope.
 

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import HSet TruncType.
-Require Import Truncations.
+Require Import Truncations.Core Modalities.Modality.
 
 Local Open Scope path_scope.
 

--- a/theories/HIT/surjective_factor.v
+++ b/theories/HIT/surjective_factor.v
@@ -1,7 +1,7 @@
 Require Import
         HoTT.Types
         HoTT.Basics
-        HoTT.Truncations.
+        HoTT.Truncations.Core Modalities.Modality.
 
 (** Definition by factoring through a surjection. *)
 

--- a/theories/HIT/unique_choice.v
+++ b/theories/HIT/unique_choice.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Truncations.
+Require Import HoTT.Basics HoTT.Truncations.Core.
 
 Definition atmost1 X:=(forall x1 x2:X, (x1 = x2)).
 Definition atmost1P {X} (P:X->Type):=

--- a/theories/HSet.v
+++ b/theories/HSet.v
@@ -1,5 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
-Require Import Basics Types.
+Require Import Basics.
+Require Import Types.Sigma Types.Forall Types.Paths Types.Unit Types.Arrow.
 
 (** * H-Sets *)
 

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -132,6 +132,7 @@ Require Export HoTT.Algebra.ooGroup.
 Require Export HoTT.Algebra.Aut.
 Require Export HoTT.Algebra.ooAction.
 Require Export HoTT.Algebra.AbGroups.
+Require Export HoTT.Algebra.AbGroups.AbSES.
 Require Export HoTT.Algebra.Groups.
 Require Export HoTT.Algebra.Rings.
 Require Export HoTT.Algebra.Universal.Algebra.

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -2,7 +2,7 @@ Require Import Basics Types Cubical.
 Require Import NullHomotopy.
 Require Import Extensions.
 Require Import Colimits.Pushout.
-Require Import Truncations.
+Require Import Truncations.Core Truncations.Connectedness.
 
 Local Open Scope path_scope.
 

--- a/theories/Idempotents.v
+++ b/theories/Idempotents.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import HFiber Constant.
-Require Import HoTT.Truncations.
+Require Import Truncations.Core Modalities.Modality.
 Require Import PathAny.
 
 Local Open Scope nat_scope.

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import HFiber Limits.Pullback Factorization Truncations.
-Require Import Accessible Localization Descent Separated.
+Require Import HFiber Limits.Pullback Factorization Truncations.Core.
+Require Import Modality Accessible Localization Descent Separated.
 
 Local Open Scope path_scope.
 Local Open Scope subuniverse_scope.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -1,5 +1,5 @@
 Require Import HoTT.Basics HoTT.Types.
-Require Import HFiber Factorization HoTT.Truncations HProp.
+Require Import HFiber Factorization Truncations.Core Truncations.Connectedness HProp.
 Require Import Pointed.Core Pointed.pEquiv.
 Require Import WildCat.
 

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -1,7 +1,6 @@
 Require Import Basics Types HSet.
-Require Import Truncations.
-Require Import Modalities.Separated.
-Require Import Modalities.Identity.
+Require Import Truncations.Core Truncations.SeparatedTrunc.
+Require Import Modalities.Modality Modalities.Separated Modalities.Identity.
 Require Import Limits.Pullback.
 
 

--- a/theories/PropResizing/PropResizing.v
+++ b/theories/PropResizing/PropResizing.v
@@ -1,7 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 (** * Propositional resizing *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.Tactics Basics.Trunc.
+
 Local Open Scope path_scope.
 
 (** See the note by [Funext] in Overture.v regarding classes for axioms *)

--- a/theories/Spaces/Circle.v
+++ b/theories/Spaces/Circle.v
@@ -3,7 +3,7 @@ Require Import Basics Types.
 Require Import HSet.
 Require Import Spaces.Pos Spaces.Int.
 Require Import Colimits.Coeq.
-Require Import Truncations.
+Require Import Truncations.Core Truncations.Connectedness.
 Require Import Cubical.DPath.
 
 (** * Theorems about the [Circle]. *)

--- a/theories/Spaces/List.v
+++ b/theories/Spaces/List.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 
 Local Open Scope list_scope.
 

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import TruncType HSet.
-Require Import HoTT.Truncations.
+Require Import HoTT.Truncations.Core.
 
 Local Open Scope nat_scope.
 Local Open Scope path_scope.

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics Basics.Decidable.
 
 (* ** Binary Positive Integers *)
 

--- a/theories/Spaces/Pos/Spec.v
+++ b/theories/Spaces/Pos/Spec.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import Pos.Core.
 
 Local Open Scope positive_scope.

--- a/theories/Spaces/TwoSphere.v
+++ b/theories/Spaces/TwoSphere.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids.
 
 Local Open Scope path_scope.
 

--- a/theories/Tactics.v
+++ b/theories/Tactics.v
@@ -1,6 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import HoTT.Basics Types.Prod Types.Forall.
+Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Contractible Basics.Equivalences.
+Require Import Types.Prod Types.Forall.
 Require Export Tactics.BinderApply.
 
 (** * Extra tactics for homotopy type theory. *)

--- a/theories/Tactics/EquivalenceInduction.v
+++ b/theories/Tactics/EquivalenceInduction.v
@@ -1,5 +1,6 @@
 (** * Equivalence induction *)
-Require Import HoTT.Basics HoTT.Types.
+Require Import Basics.Overture Basics.Equivalences Basics.Tactics.
+Require Import Types.Equiv Types.Prod Types.Forall Types.Sigma Types.Universe.
 
 (** We define typeclasses and tactics for doing equivalence induction. *)
 

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -1,5 +1,6 @@
 From Coq Require Init.Tactics.
-Require Import HoTT.
+From HoTT Require Import Basics Types DProp Pointed WildCat WildCat.SetoidRewrite
+     Homotopy.Suspension Tactics.EquivalenceInduction.
 
 Fail Check Type0 : Type0.
 Check Susp nat : Type0.
@@ -125,7 +126,6 @@ Module PR_1382.
 End PR_1382.
 
 
-Require Import WildCat.SetoidRewrite.
 Section SetoidRewriteTests.
   Goal forall (A : Type) `(H : Is0Gpd A) (a b c : A),
       a $== b -> b $== c -> a $== c.

--- a/theories/Truncations.v
+++ b/theories/Truncations.v
@@ -1,2 +1,3 @@
 Require Export HoTT.Truncations.Core.
+Require Export HoTT.Truncations.SeparatedTrunc.
 Require Export HoTT.Truncations.Connectedness.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -7,7 +7,7 @@ Require Import Extensions.
 Require Import Factorization.
 Require Export Modalities.Modality.        (* [Export] since the actual definitions of connectednes appear there, in the generality of a modality. *)
 Require Import Modalities.Descent.
-Require Import Truncations.Core.
+Require Import Truncations.Core Truncations.SeparatedTrunc.
 
 Local Open Scope path_scope.
 Local Open Scope trunc_scope.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 
-Require Import Basics Types WildCat.
+Require Import Basics Types WildCat.Core WildCat.Universe.
 Require Import TruncType.
 Require Import Modalities.Modality.
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -2,7 +2,7 @@
 
 Require Import Basics Types WildCat.
 Require Import TruncType.
-Require Import Modalities.Modality Modalities.Descent.
+Require Import Modalities.Modality.
 
 (** * Truncations of types, in all dimensions. *)
 
@@ -280,54 +280,5 @@ Proof.
   refine (Trunc_min m n _ oE equiv_transport (fun k => Tr k _) _ oE (Trunc_min n m _)^-1).
   apply trunc_index_min_swap.
 Defined.
-
-(** ** Separatedness and path-spaces of truncations *)
-
-Section SeparatedTrunc.
-
-Local Open Scope subuniverse_scope.
-
-(** The [n.+1]-truncation modality consists of the separated types for the [n]-truncation modality. *)
-Global Instance O_eq_Tr (n : trunc_index)
-  : Tr n.+1 <=> Sep (Tr n).
-Proof.
-  split; intros A A_inO.
-  - intros x y; exact _.
-  - exact _.
-Defined.
-
-(** It follows that [Tr n <<< Tr n.+1].  However, it is easier to prove this directly than to go through separatedness. *)
-Global Instance O_leq_Tr (n : trunc_index)
-  : Tr n <= Tr n.+1.
-Proof.
-  intros A ?; exact _.
-Defined.
-
-Global Instance O_strong_leq_Tr (n : trunc_index)
-  : Tr n << Tr n.+1.
-Proof.
-  srapply O_strong_leq_trans_l.
-Defined.
-
-(** For some reason, this causes typeclass search to spin. *)
-Local Instance O_lex_leq_Tr `{Univalence} (n : trunc_index)
-  : Tr n <<< Tr n.+1.
-Proof.
-  intros A; unshelve econstructor; intros P' P_inO;
-    pose (P := fun x => Build_TruncType n (P' x)).
-  - refine (Trunc_rec P).
-  - intros; simpl; exact _.
-  - intros; cbn. reflexivity.
-Defined.
-
-Definition path_Tr {n A} (x y : A)
-  : Tr n (x = y) -> (tr x = tr y :> Tr n.+1 A)
-  := path_OO (Tr n.+1) (Tr n) x y.
-
-Definition equiv_path_Tr `{Univalence} {n A} (x y : A)
-  : Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A)
-  := equiv_path_OO (Tr n.+1) (Tr n) x y.
-
-End SeparatedTrunc.
 
 (** If you are looking for a theorem about truncation, you may want to read the note "Finding Theorems" in "STYLE.md". *)

--- a/theories/Truncations/SeparatedTrunc.v
+++ b/theories/Truncations/SeparatedTrunc.v
@@ -1,0 +1,55 @@
+(* -*- mode: coq; mode: visual-line -*- *)
+
+Require Import Basics Types WildCat.
+Require Import TruncType.
+Require Import Truncations.Core Modalities.Modality Modalities.Descent.
+
+(** ** Separatedness and path-spaces of truncations *)
+
+Section SeparatedTrunc.
+
+Local Open Scope subuniverse_scope.
+
+(** The [n.+1]-truncation modality consists of the separated types for the [n]-truncation modality. *)
+Global Instance O_eq_Tr (n : trunc_index)
+  : Tr n.+1 <=> Sep (Tr n).
+Proof.
+  split; intros A A_inO.
+  - intros x y; exact _.
+  - exact _.
+Defined.
+
+(** It follows that [Tr n <<< Tr n.+1].  However, it is easier to prove this directly than to go through separatedness. *)
+Global Instance O_leq_Tr (n : trunc_index)
+  : Tr n <= Tr n.+1.
+Proof.
+  intros A ?; exact _.
+Defined.
+
+Global Instance O_strong_leq_Tr (n : trunc_index)
+  : Tr n << Tr n.+1.
+Proof.
+  srapply O_strong_leq_trans_l.
+Defined.
+
+(** For some reason, this causes typeclass search to spin. *)
+Local Instance O_lex_leq_Tr `{Univalence} (n : trunc_index)
+  : Tr n <<< Tr n.+1.
+Proof.
+  intros A; unshelve econstructor; intros P' P_inO;
+    pose (P := fun x => Build_TruncType n (P' x)).
+  - refine (Trunc_rec P).
+  - intros; simpl; exact _.
+  - intros; cbn. reflexivity.
+Defined.
+
+Definition path_Tr {n A} (x y : A)
+  : Tr n (x = y) -> (tr x = tr y :> Tr n.+1 A)
+  := path_OO (Tr n.+1) (Tr n) x y.
+
+Definition equiv_path_Tr `{Univalence} {n A} (x y : A)
+  : Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A)
+  := equiv_path_OO (Tr n.+1) (Tr n) x y.
+
+End SeparatedTrunc.
+

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Theorems about Non-dependent function types *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.PathGroupoids Basics.Decidable.
 Require Import Types.Forall.
 Local Open Scope path_scope.
 

--- a/theories/Types/Empty.v
+++ b/theories/Types/Empty.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Theorems about the empty type *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.Equivalences.
 Local Open Scope path_scope.
 
 (** ** Unpacking *)

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -1,7 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Theorems about dependent products *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids
+               Basics.Tactics Basics.Trunc Basics.Contractible.
 
 Local Open Scope path_scope.
 

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Theorems about path spaces *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids Basics.Tactics.
 
 Local Open Scope path_scope.
 

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -1,7 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Theorems about cartesian products *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids
+               Basics.Tactics Basics.Trunc Basics.Decidable.
 Require Import Types.Empty.
 Local Open Scope path_scope.
 

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 (** * Theorems about the unit type *)
 
-Require Import HoTT.Basics.
+Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids.
 Local Open Scope path_scope.
 
 Generalizable Variables A.

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -12,6 +12,8 @@ Require Export WildCat.Square.
 Require Export WildCat.PointedCat.
 Require Export WildCat.Bifunctor.
 
+(* If we Export WildCat.SetoidRewrite here, other files in the library don't build. *)
+
 (* Examples *)
 Require Export WildCat.Universe.
 Require Export WildCat.Paths.

--- a/theories/WildCat/Adjoint.v
+++ b/theories/WildCat/Adjoint.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Utf8 Basics.Overture Basics.Tactics Basics.Equivalences.
 Require Import WildCat.Core.
 Require Import WildCat.NatTrans.
 Require Import WildCat.Equiv.

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -1,4 +1,5 @@
-Require Import Basics Types.
+Require Import Basics.Overture Basics.Tactics.
+Require Import Types.Forall.
 Require Import WildCat.Core WildCat.Opposite WildCat.Universe WildCat.Prod.
 
 (** * Bifunctors between WildCats *)

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 
 (** * Wild categories, functors, and transformations *)
 

--- a/theories/WildCat/EmptyCat.v
+++ b/theories/WildCat/EmptyCat.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 
 (** Empty category *)

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Utf8 Basics.Overture Basics.Tactics Basics.Equivalences.
 Require Import WildCat.Core.
 
 (** We declare a scope for printing [CatEquiv] as [≅] *)

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.NatTrans.
 Require Import WildCat.Sigma.

--- a/theories/WildCat/Forall.v
+++ b/theories/WildCat/Forall.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 
 (** ** Indexed product of categories *)

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.Induced.

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -1,5 +1,5 @@
-Require Import Basics Types.
-
+Require Import Basics.Utf8 Basics.Overture Basics.Tactics.
+Require Import Types.Forall.
 Require Import WildCat.Core WildCat.Prod WildCat.Bifunctor
   WildCat.Equiv WildCat.NatTrans.
 

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.Square.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.NatTrans.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture.
 Require Import WildCat.Core.
 
 (** * Path groupoids as wild categories *)

--- a/theories/WildCat/PointedCat.v
+++ b/theories/WildCat/PointedCat.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import Types.Prod.

--- a/theories/WildCat/SetoidRewrite.v
+++ b/theories/WildCat/SetoidRewrite.v
@@ -2,7 +2,8 @@
 
 (* Init.Tactics contains the definition of the Coq stdlib typeclass_inferences database. It must be imported before Basics.Overture. *)
 From Coq Require Init.Tactics.
-Require Import Basics Types.Forall.
+Require Import Basics.Overture Basics.Tactics.
+Require Import Types.Forall.
 From Coq Require Setoids.Setoid.
 Import CMorphisms.ProperNotations.
 Require Import WildCat.Core WildCat.Bifunctor WildCat.Prod

--- a/theories/WildCat/Sigma.v
+++ b/theories/WildCat/Sigma.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 
 (** ** Indexed sum of categories *)

--- a/theories/WildCat/Square.v
+++ b/theories/WildCat/Square.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 

--- a/theories/WildCat/Sum.v
+++ b/theories/WildCat/Sum.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 
 (** ** Sum categories *)

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture.
 Require Import WildCat.Core.
 Require Import WildCat.NatTrans.
 

--- a/theories/WildCat/UnitCat.v
+++ b/theories/WildCat/UnitCat.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 
 (** Unit category *)

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics Basics.Equivalences.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.
+Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.Universe.


### PR DESCRIPTION
I put a wrapper around coqc to make note of which parts of the build were bottlenecks to parallelization, and then adjusted things to make this better.  In most cases, the adjustment was a slight change to `Require` commands, e.g. only Requiring some parts of Basics instead of all of it.  Overall, this PR allows me to build the whole library 15% faster with -j8 on an eight core machine.

Around 10% of that is just from the change that removes AbSES from AbGroups, since most users of AbGroups don't use AbSES, and AbSES is slow to build.

The other changes are smaller, but accumulate to give the remaining 5%.  I can undo some of them if people don't like something.  I think some of them will give more benefit with even more cores, but I haven't tested that.