### PR TITLE
Reduce universes in [isgraph_op] and [is0functor_compose]

### DIFF
--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -22,8 +22,7 @@ Definition Ext' (B A : AbGroup@{u}) := Tr 0 (AbSES' B A).
 
 Global Instance isbifunctor_ext'@{u v w | u < v, v < w} `{Univalence}
   : IsBifunctor@{v v w u u v v} (Ext' : AbGroup@{u}^op -> AbGroup@{u} -> Type@{v})
-  := isbifunctor_compose@{v v w w v v u u u u u u u u v v}
-       _ _ (P:=isbifunctor_abses'@{w u v v}).
+  := isbifunctor_compose _ _ (P:=isbifunctor_abses').
 
 (** [Ext B A] is an abelian group for any [A B : AbGroup]. The proof of commutativity is a bit faster if we separate out the proof that [Ext B A] is a group. *)
 Definition grp_ext `{Univalence} (A B : AbGroup@{u}) : Group.

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -160,7 +160,7 @@ Local Definition isexact_ext_cyclic_ab_iii@{u v w | u < v, v < w} `{Univalence}
   : IsExact (Tr (-1))
       (fmap10 (A:=Group^op) ab_hom (Z1_mul_nat n) A)
       (abses_pushout_ext (abses_from_inclusion (Z1_mul_nat n)))
-  := isexact_ext_contra_sixterm_iii@{u v u w}
+  := isexact_ext_contra_sixterm_iii
        (abses_from_inclusion (Z1_mul_nat n)).
 
 (** We show exactness of [A -> A -> Ext Z/n A] where the first map is multiplication by [n], but considered in universe [v]. *)

--- a/theories/WildCat/Adjoint.v
+++ b/theories/WildCat/Adjoint.v
@@ -37,7 +37,7 @@ Record Adjunction {C D : Type} (F : C -> D) (G : D -> C)
   is1natural_equiv_adjunction_l (y : D)
     : Is1Natural (A := C^op) (yon y o F)
         (** We have to explicitly give a witness to the functoriality of [yon y o F]. *)
-        (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) F (yon y))
+        (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) _ _)
         (yon (G y)) (fun x => equiv_adjunction _ y) ;
   (** Naturality in the right variable *)
   is1natural_equiv_adjunction_r (x : C)
@@ -89,7 +89,7 @@ Section AdjunctionData.
   Definition natequiv_adjunction_l (y : D)
     : NatEquiv (A := C^op) (yon y o F)
         (** We have to explicitly give a witness to the functoriality of [yon y o F]. *)
-        (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) F (yon y))
+        (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) _ _)
         (yon (G y)).
   Proof.
     nrapply Build_NatEquiv.
@@ -214,7 +214,7 @@ Definition Build_Adjunction_natequiv_nat_left
   (e : forall x, NatEquiv (opyon (F x)) (opyon x o G))
   (is1nat_e : forall y, Is1Natural (A := C^op) (yon y o F)
       (** We have to explicitly give a witness to the functoriality of [yon y o F]. *)
-      (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) F (yon y))
+      (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) _ _)
       (yon (G y)) (fun x => e _ y))
   : Adjunction F G.
 Proof.
@@ -229,7 +229,7 @@ Definition Build_Adjunction_natequiv_nat_right
   {C D : Type} (F : C -> D) (G : D -> C)
   `{Is1Cat C, Is1Cat D, !Is0Functor F, !Is0Functor G} 
   (e : forall y, NatEquiv (A := C^op) (yon y o F) (yon (G y))
-    (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) F (yon y)))
+    (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) _ _))
   (is1nat_e : forall x, Is1Natural (opyon (F x)) (opyon x o G) (fun y => e y x))
   : Adjunction F G.
 Proof.
@@ -284,7 +284,7 @@ Section UnitCounitAdjunction.
   (** Which is natural in the left *)
   Lemma is1natural_γ_l (y : D)
     : Is1Natural (yon y o F) (yon (G y))
-      (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) F (yon y))
+      (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) _ _)
       (is0functor_G := is0functor_yon (G y))
       (fun x : C^op => γ x y).
   Proof.

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -327,29 +327,28 @@ End ConstantFunctor.
 
 (** Composite functors *)
 
-Section CompositeFunctor.
+Global Instance is0functor_compose {A B C : Type}
+  `{IsGraph A, IsGraph B, IsGraph C}
+  (F : A -> B) (G : B -> C) `{!Is0Functor F, !Is0Functor G}
+  : Is0Functor (G o F).
+Proof.
+  srapply Build_Is0Functor.
+  intros a b f; exact (fmap G (fmap F f)).
+Defined.
 
-  Context {A B C : Type} `{Is1Cat A} `{Is1Cat B} `{Is1Cat C}
-          (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-          (G : B -> C) `{!Is0Functor G, !Is1Functor G}.
-
-  Global Instance is0functor_compose : Is0Functor (G o F).
-  Proof.
-    srapply Build_Is0Functor.
-    intros a b f; exact (fmap G (fmap F f)).
-  Defined.
-
-  Global Instance is1functor_compose : Is1Functor (G o F).
-  Proof.
-    srapply Build_Is1Functor.
-    - intros a b f g p; exact (fmap2 G (fmap2 F p)).
-    - intros a; exact (fmap2 G (fmap_id F a) $@ fmap_id G (F a)).
-    - intros a b c f g.
-      refine (fmap2 G (fmap_comp F f g) $@ _).
-      exact (fmap_comp G (fmap F f) (fmap F g)).
-  Defined.
-
-End CompositeFunctor.
+Global Instance is1functor_compose {A B C : Type}
+  `{Is1Cat A, Is1Cat B, Is1Cat C}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (G : B -> C) `{!Is0Functor G, !Is1Functor G}
+  : Is1Functor (G o F).
+Proof.
+  srapply Build_Is1Functor.
+  - intros a b f g p; exact (fmap2 G (fmap2 F p)).
+  - intros a; exact (fmap2 G (fmap_id F a) $@ fmap_id G (F a)).
+  - intros a b c f g.
+    refine (fmap2 G (fmap_comp F f g) $@ _).
+    exact (fmap_comp G (fmap F f) (fmap F g)).
+Defined.
 
 (** We give all arguments names in order to refer to them later. This allows us to write things like [is0functor (isgraph_A := _)] without having to make all the variables explicit. *)
 Arguments is0functor_compose {A B C} {isgraph_A isgraph_B isgraph_C}

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -169,12 +169,8 @@ Definition fun11_id {A} `{Is1Cat A} : Fun11 A A
 (** * Composition of functors *)
 
 Definition fun01_compose {A B C} `{IsGraph A, IsGraph B, IsGraph C}
-  : Fun01 B C -> Fun01 A B -> Fun01 A C.
-Proof.
-  intros F G.
-  nrapply Build_Fun01.
-  rapply (is0functor_compose G F).
-Defined.
+  : Fun01 B C -> Fun01 A B -> Fun01 A C
+  := fun G F => Build_Fun01 _ _ (G o F).
 
 Definition fun01_postcomp {A B C}
   `{IsGraph A, Is1Cat B, Is1Cat C} (F : Fun11 B C)

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -8,58 +8,53 @@ Require Import WildCat.FunctorCat.
 
 (** ** Opposite categories *)
 
-Definition op (A : Type) : Type := A.
+Definition op (A : Type) := A.
 Notation "A ^op" := (op A).
 
 (** This stops typeclass search from trying to unfold op. *)
 #[global] Typeclasses Opaque op.
 
-Section Op.
+Global Instance isgraph_op {A : Type} `{IsGraph A}
+  : IsGraph A^op.
+Proof.
+  apply Build_IsGraph.
+  unfold op; exact (fun a b => b $-> a).
+Defined.
 
-  Context (A : Type) `{Is1Cat A}.
+Global Instance is01cat_op {A : Type} `{Is01Cat A} : Is01Cat A^op.
+Proof.
+  apply Build_Is01Cat.
+  + cbv; exact Id.
+  + cbv; exact (fun a b c g f => f $o g).
+Defined.
 
-  Global Instance isgraph_op : IsGraph A^op.
-  Proof.
-    apply Build_IsGraph.
-    unfold op; exact (fun a b => b $-> a).
-  Defined.
+(** We don't invert 2-cells as this is op on the first level. *)
+Global Instance is2graph_op {A : Type} `{Is2Graph A} : Is2Graph A^op.
+Proof.
+  intros a b; unfold op in *; cbn; exact _.
+Defined.
 
-  Global Instance is01cat_op : Is01Cat A^op.
-  Proof.
-    apply Build_Is01Cat.
-    + cbv; exact Id.
-    + cbv; exact (fun a b c g f => f $o g).
-  Defined.
-
-  (** We don't invert 2-cells as this is op on the first level. *)
-  Global Instance is2graph_op : Is2Graph A^op.
-  Proof.
-    intros a b; unfold op in *; cbn; exact _.
-  Defined.
-
-  Global Instance is1cat_op : Is1Cat A^op.
-  Proof.
-    srapply Build_Is1Cat; unfold op in *; cbv in *.
-    - intros a b.
-      apply is01cat_hom.
-    - intros a b.
-      apply is0gpd_hom.
-    - intros a b c h.
-      srapply Build_Is0Functor.
-      intros f g p.
-      cbn in *.
-      exact (p $@R h).
-    - intros a b c h.
-      srapply Build_Is0Functor.
-      intros f g p.
-      cbn in *.
-      exact (h $@L p).
-    - intros a b c d f g h; exact (cat_assoc_opp h g f).
-    - intros a b f; exact (cat_idr f).
-    - intros a b f; exact (cat_idl f).
-   Defined.
-
-End Op.
+Global Instance is1cat_op {A : Type} `{Is1Cat A} : Is1Cat A^op.
+Proof.
+  srapply Build_Is1Cat; unfold op in *; cbv in *.
+  - intros a b.
+    apply is01cat_hom.
+  - intros a b.
+    apply is0gpd_hom.
+  - intros a b c h.
+    srapply Build_Is0Functor.
+    intros f g p.
+    cbn in *.
+    exact (p $@R h).
+  - intros a b c h.
+    srapply Build_Is0Functor.
+    intros f g p.
+    cbn in *.
+    exact (h $@L p).
+  - intros a b c d f g h; exact (cat_assoc_opp h g f).
+  - intros a b f; exact (cat_idr f).
+  - intros a b f; exact (cat_idl f).
+Defined.
 
 Global Instance is1cat_strong_op A `{Is1Cat_Strong A}
   : Is1Cat_Strong (A ^op).
@@ -84,7 +79,7 @@ Definition test4 A `{x : Is1Cat A} : x = is1cat_op (A^op) := 1.
 
 (** Opposite groupoids *)
 
-Global Instance is0gpd_op A `{Is0Gpd A} : Is0Gpd (A ^op).
+Global Instance is0gpd_op A `{Is0Gpd A} : Is0Gpd (A^op).
 Proof.
   srapply Build_Is0Gpd; unfold op in *; cbn in *.
   intros a b.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -4,8 +4,8 @@ Require Import WildCat.Equiv.
 
 (** ** The category of types *)
 
-Global Instance isgraph_type : IsGraph Type
-  := Build_IsGraph Type (fun a b => a -> b).
+Global Instance isgraph_type@{u v} : IsGraph@{v u} Type@{u}
+  := Build_IsGraph Type@{u} (fun a b => a -> b).
 
 Global Instance is01cat_type : Is01Cat Type.
 Proof.


### PR DESCRIPTION
By breaking up two sections and supplying precise arguments, the number of universes in `isgraph_op` and `is0functor_compose` are reduced. Previously these would generate free universes when inferred, e.g. by typeclass search. This caused issues for work in progress, and these changes make things manageable. (We also add universe annotations to `isgraph_type`, otherwise it had 3 universes with the constraint that two of them were equal.)
