### PR TITLE
Qualifying idtoiso into Category.Morphisms.idtoiso

### DIFF
--- a/theories/Categories/FunctorCategory/Morphisms.v
+++ b/theories/Categories/FunctorCategory/Morphisms.v
@@ -110,7 +110,7 @@ Section idtoiso.
   Lemma eta_idtoiso
         (F G : object (C -> D))
         (T : F = G)
-  : Morphisms.idtoiso _ T = idtoiso T.
+  : Category.Morphisms.idtoiso _ T = idtoiso T.
   Proof.
     case T.
     expand; f_ap.


### PR DESCRIPTION
Hi, there is ongoing investigations in the implementation of Coq aiming at providing all generalizations of a declaration of a section at the time of declaration, see PR coq/coq#17888. The generalized constants would use qualified names: for a constant `C` in section `S` in file `F`, the generalization would have name `F.C`.

While testing the Coq PR, I realize that Coq-HoTT has one example of a qualified name which would then clash. This PR anticipates the need for qualifying it one step further.

It is not clear yet how the Coq PR will evolve, but if ever the present PR is in any case ok for Coq-HoTT, it can also be merged as soon as now, without waiting about what coq/coq#17888 will eventually give.