### PR TITLE
Only Require Truncations.Core in Classes library

### DIFF
--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -1,6 +1,7 @@
 Require Import Cubical WildCat.
 Require Import Colimits.Coeq.
 Require Import Algebra.AbGroups.AbelianGroup.
+Require Import Modalities.ReflectiveSubuniverse.
 
 (** In this file we define what it means for a group homomorphism G -> H into an abelian group H to be an abelianization. We then construct an example of an abelianization. *)
 

--- a/theories/Algebra/AbGroups/Biproduct.v
+++ b/theories/Algebra/AbGroups/Biproduct.v
@@ -1,6 +1,7 @@
 Require Import WildCat.
 Require Import HSet.
 Require Import AbelianGroup.
+Require Import Modalities.ReflectiveSubuniverse.
 
 Local Open Scope mc_add_scope.
 

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -2,6 +2,7 @@ Require Import HSet WildCat.
 Require Import Groups.QuotientGroup Groups.ShortExactSequence.
 Require Import AbGroups.AbelianGroup AbGroups.Biproduct AbGroups.AbHom.
 Require Import Homotopy.ExactSequence Pointed.
+Require Import Modalities.ReflectiveSubuniverse.
 
 Local Open Scope pointed_scope.
 Local Open Scope type_scope.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -1,4 +1,5 @@
 Require Import Pointed WildCat.
+Require Import Truncations.SeparatedTrunc.
 Require Import AbGroups.AbelianGroup AbGroups.AbHom.
 Require Import AbSES.Pullback AbSES.BaerSum AbSES.Core.
 

--- a/theories/Algebra/AbSES/Pullback.v
+++ b/theories/Algebra/AbSES/Pullback.v
@@ -1,5 +1,6 @@
 Require Import HSet Limits.Pullback.
 Require Import WildCat Pointed Homotopy.ExactSequence.
+Require Import Modalities.ReflectiveSubuniverse.
 Require Import AbGroups.AbelianGroup AbGroups.AbPullback AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.DirectSum.
 

--- a/theories/Algebra/AbSES/PullbackFiberSequence.v
+++ b/theories/Algebra/AbSES/PullbackFiberSequence.v
@@ -3,7 +3,7 @@ Require Import WildCat Pointed Homotopy.ExactSequence.
 Require Import Groups.QuotientGroup.
 Require Import AbGroups.AbelianGroup AbGroups.AbPullback AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.Pullback. 
-Require Import Modalities.Identity.
+Require Import Modalities.Identity Modalities.Modality.
 
 Local Open Scope pointed_scope.
 

--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -1,4 +1,5 @@
 Require Import WildCat Pointed Homotopy.ExactSequence HIT.epi.
+Require Import Truncations.Connectedness.
 Require Import AbGroups.AbelianGroup AbGroups.AbPushout AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.DirectSum.
 

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -1,6 +1,7 @@
 Require Import Groups.Group.
 Require Import Colimits.Coeq.
 Require Import WildCat.
+Require Import Truncations.SeparatedTrunc.
 
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.

--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -1,6 +1,7 @@
 Require Import Cubical.
 Require Import Spaces.List.
 Require Import Colimits.Pushout.
+Require Import Truncations.SeparatedTrunc.
 Require Import Algebra.Groups.Group.
 
 Local Open Scope list_scope.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -4,6 +4,7 @@ Require Export Classes.interfaces.abstract_algebra.
 Require Export Classes.theory.groups.
 Require Import Pointed.Core.
 Require Import WildCat.
+Require Import Truncations.Connectedness.
 
 Local Set Polymorphic Inductive Cumulativity.
 

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -7,6 +7,7 @@ Require Export Colimits.Quotient.
 Require Import HSet.
 Require Import Spaces.Finite.
 Require Import WildCat.
+Require Import Modalities.Modality.
 
 (** * Quotient groups *)
 

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -3,6 +3,7 @@ Require Import Spaces.Nat.
 Require Export Classes.interfaces.abstract_algebra.
 Require Import Algebra.AbGroups.
 Require Export Classes.theory.rings.
+Require Import Modalities.ReflectiveSubuniverse.
 
 (** Theory of commutative rings *)
 

--- a/theories/Algebra/Rings/ChineseRemainder.v
+++ b/theories/Algebra/Rings/ChineseRemainder.v
@@ -1,4 +1,5 @@
 Require Import WildCat.
+Require Import Modalities.ReflectiveSubuniverse.
 Require Import Algebra.AbGroups.
 Require Import Algebra.Rings.CRing.
 Require Import Algebra.Rings.Ideal.

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -1,5 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 Require Import Pointed.
+Require Import Truncations.Connectedness.
 Require Import Homotopy.ClassifyingSpace.
 Require Import Algebra.Groups.
 Require Import WildCat.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -1,5 +1,6 @@
 Require Import Spaces.Nat.
 Require Export HoTT.Classes.interfaces.canonical_names.
+Require Import Modalities.ReflectiveSubuniverse.
 
 Local Set Polymorphic Inductive Cumulativity.
 

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -1,8 +1,7 @@
 Require Export
   HoTT.Basics
   HoTT.Types
-  HoTT.Truncations
-  HoTT.Basics.Utf8.
+  HoTT.Truncations.Core.
 
 Declare Scope mc_scope.
 Delimit Scope mc_scope with mc.
@@ -414,8 +413,7 @@ Class Bind (M : Type -> Type) := bind : forall {A B}, M A -> (A -> M B) -> M B.
 
 Class Enumerable@{i} (A : Type@{i}) :=
   { enumerator : nat -> A
-  ; enumerator_issurj :
-    IsConnMap@{i} (trunc_S minus_two) enumerator }.
+  ; enumerator_issurj : IsSurjection enumerator }.
 #[export] Existing Instance enumerator_issurj.
 Arguments enumerator A {_} _.
 Arguments enumerator_issurj A {_} _.

--- a/theories/Classes/theory/rationals.v
+++ b/theories/Classes/theory/rationals.v
@@ -591,7 +591,7 @@ destruct (le_or_lt (enumerator Q n) 0) as [E|E].
 Defined.
 
 Lemma Qpos_is_enumerator :
-  IsConnMap@{UQ} (trunc_S minus_two) Qpos_enumerator.
+  IsSurjection@{UQ} Qpos_enumerator.
 Proof.
 apply BuildIsSurjection.
 unfold hfiber.
@@ -603,7 +603,7 @@ unfold Qpos_enumerator. destruct (le_or_lt (enumerator Q n) 0) as [E1|E1].
 - apply pos_eq,E.
 Qed.
 
-Global Instance Qpos_enumerable `{Enumerable Q} : Enumerable Q+.
+Global Instance Qpos_enumerable : Enumerable Q+.
 Proof.
   exists Qpos_enumerator.
   first [exact Qpos_is_enumerator@{Uhuge Ularge}|

--- a/theories/Homotopy/Bouquet.v
+++ b/theories/Homotopy/Bouquet.v
@@ -1,5 +1,6 @@
 Require Import Pointed WildCat.
 Require Import Algebra.Groups.
+Require Import Modalities.ReflectiveSubuniverse.
 Require Import Homotopy.Suspension.
 Require Import Homotopy.ClassifyingSpace.
 Require Import Homotopy.HomotopyGroup.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -2,6 +2,7 @@ Require Import Pointed Cubical WildCat.
 Require Import Algebra.AbGroups.
 Require Import Homotopy.HSpace.Core.
 Require Import TruncType.
+Require Import Truncations.Connectedness.
 Require Import Homotopy.HomotopyGroup.
 Require Import Homotopy.WhiteheadsPrinciple.
 

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -6,6 +6,7 @@ Require Import Homotopy.ClassifyingSpace.
 Require Import Homotopy.HSpace.Core.
 Require Import Homotopy.HomotopyGroup.
 Require Import TruncType.
+Require Import Truncations.Connectedness.
 Require Import WildCat.
 
 (* Formalisation of Eilenberg-MacLane spaces *)

--- a/theories/Homotopy/HSpace/Core.v
+++ b/theories/Homotopy/HSpace/Core.v
@@ -1,5 +1,6 @@
 Require Export Classes.interfaces.abstract_algebra.
 Require Import Pointed WildCat.
+Require Import Truncations.Connectedness.
 
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -1,4 +1,5 @@
 Require Import Pointed.
+Require Import Truncations.SeparatedTrunc Modalities.ReflectiveSubuniverse.
 Require Import Algebra.AbGroups.
 Require Import WildCat.
 

--- a/theories/Homotopy/WhiteheadsPrinciple.v
+++ b/theories/Homotopy/WhiteheadsPrinciple.v
@@ -1,5 +1,6 @@
 Require Import Pointed.
 Require Import WildCat HFiber.
+Require Import Truncations.
 Require Import Algebra.Groups.
 Require Import Homotopy.HomotopyGroup.
 

--- a/theories/Sets/Hartogs.v
+++ b/theories/Sets/Hartogs.v
@@ -1,4 +1,4 @@
-From HoTT Require Import TruncType ExcludedMiddle abstract_algebra HSet.
+From HoTT Require Import TruncType ExcludedMiddle Modalities.ReflectiveSubuniverse abstract_algebra HSet.
 From HoTT Require Import PropResizing.PropResizing.
 From HoTT Require Import Spaces.Card.
 
@@ -222,7 +222,7 @@ Section Hartogs_Number.
     apply equiv_inverse. unshelve eexists.
     - intros a. exists (uni_fix (hartogs_number'_injection.1 a)).
       apply equiv_resize_hprop, tr. exists a. reflexivity.
-    - srapply isequiv_surj_emb.
+    - snrapply isequiv_surj_emb.
       + apply BuildIsSurjection. intros [X HX]. eapply merely_destruct.
         * eapply equiv_resize_hprop, HX.
         * intros [a <-]. cbn. apply tr. exists a. cbn. apply ap. apply ishprop_resize_hprop.

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -1,4 +1,4 @@
-From HoTT Require Import TruncType ExcludedMiddle abstract_algebra.
+From HoTT Require Import TruncType ExcludedMiddle Modalities.ReflectiveSubuniverse abstract_algebra.
 From HoTT Require Import PropResizing.PropResizing.
 From HoTT Require Import HIT.quotient.
 

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -1,4 +1,5 @@
 Require Import Pointed WildCat.
+Require Import Modalities.ReflectiveSubuniverse.
 Require Import Algebra.AbGroups.
 Require Import Homotopy.HomotopyGroup.
 Require Import Homotopy.Pi1S1.


### PR DESCRIPTION
The Classes library doesn't use anything in Truncations/Connectedness.v or Truncations/SeparatedTrunc.v, so don't import or export any of those.  Other files that were getting some of those via Classes now need to explicitly require them.

`-j1` build time improves slightly.  `-j8` build time doesn't change significantly, but looser dependencies will help if we get a smarter build system or when using more than 8 cores.

(Also, a redundant hypothesis removed from `Qpos_enumerable`.)