### PR TITLE
Make pFam into a Record to improve polymorphism of pEquiv

### DIFF
--- a/theories/Homotopy/Cover.v
+++ b/theories/Homotopy/Cover.v
@@ -15,9 +15,9 @@ Definition O_cover@{u} `{O : ReflectiveSubuniverse@{u}}
 (** Characterization of paths in [O_cover] is given by [equiv_path_hfiber]. *)
 
 (* If [x] is an actual point of [X], then the connected cover is pointed. *)
-Definition O_pcover@{u v} (O : ReflectiveSubuniverse@{u})
+Definition O_pcover@{u} (O : ReflectiveSubuniverse@{u})
   (X : Type@{u}) (x : X) : pType@{u}
-  := pfiber@{u v u u} (pto O [X,x]).
+  := pfiber@{u u u} (pto O [X,x]).
 
 (** Covers commute with products *)
 Definition O_pcover_prod `{O : ReflectiveSubuniverse} {X Y : pType@{u}}

--- a/theories/Homotopy/EncodeDecode.v
+++ b/theories/Homotopy/EncodeDecode.v
@@ -49,18 +49,18 @@ Defined.
 Definition encode_decode_loops
   (A : pType) (code : pFam A)
   (decode : forall x, code x -> point A = x)
-  (s : forall (c : code.1 (point A)), decode _ c # code.2 = c)
-  (r : decode _ (pr2 code) = idpath)
-  : loops A <~> code.1 (point A)
-  := encode_decode _ _ code.1 code.2 decode s r _.
+  (s : forall (c : code (point A)), decode _ c # (dpoint code) = c)
+  (r : decode _ (dpoint code) = idpath)
+  : loops A <~> code (point A)
+  := encode_decode _ _ code (dpoint code) decode s r _.
 
 (** Encode-decode for truncated loop spaces *)
 Definition encode_decode_trunc_loops n
   (A : pType) (code : pFam A) `{forall a, IsTrunc n (code a)}
   (decode : forall x, code x -> Tr n (point A = x))
-  (s : forall (c : code.1 (point A)),
-    Trunc_rec (fun (p : loops A) => p # code.2) (decode _ c) = c)
-  (r : decode _ code.2 = tr idpath)
+  (s : forall (c : code (point A)),
+    Trunc_rec (fun (p : loops A) => p # (dpoint code)) (decode _ c) = c)
+  (r : decode _ (dpoint code) = tr idpath)
   : pTr n (loops A) <~> code (point A)
-  := encode_decode_trunc _ _ _ code.1 code.2 decode s r _.
+  := encode_decode_trunc _ _ _ code (dpoint code) decode s r _.
 

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -35,15 +35,12 @@ Global Instance ispointed_prod `{IsPointed A, IsPointed B} : IsPointed (A * B)
 (** We override the notation for products in pointed_scope *)
 Notation "X * Y" := ([X * Y, ispointed_prod]) : pointed_scope.
 
-(** A pointed type family consists of a type family over a pointed type and a section of that family at the basepoint. By making this a Record, it has one fewer universe variable, and is cumulative. *)
-Record pFam (A : pType) := { pfam_pr1 : A -> Type; dpoint : pfam_pr1 (point A)}.
+(** A pointed type family consists of a type family over a pointed type and a section of that family at the basepoint. By making this a Record, it has one fewer universe variable, and is cumulative. We declare [pfam_pr1] to be a coercion [pFam >-> Funclass]. *)
+Record pFam (A : pType) := { pfam_pr1 :> A -> Type; dpoint : pfam_pr1 (point A)}.
 
 Arguments Build_pFam {A} _ _.
 Arguments pfam_pr1 {A} P : rename.
 Arguments dpoint {A} P : rename.
-
-(** We make [pfam_pr1] a coercion. *)
-Coercion pfam_pr1 : pFam >-> Funclass.
 
 (** The constant pointed family *)
 Definition pfam_const {A : pType} (B : pType) : pFam A

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -35,23 +35,23 @@ Global Instance ispointed_prod `{IsPointed A, IsPointed B} : IsPointed (A * B)
 (** We override the notation for products in pointed_scope *)
 Notation "X * Y" := ([X * Y, ispointed_prod]) : pointed_scope.
 
-(** A pointed type family consists of a type family over a pointed type and a section of that family at the basepoint. *)
-Definition pFam (A : pType) := {P : A -> Type & P (point A)}.
+(** A pointed type family consists of a type family over a pointed type and a section of that family at the basepoint. By making this a Record, it has one fewer universe variable, and is cumulative. *)
+Record pFam (A : pType) := { pfam_pr1 : A -> Type; dpoint : pfam_pr1 (point A)}.
 
-(** We make the first projection of a [pFam] a coercion. *)
-Definition pfam_pr1 {A : pType} (P : pFam A) : A -> Type := pr1 P.
+Arguments Build_pFam {A} _ _.
+Arguments pfam_pr1 {A} P : rename.
+Arguments dpoint {A} P : rename.
+
+(** We make [pfam_pr1] a coercion. *)
 Coercion pfam_pr1 : pFam >-> Funclass.
 
-(** We call the section of a pointed type family at the basepoint a [dpoint]. *)
-Definition dpoint {A : pType} (P : pFam A) : P (point A) := pr2 P.
-
 (** The constant pointed family *)
-Definition pfam_const {A : pType} (B : pType) : pFam A :=
-  (fun _ => pointed_type B; point B).
+Definition pfam_const {A : pType} (B : pType) : pFam A
+  := Build_pFam (fun _ => pointed_type B) (point B).
 
 (** [IsTrunc] for a pointed type family *)
-Class IsTrunc_pFam n {A} (X : pFam A)
-  := trunc_pfam_is_trunc : forall x, IsTrunc n (X.1 x).
+Class IsTrunc_pFam n {A} (P : pFam A)
+  := trunc_pfam_is_trunc : forall x, IsTrunc n (P x).
 
 (** Pointed dependent functions *)
 Record pForall (A : pType) (P : pFam A) := {
@@ -99,7 +99,7 @@ Definition psnd {A B : pType} : A * B ->* B
 (** ** Pointed homotopies *)
 
 Definition pfam_phomotopy {A : pType} {P : pFam A} (f g : pForall A P) : pFam A
-  := (fun x => f x = g x; dpoint_eq f @ (dpoint_eq g)^).
+  := Build_pFam (fun x => f x = g x) (dpoint_eq f @ (dpoint_eq g)^).
 
 (* A pointed homotopy is a homotopy with a proof that the presevation paths agree. We define it instead as a special case of a [pForall]. This means that we can define pointed homotopies between pointed homotopies. *)
 Definition pHomotopy {A : pType} {P : pFam A} (f g : pForall A P) : Type
@@ -148,7 +148,7 @@ Coercion pointed_equiv_equiv {A B} (f : A <~>* B)
 
 (** Pointed sigma types *)
 Definition psigma {A : pType} (P : pFam A) : pType
-  := [sig P, (point A; P.2)].
+  := [sig P, (point A; dpoint P)].
 
 (** Pointed pi types, note that the domain is not pointed *)
 Definition pproduct {A : Type} (F : A -> pType) : pType
@@ -218,17 +218,17 @@ Definition issig_pequiv' (A B : pType)
 (** This is [equiv_prod_coind] for pointed families. *)
 Definition equiv_pprod_coind {A : pType} (P Q : pFam A)
   : (pForall A P * pForall A Q) <~>
-      (pForall A (fun a => prod (P a) (Q a); (P.2, Q.2))).
+      (pForall A (Build_pFam (fun a => prod (P a) (Q a)) (dpoint P, dpoint Q))).
 Proof.
   transitivity {p : prod (forall a:A, P a) (forall a:A, Q a)
-                    & prod (fst p _ = P.2) (snd p _ = Q.2)}.
+                    & prod (fst p _ = dpoint P) (snd p _ = dpoint Q)}.
   1: make_equiv.
   refine (issig_pforall _ _ oE _).
   srapply equiv_functor_sigma'.
   1: apply equiv_prod_coind.
   intro f; cbn.
   unfold prod_coind_uncurried.
-  exact (equiv_path_prod (fst f _, snd f _) (P.2, Q.2)).
+  exact (equiv_path_prod (fst f _, snd f _) (dpoint P, dpoint Q)).
 Defined.
 
 (** ** Various operations with pointed homotopies *)
@@ -496,7 +496,7 @@ Definition path_pequiv `{Funext} {A B : pType} (f g : A <~>* B)
 
 (** A family of pointed types gives rise to a [pFam]. *)
 Definition pointed_fam {A : pType} (B : A -> pType) : pFam A
-  := (pointed_type o B; point (B (point A))).
+  := Build_pFam (pointed_type o B) (point (B (point A))).
 
 (** The section of a family of pointed types *)
 Definition point_pforall {A : pType} (B : A -> pType) : pForall A (pointed_fam B)

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -270,7 +270,7 @@ Defined.
 
 (* A dependent form of loops *)
 Definition loopsD {A} : pFam A -> pFam (loops A)
-  := fun Pp => (fun q => transport Pp.1 q Pp.2 = Pp.2; 1).
+  := fun Pp => Build_pFam (fun q : loops A => transport Pp q (dpoint Pp) = (dpoint Pp)) 1.
 
 Global Instance istrunc_pfam_loopsD {n} {A} (P : pFam A)
        {H :IsTrunc_pFam n.+1 P}
@@ -326,18 +326,16 @@ Proof.
   apply loops_psigma_commute.
 Defined.
 
-(** In the following lemmas we have used universe annotations explicitly as without them, coq cannot guess the universe levels correctly. Defining pointed maps as a special case of pForall has the side effect of raising the universe level since pForall requires a bigger universe for the type family. Hopefully in the future, coq's "universe guessing" will be smarter and we can drop the annotations here. *)
-
-(* We can convert between families of loops in a type and loops in Type at that type. *)
-Definition loops_type@{i j k} `{Univalence} (A : Type@{i})
-  : pEquiv@{j j k} (loops@{j} (Build_pType@{j} Type@{i} A))
-          [A <~> A, equiv_idmap].
+(* We can convert between loops in a type and loops in [Type] at that type. *)
+Definition loops_type `{Univalence} (A : Type@{i})
+  : loops [Type@{i}, A] <~>* [A <~> A, equiv_idmap].
 Proof.
   apply issig_pequiv'.
   exists (equiv_equiv_path A A).
   reflexivity.
 Defined.
 
+(* An iterated version.  Note that the statement with "-1" substituted for [n] is [loops [Type, A] <~>* [A -> A, idmap]], which is not true in general. Compare the previous result. *)
 Lemma local_global_looping `{Univalence} (A : Type@{i}) (n : nat)
   : iterated_loops@{j} n.+2 [Type@{i}, A]
     <~>* pproduct (fun a => iterated_loops@{j} n.+1 [A, a]).

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -24,10 +24,10 @@ Proof.
   intros ? ?; apply pequiv_inverse.
 Defined.
 
-(* Pointed equivalences compose. We use this definition rather than [g $oE f] so that we can compose equivalences between pointed types in different universes. *)
+(* Pointed equivalences compose. *)
 Definition pequiv_compose {A B C : pType} (f : A <~>* B) (g : B <~>* C)
   : A <~>* C
-  := Build_pEquiv _ _ (g o* f) _.
+  := g $oE f.
 
 (* pointed equivalence is a transitive relation *)
 Global Instance pequiv_transitive : Transitive pEquiv.

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -18,8 +18,8 @@ Definition pmap_from_pointed {A : pType} {B : Type} (f : A -> B)
 
 (** The same, for a dependent pointed map. *)
 Definition pforall_from_pointed {A : pType} {B : A -> Type} (f : forall x, B x)
-  : pForall A (B; f (point A))
-  := Build_pForall A (B; (f (point A))) f 1%path.
+  : pForall A (Build_pFam B (f (point A)))
+  := Build_pForall A (Build_pFam B (f (point A))) f 1%path.
 
 (* precomposing the zero map is the zero map *)
 Lemma precompose_pconst {A B C : pType} (f : B ->* C)

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -37,7 +37,8 @@ Definition pTr_rec_beta n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
   := phomotopy_path (pTr_rec_beta_path n f).
 
 (** A pointed version of the induction principle. *)
-Definition pTr_ind n {X : pType} {Y : pFam (pTr n X)} `{forall x, IsTrunc n (Y x)} (f : pForall X (Y.1 o tr; Y.2))
+Definition pTr_ind n {X : pType} {Y : pFam (pTr n X)} `{forall x, IsTrunc n (Y x)}
+  (f : pForall X (Build_pFam (Y o tr) (dpoint Y)))
   : pForall (pTr n X) Y
   := Build_pForall (pTr n X) Y (Trunc_ind Y f) (dpoint_eq f).
 


### PR DESCRIPTION
I finally figured out how to make `pEquiv` have irrelevant universe variables (the best kind):  I had to make `pFam` into a Record.  This has the added benefit of getting rid of the third universe variable.  So now `pEquiv` has just two universe variables, for the two types.

This allows me to revert part of #1706.  `pequiv_compose` can be defined using the WildCat composition, and ends up with fully flexible universe variables:
```
pequiv_compose@{u u0 u1 u2 u3} = 
fun (A : pType@{u}) (B : pType@{u0}) (C : pType@{u1}) (f : pEquiv@{u2 u2} A B)
  (g : pEquiv@{u2 u2} B C) => compose_cate@{u2 u2 u2 u2 u3} g f
     : forall (A : pType@{u}) (B : pType@{u0}) (C : pType@{u1})
         (_ : pEquiv@{u2 u2} A B) (_ : pEquiv@{u2 u2} B C), 
       pEquiv@{u2 u2} A C
(* u u0 u1 u2 u3 |= u2 < u3
                    u <= u2
                    u0 <= u2
                    u1 <= u2 *)
```
No constraints between `u`, `u0` and `u1`. Unfortunately, it does get two extra universe variables, `u2` and `u3` above, that it doesn't have if you define it directly.  But I think it'll be useful to have it match the WildCat definition.

And with this, `test2` in #1703 passes.  And it works in the applications I'm working on.

Almost all of the changes are just to adjust to `pFam` being a Record.