### PR TITLE
Fix instance cycle in Homotopy.HSpace.Core

### DIFF
--- a/theories/Homotopy/HSpace/Core.v
+++ b/theories/Homotopy/HSpace/Core.v
@@ -90,7 +90,7 @@ Definition homogeneous_pt_id_beta `{Funext} {A : pType} `{IsHomogeneous A}
   := ltac:(apply path_pequiv, peisretr).
 
 (** This modified structure makes any homogeneous type into a (left-invertible) H-space. *)
-Global Instance ishspace_homogeneous {A : pType} `{IsHomogeneous A}
+Definition ishspace_homogeneous {A : pType} `{IsHomogeneous A}
   : IsHSpace A.
 Proof.
   snrapply Build_IsHSpace.


### PR DESCRIPTION
I'd previously (inadvertently) created an instance cycle in `Homotopy.HSpace.Core` by making both `ishomogeneous_hspace` and `ishspace_homogeneous` instances. By making one of these a definition we avoid the cycle. I opted to make the passage from a left-invertible H-space to a homogeneous structure an instance because it forgets data. We could make the other direction a `Hint Immediate` (or something similar), but there's currently nothing that would benefit from it.