### PR TITLE
nix: add coq-lsp to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
             dune_3
             ocaml
             coq
+            coqPackages.coq-lsp
           ];
         };
 


### PR DESCRIPTION
This lets you use coq-lsp when you do `nix develop`. More information about coq-lsp can be found here: https://github.com/ejgallego/coq-lsp


Signed-off-by: Ali Caglayan <alizter@gmail.com>

<!-- ps-id: 93071939-19a6-4d5d-b562-07788fe93741 -->