### PR TITLE
O-connected covers

### DIFF
--- a/theories/Homotopy/Cover.v
+++ b/theories/Homotopy/Cover.v
@@ -1,4 +1,4 @@
-Require Import Basics Types HFiber Truncations Pointed
+Require Import Basics Types HFiber Truncations.Core Truncations.SeparatedTrunc Pointed
   Modalities.ReflectiveSubuniverse.
 
 Local Open Scope pointed_scope.

--- a/theories/Homotopy/Cover.v
+++ b/theories/Homotopy/Cover.v
@@ -1,5 +1,5 @@
-From HoTT Require Import Basics Types Truncations.Core
-  Pointed Modalities.ReflectiveSubuniverse.
+Require Import Basics Types HFiber Truncations Pointed
+  Modalities.ReflectiveSubuniverse.
 
 Local Open Scope pointed_scope.
 
@@ -13,12 +13,76 @@ Definition O_cover@{u} `{O : ReflectiveSubuniverse@{u}}
 
 (** Characterization of paths in [O_cover] is given by [equiv_path_hfiber]. *)
 
-(** Path components are given by specializing to [O] being set-truncation. *)
-Definition comp := O_cover (O:=Tr 0).
-
 (* If [x] is an actual point of [X], then the connected cover is pointed. *)
 Definition O_pcover@{u v} (O : ReflectiveSubuniverse@{u})
   (X : Type@{u}) (x : X) : pType@{u}
   := pfiber@{u v u u} (pto O [X,x]).
 
+(** ** Functoriality of [O_cover] *)
+
+(** Given [X] and [x : O X], any map [f : X -> Y] out of [X] induces a map [O_cover X x -> O_cover Y (O_functor O f x)]. *)
+Definition functor_O_cover@{u v} `{O : ReflectiveSubuniverse} {X Y : Type@{u}}
+  (f : X -> Y) (x : O X) : O_cover@{u} X x -> O_cover@{u} Y (O_functor O f x)
+  := functor_hfiber (f:=to O _) (g:=to O _)
+       (h:=f) (k:=O_functor O f) (to_O_natural O f) x.
+
+Definition equiv_functor_O_cover `{O : ReflectiveSubuniverse}
+  {X Y : Type} (f : X -> Y) `{IsEquiv _ _ f} (x : O X)
+  : O_cover X x <~> O_cover Y (O_functor O f x)
+  := Build_Equiv _ _ (functor_O_cover f x) _.
+
+(** *** Pointed functoriality *)
+
+Definition pfunctor_O_pcover `{O : ReflectiveSubuniverse} {X Y : pType}
+  (f : X ->* Y) : O_pcover O X pt ->* O_pcover O Y pt
+  := functor_pfiber (pto_O_natural O f).
+
+Definition pequiv_pfunctor_O_pcover `{O : ReflectiveSubuniverse} {X Y : pType}
+  (f : X ->* Y) `{IsEquiv _ _ f} : O_pcover O X pt <~>* O_pcover O Y pt
+  := Build_pEquiv _ _ (pfunctor_O_pcover f) _.
+
+(** In the case of truncations, [ptr_natural] gives a better proof of pointedness. *)
+Definition pfunctor_pTr_pcover `{n : trunc_index} {X Y : pType}
+  (f : X ->* Y) : O_pcover (Tr n) X pt ->* O_pcover (Tr n) Y pt
+  := functor_pfiber (ptr_natural n f).
+
+Definition pequiv_pfunctor_pTr_pcover `{n : trunc_index}
+  {X Y : pType} (f : X ->* Y) `{IsEquiv _ _ f}
+  : O_pcover (Tr n) X pt <~>* O_pcover (Tr n) Y pt
+  := Build_pEquiv _ _ (pfunctor_pTr_pcover f) _.
+
+
+(** * Components *)
+
+(** Path components are given by specializing to [O] being set-truncation. *)
+Definition comp := O_cover (O:=Tr 0).
 Definition pcomp := O_pcover (Tr 0).
+
+Definition pfunctor_pcomp {X Y : pType} := @pfunctor_pTr_pcover (-1) X Y.
+Definition pequiv_pfunctor_pcomp {X Y : pType}
+  := @pequiv_pfunctor_pTr_pcover (-1) X Y.
+
+(** If a property holds at a given point, then it holds for the whole component. This yields equivalences like the following: *)
+Definition equiv_comp_property `{Univalence} {X : Type} (x : X)
+  (P : X -> Type) `{forall x, IsHProp (P x)} (Px : P x)
+  : comp (sig P) (tr (x; Px)) <~> comp X (tr x).
+Proof.
+  unfold comp, O_cover, hfiber. simpl.
+  refine (_ oE (equiv_sigma_assoc _ _)^-1).
+  apply equiv_functor_sigma_id; intro y.
+  apply equiv_iff_hprop.
+  - intros [py q].
+    exact (ap (Trunc_functor _ pr1) q).
+  - refine (equiv_ind (equiv_path_Tr _ _) _ _).
+    apply Trunc_rec; intros p; induction p.
+    exact (Px; idpath).
+Defined.
+
+(** For example, we may take components of equivalences among underlying maps. *)
+Definition equiv_comp_equiv_map `{Univalence} {A B : Type} (e : A <~> B)
+  : comp (A <~> B) (tr e) <~> comp (A -> B) (tr (equiv_fun e)).
+Proof.
+  refine (_ oE equiv_functor_O_cover (issig_equiv _ _)^-1 _); cbn.
+  rapply equiv_comp_property.
+Defined.
+

--- a/theories/Homotopy/Cover.v
+++ b/theories/Homotopy/Cover.v
@@ -18,6 +18,21 @@ Definition O_pcover@{u v} (O : ReflectiveSubuniverse@{u})
   (X : Type@{u}) (x : X) : pType@{u}
   := pfiber@{u v u u} (pto O [X,x]).
 
+(** Covers commute with products *)
+Definition O_pcover_prod `{O : ReflectiveSubuniverse} {X Y : pType@{u}}
+  : O_pcover O (X * Y) pt <~>* [(O_pcover O X pt) * (O_pcover O Y pt), _].
+Proof.
+  srapply Build_pEquiv'.
+  { refine (_ oE equiv_functor_sigma_id _).
+    2: intro; nrapply equiv_path_O_prod.
+    nrapply equiv_sigma_prod_prod. }
+  nrapply path_prod; cbn.
+  all: snrapply path_sigma'.
+  1,3: exact idpath.
+  all: cbn.
+  all: by rewrite concat_p1, concat_Vp.
+Defined.
+
 (** ** Functoriality of [O_cover] *)
 
 (** Given [X] and [x : O X], any map [f : X -> Y] out of [X] induces a map [O_cover X x -> O_cover Y (O_functor O f x)]. *)

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -839,8 +839,18 @@ Section Reflective_Subuniverse.
     Defined.
 
     Definition equiv_O_prod_cmp (A B : Type)
-    : O (A * B) <~> (O A * O B)
-    := Build_Equiv _ _ (O_prod_cmp A B) _.
+      : O (A * B) <~> (O A * O B)
+      := Build_Equiv _ _ (O_prod_cmp A B) _.
+
+    Definition equiv_path_O_prod {X Y : Type} {x0 x1 : X} {y0 y1 : Y}
+      : (to O _ (x0, y0) = to O _ (x1, y1))
+          <~> (to O _ x0 = to O _ x1) * (to O _ y0 = to O _ y1).
+    Proof.
+      refine (_ oE equiv_ap' (equiv_O_prod_cmp _ _) _ _).
+      refine (_ oE equiv_concat_lr _ _); only 2: symmetry.
+      2,3: apply O_rec_beta.
+      exact (equiv_path_prod _ _)^-1%equiv.
+    Defined.
 
     (** ** Pullbacks *)
 

--- a/theories/Pointed/pModality.v
+++ b/theories/Pointed/pModality.v
@@ -19,3 +19,31 @@ Definition pequiv_pto `{O : ReflectiveSubuniverse} {X : pType} `{In O X}
 Definition pO_rec `{O : ReflectiveSubuniverse} {X Y : pType}
   `{In O Y} (f : X ->* Y) : [O X, _] ->* Y
   := Build_pMap [O X, _] _ (O_rec f) (O_rec_beta _ _ @ point_eq f).
+
+(** ** Pointed functoriality *)
+
+Definition O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
+  (f : X ->* Y) : [O X, _] ->* [O Y, _].
+Proof.
+  snrapply Build_pMap.
+  1: exact (O_functor O f).
+  refine (O_rec_beta _ _ @ _).
+  exact (ap (to O Y) (point_eq f)).
+Defined.
+
+(** Coq knows that [O_pfunctor O f] is an equivalence whenever [f] is. *)
+Definition equiv_O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
+  (f : X ->* Y) `{IsEquiv _ _ f} : [O X, _] <~>* [O Y, _]
+  := Build_pEquiv _ _ (O_pfunctor O f) _.
+
+(** Pointed naturality of [O_pfunctor]. *)
+Definition pto_O_natural `(O : ReflectiveSubuniverse) {X Y : pType}
+  (f : X ->* Y) : O_pfunctor O f o* pto O X ==* pto O Y o* f.
+Proof.
+  srapply Build_pHomotopy.
+  1: apply to_O_natural.
+  cbn. unfold to_O_natural.
+  apply moveL_pV.
+  refine (whiskerL _ _ @ (concat_1p _)^).
+  apply concat_p1.
+Defined.

--- a/theories/Pointed/pModality.v
+++ b/theories/Pointed/pModality.v
@@ -20,16 +20,22 @@ Definition pO_rec `{O : ReflectiveSubuniverse} {X Y : pType}
   `{In O Y} (f : X ->* Y) : [O X, _] ->* Y
   := Build_pMap [O X, _] _ (O_rec f) (O_rec_beta _ _ @ point_eq f).
 
+Definition pO_rec_beta `{O : ReflectiveSubuniverse} {X Y : pType}
+  `{In O Y} (f : X ->* Y)
+  : pO_rec f o* pto O X ==* f.
+Proof.
+  srapply Build_pHomotopy.
+  1: nrapply O_rec_beta.
+  cbn.
+  apply moveL_pV.
+  exact (concat_1p _)^.
+Defined.
+
 (** ** Pointed functoriality *)
 
 Definition O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
-  (f : X ->* Y) : [O X, _] ->* [O Y, _].
-Proof.
-  snrapply Build_pMap.
-  1: exact (O_functor O f).
-  refine (O_rec_beta _ _ @ _).
-  exact (ap (to O Y) (point_eq f)).
-Defined.
+  (f : X ->* Y) : [O X, _] ->* [O Y, _]
+  := pO_rec (pto O Y o* f).
 
 (** Coq knows that [O_pfunctor O f] is an equivalence whenever [f] is. *)
 Definition equiv_O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
@@ -40,10 +46,5 @@ Definition equiv_O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
 Definition pto_O_natural `(O : ReflectiveSubuniverse) {X Y : pType}
   (f : X ->* Y) : O_pfunctor O f o* pto O X ==* pto O Y o* f.
 Proof.
-  srapply Build_pHomotopy.
-  1: apply to_O_natural.
-  cbn. unfold to_O_natural.
-  apply moveL_pV.
-  refine (whiskerL _ _ @ (concat_1p _)^).
-  apply concat_p1.
+  nrapply pO_rec_beta.
 Defined.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -72,6 +72,17 @@ Proof.
     by pointed_reduce.
 Defined.
 
+(** Naturality of [ptr] *)
+Definition ptr_natural (n : trunc_index) {X Y : pType}
+  (f : X ->* Y) : fmap (pTr n) f o* ptr ==* ptr o* f.
+Proof.
+  srapply Build_pHomotopy.
+  1: reflexivity.
+  cbn.
+  refine (_ @ ap011 _ (concat_1p _)^ (ap _ (concat_p1 _))^).
+  exact (concat_pV _)^.
+Defined.
+
 Definition ptr_functor_pconst {X Y : pType} n
   : fmap (pTr n) (@pconst X Y) ==* pconst.
 Proof.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -52,7 +52,7 @@ Proof.
   intro f.
   apply path_pforall.
   srapply Build_pHomotopy.
-  1: intro; by strip_truncations.
+  1: by rapply Trunc_ind.
   cbn.
   symmetry; apply concat_pp_V.
 Defined.
@@ -77,13 +77,11 @@ Proof.
       exact (concat_p1 _ @ concat_p1 _ @ ap _ (concat_p1 _))^.
   - intros X.
     srapply Build_pHomotopy.
-    { intro x.
-      by strip_truncations. }
-    reflexivity.
+    1: apply Trunc_rec_tr.
+    cbn. reflexivity.
   - intros X Y Z f g.
     srapply Build_pHomotopy.
-    { intro x.
-      by strip_truncations. }
+    1: by rapply Trunc_ind.
     by pointed_reduce.
 Defined.
 
@@ -101,8 +99,8 @@ Definition ptr_functor_pconst {X Y : pType} n
   : fmap (pTr n) (@pconst X Y) ==* pconst.
 Proof.
   srapply Build_pHomotopy.
-  - intros x; strip_truncations; reflexivity.
-  - reflexivity.
+  1: by rapply Trunc_ind.
+  reflexivity.
 Defined.
 
 Definition ptr_pequiv {X Y : pType} (n : trunc_index) (f : X <~>* Y)

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -21,17 +21,34 @@ Definition pTr_rec n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
   : pTr n X ->* Y
   := Build_pMap (pTr n X) Y (Trunc_rec f) (point_eq f).
 
+(** Note that we get an equality of pointed functions here, without Funext, while [pO_rec_beta] only gives a pointed homotopy. This is because [pTr_rec] computes on elements of the form [tr _]. *)
+Definition pTr_rec_beta_path n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
+  : pTr_rec n f o* ptr = f.
+Proof.
+  unfold pTr_rec, "o*"; cbn.
+  (* Since [f] is definitionally equal to [Build_pMap _ _ f (point_eq f)], this works: *)
+  apply (ap (Build_pMap _ _ f)).
+  apply concat_1p.
+Defined.
+
+(** The version with a pointed homotopy. *)
+Definition pTr_rec_beta n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
+  : pTr_rec n f o* ptr ==* f
+  := phomotopy_path (pTr_rec_beta_path n f).
+
+(** A pointed version of the induction principle. *)
+Definition pTr_ind n {X : pType} {Y : pFam (pTr n X)} `{forall x, IsTrunc n (Y x)} (f : pForall X (Y.1 o tr; Y.2))
+  : pForall (pTr n X) Y
+  := Build_pForall (pTr n X) Y (Trunc_ind Y f) (dpoint_eq f).
+
 Definition equiv_ptr_rec `{Funext} {n} {X Y : pType} `{IsTrunc n Y}
   : (pTr n X ->* Y) <~> (X ->* Y).
 Proof.
   srapply equiv_adjointify.
   { intro f.
-    refine (f o* ptr). }
+    exact (f o* ptr). }
   1: srapply pTr_rec.
-  { intro f.
-    destruct f as [f p].
-    apply (ap (Build_pMap _ _ f)).
-    apply concat_1p. }
+  1: nrapply pTr_rec_beta_path.
   intro f.
   apply path_pforall.
   srapply Build_pHomotopy.
@@ -46,20 +63,21 @@ Global Instance is0functor_ptr n : Is0Functor (pTr n).
 Proof.
   apply Build_Is0Functor.
   intros X Y f.
-  exact (Build_pMap (pTr n X) (pTr n Y)
-    (Trunc_functor n f) (ap (@tr n Y) (point_eq f))).
+  exact (pTr_rec _ (ptr o* f)).
 Defined.
 
 Global Instance is1functor_ptr n : Is1Functor (pTr n).
 Proof.
   apply Build_Is1Functor.
   - intros X Y f g p.
-    srapply Build_pHomotopy.
-    + intros x; strip_truncations; cbn.
-      change (@tr n Y (f x) = tr (g x)).
-      apply ap, p.
-    + exact (ap _ (dpoint_eq p) @ ap_pp (@tr n _) _ _
-        @ whiskerL _ (ap_V _ _)).
+    srapply pTr_ind; cbn.
+    snrapply Build_pForall.
+    + cbn. exact (fun x => ap tr (p x)).
+    + cbn.
+      refine (_ @ (ap011 (fun q r => q @ r^) (concat_p1 _) (concat_p1 _))^).
+      refine (_ @ (1 @@ ap_V _ _)).
+      refine (_ @ ap_pp _ _ _).
+      exact (ap _ (dpoint_eq p)).
   - intros X.
     srapply Build_pHomotopy.
     { intro x.
@@ -72,16 +90,15 @@ Proof.
     by pointed_reduce.
 Defined.
 
-(** Naturality of [ptr] *)
-Definition ptr_natural (n : trunc_index) {X Y : pType}
-  (f : X ->* Y) : fmap (pTr n) f o* ptr ==* ptr o* f.
-Proof.
-  srapply Build_pHomotopy.
-  1: reflexivity.
-  cbn.
-  refine (_ @ ap011 _ (concat_1p _)^ (ap _ (concat_p1 _))^).
-  exact (concat_pV _)^.
-Defined.
+(** Naturality of [ptr].  Note that we get a equality of pointed functions, not just a pointed homotopy. *)
+Definition ptr_natural_path (n : trunc_index) {X Y : pType} (f : X ->* Y)
+  : fmap (pTr n) f o* ptr = ptr o* f
+  := pTr_rec_beta_path n (ptr o* f).
+
+(** The version with a pointed homotopy. *)
+Definition ptr_natural (n : trunc_index) {X Y : pType} (f : X ->* Y)
+  : fmap (pTr n) f o* ptr ==* ptr o* f
+  := phomotopy_path (ptr_natural_path n f).
 
 Definition ptr_functor_pconst {X Y : pType} n
   : fmap (pTr n) (@pconst X Y) ==* pconst.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -73,11 +73,8 @@ Proof.
     srapply pTr_ind; cbn.
     snrapply Build_pForall.
     + cbn. exact (fun x => ap tr (p x)).
-    + cbn.
-      refine (_ @ (ap011 (fun q r => q @ r^) (concat_p1 _) (concat_p1 _))^).
-      refine (_ @ (1 @@ ap_V _ _)).
-      refine (_ @ ap_pp _ _ _).
-      exact (ap _ (dpoint_eq p)).
+    + pointed_reduce.
+      exact (concat_p1 _ @ concat_p1 _ @ ap _ (concat_p1 _))^.
   - intros X.
     srapply Build_pHomotopy.
     { intro x.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -50,6 +50,10 @@ Definition Trunc_rec {n A X} `{IsTrunc n X}
   : (A -> X) -> (Trunc n A -> X)
 := Trunc_ind (fun _ => X).
 
+Definition Trunc_rec_tr n {A : Type}
+  : Trunc_rec (A:=A) (tr (n:=n)) == idmap
+  := Trunc_ind _ (fun a => idpath).
+
 (** ** [Trunc] is a modality *)
 
 Definition Tr (n : trunc_index) : Modality.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -520,6 +520,10 @@ Definition equiv_sigma_prod1 (A B C : Type)
   : {a : A & {b : B & C}} <~> A * B * C
   := ltac:(make_equiv).
 
+Definition equiv_sigma_prod_prod {X Y : Type} (P : X -> Type) (Q : Y -> Type)
+  : {z : X * Y & (P (fst z)) * (Q (snd z))} <~> (sig P) * (sig Q)
+  := ltac:(make_equiv).
+
 (** ** Symmetry *)
 
 Definition equiv_sigma_symm `(P : A -> B -> Type)


### PR DESCRIPTION
We add basic theory about O-connected covers for a reflective subuniverse O. Specifically, (pointed) functoriality of taking covers, and that covers commute with products. By proving a pointed version of `to_O_natural`, we get pointed functoriality from `functor_pfiber`. For truncation modalities we give a more direct proof (`ptr_natural`). To show that covers commute with products we needed `equiv_path_O_prod`, which relates paths in `O (X * Y)` to paths in `O X * O Y`.

These results will let us simplify some things in `Algebra/ooGroups` (see #1700).