### PR TITLE
BAut

### DIFF
--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -43,20 +43,6 @@ Proof.
   apply ap10, ap, ap_pr1_path_baut.
 Defined.
 
-(** ** Truncation *)
-
-(** If [X] is an [n.+1]-type, then [BAut X] is an [n.+2]-type. *)
-Global Instance trunc_baut `{Univalence} {n X} `{IsTrunc n.+1 X}
-: IsTrunc n.+2 (BAut X).
-Proof.
-  intros [Z p] [W q].
-  strip_truncations.
-  refine (@istrunc_equiv_istrunc _ _ (path_baut _ _) n.+1 _); simpl.
-  symmetry in q; destruct q.
-  symmetry in p; destruct p.
-  exact _.
-Defined.
-
 (** The following tactic, which applies when trying to prove an hprop, replaces all assumed elements of [BAut X] by [X] itself. With [Univalence], this would work for any 0-connected type, but using [merely_path_component] we can avoid univalence. *)
 Ltac baut_reduce :=
   progress repeat
@@ -69,6 +55,17 @@ Ltac baut_reduce :=
            intro Zispoint;
            destruct Zispoint
     end.
+
+(** ** Truncation *)
+
+(** If [X] is an [n.+1]-type, then [BAut X] is an [n.+2]-type. *)
+Global Instance trunc_baut `{Univalence} {n X} `{IsTrunc n.+1 X}
+: IsTrunc n.+2 (BAut X).
+Proof.
+  intros Z W.
+  baut_reduce.
+  exact (@istrunc_equiv_istrunc _ _ (path_baut _ _) n.+1 _).
+Defined.
 
 (** If [X] is truncated, then so is every element of [BAut X]. *)
 Global Instance trunc_el_baut {n X} `{Funext} `{IsTrunc n X} (Z : BAut X)

--- a/theories/Spaces/BAut.v
+++ b/theories/Spaces/BAut.v
@@ -11,7 +11,7 @@ Local Open Scope path_scope.
 
 (** ** Basics *)
 
-(** [BAut X] is the type of types that are merely equal to [X]. It is connected, by [is0connected_component]. *)
+(** [BAut X] is the type of types that are merely equal to [X]. It is connected, by [is0connected_component] and any two points are merely equal by [merely_path_component]. *)
 Definition BAut (X : Type@{u}) := { Z : Type@{u} & merely (Z = X) }.
 
 Coercion BAut_pr1 X : BAut X -> Type := pr1.
@@ -57,18 +57,13 @@ Proof.
   exact _.
 Defined.
 
-(** Since it is 0-connected, any two points in it are merely equal. *)
-Definition merely_path_baut `{Univalence} {X} (Z Z' : BAut X)
-: merely (Z = Z')
-:= merely_path_is0connected (BAut X) Z Z'.
-
-(** The following tactic, which applies when trying to prove an hprop, replaces all assumed elements of [BAut X] by [X] itself. *)
+(** The following tactic, which applies when trying to prove an hprop, replaces all assumed elements of [BAut X] by [X] itself. With [Univalence], this would work for any 0-connected type, but using [merely_path_component] we can avoid univalence. *)
 Ltac baut_reduce :=
   progress repeat
     match goal with
       | [ Z : BAut ?X |- _ ]
         => let Zispoint := fresh "Zispoint" in
-           assert (Zispoint := merely_path_baut (point (BAut X)) Z);
+           assert (Zispoint := merely_path_component (point (BAut X)) Z);
            revert Zispoint;
            refine (@Trunc_ind _ _ _ _ _);
            intro Zispoint;
@@ -76,13 +71,9 @@ Ltac baut_reduce :=
     end.
 
 (** If [X] is truncated, then so is every element of [BAut X]. *)
-Global Instance trunc_el_baut `{Funext} {n X} `{IsTrunc n X} (Z : BAut X)
-: IsTrunc n Z.
-Proof.
-  destruct Z as [Z p].
-  strip_truncations.
-  destruct p; exact _.
-Defined.
+Global Instance trunc_el_baut {n X} `{Funext} `{IsTrunc n X} (Z : BAut X)
+  : IsTrunc n Z
+  := ltac:(by baut_reduce).
 
 (** ** Operations on [BAut] *)
 

--- a/theories/Spaces/BAut/Bool.v
+++ b/theories/Spaces/BAut/Bool.v
@@ -46,7 +46,7 @@ Section AssumeUnivalence.
     intros oops.
     apply nontrivial_negb_center_baut_bool.
     apply path_forall; intros Z'.
-    pose (p := merely_path_baut Z Z').
+    pose (p := merely_path_component Z Z').
     clearbody p. strip_truncations.
     destruct p.
     unfold negb_baut_bool in oops.
@@ -184,7 +184,7 @@ First we define the function that will be the equivalence. *)
   : IsEquiv (equiv_inhab_baut_bool_bool t Z).
   Proof.
     exact (isequiv_equiv_inhab_baut_bool_bool_lemma t Z
-            (merely_path_baut _ _)).
+            (merely_path_component _ _)).
   Defined.
 
   (** The names are getting pretty ridiculous; below we suggest a better name for this. *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -26,10 +26,6 @@ A handy benchmark: under our indexing, the map [S1 -> 1] is 0-connected but not 
 
 One reason for our choice is that this way, the n-truncated and n-connected maps are the modal and modally-connected maps for the n-truncation modality.  Many of the basic lemmas about connected maps are in fact true for any modality, and can be found in [Modality.v].  Thus, here we consider mainly properties that involve the interaction of connectedness at different truncation levels. *)
 
-
-Section Extensions.
-  Context `{Univalence}.
-
 (** ** Truncatedness of the type of extensions *)
 
 (** A key lemma on the interaction between connectedness and truncatedness: suppose one is trying to extend along an n-connected map, into a k-truncated family of types (k ≥ n).  Then the space of possible extensions is (k–n–2)-truncated.
@@ -37,7 +33,7 @@ Section Extensions.
 (Mnemonic for the indexing: think of the base case, where k=n; then we know we can eliminate, so the space of extensions is contractible.)
 
 This lemma is most useful via corollaries like the wedge-inclusion, the wiggly wedge, and their n-ary generalizations. *)
-Lemma istrunc_extension_along_conn {m n : trunc_index}
+Lemma istrunc_extension_along_conn `{Univalence} {m n : trunc_index}
   {A B : Type} (f : A -> B) `{IsConnMap n _ _ f}
   (P : B -> Type) {HP : forall b:B, IsTrunc (m +2+ n) (P b)}
   (d : forall a:A, P (f a))
@@ -55,7 +51,7 @@ Defined.
 
 (** ** Connectedness of path spaces *)
 
-Global Instance isconnected_paths {n A}
+Global Instance isconnected_paths `{Univalence} {n A}
        `{IsConnected n.+1 A} (x y : A)
 : IsConnected n (x = y).
 Proof.
@@ -75,7 +71,7 @@ Proof.
   rapply (OO_cancelR_conn_map (Tr n.+1) (Tr n) (unit_name a0) (fun _:A => tt)).
 Defined.
 
-Definition conn_point_incl {n : trunc_index} {A : Type} (a0:A)
+Definition conn_point_incl `{Univalence} {n : trunc_index} {A : Type} (a0:A)
            `{IsConnected n.+1 A}
   : IsConnMap n (unit_name a0).
 Proof.
@@ -86,7 +82,7 @@ Defined.
 (** Note that [OO_cancelR_conn_map] and [OO_cancelL_conn_map] (Proposition 2.31 of CORS) generalize the above statements to 2/3 of a 2-out-of-3 property for connected maps, for any reflective subuniverse and its subuniverse of separated types.  If useful, we could specialize that more general form explicitly to truncations. *)
 
 (** To prove an [n]-truncated predicate on an (n+1)-connected, pointed type, it's enough to prove it for the basepoint. *)
-Definition conn_point_elim (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
+Definition conn_point_elim `{Univalence} (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
            (P : A -> Type@{u}) `{forall a, IsTrunc n (P a)} (p0 : P (point A))
   : forall a, P a.
 Proof.
@@ -97,8 +93,6 @@ Proof.
   strip_truncations.
   exact (p # p0).
 Defined.
-
-End Extensions.
 
 #[export] Hint Immediate conn_point_incl : typeclass_instances.
 

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -37,7 +37,7 @@ Lemma istrunc_extension_along_conn `{Univalence} {m n : trunc_index}
   {A B : Type} (f : A -> B) `{IsConnMap n _ _ f}
   (P : B -> Type) {HP : forall b:B, IsTrunc (m +2+ n) (P b)}
   (d : forall a:A, P (f a))
-: IsTrunc m (ExtensionAlong f P d).
+  : IsTrunc m (ExtensionAlong f P d).
 Proof.
   revert P HP d. induction m as [ | m' IH]; intros P HP d; simpl in *.
   (* m = –2 *)
@@ -45,15 +45,14 @@ Proof.
     intros y. apply (allpath_extension_conn_map n); assumption.
     (* m = S m' *)
   - intros e e'. refine (istrunc_isequiv_istrunc _ (path_extension e e')).
-(* magically infers: paths in extensions = extensions into paths,
-                       which by induction is m'-truncated. *)
+  (* magically infers: paths in extensions = extensions into paths, which by induction is m'-truncated. *)
 Defined.
 
 (** ** Connectedness of path spaces *)
 
 Global Instance isconnected_paths `{Univalence} {n A}
        `{IsConnected n.+1 A} (x y : A)
-: IsConnected n (x = y).
+  : IsConnected n (x = y).
 Proof.
   refine (contr_equiv' _ (equiv_path_Tr x y)^-1).
 Defined.
@@ -100,7 +99,7 @@ Defined.
 
 (** An [n.+1]-connected type is also [n]-connected.  This obviously can't be an [Instance]! *)
 Definition isconnected_pred n A `{IsConnected n.+1 A}
-: IsConnected n A.
+  : IsConnected n A.
 Proof.
   apply isconnected_from_elim; intros C ? f.
   refine (isconnected_elim n.+1 C f).
@@ -137,7 +136,7 @@ Defined.
 (** To be 0-connected is the same as to be (-1)-connected and that any two points are merely equal.  TODO: This should also be generalized to separated subuniverses (CORS Remark 2.35).  *)
 Definition merely_path_is0connected `{Univalence}
            (A : Type) `{IsConnected 0 A} (x y : A)
-: merely (x = y).
+  : merely (x = y).
 Proof.
   (** This follows immediately from [isconnected_paths] above. *)
   rapply center.
@@ -146,7 +145,7 @@ Defined.
 Definition is0connected_merely_allpath `{Univalence}
            (A : Type) `{merely A}
            (p : forall (x y:A), merely (x = y))
-: IsConnected 0 A.
+  : IsConnected 0 A.
 Proof.
   strip_truncations.
   apply (contr_inhabited_hprop).
@@ -182,7 +181,7 @@ Defined.
 
 (** The path component of a point [x : X] is equivalent to the image of the constant map [Unit -> X] at [x]. *)
 Definition equiv_component_image_unit {X : Type} (x : X)
-: { z : X & merely (z = x) } <~> image (Tr (-1)) (unit_name x).
+  : { z : X & merely (z = x) } <~> image (Tr (-1)) (unit_name x).
 Proof.
   unfold image; simpl.
   apply equiv_functor_sigma_id; intros z; simpl.
@@ -194,7 +193,7 @@ Defined.
 (** 0-connected types are indecomposable *)
 Global Instance indecomposable_0connected `{Univalence}
        (X : Type) `{IsConnected 0 X}
-: Indecomposable X.
+  : Indecomposable X.
 Proof.
   assert (IsConnected (-1) X) by refine (isconnected_pred (-1) X).
   constructor.
@@ -242,7 +241,7 @@ Context `{Univalence}
   (f_a0b0 : f_a0 b0 = f_b0 a0).
 
 Corollary isconn_wedge_incl
-: { f : forall a b, P a b
+  : { f : forall a b, P a b
   & { e_a0 : forall b, f a0 b = f_a0 b
   & { e_b0 : forall a, f a b0 = f_b0 a
   & e_b0 a0 = (e_a0 b0) @ f_a0b0 }}}.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -78,6 +78,8 @@ Proof.
   apply O_lex_leq_Tr.
 Defined.
 
+#[export] Hint Immediate conn_point_incl : typeclass_instances.
+
 (** Note that [OO_cancelR_conn_map] and [OO_cancelL_conn_map] (Proposition 2.31 of CORS) generalize the above statements to 2/3 of a 2-out-of-3 property for connected maps, for any reflective subuniverse and its subuniverse of separated types.  If useful, we could specialize that more general form explicitly to truncations. *)
 
 (** To prove an [n]-truncated predicate on an (n+1)-connected, pointed type, it's enough to prove it for the basepoint. *)
@@ -92,8 +94,6 @@ Proof.
   strip_truncations.
   exact (p # p0).
 Defined.
-
-#[export] Hint Immediate conn_point_incl : typeclass_instances.
 
 (** ** Decreasing connectedness *)
 

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -55,7 +55,7 @@ Defined.
 
 (** ** Connectedness of path spaces *)
 
-Global Instance isconnected_paths `{Univalence} {n A}
+Global Instance isconnected_paths {n A}
        `{IsConnected n.+1 A} (x y : A)
 : IsConnected n (x = y).
 Proof.
@@ -86,7 +86,7 @@ Defined.
 (** Note that [OO_cancelR_conn_map] and [OO_cancelL_conn_map] (Proposition 2.31 of CORS) generalize the above statements to 2/3 of a 2-out-of-3 property for connected maps, for any reflective subuniverse and its subuniverse of separated types.  If useful, we could specialize that more general form explicitly to truncations. *)
 
 (** To prove an [n]-truncated predicate on an (n+1)-connected, pointed type, it's enough to prove it for the basepoint. *)
-Definition conn_point_elim `{Univalence} (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
+Definition conn_point_elim (n : trunc_index) {A : pType@{u}} `{IsConnected n.+1 A}
            (P : A -> Type@{u}) `{forall a, IsTrunc n (P a)} (p0 : P (point A))
   : forall a, P a.
 Proof.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -174,6 +174,18 @@ Proof.
   exact p^.
 Defined.
 
+(** Any two points in a path component are merely equal.  This follows from [merely_path_is0connected], but this proof doesn't need univalence. *)
+Definition merely_path_component {X : Type} {x : X}
+  (z1 z2 : { z : X & merely (z = x) })
+  : merely (z1 = z2).
+Proof.
+  destruct z1 as [z1 p1], z2 as [z2 p2].
+  strip_truncations.
+  apply tr.
+  apply path_sigma_hprop; cbn.
+  exact (p1 @ p2^).
+Defined.
+
 (** The path component of a point [x : X] is equivalent to the image of the constant map [Unit -> X] at [x]. *)
 Definition equiv_component_image_unit {X : Type} (x : X)
 : { z : X & merely (z = x) } <~> image (Tr (-1)) (unit_name x).


### PR DESCRIPTION
While browsing, I noticed that the `baut_reduce` tactic could be used in a few more places if the proof of its helper lemma avoids univalence.