### PR TITLE
Bifunctoriality of ab_ext

### DIFF
--- a/theories/Algebra/AbGroups/Biproduct.v
+++ b/theories/Algebra/AbGroups/Biproduct.v
@@ -217,6 +217,10 @@ Defined.
 Definition ab_codiagonal {A : AbGroup} : ab_biprod A A $-> A
   := ab_biprod_rec grp_homo_id grp_homo_id.
 
+Definition ab_codiagonal_natural {A B : AbGroup} (f : A $-> B)
+  : f $o ab_codiagonal == ab_codiagonal $o functor_ab_biprod f f
+  := fun a => grp_homo_op f _ _.
+
 Definition ab_diagonal {A : AbGroup} : A $-> ab_biprod A A
   := ab_biprod_corec grp_homo_id grp_homo_id.
 

--- a/theories/Algebra/AbGroups/Biproduct.v
+++ b/theories/Algebra/AbGroups/Biproduct.v
@@ -218,7 +218,7 @@ Definition ab_codiagonal {A : AbGroup} : ab_biprod A A $-> A
   := ab_biprod_rec grp_homo_id grp_homo_id.
 
 Definition ab_codiagonal_natural {A B : AbGroup} (f : A $-> B)
-  : f $o ab_codiagonal == ab_codiagonal $o functor_ab_biprod f f
+  : f $o ab_codiagonal $== ab_codiagonal $o functor_ab_biprod f f
   := fun a => grp_homo_op f _ _.
 
 Definition ab_diagonal {A : AbGroup} : A $-> ab_biprod A A

--- a/theories/Algebra/AbSES/BaerSum.v
+++ b/theories/Algebra/AbSES/BaerSum.v
@@ -93,7 +93,7 @@ Proof.
   refine (_ @ abses_pullback_compose ab_diagonal direct_sum_swap _).
   refine (ap (abses_pullback ab_diagonal) _).
   refine (ap (fun f => abses_pushout f _) ab_codiagonal_swap^ @ _).
-  refine ((abses_pushout_compose _ _ _)^ @ _).
+  refine ((abses_pushout_compose _ _ _) @ _).
   refine (ap _ (abses_pushout_is_pullback (abses_swap_morphism E F)) @ _).
   unfold abses_swap_morphism, component3.
   apply abses_pushout_pullback_reorder.
@@ -137,11 +137,11 @@ Lemma baer_sum_distributive_pushouts `{Univalence}
   : abses_pushout (f + g) E = abses_baer_sum (abses_pushout f E) (abses_pushout g E).
 Proof.
   unfold abses_baer_sum.
-  refine ((abses_pushout_compose (A1 := ab_biprod A A) _ _ E)^ @ _).
+  refine (abses_pushout_compose (A1 := ab_biprod A A) _ _ E @ _).
   refine (_ @ abses_pushout_pullback_reorder _ _ _).
   refine (ap (abses_pushout ab_codiagonal) _).
   refine (ap (fun f => abses_pushout f E) (ab_biprod_corec_diagonal f g) @ _).
-  refine ((abses_pushout_compose _ _ E)^ @ _).
+  refine (abses_pushout_compose _ _ E @ _).
   refine (ap (abses_pushout _) (abses_pushout_is_pullback (abses_diagonal E)) @ _).
   refine (abses_pushout_pullback_reorder _ _ _ @ _).
   exact (ap (abses_pullback _) (abses_directsum_distributive_pushouts f g)).
@@ -170,7 +170,7 @@ Proof.
     apply abses_directsum_distributive_pushouts.
   - refine (ap (abses_pullback _) (abses_pushout_pullback_reorder _ _ _) @ _).
     refine (abses_pullback_compose _ _ _ @ _).
-    refine (ap (abses_pullback _) _).
+    refine (ap (abses_pullback _) _^).
     apply abses_pushout_compose.
 Defined.
 
@@ -184,7 +184,7 @@ Proof.
   refine (_ @ abses_pullback_compose ab_triagonal ab_biprod_twist _).
   refine (ap (abses_pullback _) _).
   refine (ap (fun f => abses_pushout f _) ab_cotriagonal_twist^ @ _).
-  refine ((abses_pushout_compose _ _ _)^ @ _).
+  refine (abses_pushout_compose _ _ _ @ _).
   refine (ap _ (abses_pushout_is_pullback (abses_twist_directsum E F G)) @ _).
   unfold abses_twist_directsum, component3.
   exact (abses_pushout_pullback_reorder _ _ _).

--- a/theories/Algebra/AbSES/BaerSum.v
+++ b/theories/Algebra/AbSES/BaerSum.v
@@ -231,7 +231,7 @@ Proof.
   apply abses_pushout_pullback_reorder.
 Defined.
 
-(** ** Pushouts and pullbacks respect the baer sum *)
+(** ** Pushouts and pullbacks respect the Baer sum *)
 
 Definition baer_sum_pushout `{Univalence}
   {A A' B : AbGroup} (f : A $-> A') (E F : AbSES B A)

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -738,3 +738,11 @@ Proof.
     apply grp_moveL_M1^-1.
     exact p^.
 Defined.
+
+Definition abses_cokernel_iso_inv_beta `{Funext}
+  {A E B : AbGroup} (f : A $-> E) (g : GroupHomomorphism E B)
+  `{IsSurjection g, IsExact (Tr (-1)) _ _ _ f g}
+  : (abses_cokernel_iso f g)^-1 o g == grp_quotient_map.
+Proof.
+  intro x; by apply moveR_equiv_V.
+Defined.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -25,7 +25,7 @@ Global Instance isbifunctor_ext'@{u v w | u < v, v < w} `{Univalence}
   := isbifunctor_compose _ _ (P:=isbifunctor_abses').
 
 (** [Ext B A] is an abelian group for any [A B : AbGroup]. The proof of commutativity is a bit faster if we separate out the proof that [Ext B A] is a group. *)
-Definition grp_ext `{Univalence} (A B : AbGroup@{u}) : Group.
+Definition grp_ext `{Univalence} (B A : AbGroup@{u}) : Group.
 Proof.
   snrapply (Build_Group (Ext B A)).
   - intros E F.
@@ -45,14 +45,50 @@ Proof.
     + apply baer_sum_inverse_l.
 Defined.
 
-Definition ab_ext `{Univalence}
-  (A B : AbGroup@{u}) : AbGroup.
+(** ** The bifunctor [ab_ext] *)
+
+Definition ab_ext `{Univalence} (B A : AbGroup@{u}) : AbGroup.
 Proof.
   snrapply (Build_AbGroup (grp_ext B A)).
   intros E F.
   strip_truncations; cbn.
   apply ap.
   apply baer_sum_commutative.
+Defined.
+
+Global Instance is01functor_ext `{Univalence} (B : AbGroup^op)
+  : Is0Functor (ab_ext B).
+Proof.
+  srapply Build_Is0Functor; intros ? ? f.
+  snrapply Build_GroupHomomorphism.
+  1: exact (fmap01 (A:=AbGroup^op) Ext' B f).
+  rapply Trunc_ind; intro E0.
+  rapply Trunc_ind; intro E1.
+  apply (ap tr); cbn.
+  apply baer_sum_pushout.
+Defined.
+
+Global Instance is10functor_ext `{Univalence} (A : AbGroup)
+  : Is0Functor (fun B : AbGroup^op => ab_ext B A).
+Proof.
+  srapply Build_Is0Functor; intros ? ? f; cbn.
+  snrapply Build_GroupHomomorphism.
+  1: exact (fmap10 (A:=AbGroup^op) Ext' f A).
+  rapply Trunc_ind; intro E0.
+  rapply Trunc_ind; intro E1.
+  apply (ap tr); cbn.
+  apply baer_sum_pullback.
+Defined.
+
+Global Instance isbifunctor_ext `{Univalence}
+  : IsBifunctor (A:=AbGroup^op) ab_ext.
+Proof.
+  snrapply Build_IsBifunctor.
+  1,2: exact _.
+  intros B B' f A A' g.
+  rapply Trunc_ind; intro E.
+  apply (ap tr).
+  apply abses_pushout_pullback_reorder.
 Defined.
 
 (** We can push out a fixed extension while letting the map vary, and this defines a group homomorphism. *)

--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -152,7 +152,9 @@ Proof.
   nrapply ab_pushout_commsq.
 Defined.
 
-(** ** Functoriality of [abses_pushout f] *)
+(** ** Functoriality of [abses_pushout f : AbSES B A -> AbSES B A'] *)
+
+(** In this file we will prove various "levels" of functoriality of pushing out. Here we show that the induced map between [AbSES B A] respect the groupoid structure of [is1gpd_abses] from AbSES.Core. *)
 
 Global Instance is0functor_abses_pushout `{Univalence} {A A' B : AbGroup} (f : A $-> A')
   : Is0Functor (abses_pushout (B:=B) f).
@@ -313,7 +315,7 @@ Definition abses_pushout_id `{Univalence} {A B : AbGroup}
   := fun E => abses_pushout_component3_id (abses_morphism_id E) (fun _ => idpath).
 
 Definition abses_pushout_pmap_id `{Univalence} {A B : AbGroup}
-  : abses_pushout_pmap (B:=B) (@grp_homo_id A) ==* pmap_idmap.
+  : abses_pushout_pmap (B:=B) (@grp_homo_id A) ==* @pmap_idmap (AbSES B A).
 Proof.
   srapply Build_pHomotopy.
   1: apply abses_pushout_id.
@@ -326,7 +328,7 @@ Proof.
   by rapply Quotient_ind_hprop.
 Defined.
 
-(** Pushing out along homotopic maps induces homotopic pushout functors. *)
+(** Pushing out along homotopic maps induces homotopic pushout functors. This statement has a short proof by path induction on the homotopy [h], but we prefer to construct a path using [abses_path_data_iso] with better computational properties. *)
 Lemma abses_pushout_homotopic' `{Univalence} {A A' B : AbGroup}
   (f f' : A $-> A') (h : f == f')
   : abses_pushout (B:=B) f $=> abses_pushout f'.
@@ -413,7 +415,7 @@ Proof.
   apply abses_pushout_pcompose'.
 Defined.
 
-(** [AbSES] and [AbSES'] become covariant functors in their second parameter by pushing out. *)
+(** [AbSES B : AbGroup -> pType] and [AbSES' B : AbGroup -> Type] are covariant functors, for any [B]. *)
 
 Global Instance is0functor_abses'01 `{Univalence} {B : AbGroup^op}
   : Is0Functor (AbSES' B).
@@ -438,7 +440,7 @@ Proof.
   exact (fun _ _ g => abses_pushout_pmap g).
 Defined.
 
-Global Instance is1functor_abses10 `{Univalence} {B : AbGroup^op}
+Global Instance is1functor_abses01 `{Univalence} {B : AbGroup^op}
   : Is1Functor (AbSES B).
 Proof.
   apply Build_Is1Functor; intros; cbn.

--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -171,6 +171,26 @@ Proof.
     exact (left_identity _)^.
 Defined.
 
+Global Instance is1functor_abses_pushout `{Univalence}
+  {A A' B : AbGroup} (f : A $-> A')
+  : Is1Functor (abses_pushout (B:=B) f).
+Proof.
+  srapply Build_Is1Functor.
+  - intros E F g0 g1 h.
+    rapply Quotient_ind_hprop; intros [a' e]; simpl.
+    by rewrite (h e).
+  - intro E.
+    rapply Quotient_ind_hprop; intros [a' e]; simpl.
+    refine (ap (class_of _) (path_prod' _ _)).
+    + exact (grp_unit_r _).
+    + exact (grp_unit_l _).
+  - intros E F G g0 g1.
+    rapply Quotient_ind_hprop; intros [a' e]; simpl.
+    refine (ap (class_of _) (path_prod' _ _)).
+    + exact (grp_unit_r _)^.
+    + exact (ap (fun x => _ + g1.1 x) (grp_unit_l _)^).
+Defined.
+
 Definition abses_pushout_path_data_1 `{Univalence} {A A' B : AbGroup} (f : A $-> A') {E : AbSES B A} 
   : fmap (abses_pushout f) (Id E) = Id (abses_pushout f E).
 Proof.
@@ -292,13 +312,36 @@ Definition abses_pushout_id `{Univalence} {A B : AbGroup}
   : abses_pushout (B:=B) (@grp_homo_id A) == idmap
   := fun E => abses_pushout_component3_id (abses_morphism_id E) (fun _ => idpath).
 
+Definition abses_pushout_pmap_id `{Univalence} {A B : AbGroup}
+  : abses_pushout_pmap (B:=B) (@grp_homo_id A) ==* pmap_idmap.
+Proof.
+  srapply Build_pHomotopy.
+  1: apply abses_pushout_id.
+  refine (_ @ (concat_p1 _)^).
+  (* For some reason Coq spends time finding [x] below, so we specify it. *)
+  nrapply (ap equiv_path_abses_iso
+             (x:=abses_pushout_component3_id' (abses_morphism_id pt) _)).
+  apply path_sigma_hprop.
+  apply equiv_path_groupisomorphism.
+  by rapply Quotient_ind_hprop.
+Defined.
+
 (** Pushing out along homotopic maps induces homotopic pushout functors. *)
 Lemma abses_pushout_homotopic' `{Univalence} {A A' B : AbGroup}
   (f f' : A $-> A') (h : f == f')
   : abses_pushout (B:=B) f $=> abses_pushout f'.
 Proof.
-  induction (equiv_path_grouphomomorphism h).
-  apply id_transformation.
+  intro E; cbn.
+  apply abses_path_data_to_iso.
+  snrefine (_; (_, _)).
+  - srapply (ab_pushout_rec (inclusion _)).
+    1: apply ab_pushout_inr.
+    intro x.
+    refine (ap _ (h x) @ _).
+    apply (ab_pushout_commsq x).
+  - apply ab_pushout_rec_beta_left.
+  - rapply Quotient_ind_hprop; intros [a' e]; simpl.
+    exact (ap (fun x => _ + projection E x) (grp_unit_l _)^).
 Defined.
 
 Definition abses_pushout_homotopic `{Univalence} {A A' B : AbGroup}
@@ -306,11 +349,28 @@ Definition abses_pushout_homotopic `{Univalence} {A A' B : AbGroup}
   : abses_pushout (B:=B) f == abses_pushout f'
   := equiv_path_data_homotopy _ _ (abses_pushout_homotopic' _ _ h).
 
+Definition abses_pushout_phomotopic' `{Univalence} {A A' B : AbGroup}
+  (f f' : A $-> A') (h : f == f')
+  : abses_pushout' (B:=B) f $=>* abses_pushout' f'.
+Proof.
+  exists (abses_pushout_homotopic' _ _ h).
+  apply gpd_moveL_Vh.
+  rapply Quotient_ind_hprop; intros [a' [a b]]; simpl.
+  apply path_prod'.
+  - by rewrite grp_unit_l, grp_unit_r, (h a).
+  - apply grp_unit_l.
+Defined.
+
+Definition abses_pushout_phomotopic `{Univalence} {A A' B : AbGroup}
+  (f f' : A $-> A') (h : f == f')
+  : abses_pushout_pmap (B:=B) f ==* abses_pushout_pmap f'
+  := equiv_ptransformation_phomotopy (abses_pushout_phomotopic' f f' h).
+
 Definition abses_pushout_compose' `{Univalence} {A0 A1 A2 B : AbGroup}
   (f : A0 $-> A1) (g : A1 $-> A2)
-  : abses_pushout (B:=B) g o abses_pushout f $=> abses_pushout (g $o f).
+  : abses_pushout (g $o f) $=> abses_pushout (B:=B) g o abses_pushout f.
 Proof.
-  intro E; apply gpd_rev.
+  intro E.
   srapply abses_path_data_to_iso;
     srefine (_; (_,_)).
   - snrapply ab_pushout_rec.
@@ -330,8 +390,28 @@ Defined.
 
 Definition abses_pushout_compose `{Univalence} {A0 A1 A2 B : AbGroup}
   (f : A0 $-> A1) (g : A1 $-> A2)
-  : abses_pushout (B:=B) g o abses_pushout f == abses_pushout (g $o f)
+  : abses_pushout (g $o f) == abses_pushout (B:=B) g o abses_pushout f
   := equiv_path_data_homotopy _ _ (abses_pushout_compose' f g).
+
+Definition abses_pushout_pcompose' `{Univalence} {A0 A1 A2 B : AbGroup}
+  (f : A0 $-> A1) (g : A1 $-> A2)
+  : abses_pushout' (B:=B) (g $o f) $=>* abses_pushout' g $o* abses_pushout' f.
+Proof.
+  exists (abses_pushout_compose' f g).
+  apply gpd_moveL_Vh. (* it's easiest to construct a path in [pt] *)
+  rapply Quotient_ind_hprop; intros [a2 [a0 b]]; simpl.
+  by rewrite 7 grp_unit_l, 2 grp_unit_r.
+Defined.
+
+Definition abses_pushout_pcompose `{Univalence} {A0 A1 A2 B : AbGroup}
+  (f : A0 $-> A1) (g : A1 $-> A2)
+  : abses_pushout_pmap (B:=B) (g $o f)
+      ==* abses_pushout_pmap g o* abses_pushout_pmap f.
+Proof.
+  refine (_ @* (to_pointed_compose _ _)^*).
+  apply equiv_ptransformation_phomotopy.
+  apply abses_pushout_pcompose'.
+Defined.
 
 (** [AbSES] and [AbSES'] become covariant functors in their second parameter by pushing out. *)
 
@@ -348,14 +428,21 @@ Proof.
   apply Build_Is1Functor; intros; cbn.
   - by apply abses_pushout_homotopic.
   - apply abses_pushout_id.
-  - symmetry; apply abses_pushout_compose.
+  - apply abses_pushout_compose.
 Defined.
 
-Global Instance is0functor_abses01 `{Univalence} {B : AbGroup}
+Global Instance is0functor_abses01 `{Univalence} {B : AbGroup^op}
   : Is0Functor (AbSES B).
 Proof.
   apply Build_Is0Functor.
   exact (fun _ _ g => abses_pushout_pmap g).
 Defined.
 
-(* todo: prove that [AbSES] is a 1-functor. *)
+Global Instance is1functor_abses10 `{Univalence} {B : AbGroup^op}
+  : Is1Functor (AbSES B).
+Proof.
+  apply Build_Is1Functor; intros; cbn.
+  - by apply abses_pushout_phomotopic.
+  - apply abses_pushout_pmap_id.
+  - apply abses_pushout_pcompose.
+Defined.

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -57,7 +57,7 @@ Proof.
   - apply phomotopy_homotopy_hset; intro g; cbn.
     (* this equation holds purely *)
     apply (ap tr@{v}).
-    refine ((abses_pushout_compose _ _ _)^ @ ap _ _ @ _).
+    refine (abses_pushout_compose _ _ _ @ ap _ _ @ _).
     1: apply abses_pushout_inclusion.
     apply abses_pushout_point.
   - intros [F p].

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -17,13 +17,35 @@ Definition isexact_abses_sixterm_i `{Funext}
       (fmap10 (A:=Group^op) ab_hom (projection E) G).
 Abort. (* Left for future work. *)
 
-(** Exactness of [ab_hom B G -> ab_hom E G -> ab_hom A G]. *)
+(** Exactness of [ab_hom B G -> ab_hom E G -> ab_hom A G].
+    One can also deduce this from [isexact_abses_pullback]. *)
 Definition isexact_ext_contra_sixterm_ii `{Univalence}
   {B A G : AbGroup} (E : AbSES B A)
   : IsExact (Tr (-1))
       (fmap10 (A:=Group^op) ab_hom (projection E) G)
       (fmap10 (A:=Group^op) ab_hom (inclusion E) G).
-Abort. (* Follows from [isexact_abses_pullback]. Details left for future work. *)
+Proof.
+  snrapply Build_IsExact.
+  { apply phomotopy_homotopy_hset; intro f.
+    apply equiv_path_grouphomomorphism; intro b; cbn.
+    refine (ap f _ @ grp_homo_unit f).
+    apply isexact_inclusion_projection. }
+  hnf. intros [f q]; rapply contr_inhabited_hprop.
+  srefine (tr (_; _)).
+  { refine (grp_homo_compose _
+              (abses_cokernel_iso (inclusion E) (projection E))^-1$).
+    apply (quotient_abgroup_rec _ _ f).
+    intros e; rapply Trunc_ind.
+    intros [b r].
+    refine (ap f r^ @ _).
+    exact (equiv_path_grouphomomorphism^-1 q _). }
+  lazy beta.
+  apply path_sigma_hprop.
+  apply equiv_path_grouphomomorphism; unfold pr1.
+  intro x.
+  exact (ap (quotient_abgroup_rec _ _ f _)
+            (abses_cokernel_iso_inv_beta _ _ _)).
+Defined.
 
 (** *** Exactness of [ab_hom E G -> ab_hom A G -> Ext B G] *)
 

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -17,8 +17,7 @@ Definition isexact_abses_sixterm_i `{Funext}
       (fmap10 (A:=Group^op) ab_hom (projection E) G).
 Abort. (* Left for future work. *)
 
-(** Exactness of [ab_hom B G -> ab_hom E G -> ab_hom A G].
-    One can also deduce this from [isexact_abses_pullback]. *)
+(** Exactness of [ab_hom B G -> ab_hom E G -> ab_hom A G]. One can also deduce this from [isexact_abses_pullback]. *)
 Definition isexact_ext_contra_sixterm_ii `{Univalence}
   {B A G : AbGroup} (E : AbSES B A)
   : IsExact (Tr (-1))


### PR DESCRIPTION
We show a couple of things:

1. `ab_ext : AbGroup^op -> AbGroup -> AbGroup` is a bifunctor
2. functoriality of `AbSES B : AbGroup -> pType`, with careful proofs as in the pullback case
3. exactness at the second spot (`_ii`) of the six-term exact sequence