### PR TITLE
Use pt and [X, x] notations, psusp, pjoin, G, etc.

### DIFF
--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -355,7 +355,7 @@ Proof.
 Defined.
 
 Definition pmap_abses_const {B' A' B A : AbGroup} : AbSES B A -->* AbSES B' A'
-  := Build_BasepointPreservingFunctor (const (point _)) (Id (point _)).
+  := Build_BasepointPreservingFunctor (const pt) (Id pt).
 
 Definition to_pointed `{Univalence} {B' A' B A : AbGroup}
   : (AbSES B A -->* AbSES B' A') -> (AbSES B A ->* AbSES B' A')

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -72,7 +72,7 @@ Proof.
 Defined.
 
 (** The pointed type of short exact sequences. *)
-Definition AbSES (B A : AbGroup) : pType := Build_pType (AbSES' B A) _.
+Definition AbSES (B A : AbGroup) : pType := [AbSES' B A, _].
 
 (** ** Paths in [AbSES B A] *)
 

--- a/theories/Algebra/AbSES/Pullback.v
+++ b/theories/Algebra/AbSES/Pullback.v
@@ -165,7 +165,7 @@ Proof.
 Defined.
 
 Definition abses_pullback_point' {A B B' : AbGroup} (f : B' $-> B)
-  : (abses_pullback f (point _)) $== (point (AbSES B' A)).
+  : (abses_pullback f pt) $== (point (AbSES B' A)).
 Proof.
   snrefine (_; (_, _)).
   - snrapply Build_GroupIsomorphism.
@@ -267,7 +267,7 @@ Defined.
 (** *** Pulling back along constant maps *)
 
 Lemma abses_pullback_const' `{Funext} {A B B' : AbGroup}
-  : const (point _) $=> (@abses_pullback A B B' grp_homo_const).
+  : const pt $=> (@abses_pullback A B B' grp_homo_const).
 Proof.
   intro E.
   simpl.
@@ -284,7 +284,7 @@ Proof.
 Defined.
 
 Definition abses_pullback_const `{Univalence} {A B B' : AbGroup}
-  : const (point _) == @abses_pullback A B B' grp_homo_const
+  : const pt == @abses_pullback A B B' grp_homo_const
   := fun x => (equiv_path_abses_iso (abses_pullback_const' x)).
 
 Lemma abses_pullback_pconst' `{Funext} {A B B' : AbGroup}

--- a/theories/Algebra/AbSES/PullbackFiberSequence.v
+++ b/theories/Algebra/AbSES/PullbackFiberSequence.v
@@ -5,6 +5,8 @@ Require Import AbGroups.AbelianGroup AbGroups.AbPullback AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.Pullback. 
 Require Import Modalities.Identity.
 
+Local Open Scope pointed_scope.
+
 (** * The fiber sequence induced by pulling back along a short exact sequence *)
 
 (** We show that pulling back along a short exact sequence [E : AbSES C B] produces a fiber sequence [AbSES C A -> AbSES E A -> AbSES B A]. The associated long exact sequence of homotopy groups recovers the usual (contravariant) six-term exact sequence of Ext groups.
@@ -15,7 +17,7 @@ We will prove the analog of exactness in terms of path data, and deduce the usua
 
 Definition abses_pullback_inclusion_transpose_subgroup `{Univalence} {A B E : AbGroup}
       (i : B $-> E) `{IsEmbedding i}
-      (F : AbSES E A) (p : abses_pullback i F $== point _)
+      (F : AbSES E A) (p : abses_pullback i F $== pt)
   : NormalSubgroup F.
 Proof.
   srapply (ab_image_embedding (grp_pullback_pr1 _ _ $o (grp_iso_inverse p.1) $o ab_biprod_inr)).
@@ -26,14 +28,14 @@ Defined.
 
 Definition abses_pullback_inclusion_transpose_endpoint' `{Univalence} {A B E : AbGroup}
            (i : B $-> E) `{IsEmbedding i}
-           (F : AbSES E A) (p : abses_pullback i F $== point _)
+           (F : AbSES E A) (p : abses_pullback i F $== pt)
   : AbGroup := QuotientAbGroup F (abses_pullback_inclusion_transpose_subgroup i F p).
 
 (** By [abses_from_inclusion] we get a short exact sequence [B -> F -> F/B] associated to the subgroup and quotient just above. *)
 
 Lemma abses_pullback_inclusion_transpose_beta `{Univalence} {A B E : AbGroup}
       (i : B $-> E) `{IsEmbedding i}
-      (F : AbSES E A) (p : abses_pullback i F $== point _)
+      (F : AbSES E A) (p : abses_pullback i F $== pt)
   : projection F $o (grp_pullback_pr1 (projection F) _ $o p^$.1 $o ab_biprod_inr) == i.
 Proof.
   rapply (conn_map_elim _ (ab_biprod_pr2 (A:=A))).
@@ -44,7 +46,7 @@ Defined.
 
 (** Short exact sequences in the fiber of [inclusion E] descend along [projection E]. *)
 Definition abses_pullback_trivial_preimage `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
   : AbSES C A.
 Proof.
   snrapply Build_AbSES.
@@ -124,7 +126,7 @@ Defined.
 (** That [abses_pullback_trivial_preimage E F p] pulls back to [F] is immediate from [abses_pullback_component1_id] and the following map. As such, we've shown that sequences which become trivial after pulling back along [inclusion E] are in the image of pullback along [projection E]. *)
 
 Definition abses_pullback_inclusion0_map' `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
   : AbSESMorphism F (abses_pullback_trivial_preimage E F p).
 Proof.
   srapply Build_AbSESMorphism.
@@ -139,7 +141,7 @@ Defined.
 
 (** The analog of [cxfib] induced by pullback in terms of path data. *)
 Definition cxfib' `{Funext} {A B C : AbGroup} (E : AbSES C B)
-  : AbSES C A -> graph_hfiber (abses_pullback (A:=A) (inclusion E)) (point _).
+  : AbSES C A -> graph_hfiber (abses_pullback (A:=A) (inclusion E)) pt.
 Proof.
   intro Y.
   exists (abses_pullback (projection E) Y).
@@ -150,7 +152,7 @@ Proof.
 Defined.
 
 Definition hfiber_cxfib' `{Funext} {A B C : AbGroup} (E : AbSES C B)
-           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
   := {Y : AbSES C A & hfiber_abses_path (cxfib' E Y) (F; p)}.
 
 (* This is just [idpath], but Coq takes too long to see that. *)
@@ -187,20 +189,20 @@ Defined.
 Transparent abses_pullback'.
 
 Definition equiv_hfiber_cxfib' `{Univalence} {A B C : AbGroup} {E : AbSES C B}
-           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
   : hfiber_cxfib' E F p <~> hfiber (cxfib (iscomplex_pullback_abses E))
-                  (equiv_hfiber_abses _ (point _) (F;p)).
+                  (equiv_hfiber_abses _ pt (F;p)).
 Proof.
   srapply equiv_functor_sigma_id; intro U; lazy beta.
   refine (_ oE equiv_hfiber_abses_pullback _ _ _).
-  refine (_ oE equiv_ap' (equiv_hfiber_abses _ (point _)) _ _).
+  refine (_ oE equiv_ap' (equiv_hfiber_abses _ pt) _ _).
   apply equiv_concat_l.
   apply eq_cxfib_cxfib'.
 Defined.
 
 (** The type of paths in [hfiber_cxfib'] in terms of path data. *)
 Definition path_hfiber_cxfib' `{Funext} {A B C : AbGroup} {E : AbSES C B}
-           {F : AbSES (middle E) A} {p : abses_pullback (inclusion E) F $== point _}
+           {F : AbSES (middle E) A} {p : abses_pullback (inclusion E) F $== pt}
            (X Y : hfiber_cxfib' (B:=B) E F p)
   : Type.
 Proof.
@@ -209,7 +211,7 @@ Proof.
 Defined.
 
 Definition transport_hfiber_abses_path_cxfib'_l `{Univalence} {A B C : AbGroup} {E : AbSES C B}
-           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
            (U V : hfiber_cxfib' E F p) (q : U.1 = V.1)
   : (transport (fun Y : AbSES C A => hfiber_abses_path (cxfib' E Y) (F; p)) q U.2).1
     = fmap (abses_pullback (projection E)) (equiv_path_abses_iso^-1 q^) $@ U.2.1.
@@ -222,7 +224,7 @@ Proof.
 Defined.
 
 Definition equiv_path_hfiber_cxfib' `{Univalence} {A B C : AbGroup} {E : AbSES C B}
-           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+           (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
            (U V : hfiber_cxfib' E F p)
   : path_hfiber_cxfib' U V <~> U = V.
 Proof.
@@ -244,7 +246,7 @@ Defined.
 
 (** The fibre of [cxfib'] over [(F;p)] is inhabited. *)
 Definition hfiber_cxfib'_inhabited `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
   : hfiber_cxfib' E F p.
 Proof.
   exists (abses_pullback_trivial_preimage E F p).
@@ -274,7 +276,7 @@ Defined.
 
 (** Given a point [(Y;Q)] in the fiber of [cxfib'] over [(F;p)] there is an induced map as follows. *)
 Local Definition hfiber_cxfib'_induced_map `{Funext} {A B C : AbGroup} (E : AbSES C B)
-      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
       (Y : hfiber_cxfib' E F p)
   : ab_biprod A B $-> abses_pullback (projection E) Y.1.
 Proof.
@@ -299,7 +301,7 @@ Proof.
 Defined.
 
 Lemma fmap_hfiber_abses_lemma `{Univalence} {A B B' : AbGroup} (f : B' $-> B)
-           (X Y : graph_hfiber (abses_pullback (A:=A) f) (point _)) (Q : hfiber_abses_path X Y)
+           (X Y : graph_hfiber (abses_pullback (A:=A) f) pt) (Q : hfiber_abses_path X Y)
   : fmap (abses_pullback f) Q.1^$ $o Y.2^$ $== X.2^$.
 Proof.
   generalize Q.
@@ -314,7 +316,7 @@ Proof.
 Defined.
 
 Lemma induced_map_eq `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
       (Y : hfiber_cxfib' E F p)
   : hfiber_cxfib'_induced_map E F p Y == abses_pullback_splits_induced_map' E Y.1.
 Proof.
@@ -327,7 +329,7 @@ Defined.
 
 (** Given another point [(Y,Q)] in the fibre of [cxfib'] over [(F;p)], we get path data in [AbSES C A]. *)
 Lemma hfiber_cxfib'_induced_path'0 `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
       (Y : hfiber_cxfib' E F p)
   : abses_pullback_trivial_preimage E F p $== Y.1.
 Proof.
@@ -352,7 +354,7 @@ Proof.
 Defined.
 
 Lemma hfiber_cxfib'_induced_path' `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
       (Y : hfiber_cxfib' E F p)
   : path_hfiber_cxfib' (hfiber_cxfib'_inhabited E F p) Y.
 Proof.
@@ -368,7 +370,7 @@ Defined.
 
 (** It follows that [hfiber_cxfib'] is contractible. *)
 Lemma contr_hfiber_cxfib' `{Univalence} {A B C : AbGroup} (E : AbSES C B)
-      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== point _)
+      (F : AbSES (middle E) A) (p : abses_pullback (inclusion E) F $== pt)
   : Contr (hfiber_cxfib' E F p).
 Proof.
   srapply Build_Contr.

--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -200,7 +200,7 @@ Proof.
 Defined.
 
 Definition abses_pushout_point' `{Univalence} {A A' B : AbGroup} (f : A $-> A')
-  : abses_pushout f (point (AbSES B A)) $== point _.
+  : abses_pushout f (point (AbSES B A)) $== pt.
 Proof.
   srapply abses_path_data_to_iso;
     srefine (_; (_,_)).
@@ -218,7 +218,7 @@ Proof.
 Defined.
 
 Definition abses_pushout_point `{Univalence} {A A' B : AbGroup} (f : A $-> A')
-  : abses_pushout f (point (AbSES B A)) = point _
+  : abses_pushout f (point (AbSES B A)) = pt
   := equiv_path_abses_iso (abses_pushout_point' f).
 
 Definition abses_pushout' `{Univalence} {A A' B : AbGroup} (f : A $-> A')

--- a/theories/Algebra/Aut.v
+++ b/theories/Algebra/Aut.v
@@ -3,9 +3,12 @@ Require Import Basics.
 Require Import Truncations.
 Require Import Algebra.ooGroup.
 Require Import Spaces.BAut.
+Require Import Pointed.Core.
+
+Local Open Scope pointed_scope.
 
 (** * Automorphism oo-Groups *)
 
 (** We define [Aut X] using the pointed, connected type [BAut X]. *)
 Definition Aut (X : Type) : ooGroup
-  := Build_ooGroup (Build_pType (BAut X) _) _.
+  := Build_ooGroup [BAut X, _] _.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -80,7 +80,7 @@ Global Instance ispointed_group (G : Group)
   : IsPointed G := @mon_unit G _.
 
 Definition ptype_group : Group -> pType
-  := fun G => Build_pType G _.
+  := fun G => [G, _].
 Coercion ptype_group : Group >-> pType.
 
 (** * Some basic properties of groups *)

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -41,9 +41,8 @@ Definition group_loops (X : pType)
 Proof.
   (* Work around https://coq.inria.fr/bugs/show_bug.cgi?id=4256 *)
   pose (x0 := point X);
-  pose (BG := (Build_pType
-               { x:X & merely (x = point X) }
-               (exist (fun x:X => merely (x = point X)) x0 (tr 1)))).
+  pose (BG := [{ x:X & merely (x = point X) },
+               exist (fun x:X => merely (x = point X)) x0 (tr 1)]).
   (** Using [cut] prevents Coq from looking for these facts with typeclass search, which is slow and (for some reason) introduces scads of extra universes. *)
   cut (IsConnected 0 BG).
   { exact (Build_ooGroup BG). }

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -40,9 +40,8 @@ Definition group_loops (X : pType)
   : ooGroup.
 Proof.
   (* Work around https://coq.inria.fr/bugs/show_bug.cgi?id=4256 *)
-  pose (x0 := point X);
-  pose (BG := [{ x:X & merely (x = point X) },
-               exist (fun x:X => merely (x = point X)) x0 (tr 1)]).
+  pose (BG := [{ x:X & merely (x = pt) },
+               exist (fun x:X => merely (x = pt)) pt (tr 1)]).
   (** Using [cut] prevents Coq from looking for these facts with typeclass search, which is slow and (for some reason) introduces scads of extra universes. *)
   cut (IsConnected 0 BG).
   { exact (Build_ooGroup BG). }

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -48,7 +48,7 @@ Proof.
   cut (IsConnected 0 BG).
   { exact (Build_ooGroup BG). }
   cut (IsSurjection (unit_name (point BG))).
-  { intros; refine (conn_pointed_type (point _)). }
+  { intros; refine (conn_pointed_type pt). }
   apply BuildIsSurjection; simpl; intros [x p].
   strip_truncations; apply tr; exists tt.
   apply path_sigma_hprop; simpl.

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -39,7 +39,6 @@ Coercion group_type : ooGroup >-> Sortclass.
 Definition group_loops (X : pType)
   : ooGroup.
 Proof.
-  (* Work around https://coq.inria.fr/bugs/show_bug.cgi?id=4256 *)
   pose (BG := [{ x:X & merely (x = pt) },
                exist (fun x:X => merely (x = pt)) pt (tr 1)]).
   (** Using [cut] prevents Coq from looking for these facts with typeclass search, which is slow and (for some reason) introduces scads of extra universes. *)

--- a/theories/Homotopy/Bouquet.v
+++ b/theories/Homotopy/Bouquet.v
@@ -22,7 +22,7 @@ Section AssumeUnivalence.
   Proof.
     rapply isconnected_susp.
     rapply contr_inhabited_hprop.
-    apply tr; exact (point _).
+    apply tr; exact pt.
   Defined.
 
   (** We can directly prove that it satisfies the desired equivalence together with naturality in the second argument. *)

--- a/theories/Homotopy/Bouquet.v
+++ b/theories/Homotopy/Bouquet.v
@@ -22,7 +22,7 @@ Section AssumeUnivalence.
   Proof.
     rapply isconnected_susp.
     rapply contr_inhabited_hprop.
-    apply tr; exact pt.
+    exact (tr pt).
   Defined.
 
   (** We can directly prove that it satisfies the desired equivalence together with naturality in the second argument. *)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -85,7 +85,7 @@ Defined.
 Class CayleyDicksonImaginaroid (A : Type) := {
   cdi_negate : Negate A;
   cdi_negate_involutive : Involutive cdi_negate;
-  cdi_susp_hspace : IsHSpace (Build_pType (Susp A) _);
+  cdi_susp_hspace : IsHSpace (psusp A);
   cdi_susp_factorneg_r : FactorNegRight (negate_susp A cdi_negate) hspace_op;
   cdi_susp_conjug_left_inv : LeftInverse hspace_op (conjugate_susp A cdi_negate) mon_unit;
   cdi_susp_conjug_distr : DistrOpp hspace_op (conjugate_susp A cdi_negate);
@@ -148,7 +148,7 @@ Defined.
 
 (** Every suspension of a Cayley-Dickson imaginaroid gives a Cayley-Dickson spherioid. *)
 Global Instance cds_susp_cdi {A} `(CayleyDicksonImaginaroid A)
-  : CayleyDicksonSpheroid (Build_pType (Susp A) _) := {}.
+  : CayleyDicksonSpheroid (psusp A) := {}.
 
 Global Instance cdi_conjugate_susp_left_inverse {A} `(CayleyDicksonImaginaroid A)
   : LeftInverse hspace_op (conjugate_susp A cdi_negate) mon_unit.
@@ -245,8 +245,9 @@ Section ImaginaroidHSpace.
       (a,b) * (c,d) = (a * c - d * b*, a* * d + c * b)
       the following is the spherical form. *)
   Global Instance cd_op
-    : SgOp (Build_pType (Join (Susp A) (Susp A)) (joinl pt)).
+    : SgOp (pjoin (psusp A) (psusp A)).
   Proof.
+    unfold psusp, pjoin; cbn.
     srapply Join_rec; hnf.
     { intro a.
       srapply Join_rec; hnf.
@@ -329,7 +330,7 @@ Section ImaginaroidHSpace.
   Defined.
 
   Global Instance hspace_cdi_susp_assoc
-    : IsHSpace (Build_pType (Join (Susp A) (Susp A)) (joinl pt))
+    : IsHSpace (pjoin (psusp A) (psusp A))
     := {}.
 
 End ImaginaroidHSpace.

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -4,6 +4,7 @@ Require Import Homotopy.HSpace.Core.
 Require Import Homotopy.Suspension.
 Require Import Homotopy.Join.
 
+Local Open Scope pointed_scope.
 Local Open Scope mc_mult_scope.
 
 (** A Cayley-Dickson Spheroid is a pointed type X which is an H-space, with two operations called negation and conjugation, satisfying the seven following laws.
@@ -124,7 +125,7 @@ Proof.
 Defined.
 
 Global Instance isunitpreserving_conjugate_susp {A} `(CayleyDicksonImaginaroid A)
-  : @IsUnitPreserving _ _ (point _) (point _) (conjugate_susp A cdi_negate).
+  : @IsUnitPreserving _ _ pt pt (conjugate_susp A cdi_negate).
 Proof.
   reflexivity.
 Defined.
@@ -244,7 +245,7 @@ Section ImaginaroidHSpace.
       (a,b) * (c,d) = (a * c - d * b*, a* * d + c * b)
       the following is the spherical form. *)
   Global Instance cd_op
-    : SgOp (Build_pType (Join (Susp A) (Susp A)) (joinl (point _))).
+    : SgOp (Build_pType (Join (Susp A) (Susp A)) (joinl pt)).
   Proof.
     srapply Join_rec; hnf.
     { intro a.
@@ -296,7 +297,7 @@ Section ImaginaroidHSpace.
   Defined.
 
   Global Instance cd_op_left_identity
-    : LeftIdentity cd_op (point _).
+    : LeftIdentity cd_op pt.
   Proof.
     srapply Join_ind; simpl.
     { intro a; apply ap.
@@ -310,7 +311,7 @@ Section ImaginaroidHSpace.
   Defined.
 
   Global Instance cd_op_right_identity
-    : RightIdentity cd_op (point _).
+    : RightIdentity cd_op pt.
   Proof.
     srapply Join_ind; simpl.
     { intro a; apply ap.
@@ -328,7 +329,7 @@ Section ImaginaroidHSpace.
   Defined.
 
   Global Instance hspace_cdi_susp_assoc
-    : IsHSpace (Build_pType (Join (Susp A) (Susp A)) (joinl (point _)))
+    : IsHSpace (Build_pType (Join (Susp A) (Susp A)) (joinl pt))
     := {}.
 
 End ImaginaroidHSpace.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -156,7 +156,7 @@ Defined.
 
 (** The classifying space of a group is the following pointed type. *)
 Definition pClassifyingSpace (G : Group)
-  := Build_pType (ClassifyingSpace G) bbase.
+  := [ClassifyingSpace G, bbase].
   
 (** To use the B G notation for pClassifyingSpace import this module. *)
 Module Import ClassifyingSpaceNotation.
@@ -281,7 +281,7 @@ Section EncodeDecode.
     := Build_Equiv _ _ bloop _.
 
   (** Pointed version of the defining property. *)
-  Definition pequiv_g_loops_bg : Build_pType G _ <~>* loops (B G)
+  Definition pequiv_g_loops_bg : G <~>* loops (B G)
     := Build_pEquiv _ _ pbloop _.
 
   Definition pequiv_loops_bg_g := pequiv_g_loops_bg^-1*%equiv.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -199,7 +199,7 @@ Section EilenbergMacLane.
 
   Fixpoint EilenbergMacLane (G : Group) (n : nat) : pType
     := match n with
-        | 0    => Build_pType G _
+        | 0    => G
         | 1    => pClassifyingSpace G
         | m.+1 => pTr m.+1 (psusp (EilenbergMacLane G m))
        end.

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -491,7 +491,7 @@ Definition Pi_les `{Univalence} {F X Y : pType} (i : F ->* X) (f : X ->* Y)
 
 (** Fiber sequences correspond to pointed maps into the universe. *)
 Definition classify_fiberseq `{Univalence} {Y F : pType@{u}}
-  : (Y ->* Build_pType Type@{u} F) <~> { X : pType@{u} & FiberSeq F X Y }.
+  : (Y ->* [Type@{u}, F]) <~> { X : pType@{u} & FiberSeq F X Y }.
 Proof.
   refine (_ oE _).
   (** To apply [equiv_sigma_pfibration] we need to invert the equivalence on the fiber. *)

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -159,7 +159,7 @@ Defined.
 
 (** Bundled version of the above. *)
 Lemma isexact_preimage_hfiber (O : Modality) {F X Y : pType} (i : F ->* X) (f : X ->* Y)
-      `{IsExact O _ _ _ i f} (x : hfiber f (point _))
+      `{IsExact O _ _ _ i f} (x : hfiber f pt)
   : O (hfiber i x.1).
 Proof.
   srapply isexact_preimage; exact x.2.
@@ -184,7 +184,7 @@ Definition isexact_homotopic_f n  {F X Y : pType}
   : IsExact n i f'.
 Proof.
   exists (iscomplex_homotopic_f i ff cx_isexact).
-  pose (e := equiv_hfiber_homotopic _ _ ff (point _)).
+  pose (e := equiv_hfiber_homotopic _ _ ff pt).
   nrefine (cancelR_isequiv_conn_map n _ e).
   1: apply equiv_isequiv.
   refine (conn_map_homotopic n (cxfib (cx_isexact)) _ _ _).

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -3,7 +3,9 @@ Require Import NullHomotopy.
 Require Import Extensions.
 Require Import Colimits.Pushout.
 Require Import Truncations.Core Truncations.Connectedness.
+Require Import Pointed.Core.
 
+Local Open Scope pointed_scope.
 Local Open Scope path_scope.
 
 (** * Joins *)
@@ -223,6 +225,9 @@ Section Join.
       rewrite ap_const, concat_p1.
       reflexivity.
   Defined.
+
+  Definition pjoin (A : pType) (B : Type) : pType
+    := [Join A B, joinl pt].
 
 End Join.
 

--- a/theories/Homotopy/Pi1S1.v
+++ b/theories/Homotopy/Pi1S1.v
@@ -11,18 +11,16 @@ Local Open Scope wc_iso_scope.
 Section Pi1S1.
   Context `{Univalence}.
 
-  Local Notation "( A , a )" := (Build_pType A a).
-
   Local Open Scope int_scope.
   Local Open Scope pointed_scope.
 
-  Theorem Pi1Circle : Pi 1 (Circle, base) ≅ abgroup_Z.
+  Theorem Pi1Circle : Pi 1 [Circle, base] ≅ abgroup_Z.
   Proof.
     (** We give the isomorphism backwards, so we check the operation is preserved coming from the integer side. *)
     symmetry.
     srapply Build_GroupIsomorphism'.
     { equiv_via (base = base).
-      2: exact (equiv_tr 0 (loops (Circle, base))).
+      2: exact (equiv_tr 0 (loops [Circle, base])).
       symmetry.
       exact equiv_loopCircle_int. }
     intros a b.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -16,8 +16,7 @@ Definition sum_to_bool X Y : X + Y -> Bool
   := sum_ind _ (fun _ => false) (fun _ => true).
 
 Definition Smash (X Y : pType) : pType
-  := Build_pType (Pushout (sum_to_prod X Y) (sum_to_bool X Y))
-      (pushl (point X, point Y)).
+  := [Pushout (sum_to_prod X Y) (sum_to_bool X Y), pushl (point X, point Y)].
 
 Section Smash.
 

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -7,9 +7,7 @@ Require Import Colimits.Pushout.
 Local Open Scope pointed_scope.
 
 Definition Wedge (X Y : pType) : pType
-  := Build_pType
-    (Pushout (fun _ : Unit => point X) (fun _ => point Y))
-    (pushl (point X)).
+  := [Pushout (fun _ : Unit => point X) (fun _ => point Y), pushl (point X)].
 
 Notation "X \/ Y" := (Wedge X Y) : pointed_scope.
 

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -39,7 +39,7 @@ Definition equiv_sigma_fibration `{Univalence} {Y : Type@{u}}
 
 (** We construct the universal square for the object classifier. *)
 Local Definition topmap {A : Type} (P : A -> Type) (e : sig P) : pType
-  := Build_pType (P e.1) e.2.
+  := [(P e.1), e.2].
 
 (** The square commutes definitionally. *)
 Definition objectclassifier_square {A : Type} (P : A -> Type)
@@ -61,11 +61,9 @@ Defined.
 
 (** ** Classifying bundles with specified fiber *)
 
-Local Notation "( X , x )" := (Build_pType X x).
-
 (** Bundles over [B] with fiber [F] correspond to pointed maps into the universe pointed at [F]. *)
 Proposition equiv_sigma_fibration_p@{u v +} `{Univalence} {Y : pType@{u}} {F : Type@{u}}
-  : (Y ->* (Type@{u}, F)) <~> { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F }.
+  : (Y ->* [Type@{u}, F]) <~> { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
   refine (_ oE (issig_pmap _ _)^-1).
   srapply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
@@ -97,7 +95,7 @@ Proof.
 Defined.
 
 Definition equiv_sigma_pfibration@{u v +} `{Univalence} {Y F : pType@{u}}
-  : (Y ->* (Type@{u}, F)) <~> { p : pSlice@{u v} Y & pfiber p.2 <~>* F}
+  : (Y ->* [Type@{u}, F]) <~> { p : pSlice@{u v} Y & pfiber p.2 <~>* F}
   := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_p.
 
 (** * The classifier for O-local types *)
@@ -118,7 +116,7 @@ Defined.
 (** Pointed maps into [Type_ O] correspond to O-local bundles with fiber [F] over the base point of [Y]. *)
 Proposition equiv_sigma_fibration_Op@{u v +} `{Univalence} {O : Subuniverse}
             {Y : pType@{u}} {F : Type@{u}} `{inO : In O F}
-  : (Y ->* (Type_ O, (F; inO)))
+  : (Y ->* [Type_ O, (F; inO)])
       <~> { p : { q : Slice@{u v} Y & MapIn O q.2 } & hfiber p.1.2 (point Y) <~> F }.
 Proof.
   refine (_ oE (issig_pmap _ _)^-1); cbn.
@@ -132,7 +130,7 @@ Defined.
 (** When the base [Y] is connected, the fibers being O-local follow from the fact that the fiber [F] over the base point is. *)
 Proposition equiv_sigma_fibration_Op_connected@{u v +} `{Univalence} {O : Subuniverse}
             {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
-  : (Y ->* (Type_ O, (F; inO)))
+  : (Y ->* [Type_ O, (F; inO)])
        <~> { p : Slice@{u v} Y & hfiber p.2 (point Y) <~> F }.
 Proof.
   refine (_ oE equiv_sigma_fibration_Op).
@@ -150,7 +148,7 @@ Defined.
 (** When the fiber [F] is pointed, the right-hand side can be upgraded to pointed fiber sequences with O-local fibers.  *)
 Proposition equiv_sigma_pfibration_O `{Univalence} (O : Subuniverse)
             {Y F : pType} `{inO : In O F}
-  : (Y ->* (Type_ O, (pointed_type F; inO)))
+  : (Y ->* [Type_ O, (pointed_type F; inO)])
       <~> { p : { q : pSlice Y & MapIn O q.2 } & pfiber p.1.2 <~>* F }.
 Proof.
   refine (_ oE equiv_sigma_fibration_Op).
@@ -162,12 +160,12 @@ Defined.
 (** When moreover the base [Y] is connected, the right-hand side is exactly the type of pointed fiber sequences, since the fibers being O-local follow from [F] being O-local and [Y] connected. *)
 Definition equiv_sigma_pfibration_O_connected@{u v +} `{Univalence} (O : Subuniverse)
           {Y F : pType@{u}} `{IsConnected 0 Y} `{inO : In O F}
-  : (Y ->* (Type_ O, (pointed_type F; inO)))
+  : (Y ->* [Type_ O, (pointed_type F; inO)])
       <~> { p : pSlice@{u v} Y & pfiber p.2 <~>* F }
   := equiv_pfiber_fibration_pfibration oE equiv_sigma_fibration_Op_connected.
 
 (** As a corollary, pointed maps into the unverse of O-local types are just pointed maps into the universe, when the base [Y] is connected. *)
 Definition equiv_pmap_typeO_type_connected `{Univalence} {O : Subuniverse}
       {Y : pType@{u}} `{IsConnected 0 Y} {F : Type@{u}} `{inO : In O F}
-  : (Y ->* (Type_ O, (F; inO))) <~> (Y ->* (Type@{u}, F))
+  : (Y ->* [Type_ O, (F; inO)]) <~> (Y ->* [Type@{u}, F])
   := equiv_sigma_fibration_p^-1 oE equiv_sigma_fibration_Op_connected.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -39,7 +39,7 @@ Definition equiv_sigma_fibration `{Univalence} {Y : Type@{u}}
 
 (** We construct the universal square for the object classifier. *)
 Local Definition topmap {A : Type} (P : A -> Type) (e : sig P) : pType
-  := [(P e.1), e.2].
+  := [P e.1, e.2].
 
 (** The square commutes definitionally. *)
 Definition objectclassifier_square {A : Type} (P : A -> Type)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -31,7 +31,7 @@ Global Instance ispointed_prod `{IsPointed A, IsPointed B} : IsPointed (A * B)
   := (point A, point B).
 
 (** We override the notation for products in pointed_scope *)
-Notation "X * Y" := ([(X * Y), ispointed_prod]) : pointed_scope.
+Notation "X * Y" := ([X * Y, ispointed_prod]) : pointed_scope.
 
 (** A pointed type family consists of a type family over a pointed type and a section of that family at the basepoint. *)
 Definition pFam (A : pType) := {P : A -> Type & P (point A)}.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -31,7 +31,7 @@ Global Instance ispointed_prod `{IsPointed A, IsPointed B} : IsPointed (A * B)
   := (point A, point B).
 
 (** We override the notation for products in pointed_scope *)
-Notation "X * Y" := (Build_pType (X * Y) ispointed_prod) : pointed_scope.
+Notation "X * Y" := ([(X * Y), ispointed_prod]) : pointed_scope.
 
 (** A pointed type family consists of a type family over a pointed type and a section of that family at the basepoint. *)
 Definition pFam (A : pType) := {P : A -> Type & P (point A)}.
@@ -146,11 +146,11 @@ Coercion pointed_equiv_equiv {A B} (f : A <~>* B)
 
 (** Pointed sigma types *)
 Definition psigma {A : pType} (P : pFam A) : pType
-  := Build_pType (sig P) (point A; P.2).
+  := [sig P, (point A; P.2)].
 
 (** Pointed pi types, note that the domain is not pointed *)
 Definition pproduct {A : Type} (F : A -> pType) : pType
-  := Build_pType (forall (a : A), pointed_type (F a)) (ispointed_type o F).
+  := [forall (a : A), pointed_type (F a), ispointed_type o F].
 
 (** The following tactics often allow us to "pretend" that pointed maps and homotopies preserve basepoints strictly. *)
 
@@ -502,7 +502,7 @@ Definition point_pforall {A : pType} (B : A -> pType) : pForall A (pointed_fam B
 
 (** The pointed type of pointed maps. For dependent pointed maps we need a family of pointed types, not just a family of types with a point over the basepoint of [A]. *)
 Definition ppForall (A : pType) (B : A -> pType) : pType
-  := Build_pType (pForall A (pointed_fam B)) (point_pforall B).
+  := [pForall A (pointed_fam B), point_pforall B].
 
 Definition ppMap (A B : pType) : pType
   := ppForall A (fun _ => B).
@@ -772,7 +772,7 @@ Proof.
 Defined.
 
 (** The free base point added to a type. This is in fact a functor and left adjoint to the forgetful functor pType to Type. *)
-Definition pointify (S : Type) : pType := Build_pType (S + Unit) (inr tt).
+Definition pointify (S : Type) : pType := [S + Unit, inr tt].
 
 Global Instance is0functor_pointify : Is0Functor pointify.
 Proof.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -12,7 +12,7 @@ Local Open Scope path_scope.
 Global Instance ispointed_loops A (a : A) : IsPointed (a = a) := 1.
 
 Definition loops (A : pType) : pType
-  := Build_pType (point A = point A) _.
+  := [point A = point A, 1].
 
 Fixpoint iterated_loops (n : nat) (A : pType) : pType
   := match n with
@@ -183,10 +183,10 @@ Defined.
 
 (** It follows that loop spaces "commute with images". *)
 Definition equiv_loops_image `{Univalence} n {A B : pType} (f : A ->* B)
-  : loops (Build_pType (image n.+1 f) (factor1 (image n.+1 f) (point A)))
+  : loops ([image n.+1 f, factor1 (image n.+1 f) (point A)])
   <~> image n (fmap loops f).
 Proof.
-  set (C := (Build_pType (image n.+1 f) (factor1 (image n.+1 f) (point A)))).
+  set (C := [image n.+1 f, factor1 (image n.+1 f) (point A)]).
   pose (g := Build_pMap A C (factor1 (image n.+1 f)) 1).
   pose (h := Build_pMap C B (factor2 (image n.+1 f)) (point_eq f)).
   transparent assert (I : (Factorization

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -254,7 +254,7 @@ Definition pequiv_fmap_iterated_loops {A B} n
 Lemma loops_prod (X Y : pType) : loops (X * Y) <~>* loops X * loops Y.
 Proof.
   srefine (Build_pEquiv _ _ (Build_pMap _ _ (_ : Equiv _ _) _) _).
-  1: symmetry; refine (equiv_path_prod (point _) (point (X * Y))).
+  1: symmetry; refine (equiv_path_prod pt (point (X * Y))).
   reflexivity.
 Defined.
 

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -10,7 +10,7 @@ Local Open Scope pointed_scope.
 
 Definition pfiber {A B : pType} (f : A ->* B) : pType.
 Proof.
-  refine (Build_pType (hfiber f (point B)) _); try exact _.
+  nrefine ([hfiber f (point B), _]).
   exists (point A).
   apply point_eq.
 Defined.

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -8,13 +8,13 @@ Local Open Scope pointed_scope.
 
 (** Not infrequently we have a map between two unpointed types and want to consider it as a pointed map that trivially respects some given point in the domain. *)
 Definition pmap_from_point {A B : Type} (f : A -> B) (a : A)
-  : Build_pType A a ->* Build_pType B (f a)
-  := Build_pMap (Build_pType A a) (Build_pType B (f a)) f 1%path.
+  : [A, a] ->* [B, f a]
+  := Build_pMap [A, a] [B, f a] f 1%path.
 
 (** A variant of [pmap_from_point] where the domain is pointed, but the codomain is not. *)
 Definition pmap_from_pointed {A : pType} {B : Type} (f : A -> B)
-  : A ->* Build_pType B (f (point A))
-  := Build_pMap A (Build_pType B (f (point A))) f 1%path.
+  : A ->* [B, f (point A)]
+  := Build_pMap A [B, f (point A)] f 1%path.
 
 (** The same, for a dependent pointed map. *)
 Definition pforall_from_pointed {A : pType} {B : A -> Type} (f : forall x, B x)
@@ -66,7 +66,7 @@ Proof.
     equiv_sig_coind _ _) C.
   destruct C as [C c0].
   equiv_intros (@equiv_functor_forall_id _ A _ _
-    (fun a => issig_pmap (B a) (Build_pType (C a) (c0 a))) oE
+    (fun a => issig_pmap (B a) [C a, c0 a]) oE
     equiv_sig_coind _ _) g.
   simpl in *. destruct g as [g g0].
   unfold point in g0. unfold functor_forall, sig_coind_uncurried. simpl.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -24,8 +24,8 @@ Global Instance ispointed_path_susp `{IsPointed X}
 Global Instance ispointed_path_susp' `{IsPointed X}
   : IsPointed (South = North :> Susp X) | 0 := (merid (point X))^.
 
-Definition psusp (X : pType) : pType
-  := Build_pType (Susp X) _.
+Definition psusp (X : Type) : pType
+  := [Susp X, _].
 
 (** ** Suspension Functor *)
 

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -134,7 +134,7 @@ Global Instance conn_map_loop_susp_unit `{Univalence}
   (X : pType) `{IsConnected n.+1 X}
   : IsConnMap (n +2+ n) (fun x => merid x @ (merid (point X))^).
 Proof.
-  refine (conn_map_compose _ _ (equiv_concat_r (merid (point _))^ _)).
+  refine (conn_map_compose _ _ (equiv_concat_r (merid pt)^ _)).
 Defined.
 
 (** We also have this corollary *)

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -6,7 +6,7 @@ Local Open Scope pointed_scope.
 (** * Truncations of pointed types *)
 
 Definition pTr (n : trunc_index) (A : pType) : pType
-  := Build_pType (Tr n A) _.
+  := [Tr n A, _].
 
 (** We specialize [pto] and [pequiv_pto] from pModalities.v to truncations. *)
 

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -20,7 +20,7 @@ Global Instance ispointed_baut {X : Type} : IsPointed (BAut X) := (X; tr 1).
 
 (** We also define a pointed version [pBAut X], since the coercion [BAut_pr1] doesn't work if [BAut X] is a [pType]. *)
 Definition pBAut (X : Type) : pType
-  := Build_pType (BAut X) _.
+  := [BAut X, _].
 
 Definition path_baut `{Univalence} {X} (Z Z' : BAut X)
 : (Z <~> Z') <~> (Z = Z' :> BAut X)
@@ -277,7 +277,7 @@ Section ClassifyingMaps.
 
   (** The pointed version of [equiv_baut_typeO] above. *)
   Proposition pequiv_pbaut_typeOp@{u v +} `{Univalence} {F : Type@{u}}
-    : pBAut@{u v} F <~>* Build_pType (Type_ (subuniverse_merely_equiv F)) (F; tr equiv_idmap).
+    : pBAut@{u v} F <~>* [Type_ (subuniverse_merely_equiv F), (F; tr equiv_idmap)].
   Proof.
     snrapply Build_pEquiv'; cbn.
     1: exact equiv_baut_typeO.
@@ -293,7 +293,7 @@ Section ClassifyingMaps.
   (** When [Y] is connected, pointed maps into [pBAut F] correspond to maps into the universe sending the base point to [F]. *)
   Proposition equiv_pmap_pbaut_type_p `{Univalence}
               {Y : pType@{u}} {F : Type@{u}} `{IsConnected 0 Y}
-    : (Y ->* pBAut F) <~> (Y ->* Build_pType Type@{u} F).
+    : (Y ->* pBAut F) <~> (Y ->* [Type@{u}, F]).
   Proof.
     refine (_ oE equiv_pequiv_postcompose pequiv_pbaut_typeOp).
     rapply equiv_pmap_typeO_type_connected.

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -161,7 +161,7 @@ First we define the function that will be the equivalence. *)
 
   (** In fact, the map sending [z:Z] to this equivalence [Bool <~> Z] is also an equivalence.  To assist with computing the result when [Z] is [Bool], we prove it with an extra parameter first. *)
   Definition isequiv_equiv_inhab_baut_bool_bool_lemma
-             (t : Bool) (Z : BAut Bool) (m : merely (point _ = Z))
+             (t : Bool) (Z : BAut Bool) (m : merely (pt = Z))
   : IsEquiv (equiv_inhab_baut_bool_bool t Z).
   Proof.
     strip_truncations. destruct m.

--- a/theories/Spaces/Spheres.v
+++ b/theories/Spaces/Spheres.v
@@ -27,7 +27,7 @@ Fixpoint Sphere (n : trunc_index)
 (** ** Pointed sphere for non-negative dimensions *)
 Fixpoint psphere (n : nat) : pType
   := match n with
-      | O => Build_pType (Susp Empty) North
+      | O => psusp Empty
       | S n' => psusp (psphere n')
      end.
 
@@ -95,7 +95,7 @@ Defined.
 Definition equiv_S1_Circle : Sphere 1 <~> Circle
   := Build_Equiv _ _ _ isequiv_S1_to_Circle.
 
-Definition pequiv_S1_Circle : psphere 1 <~>* (Build_pType Circle _).
+Definition pequiv_S1_Circle : psphere 1 <~>* [Circle, _].
 Proof.
   srapply Build_pEquiv'.
   1: apply equiv_S1_Circle.

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -28,8 +28,8 @@ Proof.
 Qed.
 
 (** We give these notations for the pointed versions. *)
-Local Notation T := (Build_pType Torus _).
-Local Notation S1 := (Build_pType Circle _).
+Local Notation T := ([Torus, _]).
+Local Notation S1 := ([Circle, _]).
 
 (** Loop space of Torus *)
 Theorem loops_torus `{Univalence} : loops T <~>* Int * Int.


### PR DESCRIPTION
Mainly replaces `(point _)` with `pt` and `Build_pType (foo) (bar)` with `[foo, bar]`, but also makes use of `psusp`, the coercion of a group to a pointed type, and a new `pjoin`.

Note that `[X, x]` was chosen as the notation for a pointed type rather than `(X, x)` because the latter conflicts with ordered pairs.  The former conflicts with functor categories, but those are used less often than ordered pairs, and generally in different contexts.  Another nice thing is that there are often many nested parentheses, and the square brackets make it easier to see the matching pairs.  Also, this notation often has fewer parentheses than when using`Build_pType`.