### PR TITLE
Make sig and everything else in Overture cumulative

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -34,12 +34,12 @@ Proof.
   refine (equiv_ap_inv issig_abgroup _ _ oE _).
   About equiv_path_sigma_hprop.
   refine (equiv_path_sigma_hprop _ _ oE _).
-  exact equiv_path_group@{v u u u u u u u u u}.
+  exact equiv_path_group.
 Defined.
 
 Definition equiv_path_abgroup_group `{Univalence} {A B : AbGroup}
   : (A = B :> AbGroup) <~> (A = B :> Group)
-  := equiv_path_group@{v u u u u u u u u u} oE equiv_path_abgroup^-1.
+  := equiv_path_group oE equiv_path_abgroup^-1.
 
 (** ** Subgroups of abelian groups *)
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -13,6 +13,8 @@ Create HintDb rewrite discriminated.
 #[export] Hint Variables Opaque : rewrite.
 Create HintDb typeclass_instances discriminated.
 
+Local Set Polymorphic Inductive Cumulativity.
+
 (** ** Type classes *)
 
 (** This command prevents Coq from trying to guess the values of existential variables while doing typeclass resolution.  If you don't know what that means, ignore it. *)
@@ -151,7 +153,7 @@ Definition const {A B} (b : B) := fun x : A => b.
 (** ** Sigma types *)
 
 (** [(sig A P)], or more suggestively [{x:A & (P x)}] is a Sigma-type. *)
-Cumulative Record sig {A} (P : A -> Type) := exist {
+Record sig {A} (P : A -> Type) := exist {
   proj1 : A ;
   proj2 : P proj1 ;
 }.
@@ -236,7 +238,7 @@ Notation "g 'oD' f" := (composeD g f) : function_scope.
 (** The results in this file are used everywhere else, so we need to be extra careful about how we define and prove things.  We prefer hand-written terms, or at least tactics that allow us to retain clear control over the proof-term produced. *)
 
 (** We define our own identity type, rather than using the one in the Coq standard library, so as to have more control over transitivity, symmetry and inverse.  It seems impossible to change these for the standard eq/identity type (or its Type-valued version) because it breaks various other standard things.  Merely changing notations also doesn't seem to quite work. *)
-Cumulative Inductive paths {A : Type} (a : A) : A -> Type :=
+Inductive paths {A : Type} (a : A) : A -> Type :=
   idpath : paths a a.
 
 Arguments idpath {A a} , [A] a.
@@ -482,7 +484,7 @@ Arguments apD {A%type_scope B} f%function_scope {x y} p%path_scope : simpl nomat
 (** Naming convention: we use [equiv] and [Equiv] systematically to denote types of equivalences, and [isequiv] and [IsEquiv] systematically to denote the assertion that a given map is an equivalence. *)
 
 (** A typeclass that includes the data making [f] into an adjoint equivalence. *)
-Cumulative Class IsEquiv {A B : Type} (f : A -> B) := {
+Class IsEquiv {A B : Type} (f : A -> B) := {
   equiv_inv : B -> A ;
   eisretr : f o equiv_inv == idmap ;
   eissect : equiv_inv o f == idmap ;
@@ -498,7 +500,7 @@ Arguments IsEquiv {A B}%type_scope f%function_scope.
 Global Opaque eisadj.
 
 (** A record that includes all the data of an adjoint equivalence. *)
-Cumulative Record Equiv A B := {
+Record Equiv A B := {
   equiv_fun : A -> B ;
   equiv_isequiv : IsEquiv equiv_fun
 }.
@@ -539,7 +541,7 @@ In order to achieve moderate coverage and speedy resolution, we currently follow
 (** A space [A] is contractible if there is a point [x : A] and a (pointwise) homotopy connecting the identity on [A] to the constant map at [x].  Thus an element of [contr A] is a pair whose first component is a point [x] and the second component is a pointwise retraction of [A] to [x]. *)
 
 (** We use the [Contr_internal] record so as not to pollute typeclass search; we only do truncation typeclass search on the [IsTrunc] datatype, usually.  We will define a notation [Contr] which is equivalent to [Contr_internal], but picked up by typeclass search.  However, we must make [Contr_internal] a class so that we pick up typeclasses on [center] and [contr].  However, the only typeclass rule we register is the one that turns it into a [Contr]/[IsTrunc].  Unfortunately, this means that declaring an instance like [Instance contr_foo : Contr foo := { center := bar }.] will fail with mismatched instances/contexts.  Instead, we must iota expand such definitions to get around Coq's deficiencies, and write [Instance contr_foo : Contr foo := let x := {| center := bar |} in x.] *)
-Cumulative Class Contr_internal (A : Type) := Build_Contr {
+Class Contr_internal (A : Type) := Build_Contr {
   center : A ;
   contr : (forall y : A, center = y)
 }.
@@ -766,7 +768,7 @@ Class IsPointed (A : Type) := point : A.
 
 Arguments point A {_}.
 
-Cumulative Record pType :=
+Record pType :=
   { pointed_type : Type ;
     ispointed_type : IsPointed pointed_type }.
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -151,7 +151,7 @@ Definition const {A B} (b : B) := fun x : A => b.
 (** ** Sigma types *)
 
 (** [(sig A P)], or more suggestively [{x:A & (P x)}] is a Sigma-type. *)
-Record sig {A} (P : A -> Type) := exist {
+Cumulative Record sig {A} (P : A -> Type) := exist {
   proj1 : A ;
   proj2 : P proj1 ;
 }.

--- a/theories/Metatheory/UnivalenceVarieties.v
+++ b/theories/Metatheory/UnivalenceVarieties.v
@@ -76,7 +76,7 @@ Proof.
     rewrite !transport_pp.
     refine (moveR_transport_V idmap (unit vwu B) _ (f a) _).
     rewrite !(unit_comp vwu).
-    rewrite <- !transport_compose.
+    rewrite <- !(transport_compose idmap sig).
     rewrite (transport_sigma' (C := fun P (a0:A) => P a0)); cbn.
     refine (ap _ _ @ _).
     1:{ apply ap, ap.

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -104,8 +104,8 @@ Definition equiv_sigma_pfibration@{u v +} `{Univalence} {Y F : pType@{u}}
 Theorem equiv_sigma_fibration_O@{u v} `{Univalence} {O : Subuniverse} {Y : Type@{u}}
   : (Y -> Type_@{u v} O) <~> { p : { X : Type@{u} & X -> Y } & MapIn O p.2 }.
 Proof.
-  refine (_ oE (equiv_sig_coind _ _)^-1).
-  apply (equiv_functor_sigma' equiv_sigma_fibration); intro P; cbn.
+  refine (_ oE (equiv_sig_coind@{u v u v v v u} _ _)^-1).
+  apply (equiv_functor_sigma'@{v u v v v v} equiv_sigma_fibration@{u v}); intro P; cbn.
   rapply equiv_forall_inO_mapinO_pr1.
 Defined.
 

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -1018,7 +1018,7 @@ Section AssumeStuff.
       : partial_Nrec_restr n (nrec_partials f (succ n)) = nrec_partials f n.
     Proof.
       change (?x = ?y) with ((x.1; x.2) = (y.1; y.2)).
-      srefine (path_sigma' _ 1 _).
+      srefine (path_sigma'@{nr nr nr} _ 1 _).
       abstract (rewrite transport_1;
       apply path_prod;
       [ cbn [partial_Nrec_restr nrec_partials fst pr2 pr1];


### PR DESCRIPTION
The first commit changes `sig` to be a Cumulative Record.  This loosens universe constraints. This means that sometimes Coq isn't forced to equate universe variables, which means that the user needs to supply them if they want to keep the number small.  This happens in two places, in ObjectClassifier.v and PropResizing/Nat.v.   The other effect is that if the user doesn't manage universe variables, there are sometimes more of them.  For example, `equiv_path_group` goes from having 10 universe variables to 16.  Luckily, in the places where they were listed explicitly, it worked to just delete them.  In addition, one minor change was needed for some reason in `Metatheory/UnivalenceVarieties.v`.  In total, only four files besides Overture.v needed adjustments.

The second commit makes everything else in Overture.v cumulative, and no other changes were needed to the library.  This was surprising to me, as there are many Records/Inductives/Classes in there that weren't already marked as being Cumulative!

It's a bit unfortunate that making things cumulative can *increase* the number of universe variables, but I've seen enough cases where cumulativity was very helpful to think that this is worth it.
