### PR TITLE
Yoneda lemma using 0-groupoids

### DIFF
--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -10,7 +10,7 @@ Local Open Scope wc_iso_scope.
 
 (** Definition of Abelianization.
 
-  A "unit" homomorphism [eta : G -> G_ab], with [G_ab] abelian, is considered an abelianization if and only if for all homomorphisms [G -> A], where [A] is abelian, there exists a unique [g : G_ab -> A] such that [h == g o eta X].   We express this in funext-free form by saying that precomposition with [eta] in the wild 1-category [Group] induces an equivalence of hom 0-groupoids.
+  A "unit" homomorphism [eta : G -> G_ab], with [G_ab] abelian, is considered an abelianization if and only if for all homomorphisms [G -> A], where [A] is abelian, there exists a unique [g : G_ab -> A] such that [h == g o eta X].   We express this in funext-free form by saying that precomposition with [eta] in the wild 1-category [Group] induces an equivalence of hom 0-groupoids, in the sense of WildCat/EquivGpd.
 
   Unfortunately, if [eta : GroupHomomorphism G G_ab] and we write [cat_precomp A eta] then Coq is unable to guess that the relevant 1-category is [Group].  Even writing [cat_precomp (A := Group) A eta] isn't good enough, I guess because the typeclass inference that finds the instance [is01cat_group] doesn't happen until after the type of [eta] would have to be resolved to a [Hom] in some wild category.  However, with the following auxiliary definition we can force the typeclass inference to happen first.  (It would be worth thinking about whether the design of the wild categories library could be improved to avoid this.)  *)
 Definition group_precomp {a b} := @cat_precomp Group _ _ a b.

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -18,7 +18,7 @@ Definition group_precomp {a b} := @cat_precomp Group _ _ a b.
 Class IsAbelianization {G : Group} (G_ab : AbGroup)
       (eta : GroupHomomorphism G G_ab)
   := isequiv0gpd_isabel : forall (A : AbGroup),
-      IsEquiv0Gpd (group_precomp A eta).
+      IsSurjInj (group_precomp A eta).
 Global Existing Instance isequiv0gpd_isabel.
 
 (** Here we define abelianization as a HIT. Specifically as a set-coequalizer of the following two maps: (a, b, c) |-> a (b c) and (a, b, c) |-> a (c b).
@@ -323,13 +323,13 @@ Proof.
   destruct (esssurj (group_precomp A eta2) eta1) as [b bc].
   srapply (Build_GroupIsomorphism _ _ a).
   srapply (isequiv_adjointify _ b).
-  { refine (essinj0 (group_precomp B eta2)
-                    (x := a $o b) (y := Id (A := Group) B) _).
+  { refine (essinj (group_precomp B eta2)
+                   (x := a $o b) (y := Id (A := Group) B) _).
     intros x; cbn in *.
     refine (_ @ ac x).
     apply ap, bc. }
-  { refine (essinj0 (group_precomp A eta1)
-                    (x := b $o a) (y := Id (A := Group) A) _).
+  { refine (essinj (group_precomp A eta1)
+                   (x := b $o a) (y := Id (A := Group) A) _).
     intros x; cbn in *.
     refine (_ @ bc x).
     apply ap, ac. }

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -565,11 +565,11 @@ Lemma natequiv_bg_pi1_adjoint `{Univalence} (X : pType) `{IsConnected 0 X}
   : NatEquiv (opyon (Pi1 X)) (opyon X o B).
 Proof.
   nrefine (natequiv_compose (G := opyon (Pi1 (pTr 1 X))) _ _).
-  2: exact (natequiv_opyon_equiv (Pi1 X) _ (grp_iso_pi1_Tr _)).
+  2: exact (natequiv_opyon_equiv (A:=Group) (grp_iso_pi1_Tr _)).
   refine (natequiv_compose _ (natequiv_grp_homo_pmap_bg _)).
   refine (natequiv_compose (G := opyon (pTr 1 X) o B) _ _); revgoals.
   { refine (natequiv_prewhisker _ _).
-    refine (natequiv_opyon_equiv _ _ _^-1$).
+    refine (natequiv_opyon_equiv _^-1$).
     rapply pequiv_pclassifyingspace_pi1. }
   snrapply Build_NatEquiv.
   1: intro; exact equiv_ptr_rec.

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -249,7 +249,7 @@ Section UnivProp.
   Defined.
 
   (** And now we can prove that it's an equivalence. *)
-  Definition equiv0gpd_Susp_ind_inv : IsEquiv0Gpd Susp_ind_inv.
+  Definition issurjinj_Susp_ind_inv : IsSurjInj Susp_ind_inv.
   Proof.
     constructor.
     - intros [[n s] g].
@@ -336,8 +336,8 @@ Section UnivPropNat.
   Defined.
 
   (** And therefore a fiberwise equivalence of 0-groupoids. *)
-  Local Instance isequiv0gpd_functor_Susp_ind_data' NS
-    : IsEquiv0Gpd (functor_Susp_ind_data' NS).
+  Local Instance issurjinj_functor_Susp_ind_data' NS
+    : IsSurjInj (functor_Susp_ind_data' NS).
   Proof.
     constructor.
     - intros g.
@@ -402,7 +402,7 @@ Section UnivPropNat.
     { reflexivity. }
     etransitivity.
     { refine (isesssurj_iff_commsq Susp_ind_inv_nat); try exact _.
-      all:apply equiv0gpd_Susp_ind_inv. }
+      all:apply issurjinj_Susp_ind_inv. }
     etransitivity.
     { refine (isesssurj_iff_sigma _ _ 
                 (fun NS => functor_Susp_ind_data' NS o functor_Susp_ind_data'' NS)). }

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -248,7 +248,7 @@ Section UnivProp.
       exact (dp_apD_nat p (merid x)).
   Defined.
 
-  (** And now we can prove that it's an equivalence. *)
+  (** And now we can prove that it's an equivalence of 0-groupoids, using the definition from WildCat/EquivGpd. *)
   Definition issurjinj_Susp_ind_inv : IsSurjInj Susp_ind_inv.
   Proof.
     constructor.
@@ -423,7 +423,7 @@ Definition extendable_iff_functor_susp
     <-> (forall NS, ExtendableAlong n f (fun x => DPath P (merid x) (fst NS) (snd NS))).
 Proof.
   revert P. induction n as [|n IHn]; intros P; [ split; intros; exact tt | ].
-  (** It would be nice to be able to do this proof by chaining logcal equivalences too, especially since the two parts seem very similar.  But I haven't managed to make that work. *)
+  (** It would be nice to be able to do this proof by chaining logical equivalences too, especially since the two parts seem very similar.  But I haven't managed to make that work. *)
   split.
   - intros [e1 en] [N S]; split.
     + apply extension_iff_functor_susp.

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -23,6 +23,7 @@ Require Export WildCat.Prod.
 Require Export WildCat.Sum.
 Require Export WildCat.Forall.
 Require Export WildCat.Sigma.
+Require Export WildCat.ZeroGroupoid.
 
 (* Higher categories *)
 Require Export WildCat.TwoOneCat.

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -7,6 +7,8 @@ Require Import WildCat.Sigma.
 
 (** * Equivalences of 0-groupoids, and split essentially surjective functors *)
 
+(** For an alternate definition of equivalences of 0-groupoids, see ZeroGroupoid.v. *)
+
 (** We could define these similarly for more general categories too, but we'd need to use [HasEquivs] and [$<~>] instead of [$==]. *)
 
 Class SplEssSurj {A B : Type} `{Is0Gpd A, Is0Gpd B}

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -17,7 +17,7 @@ Class SplEssSurj {A B : Type} `{Is0Gpd A, Is0Gpd B}
 
 Arguments esssurj {A B _ _ _ _ _ _} F {_ _} b.
 
-(** A 0-functor between 0-groupoids is an equivalence if it is essentially surjective and reflects the existence of morphisms.  This is "surjective and injective" in setoid-language.  (To define essential surjectivity for non-groupoids, we would need [HasEquivs] from [WildCat.Equiv]. *)
+(** A 0-functor between 0-groupoids is an "equivalence" if it is essentially surjective and reflects the existence of morphisms.  This is "surjective and injective" in setoid-language, so we use the name [IsSurjInj].  (To define essential surjectivity for non-groupoids, we would need [HasEquivs] from [WildCat.Equiv]. *)
 Class IsSurjInj {A B : Type} `{Is0Gpd A, Is0Gpd B}
       (F : A -> B) `{!Is0Functor F} :=
 {

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -7,7 +7,7 @@ Require Import WildCat.Sigma.
 
 (** * Equivalences of 0-groupoids, and split essentially surjective functors *)
 
-(** For an alternate definition of equivalences of 0-groupoids, see ZeroGroupoid.v. *)
+(** For a logically equivalent definition of equivalences of 0-groupoids, see ZeroGroupoid.v. *)
 
 (** We could define these similarly for more general categories too, but we'd need to use [HasEquivs] and [$<~>] instead of [$==]. *)
 

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -18,49 +18,49 @@ Class SplEssSurj {A B : Type} `{Is0Gpd A, Is0Gpd B}
 Arguments esssurj {A B _ _ _ _ _ _} F {_ _} b.
 
 (** A 0-functor between 0-groupoids is an equivalence if it is essentially surjective and reflects the existence of morphisms.  This is "surjective and injective" in setoid-language.  (To define essential surjectivity for non-groupoids, we would need [HasEquivs] from [WildCat.Equiv]. *)
-Class IsEquiv0Gpd {A B : Type} `{Is0Gpd A, Is0Gpd B}
+Class IsSurjInj {A B : Type} `{Is0Gpd A, Is0Gpd B}
       (F : A -> B) `{!Is0Functor F} :=
 {
-  esssurj_isequiv0gpd : SplEssSurj F ;
-  essinj0 : forall (x y:A), (F x $== F y) -> (x $== y) ;
+  esssurj_issurjinj : SplEssSurj F ;
+  essinj : forall (x y:A), (F x $== F y) -> (x $== y) ;
 }.
 
-Global Existing Instance esssurj_isequiv0gpd.
-Arguments essinj0 {A B _ _ _ _ _ _} F {_ _ x y} f.
+Global Existing Instance esssurj_issurjinj.
+Arguments essinj {A B _ _ _ _ _ _} F {_ _ x y} f.
 
-Definition equiv0gpd_inv {A B : Type} (F : A -> B) `{IsEquiv0Gpd A B F} : B -> A
+Definition surjinj_inv {A B : Type} (F : A -> B) `{IsSurjInj A B F} : B -> A
   := fun b => (esssurj F b).1.
 
 (** Some of the results below also follow from the logical equivalence with [IsEquiv_0Gpd] and the fact that [ZeroGpd] satisfies [HasEquivs].  But it is sometimes awkward to deduce the results this way, mostly because [ZeroGpd] requires bundled objects rather than typeclass instances. *)
 
 (** Equivalences have inverses *)
 
-Global Instance is0functor_equiv0gpd_inv
-       {A B : Type} (F : A -> B) `{IsEquiv0Gpd A B F}
-  : Is0Functor (equiv0gpd_inv F).
+Global Instance is0functor_surjinj_inv
+       {A B : Type} (F : A -> B) `{IsSurjInj A B F}
+  : Is0Functor (surjinj_inv F).
 Proof.
   constructor; intros x y f.
   pose (p := (esssurj F x).2).
   pose (q := (esssurj F y).2).
   cbn in *.
   pose (f' := p $@ f $@ q^$).
-  exact (essinj0 F f').
+  exact (essinj F f').
 Defined.
 
 (** The inverse is an inverse, up to unnatural transformations *)
 
-Definition eisretr0gpd_inv {A B : Type} (F : A -> B) `{IsEquiv0Gpd A B F}
-  : F o equiv0gpd_inv F $=> idmap.
+Definition eisretr0gpd_inv {A B : Type} (F : A -> B) `{IsSurjInj A B F}
+  : F o surjinj_inv F $=> idmap.
 Proof.
   intros b.
   exact ((esssurj F b).2).
 Defined.
 
-Definition eissect0gpd_inv {A B : Type} (F : A -> B) `{IsEquiv0Gpd A B F}
-  : equiv0gpd_inv F o F $=> idmap.
+Definition eissect0gpd_inv {A B : Type} (F : A -> B) `{IsSurjInj A B F}
+  : surjinj_inv F o F $=> idmap.
 Proof.
   intros a.
-  apply (essinj0 F).
+  apply (essinj F).
   apply eisretr0gpd_inv.
 Defined.
 
@@ -75,14 +75,14 @@ Proof.
   apply alpha.
 Defined.
 
-Definition isequiv0gpd_transf {A B : Type} {F : A -> B} {G : A -> B}
-           `{IsEquiv0Gpd A B F} `{!Is0Functor G} (alpha : G $=> F)
-  : IsEquiv0Gpd G.
+Definition issurjinj_transf {A B : Type} {F : A -> B} {G : A -> B}
+           `{IsSurjInj A B F} `{!Is0Functor G} (alpha : G $=> F)
+  : IsSurjInj G.
 Proof.
   constructor.
   - apply (isesssurj_transf alpha).
   - intros x y f.
-    apply (essinj0 F).
+    apply (essinj F).
     refine (_ $@ f $@ _).
     + symmetry; apply alpha.
     + apply alpha.
@@ -105,47 +105,47 @@ Section ComposeAndCancel.
     apply (esssurj F).
   Defined.
 
-  Global Instance isequiv0gpd_compose
-         `{!IsEquiv0Gpd G, !IsEquiv0Gpd F}
-    : IsEquiv0Gpd (G o F).
+  Global Instance issurjinj_compose
+         `{!IsSurjInj G, !IsSurjInj F}
+    : IsSurjInj (G o F).
   Proof.
     constructor.
     - exact _.
     - intros x y f.
-      apply (essinj0 F).
-      exact (essinj0 G f).
+      apply (essinj F).
+      exact (essinj G f).
   Defined.
 
   Definition cancelL_isesssurj
-             `{!IsEquiv0Gpd G, !SplEssSurj (G o F)}
+             `{!IsSurjInj G, !SplEssSurj (G o F)}
     : SplEssSurj F.
   Proof.
     intros b.
     exists ((esssurj (G o F) (G b)).1).
-    apply (essinj0 G).
+    apply (essinj G).
     exact ((esssurj (G o F) (G b)).2).
   Defined.
 
-  Definition iffL_isesssurj `{!IsEquiv0Gpd G}
+  Definition iffL_isesssurj `{!IsSurjInj G}
     : SplEssSurj (G o F) <-> SplEssSurj F.
   Proof.
     split; [ apply @cancelL_isesssurj | apply @isesssurj_compose ]; exact _.
   Defined.
 
-  Definition cancelL_isequiv0gpd
-             `{!IsEquiv0Gpd G, !IsEquiv0Gpd (G o F)}
-    : IsEquiv0Gpd F.
+  Definition cancelL_issurjinj
+             `{!IsSurjInj G, !IsSurjInj (G o F)}
+    : IsSurjInj F.
   Proof.
     constructor.
     - apply cancelL_isesssurj.
     - intros x y f.
-      exact (essinj0 (G o F) (fmap G f)).
+      exact (essinj (G o F) (fmap G f)).
   Defined.
 
-  Definition iffL_isequiv0gpd `{!IsEquiv0Gpd G}
-    : IsEquiv0Gpd (G o F) <-> IsEquiv0Gpd F.
+  Definition iffL_issurjinj `{!IsSurjInj G}
+    : IsSurjInj (G o F) <-> IsSurjInj F.
   Proof.
-    split; [ apply @cancelL_isequiv0gpd | apply @isequiv0gpd_compose ]; exact _.
+    split; [ apply @cancelL_issurjinj | apply @issurjinj_compose ]; exact _.
   Defined.
 
   Definition cancelR_isesssurj `{!SplEssSurj (G o F)}
@@ -162,9 +162,9 @@ Section ComposeAndCancel.
     split; [ apply @cancelR_isesssurj | intros; apply @isesssurj_compose ]; exact _.
   Defined.
 
-  Definition cancelR_isequiv0gpd
-             `{!IsEquiv0Gpd F, !IsEquiv0Gpd (G o F)}
-    : IsEquiv0Gpd G.
+  Definition cancelR_issurjinj
+             `{!IsSurjInj F, !IsSurjInj (G o F)}
+    : IsSurjInj G.
   Proof.
     constructor.
     - apply cancelR_isesssurj.
@@ -174,16 +174,16 @@ Section ComposeAndCancel.
       cbn in *.
       refine (p^$ $@ _ $@ q).
       apply (fmap F).
-      apply (essinj0 (G o F)).
+      apply (essinj (G o F)).
       refine (_ $@ f $@ _).
       + exact (fmap G p).
       + exact (fmap G q^$).
   Defined.
 
-  Definition iffR_isequiv0gpd `{!IsEquiv0Gpd F}
-    : IsEquiv0Gpd (G o F) <-> IsEquiv0Gpd G.
+  Definition iffR_issurjinj `{!IsSurjInj F}
+    : IsSurjInj (G o F) <-> IsSurjInj G.
   Proof.
-    split; [ apply @cancelR_isequiv0gpd | intros; apply @isequiv0gpd_compose ]; exact _.
+    split; [ apply @cancelR_issurjinj | intros; apply @issurjinj_compose ]; exact _.
   Defined.
 
 End ComposeAndCancel.
@@ -191,7 +191,7 @@ End ComposeAndCancel.
 (** In particular, essential surjectivity and being an equivalence transfer across commutative squares of functors. *)
 Definition isesssurj_iff_commsq {A B C D : Type}
            {F : A -> B} {G : C -> D} {H : A -> C} {K : B -> D}
-           `{IsEquiv0Gpd A C H} `{IsEquiv0Gpd B D K}
+           `{IsSurjInj A C H} `{IsSurjInj B D K}
            `{!Is0Functor F} `{!Is0Functor G}
            (p : K o F $=> G o H)
   : SplEssSurj F <-> SplEssSurj G.
@@ -203,18 +203,18 @@ Proof.
     apply (isesssurj_transf p).
 Defined.
 
-Definition isequiv0gpd_iff_commsq {A B C D : Type}
+Definition issurjinj_iff_commsq {A B C D : Type}
            {F : A -> B} {G : C -> D} {H : A -> C} {K : B -> D}
-           `{IsEquiv0Gpd A C H} `{IsEquiv0Gpd B D K}
+           `{IsSurjInj A C H} `{IsSurjInj B D K}
            `{!Is0Functor F} `{!Is0Functor G}
            (p : K o F $=> G o H)
-  : IsEquiv0Gpd F <-> IsEquiv0Gpd G.
+  : IsSurjInj F <-> IsSurjInj G.
 Proof.
   split; intros ?.
-  - srapply (cancelR_isequiv0gpd G H); try exact _.
-    apply (isequiv0gpd_transf (fun a => (p a)^$)).
-  - srapply (cancelL_isequiv0gpd K F); try exact _.
-    apply (isequiv0gpd_transf p).
+  - srapply (cancelR_issurjinj G H); try exact _.
+    apply (issurjinj_transf (fun a => (p a)^$)).
+  - srapply (cancelL_issurjinj K F); try exact _.
+    apply (issurjinj_transf p).
 Defined.
 
 (** Equivalences and essential surjectivity are preserved by sigmas (for now, just over constant bases), and essential surjectivity at least is also reflected. *)
@@ -239,17 +239,17 @@ Proof.
     exact ((esssurj (F a) c).2).
 Defined.
 
-Definition isequiv0gpd_sigma {A : Type} (B C : A -> Type)
+Definition issurjinj_sigma {A : Type} (B C : A -> Type)
  `{forall a, IsGraph (B a)} `{forall a, Is01Cat (B a)} `{forall a, Is0Gpd (B a)}
  `{forall a, IsGraph (C a)} `{forall a, Is01Cat (C a)} `{forall a, Is0Gpd (C a)}
   (F : forall a, B a -> C a)
-  `{forall a, Is0Functor (F a)} `{forall a, IsEquiv0Gpd (F a)}
-  : IsEquiv0Gpd (fun (x:sig B) => (x.1 ; F x.1 x.2)).
+  `{forall a, Is0Functor (F a)} `{forall a, IsSurjInj (F a)}
+  : IsSurjInj (fun (x:sig B) => (x.1 ; F x.1 x.2)).
 Proof.
   constructor.
   - apply isesssurj_iff_sigma; exact _.
   - intros [a1 b1] [a2 b2] [p f]; cbn in *.
     destruct p; cbn in *.
     exists idpath; cbn.
-    exact (essinj0 (F a1) f).
+    exact (essinj (F a1) f).
 Defined.

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -31,6 +31,8 @@ Arguments essinj0 {A B _ _ _ _ _ _} F {_ _ x y} f.
 Definition equiv0gpd_inv {A B : Type} (F : A -> B) `{IsEquiv0Gpd A B F} : B -> A
   := fun b => (esssurj F b).1.
 
+(** Some of the results below also follow from the logical equivalence with [IsEquiv_0Gpd] and the fact that [ZeroGpd] satisfies [HasEquivs].  But it is sometimes awkward to deduce the results this way, mostly because [ZeroGpd] requires bundled objects rather than typeclass instances. *)
+
 (** Equivalences have inverses *)
 
 Global Instance is0functor_equiv0gpd_inv

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -172,7 +172,7 @@ Proof.
     rapply (Build_ZeroGpd (opyon a b)).
   - snrapply Build_Is0Functor.
     intros b c f; cbn beta.
-    snrapply Build_ZeroGpdMorphism; cbn.
+    snrapply Build_Morphism_0Gpd; cbn.
     + exact (fmap (opyon a) f).
     + apply is0functor_postcomp.
 Defined.
@@ -187,15 +187,15 @@ Proof.
   - pose proof (gn := is1natural_natequiv _ _ g).
     refine ((isnat (alnat:=gn) g (f a (Id a)) (Id b))^$ $@ _).
     refine (fmap (g a) (cat_idr (f a (Id a))) $@ _).
-    1: rapply is0functor_zerogpd_fun.
+    1: rapply is0functor_fun_0gpd.
     1: exact _.
-    rapply zerogpd_eissect.
+    rapply eissect_0gpd.
   - pose proof (fn := is1natural_natequiv _ _ f).
     refine ((isnat (alnat:=fn) f (g b (Id b)) (Id a))^$ $@ _).
     refine (fmap (f b) (cat_idr (g b (Id b))) $@ _).
-    1: rapply is0functor_zerogpd_fun.
+    1: rapply is0functor_fun_0gpd.
     1: exact _.
-    rapply zerogpd_eisretr.
+    rapply eisretr_0gpd.
   (* Not sure why typeclass inference doesn't find [is1natural_natequiv] and [is0functor_zerogpd_fun] above. *)
 Defined.
 
@@ -205,10 +205,10 @@ Definition equiv_precompose_cat_equiv_0gpd {A : Type} `{HasEquivs A}
   : opyon_0gpd y z $<~> opyon_0gpd x z.
 Proof.
   snrapply cate_adjointify.
-  - snrapply Build_ZeroGpdMorphism.
+  - snrapply Build_Morphism_0Gpd.
     1: exact (cat_precomp z f).
     exact _.
-  - snrapply Build_ZeroGpdMorphism.
+  - snrapply Build_Morphism_0Gpd.
     1: exact (cat_precomp z f^-1$).
     exact _.
   - cbn.

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -134,7 +134,7 @@ Defined.
 
 (** We can also deduce "full-faithfulness" on equivalences. *)
 Definition opyon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
-           (a b : A)
+           {a b : A}
   : (opyon1 a $<~> opyon1 b) -> (b $<~> a).
 Proof.
   intros f.
@@ -154,7 +154,7 @@ Proof.
 Defined.
 
 Definition natequiv_opyon_equiv {A : Type} `{HasEquivs A}
-  `{!HasMorExt A} (a b : A)
+  `{!HasMorExt A} {a b : A}
   : (b $<~> a) -> (opyon1 a $<~> opyon1 b).
 Proof.
   intro e.
@@ -238,19 +238,15 @@ Defined.
 (** We can deduce this from the covariant version with some boilerplate. *)
 
 Definition yon {A : Type} `{IsGraph A} (a : A) : A^op -> Type
-  := @opyon (A^op) _ a.
+  := opyon (A:=A^op) a.
 
 Global Instance is0functor_yon {A : Type} `{H : Is01Cat A} (a : A)
-  : Is0Functor (yon a).
-Proof.
-  apply is0functor_opyon.
-Defined.
+  : Is0Functor (yon a)
+  := is0functor_opyon (A:=A^op) a.
 
 Global Instance is1functor_yon {A : Type} `{H : Is1Cat A} `{!HasMorExt A} (a : A)
-  : Is1Functor (yon a).
-Proof.
-  rapply is1functor_opyon.
-Defined.
+  : Is1Functor (yon a)
+  := is1functor_opyon (A:=A^op) a.
 
 Definition yoneda {A : Type} `{Is01Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F}
@@ -260,17 +256,17 @@ Definition yoneda {A : Type} `{Is01Cat A} (a : A)
 Definition un_yoneda {A : Type} `{Is01Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F}
   : (yon a $=> F) -> F a
-  := @un_opyoneda (A^op) _ _ a F _.
+  := un_opyoneda (A:=A^op) a F.
 
 Global Instance is1natural_yoneda {A : Type} `{Is1Cat A} (a : A)
        (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : Is1Natural (yon a) F (yoneda a F x)
-  := @is1natural_opyoneda (A^op) _ _ _ _ a F _ _ x.
+  := is1natural_opyoneda (A:=A^op) a F x.
 
 Definition yoneda_issect {A : Type} `{Is1Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : un_yoneda a F (yoneda a F x) = x
-  := @opyoneda_issect (A^op) _ _ _ _ a F _ _ x.
+  := opyoneda_issect (A:=A^op) a F x.
 
 Definition yoneda_isretr {A : Type} `{Is1Cat_Strong A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F}
@@ -279,24 +275,24 @@ Definition yoneda_isretr {A : Type} `{Is1Cat_Strong A} (a : A)
            (alpha : yon a $=> F) {alnat : Is1Natural (yon a) F alpha}
            (b : A)
   : yoneda a F (un_yoneda a F alpha) b $== alpha b
-  := @opyoneda_isretr A^op _ _ _ (is1cat_strong_op A) a F _ _ alpha alnat b.
+  := opyoneda_isretr (A:=A^op) a F alpha b.
 
 Definition yon_cancel {A : Type} `{Is01Cat A} (a b : A)
   : (yon a $=> yon b) -> (a $-> b)
   := un_yoneda a (yon b).
 
 Definition yon1 {A : Type} `{Is01Cat A} (a : A) : Fun01 A^op Type
-  := @opyon1 A^op _ _ a.
+  := opyon1 (A:=A^op) a.
 
 Definition yon11 {A : Type} `{Is1Cat A} `{!HasMorExt A} (a : A) : Fun11 A^op Type
-  := @opyon11 A^op _ _ _ _ _ a.
+  := opyon11 (A:=A^op) a.
 
 Definition yon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
            (a b : A)
   : (yon1 a $<~> yon1 b) -> (a $<~> b)
-  := (@opyon_equiv A^op _ _ _ _ _ _ a b).
+  := opyon_equiv (A:=A^op).
 
 Definition natequiv_yon_equiv {A : Type} `{HasEquivs A}
   `{!HasMorExt A} (a b : A)
   : (a $<~> b) -> (yon1 a $<~> yon1 b)
-  := (@natequiv_opyon_equiv A^op _ _ _ _ _ _ a b).
+  := natequiv_opyon_equiv (A:=A^op).

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -296,3 +296,16 @@ Definition natequiv_yon_equiv {A : Type} `{HasEquivs A}
   `{!HasMorExt A} (a b : A)
   : (a $<~> b) -> (yon1 a $<~> yon1 b)
   := natequiv_opyon_equiv (A:=A^op).
+
+Definition yon_0gpd {A : Type} `{Is1Cat A} (a : A) : Fun01 A^op ZeroGpd
+  := opyon_0gpd (A:=A^op) a.
+
+Definition yon_equiv_0gpd {A : Type} `{HasEquivs A}
+  {a b : A}
+  : yon_0gpd a $<~> yon_0gpd b -> a $<~> b
+  := opyon_equiv_0gpd (A:=A^op).
+
+Definition natequiv_yon_equiv_0gpd {A : Type} `{HasEquivs A}
+  {a b : A}
+  : a $<~> b -> yon_0gpd a $<~> yon_0gpd b
+  := natequiv_opyon_equiv_0gpd (A:=A^op).

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -182,20 +182,25 @@ Definition opyon_equiv_0gpd {A : Type} `{HasEquivs A}
   {a b : A} (f : opyon_0gpd a $<~> opyon_0gpd b)
   : b $<~> a.
 Proof.
-  set (g := f^-1$).
-  srapply (cate_adjointify (f a (Id a)) (g b (Id b))).
-  - pose proof (gn := is1natural_natequiv _ _ g).
-    refine ((isnat (alnat:=gn) g (f a (Id a)) (Id b))^$ $@ _).
-    refine (fmap (g a) (cat_idr (f a (Id a))) $@ _).
+  (* Coq can't find the composite Coercion from equivalences of 0-groupoids to Funclass, so we make names for the underlying natural transformations of [f] and its inverse. *)
+  set (ft := cate_fun f).
+  set (gt := cate_fun f^-1$).
+  (* These are the maps that will define the desired equivalence: *)
+  set (fa := (ft a) (Id a)).
+  set (gb := (gt b) (Id b)).
+  srapply (cate_adjointify fa gb).
+  - pose proof (gn := is1natural_nattrans _ _ gt).
+    refine ((isnat (alnat:=gn) gt fa (Id b))^$ $@ _).
+    refine (fmap (gt a) (cat_idr fa) $@ _).
     1: rapply is0functor_fun_0gpd.
     1: exact _.
-    rapply eissect_0gpd.
+    exact (cat_eissect (f a) (Id a)).
   - pose proof (fn := is1natural_natequiv _ _ f).
-    refine ((isnat (alnat:=fn) f (g b (Id b)) (Id a))^$ $@ _).
-    refine (fmap (f b) (cat_idr (g b (Id b))) $@ _).
+    refine ((isnat (alnat:=fn) ft gb (Id a))^$ $@ _).
+    refine (fmap (ft b) (cat_idr gb) $@ _).
     1: rapply is0functor_fun_0gpd.
     1: exact _.
-    rapply eisretr_0gpd.
+    exact (cat_eisretr (f b) (Id b)).
   (* Not sure why typeclass inference doesn't find [is1natural_natequiv] and [is0functor_zerogpd_fun] above. *)
 Defined.
 

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -164,7 +164,7 @@ Proof.
   - rapply is1natural_opyoneda.
 Defined.
 
-(** We define a version of [opyon] that lands in 0-groupoids, which we regard as setoids. *)
+(** We define a version of [opyon] that lands in 0-groupoids. *)
 Definition opyon_0gpd {A : Type} `{Is1Cat A} (a : A) : Fun01 A ZeroGpd.
 Proof.
   snrapply Build_Fun01.

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -79,7 +79,7 @@ Proof.
   - reflexivity.
 Defined.
 
-(** We define equivalences of 0-groupoids.  Note that this differs from [IsEquiv0Gpd] in [EquivGpd.v].  It is chosen to provide what is needed for the Yoneda lemma, and to match the concept for types, with paths replaced by 1-cells.  We are able to match the biinvertible definition.  The half-adjoint definition doesn't work, as we can prove adjointification.  We would need to be in a 1-groupoid for that to be possible.  We could also use the "wrong" definition, without the eisadj condition, and things would go through, but it wouldn't match the definition for types. *)
+(** We define equivalences of 0-groupoids.  The definition is chosen to provide what is needed for the Yoneda lemma, and to match the concept for types, with paths replaced by 1-cells.  We are able to match the biinvertible definition.  The half-adjoint definition doesn't work, as we can't prove adjointification.  We would need to be in a 1-groupoid for that to be possible.  We could also use the "wrong" definition, without the eisadj condition, and things would go through, but it wouldn't match the definition for types. *)
 Class ZeroGpdIsEquiv {G H : ZeroGpd} (f : G $-> H) := {
   zerogpd_equiv_inv : H $-> G;
   zerogpd_eisretr : f $o zerogpd_equiv_inv $== Id H;
@@ -129,3 +129,42 @@ Proof.
     exact (Build_ZeroGpdIsEquiv _ _ f g r g s).
 Defined.
 
+(* In fact, being an equivalence in the sense above is logically equivalent to being an equivalence in the sense of EquivGpd. *)
+
+(* This is just a rough draft showing this.  Some further work is required to reorganize this. *)
+
+Require Import WildCat.EquivGpd.
+
+Definition IsEquiv0Gpd_ZeroGpdEquiv {G H : ZeroGpd} (f : G $<~> H)
+  : IsEquiv0Gpd f.
+Proof.
+  econstructor.
+  - intro y.
+    exists (f^-1$ y).
+    rapply zerogpd_eisretr.
+  - intros x1 x2 m.
+    refine ((zerogpd_eissect f x1)^$ $@ _ $@ zerogpd_eissect f x2).
+    exact (fmap f^-1$ m).
+Defined.
+
+Definition ZeroGpdEquiv_IsEquiv0Gpd {G H : ZeroGpd} (f : G -> H) `{!Is0Functor f}
+  (e : IsEquiv0Gpd f)
+  : G $<~> H.
+Proof.
+  destruct e as [e0 e1]; unfold SplEssSurj in e0.
+  snrapply cate_adjointify.
+  - exact (Build_ZeroGpdMorphism _ _ f _).
+  - snrapply Build_ZeroGpdMorphism.
+    1: exact (fun y => (e0 y).1).
+    snrapply Build_Is0Functor; cbn beta.
+    intros y1 y2 m.
+    apply e1.
+    exact ((e0 y1).2 $@ m $@ ((e0 y2).2)^$).
+  - cbn.
+    intro y.
+    apply e0.
+  - cbn.
+    intro x.
+    apply e1.
+    apply e0.
+Defined.

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -1,0 +1,131 @@
+Require Import Basics.Overture Basics.Tactics.
+Require Import WildCat.Core WildCat.Equiv.
+
+(** * The wild 1-category of 0-groupoids. *)
+
+(** Here we define a wild 1-category structure on the type of 0-groupoids.  We think of the 1-cells [g $== h] in a 0-groupoid [G] as a substitute for the paths [g = h], and so we closely follow the definitions used for the 1-category of types with [=] replaced by [$==].  In fact, the 1-category structure on types should be the pullback of the 1-category structure on 0-groupoids along a natural map [Type -> ZeroGpd] which sends [A] to [A] equipped with its path types.  A second motivating example is the 0-groupoid with underlying type [A -> B] and homotopies as the 1-cells.  The definitions chosen here exactly make the Yoneda lemma [opyon_equiv_0gpd] go through. *)
+
+Record ZeroGpd := {
+  carrier :> Type;
+  isgraph_carrier : IsGraph carrier;
+  is01cat_carrier : Is01Cat carrier;
+  is0gpd_carrier : Is0Gpd carrier;  
+}.
+
+Global Existing Instance isgraph_carrier.
+Global Existing Instance is01cat_carrier.
+Global Existing Instance is0gpd_carrier.
+
+Record ZeroGpdMorphism (G H : ZeroGpd) := {
+  zerogpd_fun :> carrier G -> carrier H;
+  is0functor_zerogpd_fun : Is0Functor zerogpd_fun;
+}.
+
+Global Existing Instance is0functor_zerogpd_fun.
+
+Global Instance isgraph_0gpd : IsGraph ZeroGpd.
+Proof.
+  apply Build_IsGraph.
+  exact ZeroGpdMorphism.
+Defined.
+
+Global Instance is01cat_0gpd : Is01Cat ZeroGpd.
+Proof.
+  srapply Build_Is01Cat.
+  - intro G.
+    snrapply Build_ZeroGpdMorphism.
+    1: exact idmap.
+    snrapply Build_Is0Functor.
+    intros g1 g2.
+    exact idmap.
+  - intros G H K f g.
+    snrapply Build_ZeroGpdMorphism.
+    1: exact (f o g).
+    snrapply Build_Is0Functor; cbn beta.
+    intros g1 g2 p.
+    apply is0functor_zerogpd_fun, is0functor_zerogpd_fun, p.
+Defined.
+
+Global Instance is2graph_0gpd : Is2Graph ZeroGpd.
+Proof.
+  intros G H.
+  snrapply Build_IsGraph.
+  intros f g.
+  exact (forall x : G, f x $== g x).
+Defined.
+
+Global Instance is1cat_0gpd : Is1Cat ZeroGpd.
+Proof.
+  snrapply Build_Is1Cat.
+  - intros G H.
+    srapply Build_Is01Cat.
+    + intro f. exact (fun x => Id (f x)).
+    + intros f g h p q. exact (fun x => q x $@ p x).
+  - intros G H.
+    srapply Build_Is0Gpd.
+    intros f g p. exact (fun x => (p x)^$).
+  - intros G H K f.
+    srapply Build_Is0Functor.
+    intros g h p x.
+    cbn.
+    exact (fmap f (p x)).
+  - intros G H K f.
+    srapply Build_Is0Functor.
+    intros g h p x.
+    cbn.
+    exact (p (f x)).
+  - reflexivity.
+  - reflexivity.
+  - reflexivity.
+Defined.
+
+(** We define equivalences of 0-groupoids.  Note that this differs from [IsEquiv0Gpd] in [EquivGpd.v].  It is chosen to provide what is needed for the Yoneda lemma, and to match the concept for types, with paths replaced by 1-cells.  We are able to match the biinvertible definition.  The half-adjoint definition doesn't work, as we can prove adjointification.  We would need to be in a 1-groupoid for that to be possible.  We could also use the "wrong" definition, without the eisadj condition, and things would go through, but it wouldn't match the definition for types. *)
+Class ZeroGpdIsEquiv {G H : ZeroGpd} (f : G $-> H) := {
+  zerogpd_equiv_inv : H $-> G;
+  zerogpd_eisretr : f $o zerogpd_equiv_inv $== Id H;
+  zerogpd_equiv_inv' : H $-> G;
+  zerogpd_eissect' : zerogpd_equiv_inv' $o f $== Id G;
+}.
+
+Arguments zerogpd_equiv_inv {G H}%type_scope f {_}.
+Arguments zerogpd_eisretr {G H}%type_scope f {_} _.
+Arguments zerogpd_equiv_inv' {G H}%type_scope f {_}.
+Arguments zerogpd_eissect' {G H}%type_scope f {_} _.
+
+Definition zerogpd_inverses_homotopic {G H : ZeroGpd} (f : G $-> H) `{ZeroGpdIsEquiv _ _ f}
+  : zerogpd_equiv_inv f $== zerogpd_equiv_inv' f.
+Proof.
+  set (g := zerogpd_equiv_inv f).
+  set (g' := zerogpd_equiv_inv' f).
+  intro x.
+  refine ((zerogpd_eissect' f (g x))^$ $@ _); cbn.
+  refine (fmap g' _).
+  rapply zerogpd_eisretr.
+Defined.
+
+Definition zerogpd_eissect {G H : ZeroGpd} (f : G $-> H) `{ZeroGpdIsEquiv _ _ f}
+  : zerogpd_equiv_inv f $o f $== Id G
+  := (zerogpd_inverses_homotopic f $@R f) $@ zerogpd_eissect' f.
+
+Record ZeroGpdEquiv (G H : ZeroGpd) := {
+  zerogpd_equiv_fun :> ZeroGpdMorphism G H;
+  zerogpd_isequiv_equiv : ZeroGpdIsEquiv zerogpd_equiv_fun;
+}.
+
+Global Instance hasequivs_zerogpd : HasEquivs ZeroGpd.
+Proof.
+  srapply Build_HasEquivs; intros G H.
+  1: exact (ZeroGpdEquiv G H).
+  all:intros f.
+  - exact (ZeroGpdIsEquiv f).
+  - exact f.
+  - cbn. exact (zerogpd_isequiv_equiv _ _ f).
+  - apply Build_ZeroGpdEquiv.
+  - intros; reflexivity.
+  - exact (@zerogpd_equiv_inv _ _ f (zerogpd_isequiv_equiv _ _ f)).
+  - cbn. apply zerogpd_eissect.
+  - cbn. apply zerogpd_eisretr.
+  - intros g r s; cbn beta.
+    exact (Build_ZeroGpdIsEquiv _ _ f g r g s).
+Defined.
+

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -1,5 +1,5 @@
 Require Import Basics.Overture Basics.Tactics.
-Require Import WildCat.Core WildCat.Equiv.
+Require Import WildCat.Core WildCat.Equiv WildCat.EquivGpd.
 
 (** * The wild 1-category of 0-groupoids. *)
 
@@ -128,12 +128,11 @@ Proof.
     exact (Build_IsEquiv_0Gpd _ _ f g r g s).
 Defined.
 
-(* In fact, being an equivalence in the sense above is logically equivalent to being an equivalence in the sense of EquivGpd. *)
+(** * We now give a different characterization of the equivalences of 0-groupoids, as the injective split essentially surjective 0-functors which are defined in EquivGpd. *)
 
-(* This is just a rough draft showing this.  Some further work is required to reorganize this. *)
+(** Advantages of this logically equivalent formulation are that it tends to be easier to prove in examples and in some cases it is definitionally equal to [ExtensionAlong], which is convenient.  See Homotopy/Suspension.v and Algebra/AbGroups/Abelianization for examples. Advantages of the bi-invertible definition are that it reproduces a definition that is equivalent to [IsEquiv] when applied to types, assuming [Funext].  It also makes the proof of [HasEquivs] above easy. *)
 
-Require Import WildCat.EquivGpd.
-
+(** Every equivalence is injective and essentially surjective. *)
 Definition IsEquiv0Gpd_Equiv_0Gpd {G H : ZeroGpd} (f : G $<~> H)
   : IsEquiv0Gpd f.
 Proof.
@@ -145,13 +144,13 @@ Proof.
     exact ((eissect_0gpd f x1)^$ $@ fmap f^-1$ m $@ eissect_0gpd f x2).
 Defined.
 
-Definition Equiv_0Gpd_IsEquiv0Gpd {G H : ZeroGpd} (f : G -> H) `{!Is0Functor f}
-  (e : IsEquiv0Gpd f)
-  : G $<~> H.
+(** Conversely, every injective essentially surjective 0-functor is an equivalence. *)
+Global Instance IsEquiv_0Gpd_IsEquiv0Gpd {G H : ZeroGpd} (F : G $-> H)
+  {e : IsEquiv0Gpd F}
+  : IsEquiv_0Gpd F.
 Proof.
   destruct e as [e0 e1]; unfold SplEssSurj in e0.
-  snrapply cate_adjointify.
-  - exact (Build_Morphism_0Gpd _ _ f _).
+  srapply catie_adjointify.
   - snrapply Build_Morphism_0Gpd.
     1: exact (fun y => (e0 y).1).
     snrapply Build_Is0Functor; cbn beta.

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -133,8 +133,8 @@ Defined.
 (** Advantages of this logically equivalent formulation are that it tends to be easier to prove in examples and in some cases it is definitionally equal to [ExtensionAlong], which is convenient.  See Homotopy/Suspension.v and Algebra/AbGroups/Abelianization for examples. Advantages of the bi-invertible definition are that it reproduces a definition that is equivalent to [IsEquiv] when applied to types, assuming [Funext].  It also makes the proof of [HasEquivs] above easy. *)
 
 (** Every equivalence is injective and split essentially surjective. *)
-Definition IsEquiv0Gpd_Equiv_0Gpd {G H : ZeroGpd} (f : G $<~> H)
-  : IsEquiv0Gpd f.
+Definition IsSurjInj_Equiv_0Gpd {G H : ZeroGpd} (f : G $<~> H)
+  : IsSurjInj f.
 Proof.
   econstructor.
   - intro y.
@@ -145,8 +145,8 @@ Proof.
 Defined.
 
 (** Conversely, every injective split essentially surjective 0-functor is an equivalence. *)
-Global Instance IsEquiv_0Gpd_IsEquiv0Gpd {G H : ZeroGpd} (F : G $-> H)
-  {e : IsEquiv0Gpd F}
+Global Instance IsEquiv_0Gpd_IsSurjInj {G H : ZeroGpd} (F : G $-> H)
+  {e : IsSurjInj F}
   : IsEquiv_0Gpd F.
 Proof.
   destruct e as [e0 e1]; unfold SplEssSurj in e0.

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -16,34 +16,35 @@ Global Existing Instance isgraph_carrier.
 Global Existing Instance is01cat_carrier.
 Global Existing Instance is0gpd_carrier.
 
-Record ZeroGpdMorphism (G H : ZeroGpd) := {
-  zerogpd_fun :> carrier G -> carrier H;
-  is0functor_zerogpd_fun : Is0Functor zerogpd_fun;
+Record Morphism_0Gpd (G H : ZeroGpd) := {
+  fun_0gpd :> carrier G -> carrier H;
+  is0functor_fun_0gpd : Is0Functor fun_0gpd;
 }.
 
-Global Existing Instance is0functor_zerogpd_fun.
+Global Existing Instance is0functor_fun_0gpd.
 
+(** Now we show that the type [ZeroGpd] of 0-groupoids is itself a 1-category. *)
 Global Instance isgraph_0gpd : IsGraph ZeroGpd.
 Proof.
   apply Build_IsGraph.
-  exact ZeroGpdMorphism.
+  exact Morphism_0Gpd.
 Defined.
 
 Global Instance is01cat_0gpd : Is01Cat ZeroGpd.
 Proof.
   srapply Build_Is01Cat.
   - intro G.
-    snrapply Build_ZeroGpdMorphism.
+    snrapply Build_Morphism_0Gpd.
     1: exact idmap.
     snrapply Build_Is0Functor.
     intros g1 g2.
     exact idmap.
   - intros G H K f g.
-    snrapply Build_ZeroGpdMorphism.
+    snrapply Build_Morphism_0Gpd.
     1: exact (f o g).
     snrapply Build_Is0Functor; cbn beta.
     intros g1 g2 p.
-    apply is0functor_zerogpd_fun, is0functor_zerogpd_fun, p.
+    apply is0functor_fun_0gpd, is0functor_fun_0gpd, p.
 Defined.
 
 Global Instance is2graph_0gpd : Is2Graph ZeroGpd.
@@ -80,53 +81,53 @@ Proof.
 Defined.
 
 (** We define equivalences of 0-groupoids.  The definition is chosen to provide what is needed for the Yoneda lemma, and to match the concept for types, with paths replaced by 1-cells.  We are able to match the biinvertible definition.  The half-adjoint definition doesn't work, as we can't prove adjointification.  We would need to be in a 1-groupoid for that to be possible.  We could also use the "wrong" definition, without the eisadj condition, and things would go through, but it wouldn't match the definition for types. *)
-Class ZeroGpdIsEquiv {G H : ZeroGpd} (f : G $-> H) := {
-  zerogpd_equiv_inv : H $-> G;
-  zerogpd_eisretr : f $o zerogpd_equiv_inv $== Id H;
-  zerogpd_equiv_inv' : H $-> G;
-  zerogpd_eissect' : zerogpd_equiv_inv' $o f $== Id G;
+Class IsEquiv_0Gpd {G H : ZeroGpd} (f : G $-> H) := {
+  equiv_inv_0gpd : H $-> G;
+  eisretr_0gpd : f $o equiv_inv_0gpd $== Id H;
+  equiv_inv_0gpd' : H $-> G;
+  eissect_0gpd' : equiv_inv_0gpd' $o f $== Id G;
 }.
 
-Arguments zerogpd_equiv_inv {G H}%type_scope f {_}.
-Arguments zerogpd_eisretr {G H}%type_scope f {_} _.
-Arguments zerogpd_equiv_inv' {G H}%type_scope f {_}.
-Arguments zerogpd_eissect' {G H}%type_scope f {_} _.
+Arguments equiv_inv_0gpd {G H}%type_scope f {_}.
+Arguments eisretr_0gpd {G H}%type_scope f {_} _.
+Arguments equiv_inv_0gpd' {G H}%type_scope f {_}.
+Arguments eissect_0gpd' {G H}%type_scope f {_} _.
 
-Definition zerogpd_inverses_homotopic {G H : ZeroGpd} (f : G $-> H) `{ZeroGpdIsEquiv _ _ f}
-  : zerogpd_equiv_inv f $== zerogpd_equiv_inv' f.
+Definition inverses_homotopic_0gpd {G H : ZeroGpd} (f : G $-> H) `{IsEquiv_0Gpd _ _ f}
+  : equiv_inv_0gpd f $== equiv_inv_0gpd' f.
 Proof.
-  set (g := zerogpd_equiv_inv f).
-  set (g' := zerogpd_equiv_inv' f).
+  set (g := equiv_inv_0gpd f).
+  set (g' := equiv_inv_0gpd' f).
   intro x.
-  refine ((zerogpd_eissect' f (g x))^$ $@ _); cbn.
+  refine ((eissect_0gpd' f (g x))^$ $@ _); cbn.
   refine (fmap g' _).
-  rapply zerogpd_eisretr.
+  rapply eisretr_0gpd.
 Defined.
 
-Definition zerogpd_eissect {G H : ZeroGpd} (f : G $-> H) `{ZeroGpdIsEquiv _ _ f}
-  : zerogpd_equiv_inv f $o f $== Id G
-  := (zerogpd_inverses_homotopic f $@R f) $@ zerogpd_eissect' f.
+Definition eissect_0gpd {G H : ZeroGpd} (f : G $-> H) `{IsEquiv_0Gpd _ _ f}
+  : equiv_inv_0gpd f $o f $== Id G
+  := (inverses_homotopic_0gpd f $@R f) $@ eissect_0gpd' f.
 
-Record ZeroGpdEquiv (G H : ZeroGpd) := {
-  zerogpd_equiv_fun :> ZeroGpdMorphism G H;
-  zerogpd_isequiv_equiv : ZeroGpdIsEquiv zerogpd_equiv_fun;
+Record Equiv_0Gpd (G H : ZeroGpd) := {
+  equiv_fun_0gpd :> Morphism_0Gpd G H;
+  isequiv_equiv_0gpd : IsEquiv_0Gpd equiv_fun_0gpd;
 }.
 
-Global Instance hasequivs_zerogpd : HasEquivs ZeroGpd.
+Global Instance hasequivs_0gpd : HasEquivs ZeroGpd.
 Proof.
   srapply Build_HasEquivs; intros G H.
-  1: exact (ZeroGpdEquiv G H).
+  1: exact (Equiv_0Gpd G H).
   all:intros f.
-  - exact (ZeroGpdIsEquiv f).
+  - exact (IsEquiv_0Gpd f).
   - exact f.
-  - cbn. exact (zerogpd_isequiv_equiv _ _ f).
-  - apply Build_ZeroGpdEquiv.
+  - cbn. exact (isequiv_equiv_0gpd _ _ f).
+  - apply Build_Equiv_0Gpd.
   - intros; reflexivity.
-  - exact (@zerogpd_equiv_inv _ _ f (zerogpd_isequiv_equiv _ _ f)).
-  - cbn. apply zerogpd_eissect.
-  - cbn. apply zerogpd_eisretr.
+  - exact (@equiv_inv_0gpd _ _ f (isequiv_equiv_0gpd _ _ f)).
+  - cbn. apply eissect_0gpd.
+  - cbn. apply eisretr_0gpd.
   - intros g r s; cbn beta.
-    exact (Build_ZeroGpdIsEquiv _ _ f g r g s).
+    exact (Build_IsEquiv_0Gpd _ _ f g r g s).
 Defined.
 
 (* In fact, being an equivalence in the sense above is logically equivalent to being an equivalence in the sense of EquivGpd. *)
@@ -135,33 +136,31 @@ Defined.
 
 Require Import WildCat.EquivGpd.
 
-Definition IsEquiv0Gpd_ZeroGpdEquiv {G H : ZeroGpd} (f : G $<~> H)
+Definition IsEquiv0Gpd_Equiv_0Gpd {G H : ZeroGpd} (f : G $<~> H)
   : IsEquiv0Gpd f.
 Proof.
   econstructor.
   - intro y.
     exists (f^-1$ y).
-    rapply zerogpd_eisretr.
+    rapply eisretr_0gpd.
   - intros x1 x2 m.
-    refine ((zerogpd_eissect f x1)^$ $@ _ $@ zerogpd_eissect f x2).
-    exact (fmap f^-1$ m).
+    exact ((eissect_0gpd f x1)^$ $@ fmap f^-1$ m $@ eissect_0gpd f x2).
 Defined.
 
-Definition ZeroGpdEquiv_IsEquiv0Gpd {G H : ZeroGpd} (f : G -> H) `{!Is0Functor f}
+Definition Equiv_0Gpd_IsEquiv0Gpd {G H : ZeroGpd} (f : G -> H) `{!Is0Functor f}
   (e : IsEquiv0Gpd f)
   : G $<~> H.
 Proof.
   destruct e as [e0 e1]; unfold SplEssSurj in e0.
   snrapply cate_adjointify.
-  - exact (Build_ZeroGpdMorphism _ _ f _).
-  - snrapply Build_ZeroGpdMorphism.
+  - exact (Build_Morphism_0Gpd _ _ f _).
+  - snrapply Build_Morphism_0Gpd.
     1: exact (fun y => (e0 y).1).
     snrapply Build_Is0Functor; cbn beta.
     intros y1 y2 m.
     apply e1.
     exact ((e0 y1).2 $@ m $@ ((e0 y2).2)^$).
   - cbn.
-    intro y.
     apply e0.
   - cbn.
     intro x.

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -132,7 +132,7 @@ Defined.
 
 (** Advantages of this logically equivalent formulation are that it tends to be easier to prove in examples and in some cases it is definitionally equal to [ExtensionAlong], which is convenient.  See Homotopy/Suspension.v and Algebra/AbGroups/Abelianization for examples. Advantages of the bi-invertible definition are that it reproduces a definition that is equivalent to [IsEquiv] when applied to types, assuming [Funext].  It also makes the proof of [HasEquivs] above easy. *)
 
-(** Every equivalence is injective and essentially surjective. *)
+(** Every equivalence is injective and split essentially surjective. *)
 Definition IsEquiv0Gpd_Equiv_0Gpd {G H : ZeroGpd} (f : G $<~> H)
   : IsEquiv0Gpd f.
 Proof.
@@ -144,7 +144,7 @@ Proof.
     exact ((eissect_0gpd f x1)^$ $@ fmap f^-1$ m $@ eissect_0gpd f x2).
 Defined.
 
-(** Conversely, every injective essentially surjective 0-functor is an equivalence. *)
+(** Conversely, every injective split essentially surjective 0-functor is an equivalence. *)
 Global Instance IsEquiv_0Gpd_IsEquiv0Gpd {G H : ZeroGpd} (F : G $-> H)
   {e : IsEquiv0Gpd F}
   : IsEquiv_0Gpd F.


### PR DESCRIPTION
This PR adds a covariant Yoneda lemma using the representable functor `Hom a -` that lands in the 1-category of 0-groupoids.  This is based on discussion in #1744.

I've marked this as WIP for now, as I'd like feedback, e.g. on naming, but also on anything else.  I will likely also add the dual version if this looks good.