### PR TITLE
dune: make Coq warnings fatal when building locally

### DIFF
--- a/theories/dune
+++ b/theories/dune
@@ -10,5 +10,10 @@
  (modules :standard)
  (flags -noinit -indices-matter -color on))
 
-; TODO: Tests
-; Prob need to move tests into tests folder
+; On the dev profile, we want to use the -w +all flag to make sure
+; that all warnings are fatal. 
+
+(env
+ (dev
+  (coq
+   (flags -w +all))))


### PR DESCRIPTION
When building with the `dev` profile, we make all Coq warnings fatal.

The `dev` profile is selected by default when building locally. Only the opam package CI job builds dune with the `release` profile where the warnings will not be fatal.

We need to think about this some more, since warnings might be introduced outside of our control which would make development annoying. I'll probably end up using another profile like `warn-error` so that `dune build --profile warn-error` would be strict about warnings.