### PR TITLE
Explicitly use : Type0 more

### DIFF
--- a/theories/Basics/Decimal.v
+++ b/theories/Basics/Decimal.v
@@ -25,7 +25,7 @@ Require Import Basics.Overture.
 (** Unsigned integers are just lists of digits.
     For instance, ten is (D1 (D0 Nil)) *)
 
-Inductive uint :=
+Inductive uint : Type0 :=
  | Nil
  | D0 (_:uint)
  | D1 (_:uint)
@@ -46,14 +46,14 @@ Notation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
-Variant int := Pos (d:uint) | Neg (d:uint).
+Variant int : Type0 := Pos (d:uint) | Neg (d:uint).
 
 (** For decimal numbers, we use two constructors [Decimal] and
     [DecimalExp], depending on whether or not they are given with an
     exponent (e.g., 1.02e+01). [i] is the integral part while [f] is
     the fractional part (beware that leading zeroes do matter). *)
 
-Variant decimal :=
+Variant decimal : Type0 :=
  | Decimal (i:int) (f:uint)
  | DecimalExp (i:int) (f:uint) (e:int).
 

--- a/theories/Basics/Hexadecimal.v
+++ b/theories/Basics/Hexadecimal.v
@@ -25,7 +25,7 @@ Require Import Basics.Overture Basics.Decimal.
 (** Unsigned integers are just lists of digits.
     For instance, sixteen is (D1 (D0 Nil)) *)
 
-Inductive uint :=
+Inductive uint : Type0 :=
  | Nil
  | D0 (_:uint)
  | D1 (_:uint)
@@ -52,14 +52,14 @@ Notation zero := (D0 Nil).
 
 (** For signed integers, we use two constructors [Pos] and [Neg]. *)
 
-Variant int := Pos (d:uint) | Neg (d:uint).
+Variant int : Type0 := Pos (d:uint) | Neg (d:uint).
 
 (** For decimal numbers, we use two constructors [Hexadecimal] and
     [HexadecimalExp], depending on whether or not they are given with an
     exponent (e.g., 0x1.a2p+01). [i] is the integral part while [f] is
     the fractional part (beware that leading zeroes do matter). *)
 
-Variant hexadecimal :=
+Variant hexadecimal : Type0 :=
  | Hexadecimal (i:int) (f:uint)
  | HexadecimalExp (i:int) (f:uint) (e:Decimal.int).
 

--- a/theories/Basics/Numeral.v
+++ b/theories/Basics/Numeral.v
@@ -1,12 +1,12 @@
-Require Import Basics.Hexadecimal.
+Require Import Basics.Overture Basics.Hexadecimal.
 
 (** * Decimal or Hexadecimal numbers *)
 
-Variant uint := UIntDec (u:Decimal.uint) | UIntHex (u:Hexadecimal.uint).
+Variant uint : Type0 := UIntDec (u:Decimal.uint) | UIntHex (u:Hexadecimal.uint).
 
-Variant int := IntDec (i:Decimal.int) | IntHex (i:Hexadecimal.int).
+Variant int : Type0 := IntDec (i:Decimal.int) | IntHex (i:Hexadecimal.int).
 
-Variant numeral := Dec (d:Decimal.decimal) | Hex (h:Hexadecimal.hexadecimal).
+Variant numeral : Type0 := Dec (d:Decimal.decimal) | Hex (h:Hexadecimal.hexadecimal).
 
 Register uint as num.num_uint.type.
 Register int as num.num_int.type.

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -381,7 +381,7 @@ Tactic Notation "do_with_holes'" tactic3(x) uconstr(p) :=
 
 (** We keep a list of global axioms that we will solve automatically, even when not using typeclass search. *)
 Unset Primitive Projections.
-Class IsGlobalAxiom (A : Type) := {}.
+Class IsGlobalAxiom (A : Type) : Type0 := {}.
 Set Primitive Projections.
 Global Hint Mode IsGlobalAxiom + : typeclass_instances.
 

--- a/theories/Categories/InitialTerminalCategory/Core.v
+++ b/theories/Categories/InitialTerminalCategory/Core.v
@@ -16,7 +16,8 @@ Notation terminal_category := (nat_category 1) (only parsing).
 (** A precategory is terminal if its objects and morphisms are contractible types. *)
 Class IsTerminalCategory (C : PreCategory)
       `{Contr (object C)}
-      `{forall s d, Contr (morphism C s d)} := {}.
+      `{forall s d, Contr (morphism C s d)}
+  : Type0 := {}.
 
 (** ** Initial categories *)
 (** An initial precategory is one whose objects have the recursion priniciple of the empty type *)

--- a/theories/Classes/implementations/binary_naturals.v
+++ b/theories/Classes/implementations/binary_naturals.v
@@ -16,7 +16,7 @@ Section basics.
   (* This definition of binary naturals is due to Martín Escardó and
      Cory Knapp *)
 
-  Inductive binnat : Type :=
+  Inductive binnat : Type0 :=
   | bzero   :           binnat  (* zero *)
   | double1 : binnat -> binnat  (* 2n+1 *)
   | double2 : binnat -> binnat. (* 2n+2 *)

--- a/theories/Classes/tactics/ring_quote.v
+++ b/theories/Classes/tactics/ring_quote.v
@@ -20,7 +20,7 @@ End almostring_mor.
 
 Module Quoting.
 
-Inductive Expr (V:Type0) :=
+Inductive Expr (V:Type0) : Type0 :=
   | Var (v : V)
   | Zero
   | One

--- a/theories/Spaces/Nat/Arithmetic.v
+++ b/theories/Spaces/Nat/Arithmetic.v
@@ -796,7 +796,7 @@ Defined.
 
 Local Unset Elimination Schemes.
 
-Inductive increasing_geq (n : nat) : nat -> Type :=
+Inductive increasing_geq (n : nat) : nat -> Type0 :=
 | increasing_geq_n : increasing_geq n n
 | increasing_geq_S (m : nat) : increasing_geq n m.+1 ->
                                increasing_geq n m.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -344,7 +344,7 @@ Global Instance hset_nat : IsHSet nat := _.
 
 (** ** Inequality of natural numbers *)
 
-Inductive leq (n : nat) : nat -> Type :=
+Inductive leq (n : nat) : nat -> Type0 :=
 | leq_n : leq n n
 | leq_S : forall m, leq n m -> leq n (S m).
 

--- a/theories/Tactics/EquivalenceInduction.v
+++ b/theories/Tactics/EquivalenceInduction.v
@@ -20,7 +20,7 @@ Global Arguments RespectsEquivalenceL : clear implicits.
 Global Arguments RespectsEquivalenceR : clear implicits.
 
 (** When doing equivalence induction, typeclass inference will either fully solve the respectfulness side-conditions, or not make any progress.  We would like to progress as far as we can on the side-conditions, so that we leave the user with as little to prove as possible.  To do this, we create a "database", implemented using typeclasses, to look up the refinement lemma, keyed on the head of the term we want to respect equivalence. *)
-Class respects_equivalence_db {KT VT} (Key : KT) {lem : VT} := make_respects_equivalence_db : Unit.
+Class respects_equivalence_db {KT VT} (Key : KT) {lem : VT} : Type0 := make_respects_equivalence_db : Unit.
 Definition get_lem' {KT VT} Key {lem} `{@respects_equivalence_db KT VT Key lem} : VT := lem.
 Notation get_lem key := ltac:(let res := constr:(get_lem' key) in let res' := (eval unfold get_lem' in res) in exact res') (only parsing).
 

--- a/theories/Tests.v
+++ b/theories/Tests.v
@@ -112,7 +112,7 @@ Module PR_1382.
 
   (* Check discriminate on types with local definitions *)
 
-  Inductive A := B (T := Unit) (x y : Bool) (z := x).
+  Inductive A : Type0 := B (T := Unit) (x y : Bool) (z := x).
   Goal forall x y, B x true = B y false -> Empty.
   discriminate.
   Qed.


### PR DESCRIPTION
Currently "Unset Universe Minimization ToSet" is somewhat buggy and these inductives still get minimized to Set automatically, but if that's fixed we need this patch to avoid putting them in floating universes.

Alternatively we could enable minimization to set in these files.