### PR TITLE
ci: auto-cancel last run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [ push , pull_request ]
 
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 # We set the supported coq-version from here. In order to use this environment variable correctly, look at how they are used in the following jobs.
 env:
   coq-version-supported: '8.16'


### PR DESCRIPTION
This will auto-cancel the last run of the CI on the same PR. This is helpful when there is a lot of traffic on a PR and you don't want all the workers busy.

Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: fd6970c4-ef5f-4c00-a323-c9c39f3c0684 -->