### PR TITLE
Makefile.coq.local: improve etags support

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -277,7 +277,7 @@ dot-file-dep-graphs: $(ALL_DOTFILES)
 TAGS_FILES = $(ALL_VFILES)
 TAGS : $(TAGS_FILES)
 	$(ETAGS) --language=none \
-	-r '/^[ \t]*\(\(Local\|Global\|Cumulative\|NonCumulative\|Monomorphic\|Polymorphic\|Private\)[ \t]+\)*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Let\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\4/' \
+	-r '/^[ \t]*\(\(Local\|Global\|Cumulative\|NonCumulative\|Monomorphic\|Polymorphic\|Private\)[ \t]+\)*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\4/' \
 	-r '/^[ \t]*\([a-zA-Z0-9_'\'']+\)[ \t]*:/\1/' \
 	$^
 

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -277,7 +277,7 @@ dot-file-dep-graphs: $(ALL_DOTFILES)
 TAGS_FILES = $(ALL_VFILES)
 TAGS : $(TAGS_FILES)
 	$(ETAGS) --language=none \
-	-r '/^[ \t]*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Let\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\2/' \
+	-r '/^[ \t]*\(Local\|Global\|Cumulative\|Monomorphic\|Private\)*[ \t]*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Let\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\3/' \
 	-r '/^[ \t]*\([a-zA-Z0-9_'\'']+\)[ \t]*:/\1/' \
 	$^
 

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -277,7 +277,7 @@ dot-file-dep-graphs: $(ALL_DOTFILES)
 TAGS_FILES = $(ALL_VFILES)
 TAGS : $(TAGS_FILES)
 	$(ETAGS) --language=none \
-	-r '/^[ \t]*\(Local\|Global\|Cumulative\|Monomorphic\|Private\)*[ \t]*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Let\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\3/' \
+	-r '/^[ \t]*\(\(Local\|Global\|Cumulative\|NonCumulative\|Monomorphic\|Polymorphic\|Private\)[ \t]+\)*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Let\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\4/' \
 	-r '/^[ \t]*\([a-zA-Z0-9_'\'']+\)[ \t]*:/\1/' \
 	$^
 


### PR DESCRIPTION
Handle things like `Global` and `Cumulative` before things like `Definition`, `Instance`, etc.
