### PR TITLE
two proofs of join bool being equivalent to suspension

### DIFF
--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -390,7 +390,6 @@ Section PathSquareConcat.
     1,2: apply inverse, concat_p1.
   Defined.
 
-  Infix "@@h" := sq_concat_h : square_scope.
 
   (* Vertical concatenation of squares *)
   Definition sq_concat_v {a20 a21 : A}
@@ -404,9 +403,11 @@ Section PathSquareConcat.
     1,2: apply inverse, concat_p1.
   Defined.
 
-  Infix "@@v" := sq_concat_v : square_scope.
 
 End PathSquareConcat.
+
+Infix "@@h" := sq_concat_h : square_scope.
+Infix "@@v" := sq_concat_v : square_scope.
 
 (* Horizontal groupoid laws for concatenation *)
 Section GroupoidLawsH.

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -1,4 +1,4 @@
 Require Export Join.Core.
 Require Export Join.TriJoin.
 Require Export Join.JoinAssoc.
-
+Require Export Join.JoinSusp.

--- a/theories/Homotopy/Join/JoinSusp.v
+++ b/theories/Homotopy/Join/JoinSusp.v
@@ -1,0 +1,142 @@
+Require Import Basics Types.
+Require Import Cubical.
+Require Import Join.Core Suspension.
+Require Import WildCat.
+
+(** Two proofs of the join with bool being equivalent to the suspension. *)
+
+(** This is a direct proof that the join of bool with a type is equivalent to a suspension. The path algebra when showing the retractions is a bit unsavoury however. *)
+Theorem equiv_join_susp {A : Type} : Join Bool A <~> Susp A.
+Proof.
+  srapply equiv_adjointify.
+  - srapply Join_rec.
+    + intros [|].
+      * exact North.
+      * exact South.
+    + intros a.
+      exact South.
+    + intros [|] a.
+      * exact (merid a).
+      * reflexivity.
+  - srapply Susp_rec.
+    + exact (joinl true).
+    + exact (joinl false).
+    + intros a.
+      exact (jglue _ a @ (jglue _ a)^).
+  - srapply Susp_ind.
+    1,2: reflexivity.
+    intros a.
+    simpl.
+    rewrite transport_paths_FFlr.
+    hott_simpl.
+    rewrite 2 ap_V.
+    rewrite Susp_rec_beta_merid.
+    rewrite ap_pp.
+    rewrite ap_V.
+    rewrite 2 Join_rec_beta_jglue.
+    hott_simpl.
+  - srapply Join_ind.
+    1: intros [|]; reflexivity.
+    1: intros a; apply jglue.
+    intros [|] a.
+    + rewrite transport_paths_FFlr.
+      rewrite Join_rec_beta_jglue.
+      rewrite Susp_rec_beta_merid.
+      rewrite inv_pp.
+      hott_simpl.
+    + rewrite transport_paths_FFlr.
+      rewrite Join_rec_beta_jglue.
+      hott_simpl.
+Defined.
+
+Lemma joinrecdata_susprecdata_0gpd {A} P
+  : susprecdata_0gpd_fun A P $-> joinrecdata_0gpd_fun Bool A P.
+Proof.
+  snrapply Build_Morphism_0Gpd.
+  - intros [srd_n srd_s srd_m].
+    snrapply Build_JoinRecData.
+    1: intros [|].
+    + exact srd_n.
+    + exact srd_s.
+    + intro; exact srd_s.
+    + intros [|].
+      * exact srd_m.
+      * reflexivity.
+  - split; intros f g [srp_n srp_s srp_m]; simpl.
+    snrapply Build_JoinRecPath.
+    + intros [|].
+      * exact srp_n.
+      * exact srp_s.
+    + intro; exact srp_s.
+    + intros [|].
+      * intros b.
+        apply sq_path.
+        apply srp_m.
+      * intros y.
+        exact ((concat_1p _) @ (concat_p1 _)^).
+Defined.
+
+Lemma susprecdata_joinrecdata_0gpd {A} P
+  : joinrecdata_0gpd_fun Bool A P $-> susprecdata_0gpd_fun A P.
+Proof.
+  snrapply Build_Morphism_0Gpd.
+  - intros [jl jr jglue]; simpl.
+    snrapply Build_SuspRecData.
+    + exact (jl true).
+    + exact (jl false).
+    + intros a.
+      exact (jglue _ a @ (jglue _ a)^).
+  - split; intros f g [srp_n srp_s srp_m]; simpl.
+    snrapply Build_SuspRecPath; simpl.
+    3: intros a; refine (_ @@v sq_flip_v _)%square; apply sq_path, srp_m.
+Defined.
+
+Lemma equiv_susprecdata_joinrecdata_0gpd {A} P
+  : susprecdata_0gpd_fun A P $<~> joinrecdata_0gpd_fun Bool A P.
+Proof.
+  snrapply cate_adjointify.
+  1: exact (joinrecdata_susprecdata_0gpd P).
+  1: exact (susprecdata_joinrecdata_0gpd P).
+  - intros x; snrapply Build_JoinRecPath.
+    + intros [|]; reflexivity.
+    + apply jg.
+    + intros [|] a; simpl.
+      * (* TODO use correct path algebra *)
+        hott_simpl.
+      * reflexivity.
+  - intros x; snrapply Build_SuspRecPath; simpl. 
+    1,2: reflexivity.        
+    intros a.
+    apply sq_G1.
+    apply concat_p1.
+Defined.
+
+Global Instance is1natural_susprecdata_joinrecdata_0gpd {A}
+  : Is1Natural _ _ (@equiv_susprecdata_joinrecdata_0gpd A).
+Proof.
+  hnf. intros X Y f [srd_n srd_s srd_m].
+  simpl in *.
+  snrapply Build_JoinRecPath; simpl.
+  1: intros [|]; reflexivity.
+  1: intro; reflexivity.
+  intros [|] a; simpl.
+  2: reflexivity.
+  exact ((concat_p1 _) @ (concat_1p _)^).
+Defined.
+
+Lemma natequiv_susprecdata_joinrecdata_0gpd{A : Type}
+  : susprecdata_0gpd_fun A $<~> joinrecdata_0gpd_fun Bool A.
+Proof.
+  snrapply Build_NatEquiv.
+  1: apply equiv_susprecdata_joinrecdata_0gpd.
+  exact _.
+Defined.
+
+Theorem equiv_join_susp' {A : Type} : Join Bool A $<~> Susp A.
+Proof.
+  srapply opyon_equiv_0gpd.
+  refine (_ $oE _ $oE _).
+  - rapply join_rec_natequiv. 
+  - apply natequiv_susprecdata_joinrecdata_0gpd.
+  - apply susp_rec_inv_natequiv.
+Defined.

--- a/theories/Spaces/Spheres.v
+++ b/theories/Spaces/Spheres.v
@@ -2,6 +2,8 @@
 Require Import Basics Types.
 Require Import NullHomotopy.
 Require Import Homotopy.Suspension.
+Require Import Spaces.Nat.
+Require Import Homotopy.Join.
 Require Import Pointed.
 Require Import Truncations.
 Require Import Spaces.Circle Spaces.TwoSphere.
@@ -290,4 +292,31 @@ Proof.
   - (* n ≥ -1 *) intros x0 x1.
     apply (istrunc_allnullhomot n').
     intro f. apply nullhomot_paths_from_susp, HX.
+Defined.
+
+(** ** Joins of spheres *)
+
+(** The join of two spheres is a sphere. *)
+Definition equiv_join_sphere (n m : nat)
+  : Join (Sphere n) (Sphere m) <~> Sphere (n + m.+1)%nat.
+Proof.
+  induction n in m |- *.
+  { refine (_ oE equiv_functor_join equiv_S0_Bool equiv_idmap).
+    rapply equiv_join_susp. }
+  cbn.
+  rewrite nat_add_n_Sm.
+  refine (IHn _ oE _).
+  refine (_ oE equiv_functor_join _ equiv_idmap). 
+  2: { symmetry.
+    change (?x <~> Sphere (n.+1)%nat) with (x <~> Sphere (1 + n)%nat).
+    rewrite nat_add_comm.
+    apply (IHn 0%nat). }
+  refine (equiv_functor_join equiv_idmap _ oE _). 
+  1: apply equiv_join_susp.
+  change (Join (Join (Sphere n) (Sphere 0%nat)) (Sphere m)
+    <~> Join (Sphere n) (Join Bool (Sphere m))).
+  refine (_ oE (join_assoc _ _ _)^-1%equiv). 
+  apply (equiv_functor_join equiv_idmap).
+  rapply (equiv_functor_join _ equiv_idmap).
+  apply equiv_S0_Bool.
 Defined.


### PR DESCRIPTION
Here are two proofs that `Join Bool A <~> Susp A`.

The first is using a direct adjointified equivalence. However some rewriting is needed to prove the cancellation. Not easy to do with just path algebra either.

The second proof is more abstract, takes longer to setup but is arguably better. Using 0gpd yoneda we can show that the recursion data of both things are naturally equivalent.

This should let us show that joins of spheres are spheres now.