### PR TITLE
Reduce universes in [equiv_path_Tr] and [equiv_path_group]

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -32,7 +32,6 @@ Definition equiv_path_abgroup `{Univalence} {A B : AbGroup@{u}}
   : GroupIsomorphism A B <~> (A = B).
 Proof.
   refine (equiv_ap_inv issig_abgroup _ _ oE _).
-  About equiv_path_sigma_hprop.
   refine (equiv_path_sigma_hprop _ _ oE _).
   exact equiv_path_group.
 Defined.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -306,10 +306,9 @@ Proof.
       1: exact _.
       intros [[op' [unit' [neg' ax']]] eq].
       apply path_sigma_hprop; cbn.
-      (* We really need to fix https://github.com/HoTT/HoTT/issues/976 *)
       refine (@ap _ _ (fun x : { oun :
-        { oo : SgOp G | { u : MonUnit G | Negate G}}
-        | @IsGroup G oun.1 oun.2.1 oun.2.2}
+        { oo : SgOp G & { u : MonUnit G & Negate G}}
+        & @IsGroup G oun.1 oun.2.1 oun.2.2}
         => (x.1.1 ; x.1.2.1 ; x.1.2.2 ; x.2))
         ((op;unit;neg);ax) ((op';unit';neg');ax') _).
       apply path_sigma_hprop; cbn.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -290,50 +290,58 @@ Proof.
 Defined.
 
 (** Under univalence, equality of groups is equivalent to isomorphism of groups. *)
-Definition equiv_path_group {U : Univalence} {G H : Group}
+Definition equiv_path_group' {U : Univalence} {G H : Group@{u}}
   : GroupIsomorphism G H <~> G = H.
 Proof.
-  refine (equiv_compose'
-    (B := sig (fun f : G <~> H => IsMonoidPreserving f)) _ _).
-  { revert G H; apply (equiv_path_issig_contr issig_group).
+  refine (equiv_compose'@{u u v}
+    (B := sig@{u u} (fun f : Equiv@{u u} G H => IsMonoidPreserving@{u u} f)) _ _).
+  { revert G H; apply (equiv_path_issig_contr@{v v v v v} issig_group@{u v}).
     + intros [G [? [? [? ?]]]].
-      exists 1%equiv.
-      exact _.
+      exists equiv_idmap@{u}.
+      exact id_monoid_morphism@{u u u}.
     + intros [G [op [unit [neg ax]]]]; cbn.
-      contr_sigsig G (equiv_idmap G).
+      contr_sigsig G (equiv_idmap@{u} G).
       srefine (Build_Contr _ ((_;(_;(_;_)));_) _); cbn;
-        try assumption; try exact _.
+        try assumption.
+      1: exact id_monoid_morphism@{u u u}.
       intros [[op' [unit' [neg' ax']]] eq].
-      apply path_sigma_hprop; cbn.
+      apply path_sigma_hprop@{u u u}; cbn.
       (* We really need to fix https://github.com/HoTT/HoTT/issues/976 *)
       refine (@ap _ _ (fun x : { oun :
         { oo : SgOp G | { u : MonUnit G | Negate G}}
         | @IsGroup G oun.1 oun.2.1 oun.2.2}
         => (x.1.1 ; x.1.2.1 ; x.1.2.2 ; x.2))
-        ((op;unit;neg);ax) ((op';unit';neg');ax') _).
-      apply path_sigma_hprop; cbn.
-      srefine (path_sigma' _ _ _).
+                ((op;unit;neg);ax) ((op';unit';neg');ax') _).
+      apply path_sigma_hprop@{u u u}; cbn.
+      srefine (path_sigma'@{u u u} _ _ _).
       1: funext x y; apply eq.
       rewrite transport_const.
-      srefine (path_sigma' _ _ _).
+      srefine (path_sigma'@{u u u} _ _ _).
       1: apply eq.
       rewrite transport_const.
       funext x.
-      exact (preserves_negate (f:=idmap) _). }
-  refine (_ oE (issig_GroupIsomorphism G H)^-1).
-  refine (_ oE (equiv_functor_sigma' (issig_GroupHomomorphism G H)
-    (fun f => 1%equiv))^-1).
-  refine (equiv_functor_sigma' (issig_equiv G H) (fun f => 1%equiv) oE _).
-  cbn.
+      exact (preserves_negate@{u u} (f:=idmap) _). }
+  refine (equiv_compose'@{u u u} _ (issig_GroupIsomorphism@{u} G H)^-1).
+  refine (equiv_compose'@{u u u} _
+            (equiv_functor_sigma'@{u u u u u u}
+               (issig_GroupHomomorphism@{u} G H) (fun f => 1%equiv))^-1).
+  refine (equiv_compose'@{u u u}
+            (equiv_functor_sigma'@{u u u u u u}
+               (issig_equiv@{u u u} G H) (fun f => 1%equiv)) _); cbn.
   refine (
-    equiv_adjointify
+    equiv_adjointify@{u u}
       (fun f => (exist (IsMonoidPreserving o pr1)
-        (exist IsEquiv f.1.1 f.2) f.1.2))
-      (fun f => (exist (IsEquiv o pr1)
+        (exist IsEquiv@{u u} f.1.1 f.2) f.1.2))
+      (fun f => (exist (IsEquiv@{u u} o pr1)
         (exist IsMonoidPreserving f.1.1 f.2) f.1.2))
        _ _).
   all: intros [[]]; reflexivity.
 Defined.
+
+(** A version with nicer universe variables. *)
+Definition equiv_path_group@{u v} {U : Univalence} {G H : Group@{u}}
+  : GroupIsomorphism G H <~> (paths@{v} G H)
+  := equiv_path_group'@{u v v u v v v v u}.
 
 (** * Simple group equivalences *)
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -290,49 +290,47 @@ Proof.
 Defined.
 
 (** Under univalence, equality of groups is equivalent to isomorphism of groups. *)
-Definition equiv_path_group' {U : Univalence} {G H : Group@{u}}
+Definition equiv_path_group' {U : Univalence} {G H : Group}
   : GroupIsomorphism G H <~> G = H.
 Proof.
-  refine (equiv_compose'@{u u v}
-    (B := sig@{u u} (fun f : Equiv@{u u} G H => IsMonoidPreserving@{u u} f)) _ _).
-  { revert G H; apply (equiv_path_issig_contr@{v v v v v} issig_group@{u v}).
+  refine (equiv_compose'
+    (B := sig (fun f : G <~> H => IsMonoidPreserving f)) _ _).
+  { revert G H; apply (equiv_path_issig_contr issig_group).
     + intros [G [? [? [? ?]]]].
-      exists equiv_idmap@{u}.
-      exact id_monoid_morphism@{u u u}.
+      exists 1%equiv.
+      exact _.
     + intros [G [op [unit [neg ax]]]]; cbn.
-      contr_sigsig G (equiv_idmap@{u} G).
-      srefine (Build_Contr _ ((_;(_;(_;_)));_) _); cbn;
-        try assumption.
-      1: exact id_monoid_morphism@{u u u}.
+      contr_sigsig G (equiv_idmap G).
+      srefine (Build_Contr _ ((_;(_;(_;_)));_) _); cbn.
+      1: assumption.
+      1: exact _.
       intros [[op' [unit' [neg' ax']]] eq].
-      apply path_sigma_hprop@{u u u}; cbn.
+      apply path_sigma_hprop; cbn.
       (* We really need to fix https://github.com/HoTT/HoTT/issues/976 *)
       refine (@ap _ _ (fun x : { oun :
         { oo : SgOp G | { u : MonUnit G | Negate G}}
         | @IsGroup G oun.1 oun.2.1 oun.2.2}
         => (x.1.1 ; x.1.2.1 ; x.1.2.2 ; x.2))
-                ((op;unit;neg);ax) ((op';unit';neg');ax') _).
-      apply path_sigma_hprop@{u u u}; cbn.
-      srefine (path_sigma'@{u u u} _ _ _).
+        ((op;unit;neg);ax) ((op';unit';neg');ax') _).
+      apply path_sigma_hprop; cbn.
+      srefine (path_sigma' _ _ _).
       1: funext x y; apply eq.
       rewrite transport_const.
-      srefine (path_sigma'@{u u u} _ _ _).
+      srefine (path_sigma' _ _ _).
       1: apply eq.
       rewrite transport_const.
       funext x.
-      exact (preserves_negate@{u u} (f:=idmap) _). }
-  refine (equiv_compose'@{u u u} _ (issig_GroupIsomorphism G H)^-1).
-  refine (equiv_compose'@{u u u} _
-            (equiv_functor_sigma'@{u u u u u u}
-               (issig_GroupHomomorphism G H) (fun f => 1%equiv))^-1).
-  refine (equiv_compose'@{u u u}
-            (equiv_functor_sigma'@{u u u u u u}
-               (issig_equiv@{u u u} G H) (fun f => 1%equiv)) _); cbn.
+      exact (preserves_negate (f:=idmap) _). }
+  refine (_ oE (issig_GroupIsomorphism G H)^-1).
+  refine (_ oE (equiv_functor_sigma' (issig_GroupHomomorphism G H)
+    (fun f => 1%equiv))^-1).
+  refine (equiv_functor_sigma' (issig_equiv G H) (fun f => 1%equiv) oE _).
+  cbn.
   refine (
-    equiv_adjointify@{u u}
+    equiv_adjointify
       (fun f => (exist (IsMonoidPreserving o pr1)
-        (exist IsEquiv@{u u} f.1.1 f.2) f.1.2))
-      (fun f => (exist (IsEquiv@{u u} o pr1)
+        (exist IsEquiv f.1.1 f.2) f.1.2))
+      (fun f => (exist (IsEquiv o pr1)
         (exist IsMonoidPreserving f.1.1 f.2) f.1.2))
        _ _).
   all: intros [[]]; reflexivity.
@@ -341,7 +339,7 @@ Defined.
 (** A version with nicer universe variables. *)
 Definition equiv_path_group@{u v} {U : Univalence} {G H : Group@{u}}
   : GroupIsomorphism G H <~> (paths@{v} G H)
-  := equiv_path_group'@{u v v u v v v v u}.
+  := equiv_path_group'@{v u v u u u v v v u u u u u u u}.
 
 (** * Simple group equivalences *)
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -321,10 +321,10 @@ Proof.
       rewrite transport_const.
       funext x.
       exact (preserves_negate@{u u} (f:=idmap) _). }
-  refine (equiv_compose'@{u u u} _ (issig_GroupIsomorphism@{u} G H)^-1).
+  refine (equiv_compose'@{u u u} _ (issig_GroupIsomorphism G H)^-1).
   refine (equiv_compose'@{u u u} _
             (equiv_functor_sigma'@{u u u u u u}
-               (issig_GroupHomomorphism@{u} G H) (fun f => 1%equiv))^-1).
+               (issig_GroupHomomorphism G H) (fun f => 1%equiv))^-1).
   refine (equiv_compose'@{u u u}
             (equiv_functor_sigma'@{u u u u u u}
                (issig_equiv@{u u u} G H) (fun f => 1%equiv)) _); cbn.

--- a/theories/Modalities/Descent.v
+++ b/theories/Modalities/Descent.v
@@ -61,7 +61,8 @@ Defined.
 In the case of a single modality, most of these statements are equivalent to lex-ness (as stated in Theorem 3.1 of RSS).  We do not know if anything similar is true more generally. *)
 
 Section LeftExactness.
-Context (O' O : ReflectiveSubuniverse) `{O << O', O <<< O'}.
+Universe i.
+Context (O' O : ReflectiveSubuniverse@{i}) `{O << O', O <<< O'}.
 
 (** Proposition 2.30 of CORS and Theorem 3.1(xii) of RSS: any [O']-equivalence is [O]-connected.  The special case when [f = to O' A] requires only [O << O'], but the general case seems to require [O <<< O']. *)
 Global Instance conn_map_OO_inverts
@@ -146,8 +147,8 @@ Global Instance inO_TypeO_lex_leq `{Univalence} `{IsAccRSU O'}
   := fun i => ooextendable_TypeO_lex_leq (acc_lgen O' i).
 
 (** If [f] is an [O']-equivalence, then [ap f] is an [O]-equivalence. *)
-Global Instance OO_inverts_ap
-       {A B : Type} (f : A -> B) `{O_inverts O' f} (x y : A)
+Definition OO_inverts_ap'
+       {A B : Type@{i}} (f : A -> B) `{O_inverts O' f} (x y : A)
   : O_inverts O (@ap _ _ f x y).
 Proof.
   assert (Pb := OO_descend_O_inverts_beta f (fun y:A => O (x = y))).
@@ -179,6 +180,12 @@ Proof.
     destruct p; cbn.
     srapply eisretr.
 Defined.
+
+(** We give a version that only has one universe variable. *)
+Global Instance OO_inverts_ap
+       {A B : Type@{i}} (f : A -> B) `{O_inverts O' f} (x y : A)
+  : O_inverts O (@ap _ _ f x y)
+  := OO_inverts_ap'@{i i i i i i i} f x y.
 
 Definition equiv_O_functor_ap_OO_inverts
        {A B : Type} (f : A -> B) `{O_inverts O' f} (x y : A)

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -139,7 +139,7 @@ Proof.
   refine (_ oE equiv_sigma_symm0 _ _).
   apply equiv_sigma_contr; intro e.
   rapply contr_inhabited_hprop.
-  rapply conn_point_elim@{u v u u u u u u v}.
+  rapply conn_point_elim.
   apply (inO_equiv_inO F e^-1).
 Defined.
 

--- a/theories/Truncations/SeparatedTrunc.v
+++ b/theories/Truncations/SeparatedTrunc.v
@@ -47,10 +47,9 @@ Definition path_Tr {n A} (x y : A)
   : Tr n (x = y) -> (tr x = tr y :> Tr n.+1 A)
   := path_OO (Tr n.+1) (Tr n) x y.
 
-Definition equiv_path_Tr@{u v} `{Univalence} {n} {A : Type@{u}} (x y : A)
+Definition equiv_path_Tr `{Univalence} {n} {A : Type} (x y : A)
   : Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A)
-  := @equiv_path_OO@{u u u u u u u u v} (Tr n.+1) (Tr n) _
-       (O_lex_leq_Tr@{v u} n) _ _ x y.
+  := equiv_path_OO (Tr n.+1) (Tr n) x y.
 
 End SeparatedTrunc.
 

--- a/theories/Truncations/SeparatedTrunc.v
+++ b/theories/Truncations/SeparatedTrunc.v
@@ -47,9 +47,10 @@ Definition path_Tr {n A} (x y : A)
   : Tr n (x = y) -> (tr x = tr y :> Tr n.+1 A)
   := path_OO (Tr n.+1) (Tr n) x y.
 
-Definition equiv_path_Tr `{Univalence} {n A} (x y : A)
+Definition equiv_path_Tr@{u v} `{Univalence} {n} {A : Type@{u}} (x y : A)
   : Tr n (x = y) <~> (tr x = tr y :> Tr n.+1 A)
-  := equiv_path_OO (Tr n.+1) (Tr n) x y.
+  := @equiv_path_OO@{u u u u u u u u v} (Tr n.+1) (Tr n) _
+       (O_lex_leq_Tr@{v u} n) _ _ x y.
 
 End SeparatedTrunc.
 


### PR DESCRIPTION
We reduce the number of universes in `equiv_path_Tr` from 10 to 2. This has various positive downstream effects, such as reducing the number of universes in `conn_point_elim` from 9 to 2.

We also create an alternative version of `equiv_path_group` with only 2 universes, as opposed to 16. This has a positive effect on `equiv_path_abgroup`, etc. I also did a pass through the current proof of `equiv_path_group'` and cleaned up some universes.