### PR TITLE
fix(emacs): only use vfiles in etags action

### DIFF
--- a/dune
+++ b/dune
@@ -55,7 +55,8 @@
  (alias emacs)
  (mode promote)
  (deps
-  %{bin:etags}
-  (glob_files_rec ./*.v))
+  (glob_files_rec theories/*.v)
+  (glob_files_rec contrib/*.v))
  (action
-  (run etags --language=none %{read:etc/emacs/etags-args} %{deps})))
+  (system
+   "%{bin:etags} --language=none %{read-lines:etc/emacs/etags-args} %{deps}")))


### PR DESCRIPTION
@jdchristensen This should work better.