### PR TITLE
Makefile.coq.local: find: add missing parentheses and add test folder

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -263,4 +263,4 @@ clean::
 	$(SHOW)"RM *.DOT"
 	$(HIDE)rm -f $(ALL_DOTFILES)
 	rm -f $(EXTRA_CLEANFILES)
-	find contrib theories -name \*.vo -o -name \*.glob -o -name \*.timing -delete
+	find theories contrib test \( -name \*.vo -o -name \*.glob -o -name \*.timing \) -delete


### PR DESCRIPTION
I believe this find command is meant to handle renamed or removed files or directories, since in normal situations `.vo` and `.glob` files are correctly deleted by `make clean`.  But the implicit `and` between `-name \*.timing`  and `-delete` binds more tightly that the `or`s marked with `-o`, so only timing files are deleted by this command.  The parentheses fix this.

Also, now that we build things in the `test` folder, I added that as well.