### PR TITLE
add emacs TAGS support to dune

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -139,6 +139,12 @@ $ make
 You can speed up the build by passing `-jN` where `N` is the number of parallel
 recipes `make` will execute.
 
+You can also use `dune` to build the library.
+
+```shell
+$ dune build
+```
+
 ## 3.4. Installing the library using git
 
 We don't recommend you install the library using the repository and instead
@@ -171,6 +177,11 @@ provided, such as the use of `M-*` to get back where you were, or the use of
 `M-x tags-search` to search throughout the code for locations matching a given
 regular expression.
 
+Dune users may use the following to generate tags:
+
+```shell
+dune build TAGS
+```
 
 # 5. Updating the library
 If you installed the library via Coq Platform then [update your version of Coq

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -242,10 +242,7 @@ dot-file-dep-graphs: $(ALL_DOTFILES)
 # The TAGS file
 TAGS_FILES = $(ALL_VFILES)
 TAGS : $(TAGS_FILES)
-	$(ETAGS) --language=none \
-	-r '/^[ \t]*\(\(Local\|Global\|Cumulative\|NonCumulative\|Monomorphic\|Polymorphic\|Private\)[ \t]+\)*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\4/' \
-	-r '/^[ \t]*\([a-zA-Z0-9_'\'']+\)[ \t]*:/\1/' \
-	$^
+	$(ETAGS) --language=none $(shell cat etc/emacs/etags-args) $^
 
 # We separate things to work around `make: execvp: /bin/bash: Argument list too long`
 clean::

--- a/dune
+++ b/dune
@@ -46,3 +46,15 @@
  (deps
   (alias_rec contrib/all)
   (alias_rec theories/all)))
+
+; Tags for emacs
+
+(rule
+ (target TAGS)
+ (alias emacs)
+ (mode promote)
+ (deps
+  %{bin:etags}
+  (glob_files_rec ./*.v))
+ (action
+  (run etags --language=none %{read:etc/emacs/etags-args} %{deps})))

--- a/etc/emacs/etags-args
+++ b/etc/emacs/etags-args
@@ -1,0 +1,2 @@
+-r '/^[ \t]*\(\(Local\|Global\|Cumulative\|NonCumulative\|Monomorphic\|Polymorphic\|Private\)[ \t]+\)*\(Axiom\|Theorem\|Class\|Instance\|Let\|Ltac\|Definition\|Lemma\|Record\|Remark\|Structure\|Fixpoint\|Fact\|Corollary\|Inductive\|CoInductive\|Proposition\)[ \t]+\([a-zA-Z0-9_'\'']+\)/\4/' 
+-r '/^[ \t]*\([a-zA-Z0-9_'\'']+\)[ \t]*:/\1/' 


### PR DESCRIPTION
@jdchristensen Both `make` and `dune` will share the arguments to `etags` which now live in `etc/emacs/etags-args`. In both systems, the file is inlined to pass the arguments to `etags`.

We add a dune rule that builds (and promotes) the TAGS file. Simply do:

```
dune build TAGS
```

to get up to date tags. This is not included in the `@default` alias, so it won't be built by `dune build`.

I've tested it and both `make` and `dune` are able to produce the `TAGS` file now.
