### PR TITLE
dune: build _CoqProject by default

### DIFF
--- a/dune
+++ b/dune
@@ -45,7 +45,8 @@
  (name default)
  (deps
   (alias_rec contrib/all)
-  (alias_rec theories/all)))
+  (alias_rec theories/all)
+  _CoqProject))
 
 ; Tags for emacs
 


### PR DESCRIPTION
I noticed _CoqProject was not getting built by dune.  Is this the right way to fix that?