### PR TITLE
Fix coqdoc section titles

### DIFF
--- a/Makefile.coq.local-early
+++ b/Makefile.coq.local-early
@@ -6,4 +6,4 @@
 # Makefile.coq.local currently contains additional targets that need
 # access to the variables in Makefile.coq
 COQDOCEXTRAFLAGS?=
-COQDOCFLAGS?=-interpolate -utf8 --no-externals $(COQDOCEXTRAFLAGS)
+COQDOCFLAGS?=--interpolate --utf8 --no-externals --parse-comments $(COQDOCEXTRAFLAGS)

--- a/STYLE.md
+++ b/STYLE.md
@@ -44,7 +44,7 @@
   - [1.9. Formatting](#19-formatting)
     - [1.9.1. Location of commands](#191-location-of-commands)
     - [1.9.2. Indentation](#192-indentation)
-    - [1.9.3. Line lengths](#193-line-lengths)
+    - [1.9.3. Line lengths and comments](#193-line-lengths-and-comments)
     - [1.9.4. Tactic scripts](#194-tactic-scripts)
     - [1.9.5. Placement of Arguments and types](#195-placement-of-arguments-and-types)
   - [1.10. Implicit Arguments](#110-implicit-arguments)
@@ -906,14 +906,32 @@ excessive churn in the diff.  If you wish, you can submit a separate
 pull request or commit for the re-indentation, labeled as "only
 whitespace changes" so that no one bothers reading the diff carefully.
 
-### 1.9.3. Line lengths
+### 1.9.3. Line lengths and comments
 
 Lines of code should be of limited width; try to restrict yourself to
 not much more than 70 characters.  Remember that when Coq code is
 often edited in split-screen so that the screen width is cut in half,
 and that not everyone's screen is as wide as yours.
 
-Text in comments, on the other hand, should not contain hard newlines.
+[coqdoc](https://coq.inria.fr/refman/using/tools/coqdoc.html) is used to produce
+a browsable [view of the library](https://hott.github.io/Coq-HoTT/coqdoc-html/toc.html).
+coqdoc treats comments specially, so comments should follow the
+conventions described on the coqdoc page.  The most important ones are
+that Coq expressions within comments are surrounded by square brackets,
+and that headings are indicated with comments of the form
+
+```coq
+(** * This is a top-level section *)
+(** ** This is a subsection *)
+(** *** This is a sub-subsection *)
+```
+
+Section titles should be less than 80 characters, on one line, and not
+end in a period.  Other comments are generally written using the style
+`(** This is a comment. *)` or `(* This is a comment. *)`, with the
+latter generally used for inline comments during a proof.
+
+Text in comments should not contain hard newlines.
 Putting hard newlines in text makes it extremely ugly when viewed in a
 window that is narrower than the width to which you filled it.  If
 editing in Emacs, turn off `auto-fill-mode` and turn on

--- a/contrib/HoTTBookExercises.v
+++ b/contrib/HoTTBookExercises.v
@@ -789,15 +789,15 @@ Proof.
 
   (** To obtain the situation of 2.9.4, we rewrite x using
 
-      <<<
+<<
         x = transport (fun A : Type => C A) p^ x
-      >>>
+>>
 
       This equality holds because [(C A) -> (C A)] is contractible, so
 
-      <<<
+<<
         transport (fun A : Type => C A) p^ = idmap
-      >>>
+>>
 
       In both Theorem 3.2.2 and the following result, the hypothesis
       [Contr ((C A) -> (C A))] will follow from the contractibility of [(C A)].

--- a/contrib/dune
+++ b/contrib/dune
@@ -2,5 +2,5 @@
  (name HoTT.Contrib)
  (package coq-hott)
  (flags -noinit -indices-matter -color on)
- (coqdoc_flags :standard -interpolate -utf8 --no-externals)
+ (coqdoc_flags :standard --interpolate --utf8 --no-externals --parse-comments)
  (theories HoTT))

--- a/contrib/dune
+++ b/contrib/dune
@@ -2,4 +2,5 @@
  (name HoTT.Contrib)
  (package coq-hott)
  (flags -noinit -indices-matter -color on)
+ (coqdoc_flags :standard -interpolate -utf8 --no-externals)
  (theories HoTT))

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,7 @@
  (name HoTT.Tests)
  (theories HoTT)
  (flags -noinit -indices-matter -color on)
- (coqdoc_flags :standard -interpolate -utf8 --no-externals))
+ (coqdoc_flags :standard --interpolate --utf8 --no-externals --parse-comments))
 
 (include_subdirs qualified)
 

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,8 @@
 (coq.theory
  (name HoTT.Tests)
  (theories HoTT)
- (flags -noinit -indices-matter -color on))
+ (flags -noinit -indices-matter -color on)
+ (coqdoc_flags :standard -interpolate -utf8 --no-externals))
 
 (include_subdirs qualified)
 

--- a/theories/Algebra/Universal/Congruence.v
+++ b/theories/Algebra/Universal/Congruence.v
@@ -21,15 +21,15 @@ Section congruence.
 (** A finitary operation [f : A s1 * A s2 * ... * A sn -> A t]
     satisfies [OpCompatible f] iff
 
-    <<
+<<
       Φ s1 x1 y1 * Φ s2 x2 y2 * ... * Φ sn xn yn
-    >>
+>>
 
     implies
 
-    <<
+<<
       Φ t (f (x1, x2, ..., xn)) (f (y1, y2, ..., yn)).
-    >>
+>>
 
     The below definition generalizes this to infinitary operations.
 *)

--- a/theories/Algebra/Universal/Operation.v
+++ b/theories/Algebra/Universal/Operation.v
@@ -79,7 +79,8 @@ Definition FiniteOperation {σ : Signature} (A : Carriers σ)
 (** A type of curried operations
 <<
 CurriedOperation A [s1, ..., sn] t := A s1 -> ... -> A sn -> A t.
->> *)
+>>
+*)
 
 Fixpoint CurriedOperation {σ} (A : Carriers σ) {n : nat}
   : (FinSeq n (Sort σ)) -> Sort σ -> Type

--- a/theories/Algebra/Universal/TermAlgebra.v
+++ b/theories/Algebra/Universal/TermAlgebra.v
@@ -2,9 +2,9 @@
 
     We show that term algebra forms an adjoint functor from the category of hset carriers
 
-    <<
+<<
       {C : Carrier σ | forall s, IsHSet (C s)}
-    >>
+>>
 
     to the category of algebras (without equations) [Algebra σ], where [Carriers σ] is notation for [Sort σ -> Type].  See [ump_term_algebra].
 
@@ -45,9 +45,9 @@ Definition CarriersTermAlgebra_rec {σ : Signature} (C : Carriers σ)
 
 (** A family of relations [R : forall s, Relation (C s)] can be extended to a family of relations on the term algebra carriers,
 
-    <<
+<<
       forall s, Relation (CarriersTermAlgebra C s)
-    >>
+>>
 
     See [ExtendDRelTermAlgebra] and [ExtendRelTermAlgebra] below. *)
 
@@ -318,22 +318,23 @@ End hom_term_algebra.
 (** The next section proves the universal property of the term algebra,
     that [TermAlgebra] is a left adjoint functor
 
-    >>
+<<
       {C : Carriers σ | forall s, IsHSet (C s)} -> Algebra σ,
-    <<
+>>
 
     with right adjoint the forgetful functor. This is stated below as
     an equivalence
 
-    >>
+<<
       Homomorphism (TermAlgebra C) A <~> (forall s, C s -> A s),
-    <<
+>>
 
     given by precomposition with
     
-    >>
+<<
       var_term_algebra C s : C s -> TermAlgebra C s.
-    << *)
+>>
+*)
 
 Section ump_term_algebra.
   Context

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -295,7 +295,8 @@ Module inverseSymmetric (inverse : inverseT).
 End inverseSymmetric.
 
 Module Export symmetric_paths := inverseSymmetric inverse.
->> *)
+>>
+*)
 
 
 (** We define equality concatenation by destructing on both its arguments, so that it only computes when both arguments are [idpath].  This makes proofs more robust and symmetrical.  Compare with the definition of [identity_trans].  *)

--- a/theories/Categories/Functor/Composition/Functorial/Core.v
+++ b/theories/Categories/Functor/Composition/Functorial/Core.v
@@ -10,7 +10,7 @@ Set Implicit Arguments.
 Generalizable All Variables.
 Set Asymmetric Patterns.
 
-(** * Construction of the functor [_∘_ : (C → D) × (D → E) → (C → E)] and it's curried variant *)
+(** Construction of the functor [_∘_ : (C → D) × (D → E) → (C → E)] and its curried variant *)
 Section functorial_composition.
   Context `{Funext}.
   Variables C D E : PreCategory.

--- a/theories/Categories/Functor/Composition/Laws.v
+++ b/theories/Categories/Functor/Composition/Laws.v
@@ -97,7 +97,8 @@ Section coherence.
                 \\   //
                  \\ //
                  G ∘ F
->> *)
+>>
+*)
   Lemma triangle C D E (F : Functor C D) (G : Functor D E)
   : (associativity F 1 G @ ap (compose G) (left_identity F))
     = (ap (fun G' : Functor D E => G' o F) (right_identity G)).
@@ -121,7 +122,8 @@ Section coherence.
               ||                      ||
               ||                      ||
       ((K ∘ H) ∘ G) ∘ F ====== (K ∘ (H ∘ G)) ∘ F
->> *)
+>>
+*)
   Lemma pentagon A B C D E
         (F : Functor A B) (G : Functor B C) (H : Functor C D) (K : Functor D E)
   : (associativity F G (K o H) @ associativity (G o F) H K)

--- a/theories/Categories/LaxComma/CoreLaws.v
+++ b/theories/Categories/LaxComma/CoreLaws.v
@@ -151,7 +151,8 @@ Module Import LaxCommaCategory.
         repeat (let H := fresh "x" in intro H).
         repeat match goal with H : _ |- _ => revert H end.
         intro.
->> *)
+>>
+*)
 
     Lemma associativity_helper
           {x x0 : PreCategory} {x1 : Functor x0 x}
@@ -269,7 +270,8 @@ Lemma left_identity (s d : object) (m : morphism s d)
         repeat (let H := fresh "x" in intro H).
         repeat match goal with H : _ |- _ => revert H end.
         intro.
->> *)
+>>
+*)
 
     Lemma left_identity_helper
           {x x0 : PreCategory} {x1 : Functor x0 x}
@@ -364,7 +366,8 @@ Lemma left_identity (s d : object) (m : morphism s d)
         repeat (let H := fresh "x" in intro H).
         repeat match goal with H : _ |- _ => revert H end.
         intro.
->> *)
+>>
+*)
 
     Lemma right_identity_helper
           {x x0 : PreCategory} {x1 : Functor x0 x}

--- a/theories/Categories/PseudonaturalTransformation/Core.v
+++ b/theories/Categories/PseudonaturalTransformation/Core.v
@@ -189,7 +189,8 @@ Print PseudonaturalTransformationParts.a_part.
 Print PseudonaturalTransformationParts.b_part.
 Print PseudonaturalTransformationParts.b_id_part.
 Print PseudonaturalTransformationParts.c_part.
->> *)
+>>
+*)
 
 Record PseudonaturalTransformation `{Funext} (X : PreCategory)
        (F G : Pseudofunctor X) :=

--- a/theories/Classes/implementations/family_prod.v
+++ b/theories/Classes/implementations/family_prod.v
@@ -11,9 +11,9 @@ Section family_prod.
 
   (** [FamilyProd F ℓ] is a product type defined by
   
-      <<
+<<
         FamilyProd F [i1;i2;...;in] = F i1 * F i2 * ... * F in * Unit
-      >>
+>>
 
       It is convenient to have the [Unit] in the end.
   *)
@@ -23,10 +23,11 @@ Section family_prod.
 
   (** Map function for [FamilyProd F ℓ],
 
-      <<
+<<
         map_family_prod f (x1, x2, ..., xn, tt)
         = (f x1, f x2, ..., f xn, tt)
-      >> *)
+>>
+*)
 
   Fixpoint map_family_prod {F G : I → Type} {ℓ : list I}
       (f : ∀ i, F i → G i)
@@ -60,9 +61,9 @@ Section family_prod.
   (** If [R : ∀ i, relation (F i)] is a family of relations indexed by
       [i:I] and [R i] is reflexive for all [i], then
 
-      <<
+<<
         for_all_2_family_prod F F R s s
-      >>
+>>
 
       holds. *)
   Lemma reflexive_for_all_2_family_prod (F : I → Type)

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -85,9 +85,9 @@ Notation Carriers σ := (Sort σ → Type).
 (** The function [Operation] maps a family of carriers [A : Carriers σ]
     and [w : SymbolType σ] to the corresponding function type.
 
-    <<
+<<
       Operation A [:s1; s2; ...; sn; t:] = A s1 → A s2 → ... → A sn → A t
-    >>
+>>
 
     where [[:s1; s2; ...; sn; t:] : SymbolType σ] is a symbol type
     with domain [[s1; s2; ...; sn]] and codomain [t]. *)
@@ -107,9 +107,9 @@ Defined.
 
 (** Uncurry of an [f : Operation A w], such that
 
-    <<
+<<
       ap_operation f (x1,x2,...,xn) = f x1 x2 ... xn
-    >>
+>>
 *)
 
 Fixpoint ap_operation {σ} {A : Carriers σ} {w : SymbolType σ}
@@ -123,9 +123,9 @@ Fixpoint ap_operation {σ} {A : Carriers σ} {w : SymbolType σ}
 
 (** Funext for uncurried [Operation A w]. If
 
-    <<
+<<
       ap_operation f (x1,x2,...,xn) = ap_operation g (x1,x2,...,xn)
-    >>
+>>
 
     for all [(x1,x2,...,xn) : A s1 * A s2 * ... * A sn], then [f = g]. *)
 

--- a/theories/Classes/interfaces/ua_congruence.v
+++ b/theories/Classes/interfaces/ua_congruence.v
@@ -11,15 +11,15 @@ Section congruence.
 (** An operation [f : A s1 → A s2 → ... → A sn → A t] satisfies
     [OpCompatible f] iff
 
-    <<
+<<
       Φ s1 x1 y1 ∧ Φ s2 x2 y2 ∧ ... ∧ Φ sn xn yn
-    >>
+>>
 
     implies
 
-    <<
+<<
       Φ t (f x1 x2 ... xn) (f y1 y2 ... yn).
-    >>
+>>
 *)
 
   Definition OpCompatible {w : SymbolType σ} (f : Operation A w)

--- a/theories/Classes/theory/ua_first_isomorphism.v
+++ b/theories/Classes/theory/ua_first_isomorphism.v
@@ -110,9 +110,9 @@ Section first_isomorphism.
 
 (** The homomorphism [def_first_isomorphism] is informally given by
 
-    <<
+<<
       def_first_isomorphism s (class_of _ x) := f s x.
-    >>
+>>
 *)
 
   Definition def_first_isomorphism (s : Sort σ)

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -18,9 +18,9 @@ Section is_homomorphism.
     respect to operations [α : A s1 → A s2 → ... → A sn → A t] and
     [β : B s1 → B s2 → ... → B sn → B t] if
 
-    <<
+<<
       f t (α x1 x2 ... xn) = β (f s1 x1) (f s2 x2) ... (f sn xn)
-    >>
+>>
 *)
 
   Fixpoint OpPreserving {w : SymbolType σ}
@@ -147,9 +147,9 @@ Qed.
     section proves that [f] is "OpPreserving" with respect to
     uncurried algebra operations in the sense that
 
-    <<
+<<
       f t (α (x1,x2,...,xn,tt)) = β (f s1 x1,f s2 x1,...,f sn xn,tt)
-    >>
+>>
 
     for all [(x1,x2,...,xn,tt) : FamilyProd A [s1;s2;...;sn]], where
     [α] and [β] are uncurried algebra operations in [A] and [B]
@@ -172,10 +172,10 @@ Section homomorphism_ap_operation.
 
 (** A homomorphism [f : ∀ s, A s → B s] satisfies
 
-    <<
+<<
       f t (α (a1, a2, ..., an, tt))
       = β (f s1 a1, f s2 a2, ..., f sn an, tt)
-    >>
+>>
 
     where [(a1, a2, ..., an, tt) : FamilyProd A [s1; s2; ...; sn]] and
     [α], [β] uncurried versions of [u.#A], [u.#B] respectively. *)
@@ -305,10 +305,10 @@ Section path_isomorphism.
 (** Given a family of equivalences [f : ∀ (s : Sort σ), A s <~> B s]
     which is [OpPreserving f α β] with respect to algebra operations
 
-    <<
+<<
       α : A s1 → A s2 → ... → A sn → A t
       β : B s1 → B s2 → ... → B sn → B t
-    >>
+>>
 
     By transporting [α] along the path [path_equiv_family f] we
     find a path from the transported operation [α] to [β]. *)

--- a/theories/Classes/theory/ua_prod_algebra.v
+++ b/theories/Classes/theory/ua_prod_algebra.v
@@ -122,9 +122,9 @@ Section ump_prod_algebra.
       there is a unique homomorphism [f : Homomorphism C (ProdAlgebra I A)]
       such that [h i = hom_compose (pr i) f], where
 
-      <<
+<<
         pr i = hom_proj_prod_algebra I A i
-      >>
+>>
 
       is the ith projection homomorphism. *)
 

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -45,10 +45,10 @@ Section quotient_algebra.
     If [g] is the quotient algebra operation induced by [f], then we want
     [ComputeOpQuotient f g] to hold, since then
 
-    <<
+<<
       β (class_of _ a1, class_of _ a2, ..., class_of _ an)
       = class_of _ (α (a1, a2, ..., an)),
-    >>
+>>
 
     where [α] is the uncurried [f] operation and [β] is the uncurried
     [g] operation. *)
@@ -94,16 +94,16 @@ Section quotient_algebra.
    the [op_quotient_algebra_well_def] lemma, which is used to show that
    the quotient algebra operation [g] is well defined, i.e. that
 
-   <<
+<<
     Φ s1 x1 y1 ∧ Φ s2 x2 y2 ∧ ... ∧ Φ sn xn yn
-   >>
+>>
 
    implies
 
-   <<
+<<
     g (class_of _ x1) (class_of _ x2) ... (class_of _ xn)
     = g (class_of _ y1) (class_of _ y2) ... (class_of _ yn).
-   >>
+>>
 *)
 
   Fixpoint op_quotient_algebra {w : SymbolType σ} : QuotOp w.
@@ -143,10 +143,10 @@ Section quotient_algebra.
     algebra operations. It says that for
     [(a1, a2, ..., an) : A s1 * A s2 * ... * A sn],
 
-    <<
+<<
       β (class_of _ a1, class_of _ a2, ..., class_of _ an)
       = class_of _ (α (a1, a2, ..., an))
-    >>
+>>
 
     where [α] is the uncurried [u.#A] operation and [β] is the
     uncurried [u.#QuotientAlgebra] operation. *)
@@ -293,9 +293,9 @@ Section ump_quotient_algebra.
 
 (** The computation rule for [hom_quotient_algebra_mapout] is
 
-    <<
+<<
       hom_quotient_algebra_mapout s (class_of (Φ s) x) = f s x.
-    >>
+>>
 *)
 
     Lemma compute_quotient_algebra_mapout
@@ -334,9 +334,9 @@ Section ump_quotient_algebra.
     [Φ] to equal elements, there is a unique homomorphism
     [g : Homomorphism (A/Φ) B] satisfying
 
-    <<
+<<
       f = hom_compose g (hom_quotient Φ).
-    >>
+>>
 *)
 
   Lemma ump_quotient_algebra

--- a/theories/Classes/theory/ua_second_isomorphism.v
+++ b/theories/Classes/theory/ua_second_isomorphism.v
@@ -122,9 +122,9 @@ End is_subalgebra_class.
 
 (** The next section proves the second isomorphism theorem,
 
-    <<
+<<
       (A&&P) / (cong_trace P Φ) ≅ (A/Φ) && (is_subalgebra_class P Φ).
-    >>
+>>
 *)
 
 (* There is an alternative proof using the first isomorphism theorem,

--- a/theories/Classes/theory/ua_subalgebra.v
+++ b/theories/Classes/theory/ua_subalgebra.v
@@ -12,15 +12,15 @@ Section closed_under_op.
       operation. Then [P] satisfies [ClosedUnderOp α] iff
       for [x1 : A s1], [x2 : A s2], ..., [xn : A sn],
 
-    <<
+<<
       P s1 x1 ∧ P s2 x2 ∧ ... ∧ P sn xn
-    >>
+>>
 
     implies
 
-    <<
+<<
       P t (α x1 x2 ... xn)
-    >>
+>>
   *)
 
   Fixpoint ClosedUnderOp {w : SymbolType σ} : Operation A w → Type :=
@@ -89,10 +89,10 @@ Section subalgebra.
     [op_subalgebra α C : (A&P) s1 → ... → (A&P) sn → (A&P) t] is
     given by
 
-    <<
+<<
       op_subalgebra α C (x1; p1) ... (xn; pn) =
         (α x1 ... xn; C x1 p1 x2 p2 ... xn pn).
-    >>
+>>
 *)
 
   Fixpoint op_subalgebra {w : SymbolType σ}

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -38,23 +38,24 @@ Definition cocone_postcompose_inv `{D: Diagram G} {Q X}
 (** Whatever the diagram considered, there exists a colimit of it. The existence is given by the HIT [colimit]. *)
 
 (** ** Definition of the HIT 
-
+<<
   HIT Colimit {G : Graph} (D : Diagram G) : Type :=
   | colim : forall i, D i -> Colimit D
   | colimp : forall i j (f : G i j) (x : D i) : colim j (D _f f x) = colim i x
   .
-
+>>
 *)
 
-(** A colimit is just the coequializer of the source and target maps of the diagram. *)
+(** A colimit is just the coequalizer of the source and target maps of the diagram. *)
 (** The source type in the coequalizer ought to be:
->>>
+<<
 {x : sig D & {y : sig D & {f : G x.1 y.1 & D _f f x.2 = y.2}}}
-<<<
+>>
 However we notice that the path type forms a contractible component, so we can use the more efficient:
->>>
+<<
 {x : sig D & {j : G & G x.1 j}}
-<<< *)
+>>
+*)
 Definition Colimit {G : Graph} (D : Diagram G) : Type :=
   @Coeq
     {x : sig D & {j : G & G x.1 j}}

--- a/theories/HIT/Flattening.v
+++ b/theories/HIT/Flattening.v
@@ -133,7 +133,8 @@ Proof.
   unfold sWtil_ind.
   (** ... but it's a doozy! *)
 Abort.
->> *)
+>>
+*)
 
 (** Fortunately, it turns out to be enough to have the computation rule for the *non-dependent* eliminator! *)
 
@@ -144,7 +145,8 @@ Definition sWtil_rec (P : Type)
   (sppt' : forall b (y : C (f b)), scct' (f b) y = scct' (g b) (D b y))
   : sWtil -> P
   := sWtil_ind (fun _ => P) scct' (fun b y => transport_const _ _ @ sppt' b y).
->> *)
+>>
+*)
 
 (** ...but if we define it diindly, then it's easier to reason about. *)
 Definition sWtil_rec (Q : Type)

--- a/theories/HIT/epi.v
+++ b/theories/HIT/epi.v
@@ -135,7 +135,8 @@ Proof.
         by symmetry.
     + apply (transport hproptype p tt).
 Defined.
->> *)
+>>
+*)
 
 Section isepi_issurj.
   Context {X Y : HSet} (f : X -> Y) (Hisepi : isepi f).

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -271,7 +271,7 @@ Defined.
 Definition joinrecdata_0gpd (A B P : Type) : ZeroGpd
   := Build_ZeroGpd (JoinRecData A B P) _ _ _.
 
-(** * [joinrecdata_0gpd A B] is a 1-functor from [Type] to [ZeroGpd]
+(** ** [joinrecdata_0gpd A B] is a 1-functor from [Type] to [ZeroGpd]
 
   It's a 1-functor that lands in [ZeroGpd], and the morphisms of [ZeroGpd] are 0-functors, so it's easy to get confused about the levels. *)
 

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -42,7 +42,7 @@ Section Join.
     : apD (Join_ind P P_A P_B P_g) (jglue a b) = P_g a b
     := Pushout_ind_beta_pglue _ _ _ _ _.
 
-  (* A version of [Join_ind] that uses dependant paths. *)
+  (** A version of [Join_ind] that uses dependant paths. *)
   Definition Join_ind_dp {A B : Type} (P : Join A B -> Type)
     (P_A : forall a, P (joinl a)) (P_B : forall b, P (joinr b))
     (P_g : forall a b, DPath P (jglue a b) (P_A a) (P_B b))
@@ -113,7 +113,9 @@ Section Join.
 
 End Join.
 
-(** * We now prove many things about [Join_rec], for example, that it is an equivalence of 0-groupoids from the [JoinRecData] that we define next.  The framework we use is a bit elaborate, but it parallels the framework used in TriJoin.v, where careful organization is essential. *)
+(** * [Join_rec] gives an equivalence of 0-groupoids
+
+  We now prove many things about [Join_rec], for example, that it is an equivalence of 0-groupoids from the [JoinRecData] that we define next.  The framework we use is a bit elaborate, but it parallels the framework used in TriJoin.v, where careful organization is essential. *)
 
 Record JoinRecData {A B P : Type} := {
     jl : A -> P;
@@ -133,7 +135,7 @@ Definition join_rec_beta_jg {A B P : Type} (f : JoinRecData A B P) (a : A) (b : 
   : ap (join_rec f) (jglue a b) = jg f a b
   := Join_rec_beta_jglue _ _ _ a b.
 
-(** * We're next going to define a map in the other direction.  We do it via showing that [JoinRecData] is a 0-coherent 1-functor to [Type]. We'll later show that it is a 1-functor to 0-groupoids. *)
+(** We're next going to define a map in the other direction.  We do it via showing that [JoinRecData] is a 0-coherent 1-functor to [Type]. We'll later show that it is a 1-functor to 0-groupoids. *)
 Definition joinrecdata_fun {A B P Q : Type} (g : P -> Q) (f : JoinRecData A B P)
   : JoinRecData A B Q.
 Proof.
@@ -152,7 +154,11 @@ Definition join_rec_inv {A B P : Type} (f : Join A B -> P)
   : JoinRecData A B P
   := joinrecdata_fun f (joinrecdata_join A B).
 
-(** * Under [Funext], [join_rec] and [join_rec_inv] should be inverse equivalences.  We'll avoid [Funext] and show that they are equivalences of 0-groupoids, where we choose the path structures carefully.  We begin by describing a notion of paths between elements of [JoinRecData A B P]. Under [Funext], this type will be equivalent to the identity type.  But without [Funext], this definition will be more useful. *)
+(** Under [Funext], [join_rec] and [join_rec_inv] should be inverse equivalences.  We'll avoid [Funext] and show that they are equivalences of 0-groupoids, where we choose the path structures carefully. *)
+
+(** ** The graph structure on [JoinRecData A B P]
+
+  Under [Funext], this type will be equivalent to the identity type.  But without [Funext], this definition will be more useful. *)
 
 Record JoinRecPath {A B P : Type} {f g : JoinRecData A B P} := {
     hl : forall a, jl f a = jl g a;
@@ -190,7 +196,9 @@ Definition isinj_join_rec_inv {A B P : Type} {f g : Join A B -> P}
   : f == g
   := Join_ind_FlFr _ _ (hl h) (hr h) (hg h).
 
-(** * We now introduce several lemmas and tactics that will dispense with some routine goals. The idea is that a generic interval can be assumed to be trivial on the first vertex, and a generic square can be assumed to be the identity on the domain edge. In order to apply the [paths_ind] and [square_ind] lemmas that make this precise, we need to generalize various terms in the goal. *)
+(** ** Lemmas and tactics about intervals and squares
+
+  We now introduce several lemmas and tactics that will dispense with some routine goals. The idea is that a generic interval can be assumed to be trivial on the first vertex, and a generic square can be assumed to be the identity on the domain edge. In order to apply the [paths_ind] and [square_ind] lemmas that make this precise, we need to generalize various terms in the goal. *)
 
 (** This destructs a three component term [f], generalizes each piece evaluated appropriately, and clears all pieces. *)
 Ltac generalize_three f a b :=
@@ -226,7 +234,7 @@ Global Ltac square_ind g h a b :=
   generalize_three g a b;
   apply square_ind.
 
-(** * Here we start using the WildCat library to organize things. *)
+(** ** Use the WildCat library to organize things *)
 
 (** We begin by showing that [JoinRecData A B P] is a 0-groupoid, one piece at a time. *)
 Global Instance isgraph_joinrecdata (A B P : Type) : IsGraph (JoinRecData A B P)
@@ -263,9 +271,9 @@ Defined.
 Definition joinrecdata_0gpd (A B P : Type) : ZeroGpd
   := Build_ZeroGpd (JoinRecData A B P) _ _ _.
 
-(** * Next we show that [joinrecdata_0gpd A B] is a 1-functor from [Type] to [ZeroGpd]. *)
+(** * [joinrecdata_0gpd A B] is a 1-functor from [Type] to [ZeroGpd]
 
-(** It's a 1-functor that lands in [ZeroGpd], and the morphisms of [ZeroGpd] are 0-functors, so it's easy to get confused about the levels. *)
+  It's a 1-functor that lands in [ZeroGpd], and the morphisms of [ZeroGpd] are 0-functors, so it's easy to get confused about the levels. *)
 
 (** First we need to show that the induced map is a morphism in [ZeroGpd], i.e. that it is a 0-functor. *)
 Global Instance is0functor_joinrecdata_fun {A B P Q : Type} (g : P -> Q)
@@ -365,7 +373,7 @@ Proof.
   exact (isnat (join_rec_natequiv A B) g f).
 Defined.
 
-(** * Various types of equalities between paths in joins. *)
+(** * Various types of equalities between paths in joins *)
 
 (** Naturality squares for given paths in [A] and [B]. *)
 Section JoinNatSq.
@@ -553,7 +561,9 @@ Section FunctorJoin.
 
 End FunctorJoin.
 
-(** * We'll use the recursion equivalence above to prove the symmetry of Join, using the Yoneda lemma.  The idea is that [Join A B -> P] is equivalent (as a 0-groupoid) to [JoinRecData A B P], and the latter is very symmetrical by construction, which makes it easy to show that it is equivalent to [JoinRecData B A P].  Going back along the first equivalence gets us to [Join B A -> P].  These equivalences are natural in [P], so the symmetry equivalence follows from the Yoneda lemma.  This is mainly meant as a warmup to proving the associativity of the join. *)
+(** * Symmetry of Join
+
+  We'll use the recursion equivalence above to prove the symmetry of Join, using the Yoneda lemma.  The idea is that [Join A B -> P] is equivalent (as a 0-groupoid) to [JoinRecData A B P], and the latter is very symmetrical by construction, which makes it easy to show that it is equivalent to [JoinRecData B A P].  Going back along the first equivalence gets us to [Join B A -> P].  These equivalences are natural in [P], so the symmetry equivalence follows from the Yoneda lemma.  This is mainly meant as a warmup to proving the associativity of the join. *)
 
 Section JoinSym.
 

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -144,7 +144,8 @@ Definition equiv_trijoin_twist (A B C : Type)
                             (trijoin_twist_homotopic A B C)
                             (trijoin_twist_homotopic B A C).
 
-(** Finally, we get that Join is associative. *)
+(** ** The associativity of [Join] *)
+
 Definition join_assoc A B C : Join A (Join B C) <~> Join (Join A B) C.
 Proof.
   refine (_ oE equiv_functor_join equiv_idmap (equiv_join_sym B C)).

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -1,8 +1,12 @@
 Require Import Basics Types WildCat Join.Core Join.TriJoin Spaces.Nat.Core.
 
-(** * We use the recursion principle for the triple join (from TriJoin.v) to prove the associativity of Join.  We'll use the common technique of combining symmetry and a twist equivalence.  Temporarily writing * for Join, symmetry says that [A * B <~> B * A] and the twist says that [A * (B * C) <~> B * (A * C)].  From these we get a composite equivalence [A * (B * C) <~> A * (C * B) <~> C * (A * B) <~> (A * B) * C].  One advantage of this approach is that both symmetry and the twist are their own inverses, so there are fewer maps to define and fewer composites to prove are homotopic to the identity. Symmetry is proved in Join/Core.v. *)
+(** * The associativity of [Join]
 
-(** * We prove the twist equivalence [TriJoin A B C <~> TriJoin B A C], using the Yoneda lemma.  The idea is that [TriJoin A B C -> P] is equivalent (as a 0-groupoid) to [TriJoinRecData A B C P], and the latter is very symmetrical by construction, which makes it easy to show that it is equivalent to [TriJoinRecData B A C P].  Going back along the first equivalence gets us to [TriJoin B A C -> P].  These equivalences are natural in [P], so the twist equivalence follows from the Yoneda lemma. *)
+  We use the recursion principle for the triple join (from TriJoin.v) to prove the associativity of Join.  We'll use the common technique of combining symmetry and a twist equivalence.  Temporarily writing * for Join, symmetry says that [A * B <~> B * A] and the twist says that [A * (B * C) <~> B * (A * C)].  From these we get a composite equivalence [A * (B * C) <~> A * (C * B) <~> C * (A * B) <~> (A * B) * C].  One advantage of this approach is that both symmetry and the twist are their own inverses, so there are fewer maps to define and fewer composites to prove are homotopic to the identity. Symmetry is proved in Join/Core.v. *)
+
+(** ** The twist equivalence [TriJoin A B C <~> TriJoin B A C]
+
+  We prove the twist equivalence using the Yoneda lemma.  The idea is that [TriJoin A B C -> P] is equivalent (as a 0-groupoid) to [TriJoinRecData A B C P], and the latter is very symmetrical by construction, which makes it easy to show that it is equivalent to [TriJoinRecData B A C P].  Going back along the first equivalence gets us to [TriJoin B A C -> P].  These equivalences are natural in [P], so the twist equivalence follows from the Yoneda lemma. *)
 
 (** First we define a map of 0-groupoids that will underlie the natural equivalence. *)
 Definition trijoinrecdata_twist (A B C P : Type)

--- a/theories/Homotopy/Join/JoinSusp.v
+++ b/theories/Homotopy/Join/JoinSusp.v
@@ -3,7 +3,9 @@ Require Import Join.Core Join.JoinAssoc Suspension Spaces.Spheres.
 Require Import WildCat.
 Require Import Spaces.Nat.Core.
 
-(** We give a direct proof that the join of [bool] with a type is equivalent to a suspension. It is also possible to give a proof using [opyon_equiv_0gpd]; see PR#1769. *)
+(** * [Join Bool A] is equivalent to [Susp A]
+
+  We give a direct proof of this fact. It is also possible to give a proof using [opyon_equiv_0gpd]; see PR#1769. *)
 
 Definition join_to_susp (A : Type) : Join Bool A -> Susp A.
 Proof.

--- a/theories/Homotopy/Join/TriJoin.v
+++ b/theories/Homotopy/Join/TriJoin.v
@@ -1,6 +1,8 @@
 Require Import Basics Types WildCat Join.Core.
 
-(** * We show that the iterated join satisfies symmetrical induction and recursion principles and prove that the recursion principle gives an equivalence of 0-groupoids.  We use this in JoinAssoc.v to prove that the join is associative.  Our approach parallels what is done in the two-variable case in Join/Core.v, especially starting with [TriJoinRecData] here and [JoinRecData] there.  That case is much simpler, so should be read first. *)
+(** * Induction and recursion principles for the triple join
+
+  We show that the triple join satisfies symmetrical induction and recursion principles and prove that the recursion principle gives an equivalence of 0-groupoids.  We use this in JoinAssoc.v to prove that the join is associative.  Our approach parallels what is done in the two-variable case in Join/Core.v, especially starting with [TriJoinRecData] here and [JoinRecData] there.  That case is much simpler, so should be read first. *)
 
 Section TriJoinStructure.
   Context {A B C : Type}.
@@ -18,7 +20,7 @@ End TriJoinStructure.
 
 Arguments TriJoin A B C : clear implicits.
 
-(** * The goal of the next few results is to define [ap_trijoin] and [ap_trijoin_transport]. *)
+(** ** [ap_trijoin] and [ap_trijoin_transport] *)
 
 (** Functions send triangles to triangles. *)
 Definition ap_triangle {X Y} (f : X -> Y)
@@ -65,7 +67,7 @@ Proof.
   nrapply ap_trijoin_general_transport.
 Defined.
 
-(** * Now we prove the induction principle for the triple join. *)
+(** ** The induction principle for the triple join *)
 
 (** A lemma that handles the path algebra in the final step. *)
 Local Definition trijoin_ind_helper {A BC : Type} (P : Join A BC -> Type)
@@ -121,7 +123,7 @@ Proof.
       apply trijoin_ind_helper, join123'.
 Defined.
 
-(** * We now state the recursion principle and prove many things about it. *)
+(** ** The recursion principle for the triple join, and many results about it *)
 
 (** We'll bundle up the arguments into a record. *)
 Record TriJoinRecData {A B C P : Type} := {
@@ -204,7 +206,7 @@ Proof.
   nrapply trijoin_rec_beta_join123_helper.
 Qed.
 
-(** * We're next going to define a map in the other direction.  We do it via showing that [TriJoinRecData] is a 0-coherent 1-functor to [Type]. We'll later show that it is a 1-functor to 0-groupoids. *)
+(** We're next going to define a map in the other direction.  We do it via showing that [TriJoinRecData] is a 0-coherent 1-functor to [Type]. We'll later show that it is a 1-functor to 0-groupoids. *)
 Definition trijoinrecdata_fun {A B C P Q : Type} (g : P -> Q) (f : TriJoinRecData A B C P)
   : TriJoinRecData A B C Q.
 Proof.
@@ -230,7 +232,9 @@ Definition trijoin_rec_inv {A B C P : Type} (f : TriJoin A B C -> P)
   : TriJoinRecData A B C P
   := trijoinrecdata_fun f (trijoinrecdata_trijoin A B C).
 
-(** * Under [Funext], [trijoin_rec] and [trijoin_rec_inv] should be inverse equivalences.  We'll avoid [Funext] and show that they are equivalences of 0-groupoids, where we choose the path structures carefully.  We begin by describing a notion of paths between elements of [TriJoinRecData A B C P]. *)
+(** Under [Funext], [trijoin_rec] and [trijoin_rec_inv] should be inverse equivalences.  We'll avoid [Funext] and show that they are equivalences of 0-groupoids, where we choose the path structures carefully. *)
+
+(** ** The graph structure on [TriJoinRecData A B C P] *)
 
 (** The type of fillers for a triangular prism with five 2d faces [abc], [abc'], [k12], [k13], [k23]. *)
 Definition prism {P : Type}
@@ -293,7 +297,7 @@ Record TriJoinRecPath' {A B C P : Type} {j1' : A -> P} {j2' : B -> P} {j3' : C -
 
 Arguments TriJoinRecPath' {A B C P} {j1' j2' j3'} f g.
 
-(** * We can bundle and unbundle these types of data.  For unbundling, we just handle [TriJoinRecData] for now. *)
+(** We can bundle and unbundle these types of data.  For unbundling, we just handle [TriJoinRecData] for now. *)
 
 Definition bundle_trijoinrecdata {A B C P : Type} {j1' : A -> P} {j2' : B -> P} {j3' : C -> P}
   (f : TriJoinRecData' j1' j2' j3')
@@ -367,7 +371,7 @@ Definition trijoin_rec_beta {A B C P : Type} (f : TriJoinRecData A B C P)
   : TriJoinRecPath (trijoin_rec_inv (trijoin_rec f)) f
   := bundle_trijoinrecpath (trijoin_rec_beta' f).
 
-(** * Next we show that [trijoin_rec_inv] is an injective map between 0-groupoids. *)
+(** ** [trijoin_rec_inv] is an injective map between 0-groupoids *)
 
 (** We begin with a general purpose lemma. *)
 Definition triangle_ind {P : Type} (a : P)
@@ -431,7 +435,9 @@ Proof.
   exact (h123 h a b c).
 Defined.
 
-(** * We now introduce several lemmas and tactics that will dispense with some routine goals. The idea is that a generic triangle can be assumed to be trivial on the first vertex, and a generic prism can be assumed to be the identity on the domain. In order to apply the [triangle_ind] and [prism_ind] lemmas that make this precise, we need to generalize various terms in the goal. *)
+(** ** Lemmas and tactics about triangles and prisms 
+
+  We now introduce several lemmas and tactics that will dispense with some routine goals. The idea is that a generic triangle can be assumed to be trivial on the first vertex, and a generic prism can be assumed to be the identity on the domain. In order to apply the [triangle_ind] and [prism_ind] lemmas that make this precise, we need to generalize various terms in the goal. *)
 
 (** This destructs a seven component term [f], tries to generalize each piece evaluated appropriately, and clears all pieces.  If called with [a], [b] and [c] all valid terms, we expect all seven components to be generalized.  But one can also call it with one of [a], [b] and [c] a dummy value (e.g. [_X_]) that causes four of the [generalize] tactics to fail.  In this case, four components will be simply cleared, and three will be generalized and cleared, so this applies when the goal only depends on three of the seven components. *)
 Ltac generalize_some f a b c :=
@@ -495,7 +501,7 @@ Ltac prism_ind_two g h a b c :=
   generalize_some g a b c;
   apply square_ind. (* From Join/Core.v *)
 
-(** * Here we start using the WildCat library to organize things. *)
+(** ** Use the WildCat library to organize things *)
 
 (** We begin by showing that [TriJoinRecData A B C P] is a 0-groupoid, one piece at a time. *)
 Global Instance isgraph_trijoinrecdata (A B C P : Type) : IsGraph (TriJoinRecData A B C P)
@@ -554,9 +560,9 @@ Defined.
 Definition trijoinrecdata_0gpd (A B C P : Type) : ZeroGpd
   := Build_ZeroGpd (TriJoinRecData A B C P) _ _ _.
 
-(** * Next we show that [trijoinrecdata_0gpd A B C] is a 1-functor from [Type] to [ZeroGpd]. *)
+(** ** [trijoinrecdata_0gpd A B C] is a 1-functor from [Type] to [ZeroGpd]
 
-(** It's a 1-functor that lands in [ZeroGpd], and the morphisms of [ZeroGpd] are 0-functors, so it's easy to get confused about the levels. *)
+  It's a 1-functor that lands in [ZeroGpd], and the morphisms of [ZeroGpd] are 0-functors, so it's easy to get confused about the levels. *)
 
 (** First we need to show that the induced map is a morphism in [ZeroGpd], i.e. that it is a 0-functor. *)
 Global Instance is0functor_trijoinrecdata_fun {A B C P Q : Type} (g : P -> Q)

--- a/theories/Spaces/Circle.v
+++ b/theories/Spaces/Circle.v
@@ -16,11 +16,11 @@ Generalizable Variables X A B f g n.
 
 (** We define the circle as the coequalizer of two copies of the identity map of [Unit].  This is easily equivalent to the naive definition
 
-<<<
+<<
 Private Inductive Circle : Type0 :=
 | base : Circle
 | loop : base = base.
->>>
+>>
 
 but it allows us to apply the flattening lemma directly rather than having to pass across that equivalence.  *)
 

--- a/theories/Spaces/Circle.v
+++ b/theories/Spaces/Circle.v
@@ -77,7 +77,9 @@ Defined.
 (** The [Circle] is pointed by [base]. *)
 Global Instance ispointed_Circle : IsPointed Circle := base.
 
-(** ** In this section we prove that the loop space of the [Circle] is the Integers [Int]. This is the encode-decode style proof a la Licata-Shulman. *)
+(** ** The loop space of the [Circle] is the Integers [Int]
+
+  This is the encode-decode style proof a la Licata-Shulman. *)
 
 Section EncodeDecode.
   (** We assume univalence throughout this section. *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -627,7 +627,7 @@ Proof.
   intros; rewrite min_comm; by apply min_l.
 Defined.
 
-(** [n]th iteration of the function [f : A -> A].  We have definitional equalities [nat_iter 0 f x = x] and [nat_iter n.+1 f x = f (nat_iter n f x).  We make this a notation, so it doesn't add a universe variable for the universe containing [A]. *)
+(** [n]th iteration of the function [f : A -> A].  We have definitional equalities [nat_iter 0 f x = x] and [nat_iter n.+1 f x = f (nat_iter n f x)].  We make this a notation, so it doesn't add a universe variable for the universe containing [A]. *)
 Notation nat_iter n f x
   := ((fix F (m : nat)
       := match m with

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -1,7 +1,7 @@
 Require Import Basics.Overture Basics.Tactics Basics.Decidable
   Spaces.Nat.Core.
 
-(* ** Binary Positive Integers *)
+(** * Binary Positive Integers *)
 
 (** Most of this file has been adapted from the coq standard library for positive binary integers. *)
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -10,7 +10,7 @@ Require Export (coercions) Modalities.Modality.
 Local Open Scope path_scope.
 Generalizable Variables A X n.
 
-(** ** Definition *)
+(** ** The definition *)
 
 (** The definition of [Trunc n], the n-truncation of a type.
 
@@ -177,7 +177,7 @@ Defined.
 #[export]
 Hint Immediate istruncmap_mapinO_tr : typeclass_instances.
 
-(** ** A few special things about the (-1)-truncation. *)
+(** ** A few special things about the (-1)-truncation *)
 
 Local Open Scope trunc_scope.
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -5,12 +5,12 @@ Require Import Modalities.Modality.
 (* Users of this file almost always want to be able to write [Tr n] for both a [Modality] and a [ReflectiveSubuniverse], so they want the coercion [modality_to_reflective_subuniverse]: *)
 Require Export (coercions) Modalities.Modality.
 
-(** * Truncations of types, in all dimensions. *)
+(** * Truncations of types, in all dimensions *)
 
 Local Open Scope path_scope.
 Generalizable Variables A X n.
 
-(** ** Definition. *)
+(** ** Definition *)
 
 (** The definition of [Trunc n], the n-truncation of a type.
 
@@ -276,7 +276,9 @@ Proof.
   exact (ap10 (g0.2 @ g1.2^) y).
 Defined.
 
-(** ** Tactic to remove truncations in hypotheses if possible. See [strip_reflections] and [strip_modalities] for generalizations to other reflective subuniverses and modalities. *)
+(** ** Tactic to remove truncations in hypotheses if possible
+
+  See [strip_reflections] and [strip_modalities] for generalizations to other reflective subuniverses and modalities. *)
 Ltac strip_truncations :=
   (** search for truncated hypotheses *)
   progress repeat

--- a/theories/Types/IWType.v
+++ b/theories/Types/IWType.v
@@ -441,7 +441,7 @@ Proof.
   exact q.
 Defined.
 
-(** ** IW-types have decidable equality if liftP holds and the fibers of the indexing map have decidable paths. Notably, if B x is finitely enumerable, then liftP holds. *)
+(** IW-types have decidable equality if liftP holds and the fibers of the indexing map have decidable paths. Notably, if B x is finitely enumerable, then liftP holds. *)
 Section DecidablePaths.
 
   Context `{Funext}

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -84,7 +84,9 @@ Global Instance hasequivs_0gpd : HasEquivs ZeroGpd
 Definition equiv_fun_0gpd {G H : ZeroGpd} (f : G $<~> H) : G -> H
   := fun_0gpd _ _ (cat_equiv_fun _ _ _ f).
 
-(** * Some tools for manipulating equivalences of 0-groupoids.  Even though the proofs are easy, in certain contexts Coq gets confused about [$==] vs [$->], which makes it hard to prove this inline.  So we record them here. *)
+(** ** Tools for manipulating equivalences of 0-groupoids
+
+  Even though the proofs are easy, in certain contexts Coq gets confused about [$==] vs [$->], which makes it hard to prove this inline.  So we record them here. *)
 
 (** Every equivalence is injective. *)
 Definition isinj_equiv_0gpd {G H : ZeroGpd} (f : G $<~> H)
@@ -99,9 +101,9 @@ Definition moveR_equiv_V_0gpd {G H : ZeroGpd} (f : G $<~> H) (x : H) (y : G) (p 
   : equiv_fun_0gpd f^-1$ x $== y
   := fmap (equiv_fun_0gpd f^-1$) p $@ cat_eissect f y.
 
-(** * We now give a different characterization of the equivalences of 0-groupoids, as the injective split essentially surjective 0-functors, which are defined in EquivGpd. *)
+(** ** [f] is an equivalence of 0-groupoids iff [IsSurjInj f]
 
-(** Advantages of this logically equivalent formulation are that it tends to be easier to prove in examples and that in some cases it is definitionally equal to [ExtensionAlong], which is convenient.  See Homotopy/Suspension.v and Algebra/AbGroups/Abelianization for examples. Advantages of the bi-invertible definition are that it reproduces a definition that is equivalent to [IsEquiv] when applied to types, assuming [Funext].  It also works in any 1-category. *)
+  We now give a different characterization of the equivalences of 0-groupoids, as the injective split essentially surjective 0-functors, which are defined in EquivGpd.  Advantages of this logically equivalent formulation are that it tends to be easier to prove in examples and that in some cases it is definitionally equal to [ExtensionAlong], which is convenient.  See Homotopy/Suspension.v and Algebra/AbGroups/Abelianization for examples. Advantages of the bi-invertible definition are that it reproduces a definition that is equivalent to [IsEquiv] when applied to types, assuming [Funext].  It also works in any 1-category. *)
 
 (** Every equivalence is injective and split essentially surjective. *)
 Global Instance issurjinj_equiv_0gpd {G H : ZeroGpd} (f : G $<~> H)

--- a/theories/dune
+++ b/theories/dune
@@ -8,7 +8,8 @@
  (name HoTT)
  (package coq-hott)
  (modules :standard)
- (flags -noinit -indices-matter -color on))
+ (flags -noinit -indices-matter -color on)
+ (coqdoc_flags :standard -interpolate -utf8 --no-externals))
 
 ; TODO: Tests
 ; Prob need to move tests into tests folder

--- a/theories/dune
+++ b/theories/dune
@@ -9,7 +9,7 @@
  (package coq-hott)
  (modules :standard)
  (flags -noinit -indices-matter -color on)
- (coqdoc_flags :standard -interpolate -utf8 --no-externals))
+ (coqdoc_flags :standard --interpolate --utf8 --no-externals --parse-comments))
 
 ; TODO: Tests
 ; Prob need to move tests into tests folder


### PR DESCRIPTION
I realized that I was using things like `(** * text here *)` incorrectly,  causing headings to be much too long in the generated html documentation, so I fixed my mistakes.  While I was at it, I found a few other places to fix.

Is there a way to preview the coqdoc html documentation before merging?