### PR TITLE
fix the notation "(.* x )"

### DIFF
--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -102,16 +102,20 @@ Hint Extern 4 (Apart (Pos _)) => apply @sig_apart : typeclass_instances.
 
 (* Notations: *)
 Declare Scope mc_add_scope.
+Open Scope mc_add_scope.
 Infix "+" := sg_op : mc_add_scope.
 Notation "(+)" := sg_op (only parsing) : mc_add_scope.
 Notation "( x +)" := (sg_op x) (only parsing) : mc_add_scope.
 Notation "(+ x )" := (fun y => y + x) (only parsing) : mc_add_scope.
+Close Scope mc_add_scope.
 
 Declare Scope mc_mult_scope.
+Open Scope mc_mult_scope.
 Infix "*" := sg_op : mc_mult_scope.
 Notation "( x *.)" := (sg_op x) (only parsing) : mc_mult_scope.
 Notation "(.*.)" := sg_op (only parsing) : mc_mult_scope.
 Notation "(.* x )" := (fun y => y * x) (only parsing) : mc_mult_scope.
+Close Scope mc_mult_scope.
 
 Infix "+" := plus : mc_scope.
 Notation "(+)" := plus (only parsing) : mc_scope.

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -102,20 +102,16 @@ Hint Extern 4 (Apart (Pos _)) => apply @sig_apart : typeclass_instances.
 
 (* Notations: *)
 Declare Scope mc_add_scope.
-Open Scope mc_add_scope.
 Infix "+" := sg_op : mc_add_scope.
 Notation "(+)" := sg_op (only parsing) : mc_add_scope.
 Notation "( x +)" := (sg_op x) (only parsing) : mc_add_scope.
-Notation "(+ x )" := (fun y => y + x) (only parsing) : mc_add_scope.
-Close Scope mc_add_scope.
+Notation "(+ x )" := (fun y => sg_op y x) (only parsing) : mc_add_scope.
 
 Declare Scope mc_mult_scope.
-Open Scope mc_mult_scope.
 Infix "*" := sg_op : mc_mult_scope.
 Notation "( x *.)" := (sg_op x) (only parsing) : mc_mult_scope.
 Notation "(.*.)" := sg_op (only parsing) : mc_mult_scope.
-Notation "(.* x )" := (fun y => y * x) (only parsing) : mc_mult_scope.
-Close Scope mc_mult_scope.
+Notation "(.* x )" := (fun y => sg_op y x) (only parsing) : mc_mult_scope.
 
 Infix "+" := plus : mc_scope.
 Notation "(+)" := plus (only parsing) : mc_scope.


### PR DESCRIPTION
This commit fixes the following bug with the notation `(.* x)`, intended to be short for `fun y => sg_op y x`. Previously, the relevant scopes hadn't been opened, causing the notation to use the function `prod` instead of `sg_op`. This caused issues when used in combination with type_scope, in which `prod` refers to the product of types. One can verify the issue by running `Locate "(.* x )".` right after the notation has been defined on the master branch.

Opening the relevant scopes remedies the issue. (Another solution would be to write `sg_op` explicitly, but this solution is a bit more modular, and is probably the original intention.)
