### PR TITLE
fix: dep graph links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,9 +247,8 @@ jobs:
           echo "::remove-matcher owner=coq-problem-matcher::" # remove problem matcher installed by Coq docker action, so we don't get duplicate warning annotations
           ## Make dependency graph
           make HoTT.deps HoTTCore.deps
-          # TODO: Not sure what to do about proviola here
-          runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Library Dependency Graph" < HoTT.deps > HoTT.dot
-          runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Core Library Dependency Graph" < HoTTCore.deps > HoTTCore.dot
+          runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/Coq-HoTT/alectryon-html/" --title="HoTT Library Dependency Graph" < HoTT.deps > HoTT.dot
+          runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/Coq-HoTT/alectryon-html/" --title="HoTT Core Library Dependency Graph" < HoTTCore.deps > HoTTCore.dot
           dot -Tsvg HoTT.dot -o HoTT.svg
           dot -Tsvg HoTTCore.dot -o HoTTCore.svg
           rm -rf dep-graphs

--- a/etc/ci/generate_and_push_quick_doc.sh
+++ b/etc/ci/generate_and_push_quick_doc.sh
@@ -30,8 +30,8 @@ EXTRA_ARGS="$("$DIR"/check_should_dry_run.sh "$@")"
 export MESSAGE="Autoupdate documentation with DepsToDot.hs"
 echo '$ make HoTT.deps HoTTCore.deps'
 make HoTT.deps HoTTCore.deps || exit $?
-runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Library Dependency Graph" < HoTT.deps > HoTT.dot || exit $?
-runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/HoTT/proviola-html/" --title="HoTT Core Library Dependency Graph" < HoTTCore.deps > HoTTCore.dot || exit $?
+runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/Coq-HoTT/alectryon-html/" --title="HoTT Library Dependency Graph" < HoTT.deps > HoTT.dot || exit $?
+runhaskell etc/DepsToDot.hs --coqdocbase="http://hott.github.io/Coq-HoTT/alectryon-html/" --title="HoTT Core Library Dependency Graph" < HoTTCore.deps > HoTTCore.dot || exit $?
 dot -Tsvg HoTT.dot -o HoTT.svg || exit $?
 dot -Tsvg HoTTCore.dot -o HoTTCore.svg || exit $?
 echo '$ git checkout -b gh-pages upstream/gh-pages'


### PR DESCRIPTION
There was a leftover for prviola here. The links in the dep graph would link to the non-existant proviola doc. We switch this out for the alectryon doc.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: fb8342b9-e52d-4e0a-8d4c-c5ef7ad968bb -->