### PR TITLE
Declare universe variables in Context commands

### DIFF
--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -11,7 +11,6 @@ Local Open Scope path_scope.
 
 Section Factorization.
   Universes ctxi.
-  (** It's important that these are all declared with a single [Context] command, so that the marker [@{ctxi}] refers to the same universe level in all of them. *)
   Context {class1 class2 : forall (X Y : Type@{ctxi}), (X -> Y) -> Type@{ctxi}}
           `{forall (X Y : Type@{ctxi}) (g:X->Y), IsHProp (class1 _ _ g)}
           `{forall (X Y : Type@{ctxi}) (g:X->Y), IsHProp (class2 _ _ g)}

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -384,6 +384,7 @@ On the other hand, in other examples (such as [~~] and open modalities) it is ea
 
 Section EasyModalities.
 
+  Universe i.
   Context (O_reflector : Type@{i} -> Type@{i})
           (to : forall (T : Type@{i}), T -> O_reflector T)
           (O_indO


### PR DESCRIPTION
I searched the library and only found one more place where a universe variable was used in a Context command without being declared.  I also found an out-of-date comment, which only was relevant if the universe variable in question was not declared.