### PR TITLE
Add nix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
 
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build HoTT
       uses: coq-community/docker-coq-action@v1
       with:
@@ -78,7 +78,7 @@ jobs:
       if: matrix.coq-version-dummy == 'supported'
       run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build HoTT
       uses: coq-community/docker-coq-action@v1
       with:
@@ -116,7 +116,7 @@ jobs:
       if: matrix.coq-version-dummy == 'supported'
       run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # We use the coq docker so we don't have to build coq
@@ -142,10 +142,23 @@ jobs:
       run: tar -cf workspace.tar .
     # We upload build artifacts for use by documentation
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: workspace-${{ env.coq-version }}
         path: workspace.tar
+
+  # Nix build
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+      with:
+        name: coq-hott
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        extraPullNames: coq-hott
+    - run: nix build
+
 
 #
 #  Stage 2:
@@ -164,11 +177,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # Download artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: workspace-${{ env.coq-version-supported }}
     # Unpack Tar
@@ -212,11 +225,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # Download artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: workspace-${{ env.coq-version-supported }}
     # Unpack Tar
@@ -284,12 +297,12 @@ jobs:
         tar -cf file-dep-graphs.tar file-dep-graphs
     # We upload the artifacts
     - name: 'Upload Artifact dep-graphs.tar'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: dep-graphs
         path: dep-graphs.tar
     - name: 'Upload Artifact file-dep-graphs.tar'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: file-dep-graphs
         path: file-dep-graphs.tar
@@ -301,11 +314,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # Download artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: workspace-${{ env.coq-version-supported }}
     # Unpack Tar
@@ -332,7 +345,7 @@ jobs:
       run: tar -cf coqdoc-html.tar coqdoc-html
     # Upload coqdoc-html artifact
     - name: 'Upload coqdoc-html Artifact'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: coqdoc-html
         path: coqdoc-html.tar
@@ -344,11 +357,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # Download artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: workspace-${{ env.coq-version-supported }}
     # Unpack Tar
@@ -376,7 +389,7 @@ jobs:
       run: tar -cf timing-html.tar timing-html
     # Upload timing-html artifact
     - name: 'Upload timing-html Artifact'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: timing-html
         path: timing-html.tar
@@ -401,11 +414,11 @@ jobs:
       if: matrix.coq-version-dummy == 'supported'
       run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # Download artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: workspace-${{ env.coq-version }}
     # Unpack Tar
@@ -446,11 +459,11 @@ jobs:
       if: matrix.coq-version-dummy == 'supported'
       run: echo "coq-version=${{ env.coq-version-supported }}" >> $GITHUB_ENV
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     # Download artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: workspace-${{ env.coq-version }}
     # Unpack Tar
@@ -492,25 +505,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     # Checkout branch
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # Download alectryon artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: alectryon-html
     # Download dependency graph artifacts
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: dep-graphs
     # Download file dependency graph artifacts
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: file-dep-graphs
     # Download coqdoc artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: coqdoc-html
     # Download timing artifact
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: timing-html
     # Unpack Tar files

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1677676435,
+        "narHash": "sha256-6FxdcmQr5JeZqsQvfinIMr0XcTyTuR7EXX0H3ANShpQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a08d6979dd7c82c4cef0dcc6ac45ab16051c1169",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "A Coq library for Homotopy Type Theory";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    ,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        coq_version = pkgs.coq_8_17;
+      in
+      {
+        packages.default = pkgs.coqPackages.mkCoqDerivation {
+          pname = "hott";
+          version = "8.17";
+          src = self;
+          useDune = true;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            dune_3
+            ocaml
+            coq
+          ];
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
+}


### PR DESCRIPTION
If you have Nix, you can do `nix develop` to quickly get the dependencies for building the library. You can also build the library directly with `nix build`.

- Add Nix jobs to CI. Uses cachix so should be fast.
- Update checkout@v2 to checkout@v3

Nix is a package manager that allows for completely reproducible builds. It hashes things like Dune but at the level of packages and executables. As an alternative to Opam, it allows you to quickly drop into a development environment, or build the library without having to worry about dependencies since they are always fully specified.

We have a cache associated to our CI actions, so if it has been built before it won't be rebuilt. You can even setup your own nix installation to use the cache (named "coq-hott") on cachix.

With a bit more work, we should easily be able to test multiple Coq versions.

<!-- ps-id: 3a337c23-b2ea-45f8-a86a-18841f1f2210 -->