### PR TITLE
Susp is a 1-functor; Join Bool A <~> Susp A; etc.

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -232,12 +232,9 @@ Global Instance isequiv_contr_contr {A B : Type}
                   (fun x => path_contr _ _)
                   (fun x => path_contr _ _).
 
-Lemma equiv_contr_contr {A B : Type} `{Contr A} `{Contr B}
-  : (A <~> B).
-Proof.
-  apply equiv_adjointify with (fun _ => center B) (fun _ => center A);
-  intros ?; apply contr.
-Defined.
+Definition equiv_contr_contr {A B : Type} `{Contr A} `{Contr B}
+  : (A <~> B)
+  := Build_Equiv _ _ (fun _ => center B) _.
 
 (** The projection from the sum of a family of contractible types is an equivalence. *)
 Global Instance isequiv_pr1 {A : Type} (P : A -> Type) `{forall x, Contr (P x)}

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -91,9 +91,21 @@ Definition pushout_unrec {A B C P} (f : A -> B) (g : A -> C)
   : {psh : (B -> P) * (C -> P) &
            forall a, fst psh (f a) = snd psh (g a)}.
 Proof.
-  exists (h o pushl , h o pushr).
+  exists (h o pushl, h o pushr).
   intros a; cbn.
   exact (ap h (pglue a)).
+Defined.
+
+Definition pushout_rec_unrec {A B C} (f : A -> B) (g : A -> C) P
+  (e : Pushout f g -> P)
+  : Pushout_rec P (e o pushl) (e o pushr) (fun a => ap e (pglue a)) == e.
+Proof.
+  snrapply Pushout_ind.
+  1, 2: reflexivity.
+  intro a; cbn beta.
+  apply transport_paths_FlFr'.
+  apply equiv_p1_1q.
+  nrapply Pushout_rec_beta_pglue.
 Defined.
 
 Definition isequiv_Pushout_rec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
@@ -102,20 +114,12 @@ Definition isequiv_Pushout_rec `{Funext} {A B C} (f : A -> B) (g : A -> C) P
              => Pushout_rec P (fst p.1) (snd p.1) p.2).
 Proof.
   srefine (isequiv_adjointify _ (pushout_unrec f g) _ _).
-  - intros h.
-    apply path_arrow; intros x.
-    srefine (Pushout_ind (fun x => Pushout_rec P (fst (pushout_unrec f g h).1) (snd (pushout_unrec f g h).1) (pushout_unrec f g h).2 x = h x) _ _ _ x).
-    + intros b; reflexivity.
-    + intros c; reflexivity.
-    + intros a; cbn.
-      nrapply transport_paths_FlFr'; apply equiv_p1_1q.
-      nrapply Pushout_rec_beta_pglue.
+  - intro e. apply path_arrow. apply pushout_rec_unrec.
   - intros [[pushb pushc] pusha]; unfold pushout_unrec; cbn.
-    srefine (path_sigma' _ _ _).
-    + srefine (path_prod' _ _); reflexivity.
-    + apply path_forall; intros a.
-      abstract (rewrite transport_forall_constant, Pushout_rec_beta_pglue;
-                reflexivity).
+    snrapply path_sigma'.
+    + reflexivity.
+    + cbn. apply path_forall; intros a.
+      apply Pushout_rec_beta_pglue.
 Defined.
 
 Definition equiv_Pushout_rec `{Funext} {A B C} (f : A -> B) (g : A -> C) P

--- a/theories/Homotopy/Join.v
+++ b/theories/Homotopy/Join.v
@@ -1,4 +1,4 @@
 Require Export Join.Core.
 Require Export Join.TriJoin.
 Require Export Join.JoinAssoc.
-
+Require Export Join.JoinSusp.

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -782,11 +782,18 @@ End JoinTrunc.
 (** Iterated Join powers of a type. *)
 Section JoinPower.
 
-  (** The join of n.+1 copies of a type. *)
+  (** The join of [n.+1] copies of a type. *)
   Fixpoint Join_power (A : Type) (n : nat) : Type :=
     match n with
     | 0%nat => A
     | m.+1%nat => Join A (Join_power A m)
+    end.
+
+  (** The join of [n] copies of a type. *)
+  Fixpoint Join_power' (A : Type) (n : nat) : Type :=
+    match n with
+    | 0%nat => Empty
+    | m.+1%nat => Join A (Join_power' A m)
     end.
 
 End JoinPower.

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -779,21 +779,45 @@ Section JoinTrunc.
 
 End JoinTrunc.
 
+(** Join with Empty *)
+Section JoinEmpty.
+
+  Definition equiv_join_empty A : Join A Empty <~> A.
+  Proof.
+    snrapply equiv_adjointify.
+    - srapply (Join_rec idmap); contradiction.
+    - exact joinl.
+    - reflexivity.
+    - snrapply Join_ind; [reflexivity| |]; contradiction.
+  Defined.
+
+  Definition equiv_join_empty' A : Join Empty A <~> A
+    := equiv_join_empty _ oE equiv_join_sym _ _.
+
+End JoinEmpty.
+
 (** Iterated Join powers of a type. *)
 Section JoinPower.
 
-  (** The join of [n.+1] copies of a type. *)
+  (** The join of [n.+1] copies of a type. This is convenient because it produces [A] definitionally when [n] is [0]. *)
   Fixpoint Join_power (A : Type) (n : nat) : Type :=
     match n with
     | 0%nat => A
     | m.+1%nat => Join A (Join_power A m)
     end.
 
-  (** The join of [n] copies of a type. *)
+  (** The join of [n] copies of a type. This is sometimes convenient for proofs by induction as it gives a trivial base case. *)
   Fixpoint Join_power' (A : Type) (n : nat) : Type :=
     match n with
     | 0%nat => Empty
     | m.+1%nat => Join A (Join_power' A m)
     end.
+
+  Definition equiv_join_powers (A : Type) (n : nat) : Join_power A n <~> Join_power' A n.+1.
+  Proof.
+    induction n as [|n IHn].
+    - symmetry; apply equiv_join_empty.
+    - exact (equiv_functor_join equiv_idmap IHn).
+  Defined.
 
 End JoinPower.

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -1,4 +1,4 @@
-Require Import Basics Types WildCat Join.Core Join.TriJoin.
+Require Import Basics Types WildCat Join.Core Join.TriJoin Spaces.Nat.Core.
 
 (** * We use the recursion principle for the triple join (from TriJoin.v) to prove the associativity of Join.  We'll use the common technique of combining symmetry and a twist equivalence.  Temporarily writing * for Join, symmetry says that [A * B <~> B * A] and the twist says that [A * (B * C) <~> B * (A * C)].  From these we get a composite equivalence [A * (B * C) <~> A * (C * B) <~> C * (A * B) <~> (A * B) * C].  One advantage of this approach is that both symmetry and the twist are their own inverses, so there are fewer maps to define and fewer composites to prove are homotopic to the identity. Symmetry is proved in Join/Core.v. *)
 
@@ -146,4 +146,14 @@ Proof.
   refine (_ oE equiv_functor_join equiv_idmap (equiv_join_sym B C)).
   refine (_ oE equiv_trijoin_twist _ _ _).
   apply equiv_join_sym.
+Defined.
+
+(** As a consequence, we get associativity of powers. *)
+Corollary join_join_power A n m
+  : Join (Join_power' A n) (Join_power' A m) <~> Join_power' A (n + m)%nat.
+Proof.
+  induction n as [|n IHn].
+  1: exact (equiv_join_empty' _).
+  simpl. refine (_ oE (join_assoc _ _ _)^-1%equiv).
+  exact (equiv_functor_join equiv_idmap IHn).
 Defined.

--- a/theories/Homotopy/Join/JoinSusp.v
+++ b/theories/Homotopy/Join/JoinSusp.v
@@ -1,0 +1,61 @@
+Require Import Basics Types.
+Require Import Join.Core Suspension Spaces.Spheres.
+Require Import WildCat.
+
+(** We give a direct proof that the join of [bool] with a type is equivalent to a suspension. It is also possible to give a proof using [opyon_equiv_0gpd]; see PR#1769. *)
+
+Definition join_to_susp (A : Type) : Join Bool A -> Susp A.
+Proof.
+  srapply Join_rec.
+  - exact (fun b => if b then North else South).
+  - exact (fun a => South).
+  - intros [|] a.
+    + exact (merid a).
+    + reflexivity.
+Defined.
+
+Definition susp_to_join (A : Type) : Susp A -> Join Bool A.
+Proof.
+  srapply (Susp_rec (joinl true) (joinl false)).
+  intros a.
+  exact (jglue _ a @ (jglue _ a)^).
+Defined.
+
+Global Instance isequiv_join_to_susp (A : Type) : IsEquiv (join_to_susp A).
+Proof.
+  snrapply (isequiv_adjointify _ (susp_to_join A)).
+  - snrapply Susp_ind.
+    1,2: reflexivity.
+    intros a.
+    apply (transport_paths_FFlr' (f:=susp_to_join A)).
+    apply equiv_p1_1q.
+    lhs nrapply (ap _ _); [nrapply Susp_rec_beta_merid | ].
+    lhs nrapply (ap_pp _ _ (jglue false a)^).
+    lhs nrefine (_ @@ _).
+    1: lhs nrapply ap_V; nrapply (ap inverse).
+    1,2: nrapply Join_rec_beta_jglue.
+    apply concat_p1.
+  - srapply (Join_ind_FFlr (join_to_susp A)); cbn beta.
+    1: intros [|]; reflexivity.
+    1: intros a; apply jglue.
+    intros b a; cbn beta.
+    lhs nrefine (ap _ _ @@ 1).
+    1: nrapply Join_rec_beta_jglue.
+    destruct b.
+    all: rhs nrapply concat_1p.
+    + lhs nrefine (_ @@ 1); [nrapply Susp_rec_beta_merid | ].
+      apply concat_pV_p.
+    + apply concat_1p.
+Defined.
+
+Definition equiv_join_susp (A : Type) : Join Bool A <~> Susp A
+  := Build_Equiv _ _ (join_to_susp A) _.
+
+(** It follows that the iterated join of [Bool] gives a sphere. *)
+Definition equiv_join_power_bool_sphere (n : nat): Join_power' Bool n <~> Sphere (n.-1).
+Proof.
+  induction n.
+  - reflexivity.
+  - simpl.  refine (_ oE equiv_join_susp _).
+    exact (emap Susp IHn).
+Defined.

--- a/theories/Homotopy/Join/JoinSusp.v
+++ b/theories/Homotopy/Join/JoinSusp.v
@@ -1,6 +1,7 @@
 Require Import Basics Types.
-Require Import Join.Core Suspension Spaces.Spheres.
+Require Import Join.Core Join.JoinAssoc Suspension Spaces.Spheres.
 Require Import WildCat.
+Require Import Spaces.Nat.Core.
 
 (** We give a direct proof that the join of [bool] with a type is equivalent to a suspension. It is also possible to give a proof using [opyon_equiv_0gpd]; see PR#1769. *)
 
@@ -54,8 +55,19 @@ Definition equiv_join_susp (A : Type) : Join Bool A <~> Susp A
 (** It follows that the iterated join of [Bool] gives a sphere. *)
 Definition equiv_join_power_bool_sphere (n : nat): Join_power' Bool n <~> Sphere (n.-1).
 Proof.
-  induction n.
+  induction n as [|n IHn].
   - reflexivity.
   - simpl.  refine (_ oE equiv_join_susp _).
     exact (emap Susp IHn).
+Defined.
+
+(** It follows that joins of spheres are spheres. *)
+Definition equiv_join_sphere (n m : nat)
+  : Join (Sphere n) (Sphere m) <~> Sphere (n + m)%nat.+1.
+Proof.
+  refine (_ oE equiv_functor_join _ _).
+  2,3: symmetry; exact (equiv_join_power_bool_sphere _.+1).
+  refine (equiv_join_power_bool_sphere _.+2 oE _).
+  rewrite nat_add_n_Sm.
+  apply join_join_power.
 Defined.

--- a/theories/Homotopy/Join/JoinSusp.v
+++ b/theories/Homotopy/Join/JoinSusp.v
@@ -61,13 +61,12 @@ Proof.
     exact (emap Susp IHn).
 Defined.
 
-(** It follows that joins of spheres are spheres. *)
+(** It follows that joins of spheres are spheres, starting in dimension -1. *)
 Definition equiv_join_sphere (n m : nat)
-  : Join (Sphere n) (Sphere m) <~> Sphere (n + m)%nat.+1.
+  : Join (Sphere n.-1) (Sphere m.-1) <~> Sphere (n + m)%nat.-1.
 Proof.
   refine (_ oE equiv_functor_join _ _).
-  2,3: symmetry; exact (equiv_join_power_bool_sphere _.+1).
-  refine (equiv_join_power_bool_sphere _.+2 oE _).
-  rewrite nat_add_n_Sm.
+  2,3: symmetry; exact (equiv_join_power_bool_sphere _).
+  refine (equiv_join_power_bool_sphere _ oE _).
   apply join_join_power.
 Defined.

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -229,23 +229,19 @@ Global Instance is1functor_susp : Is1Functor Susp
 (** ** Universal property *)
 
 Definition equiv_Susp_rec `{Funext} (X Y : Type)
-: (Susp X -> Y) <~> { NS : Y * Y & X -> fst NS = snd NS }.
+  : (Susp X -> Y) <~> { NS : Y * Y & X -> fst NS = snd NS }.
 Proof.
-  unshelve econstructor.
-  { intros f.
-    exists (f North , f South).
-    intros x. exact (ap f (merid x)). }
-  simple refine (isequiv_adjointify _ _ _ _).
+  snrapply equiv_adjointify.
+  - intros f.
+    exists (f North, f South).
+    intros x; exact (ap f (merid x)).
   - intros [[N S] m].
     exact (Susp_rec N S m).
   - intros [[N S] m].
-    apply ap, path_arrow. intros x; apply Susp_rec_beta_merid.
+    apply ap, path_arrow.
+    intros x; apply Susp_rec_beta_merid.
   - intros f.
-    symmetry.
-    refine (Susp_eta f @ _).
-    unfold Susp_rec; apply ap.
-    apply path_forall; intros x.
-    apply apD_const.
+    symmetry; apply Susp_rec_eta.
 Defined.
 
 (** Using wild 0-groupoids, the universal property can be proven without funext.  A simple equivalence of 0-groupoids between [Susp X -> Y] and [{ NS : Y * Y & X -> fst NS = snd NS }] would not carry all the higher-dimensional information, but if we generalize it to dependent functions, then it does suffice. *)

--- a/theories/Spaces/Spheres.v
+++ b/theories/Spaces/Spheres.v
@@ -24,12 +24,8 @@ Fixpoint Sphere (n : trunc_index)
        | n'.+1 => Susp (Sphere n')
      end.
 
-(** ** Pointed sphere for non-negative dimensions *)
-Fixpoint psphere (n : nat) : pType
-  := match n with
-      | O => psusp Empty
-      | S n' => psusp (psphere n')
-     end.
+(** ** Pointed sphere for non-negative dimensions.  Note that [n.-1] is the predecessor as a [trunc_index]. *)
+Definition psphere (n : nat) : pType := psusp (Sphere n.-1).
 
 Arguments Sphere : simpl never.
 Arguments psphere : simpl never.

--- a/theories/Spaces/Spheres.v
+++ b/theories/Spaces/Spheres.v
@@ -24,8 +24,8 @@ Fixpoint Sphere (n : trunc_index)
        | n'.+1 => Susp (Sphere n')
      end.
 
-(** ** Pointed sphere for non-negative dimensions.  Note that [n.-1] is the predecessor as a [trunc_index]. *)
-Definition psphere (n : nat) : pType := psusp (Sphere n.-1).
+(** ** Pointed sphere for non-negative dimensions. *)
+Definition psphere (n : nat) : pType := [Sphere n, _].
 
 Arguments Sphere : simpl never.
 Arguments psphere : simpl never.

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -108,21 +108,12 @@ Global Instance contr_unit : Contr Unit | 0 := {|
 (** ** Equivalences *)
 
 (** A contractible type is equivalent to [Unit]. *)
-Definition equiv_contr_unit `{Contr A} : A <~> Unit.
-Proof.
-  refine (Build_Equiv _ _
-    (fun (_ : A) => tt)
-    (Build_IsEquiv _ _ _
-      (fun (_ : Unit) => center A)
-      (fun t : Unit => match t with tt => 1 end)
-      (fun x : A => contr x) _)).
-  intro x. symmetry; apply ap_const.
-Defined.
+Definition equiv_contr_unit `{Contr A} : A <~> Unit
+  := equiv_contr_contr.
 
 (* Conversely, a type equivalent to [Unit] is contractible. *)
 Global Instance contr_equiv_unit (A : Type) (f : A <~> Unit) : Contr A | 10000
-  := Build_Contr A (f^-1 tt)
-  (fun a => ap f^-1 (contr (f a)) @ eissect f a).
+  := contr_equiv' Unit f^-1%equiv.
 
 (** The constant map to [Unit].  We define this so we can get rid of an unneeded universe variable that Coq generates when this is not annotated. If we ever turn on [Universe Minimization ToSet], then we could get rid of this and remove some imports of this file. *)
 Definition const_tt@{u} (A : Type@{u}) := @const@{Set u} A Unit tt.


### PR DESCRIPTION
The first commit proves that `Susp` is a 1-functor (and does a couple of other cleanups to Suspension.v).

The second commit proves that `Join Bool A` is equivalent to `Susp A`, using @Alizter 's direct argument, with some reorganization.  It also shows that iterated joins of `Bool` give spheres.

The third commit contains misc cleanups and isn't really related.