### PR TITLE
Better proof of equiv_path_ptype; add equiv_path_pequiv'

### DIFF
--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -5,10 +5,6 @@ Require Import Pointed.Core.
 
 Local Open Scope pointed_scope.
 
-(* The pointed identity is a pointed equivalence *)
-Definition pequiv_pmap_idmap {A} : A <~>* A
-  := Build_pEquiv _ _ pmap_idmap _.
-
 (* pointed equivalence is a reflexive relation *)
 Global Instance pequiv_reflexive : Reflexive pEquiv.
 Proof.


### PR DESCRIPTION
Replaces the definition of `equiv_path_ptype` by one whose inverse computes on reflexivity, and whose inverse can be defined without univalence.  This is for work in progress, but also simplifies the proof that pType forms a univalent 1-category.  Also add `equiv_path_pequiv'` which is analogous to `equiv_path_equiv` and also helps simplify that proof.  (It would be even simpler if `id_cate` didn't have to adjointify the identity map, but I don't see a way around that with the current set-up.)