### PR TITLE
Naturality of join_assoc and trijoin_twist

### DIFF
--- a/contrib/SetoidRewrite.v
+++ b/contrib/SetoidRewrite.v
@@ -200,7 +200,7 @@ Proposition nat_equiv_faithful {A B : Type}
 Proof.
   intros faithful_F x y f g eq_Gf_Gg.
   apply (@fmap _ _ _ _ _ (is0functor_precomp _
-       _ _ (cat_equiv_natequiv F G tau x))) in eq_Gf_Gg.
+       _ _ (cat_equiv_natequiv tau x))) in eq_Gf_Gg.
   cbn in eq_Gf_Gg.
   unfold cat_precomp in eq_Gf_Gg.
   rewrite <- is1natural_natequiv in eq_Gf_Gg.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -1021,6 +1021,18 @@ Definition inverse2 {A : Type} {x y : A} {p q : x = y} (h : p = q)
 
 (** Some higher coherences *)
 
+Lemma ap_pp_concat_p1 {A B} (f : A -> B) {a b : A} (p : a = b)
+  : ap_pp f p 1 @ concat_p1 (ap f p) = ap (ap f) (concat_p1 p).
+Proof.
+  destruct p; reflexivity.
+Defined.
+
+Lemma ap_pp_concat_1p {A B} (f : A -> B) {a b : A} (p : a = b)
+  : ap_pp f 1 p @ concat_1p (ap f p) = ap (ap f) (concat_1p p).
+Proof.
+  destruct p; reflexivity.
+Defined.
+
 Lemma ap_pp_concat_pV {A B} (f : A -> B) {x y : A} (p : x = y)
 : ap_pp f p p^ @ ((1 @@ ap_V f p) @ concat_pV (ap f p))
   = ap (ap f) (concat_pV p).

--- a/theories/Homotopy/Bouquet.v
+++ b/theories/Homotopy/Bouquet.v
@@ -37,7 +37,7 @@ Section AssumeUnivalence.
     1: refine (natequiv_prewhisker (natequiv_pointify_r S) ptype_group).
     (** Post-compose with [pequiv_loops_bg_g] *)
     nrefine (natequiv_compose _ _).
-1: rapply (natequiv_postwhisker _ (natequiv_inverse _ _ natequiv_g_loops_bg)).
+1: rapply (natequiv_postwhisker _ (natequiv_inverse natequiv_g_loops_bg)).
     (** Loop-susp adjoint *)
     nrefine (natequiv_compose _ _).
     1: refine (natequiv_prewhisker
@@ -61,7 +61,7 @@ Section AssumeUnivalence.
         (opyon S o group_type)
         (fun G => equiv_pi1bouquet_rec S G).
   Proof.
-    rapply (is1natural_natequiv _ _ (natequiv_pi1bouquet_rec _)).
+    rapply (is1natural_natequiv (natequiv_pi1bouquet_rec _)).
   Defined.
 
   (** We can define the inclusion map by using the previous equivalence on the identity group homomorphism. *)

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -589,7 +589,7 @@ Lemma is1natural_equiv_bg_pi1_adjoint_r `{Univalence}
   : Is1Natural (opyon (Pi1 X)) (opyon X o B)
       (equiv_bg_pi1_adjoint X).
 Proof.
-  rapply (is1natural_natequiv _ _ (natequiv_bg_pi1_adjoint X)).
+  rapply (is1natural_natequiv (natequiv_bg_pi1_adjoint X)).
   (** Why so slow? Fixed by making this opaque. *)
   Opaque equiv_bg_pi1_adjoint.
 Defined.

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -482,20 +482,19 @@ Defined.
 (** * Functoriality of Join. *)
 Section FunctorJoin.
 
+  (** In some cases, we'll need to refer to the recursion data that defines [functor_join], so we make it a separate definition. *)
+  Definition functor_join_recdata {A B C D} (f : A -> C) (g : B -> D)
+    : JoinRecData A B (Join C D)
+    := {| jl := joinl o f; jr := joinr o g; jg := fun a b => jglue (f a) (g b); |}.
+
   Definition functor_join {A B C D} (f : A -> C) (g : B -> D)
-    : Join A B -> Join C D.
-  Proof.
-    snrapply Join_rec.
-    1: exact (joinl o f).
-    1: exact (joinr o g).
-    intros a b.
-    apply jglue.
-  Defined.
+    : Join A B -> Join C D
+    := join_rec (functor_join_recdata f g).
 
   Definition functor_join_beta_jglue {A B C D : Type} (f : A -> C) (g : B -> D)
     (a : A) (b : B)
     : ap (functor_join f g) (jglue a b) = jglue (f a) (g b)
-    := Join_rec_beta_jglue _ _ _ a b.
+    := join_rec_beta_jg _ a b.
 
   Definition functor_join_compose {A B C D E F}
     (f : A -> C) (g : B -> D) (h : C -> E) (i : D -> F)

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -352,7 +352,7 @@ Defined.
 
 (** It will be handy to name the inverse natural equivalence. *)
 Definition join_rec_natequiv (A B : Type)
-  := natequiv_inverse _ _ (join_rec_inv_natequiv A B).
+  := natequiv_inverse (join_rec_inv_natequiv A B).
 
 (** [join_rec_natequiv A B P] is an equivalence of 0-groupoids whose underlying function is definitionally [join_rec]. *)
 Local Definition join_rec_natequiv_check (A B P : Type)

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -1,4 +1,4 @@
-Require Import Basics Types WildCat Join.Core Join.TriJoin Spaces.Nat.Core.
+Require Import Basics Types WildCat Join.Core Join.TriJoin Spaces.Nat.Core HoTT.Tactics.
 
 (** * The associativity of [Join]
 
@@ -161,4 +161,106 @@ Proof.
   1: exact (equiv_join_empty' _).
   simpl. refine (_ oE (join_assoc _ _ _)^-1%equiv).
   exact (equiv_functor_join equiv_idmap IHn).
+Defined.
+
+(** ** Naturality of [trijoin_twist] *)
+
+(** Our goal is to prove that [trijoin_twist A' B' C' o functor_join f (functor_join g h)] is homotopic to [functor_join g (functor_join f h) o trijoin_twist A B C].  We will study the LHS and RHS separately, expressed using [functor_trijoin], and meet in the middle. *)
+
+Definition trijoin_twist_nat_rhs {A B C P} (f : TriJoinRecData B A C P)  (* P is TriJoin B' A' C' above *)
+  : trijoin_rec (trijoinrecdata_twist _ _ _ _ f)
+    == trijoin_rec f o trijoin_twist A B C.
+Proof.
+  (* We first replace [trijoin_twist] with [equiv_trijoin_twist']. *)
+  transitivity (trijoin_rec f o equiv_trijoin_twist' A B C).
+  2: exact (fun x => ap (trijoin_rec f) (trijoin_twist_homotopic A B C x)^).
+  (* The RHS is now the twist natural transformation applied to [Id], followed by postcomposition; naturality states that that is the same as the natural trans applied to [trijoin_rec f]. *)
+  refine (_ $@ isnat_natequiv (trijoinrecdata_fun_twist B A C) (trijoin_rec f) _).
+  (* The RHS simplifies to [trijoinrecdata_fun_twist] applied to [trijoin_rec f].  The former is a composite of [trijoin_rec], [trijoinrecdata_twist] and [trijoin_rec_inv], so we can write the RHS as: *)
+  change (?L $== ?R) with (L $== trijoin_rec (trijoinrecdata_twist B A C P (trijoin_rec_inv (trijoin_rec f)))).
+  refine (fmap trijoin_rec _).
+  refine (fmap (trijoinrecdata_twist B A C P) _).
+  symmetry; apply trijoin_rec_beta.
+Defined.
+
+(** We can precompose [k : TriJoinRecData] with a triple of maps. *)
+Definition trijoinrecdata_tricomp {A B C A' B' C' P} (k : TriJoinRecData A B C P)
+  (f : A' -> A) (g : B' -> B) (h : C' -> C)
+  : TriJoinRecData A' B' C' P
+  := {| j1 := j1 k o f; j2 := j2 k o g; j3 := j3 k o h;
+       j12 := fun a b => j12 k (f a) (g b);
+       j13 := fun a c => j13 k (f a) (h c);
+       j23 := fun b c => j23 k (g b) (h c);
+       j123 := fun a b c => j123 k (f a) (g b) (h c); |}.
+
+(** Precomposition with a triple respects paths. *)
+Definition trijoinrecdata_tricomp_0fun {A B C A' B' C' P}
+  {k l : TriJoinRecData A B C P} (p : k $== l)
+  (f : A' -> A) (g : B' -> B) (h : C' -> C)
+  : trijoinrecdata_tricomp k f g h $== trijoinrecdata_tricomp l f g h.
+Proof.
+  (* This line is not needed, but clarifies the proof. *)
+  unfold trijoinrecdata_tricomp; destruct p.
+  snrapply Build_TriJoinRecPath; intros; cbn; apply_hyp.
+  (* E.g., the first goal is [j1 k (f a) = j1 l (f a)], and this is solved by [h1 p (f a)]. We just precompose all fields of [p] with [f], [g] and [h]. *)
+Defined.
+
+(** We generalize the LHS to the LHS of the following result, which is a partial functoriality of [trijoin_rec] in [A], [B] and [C]. *)
+Definition trijoin_twist_nat_lhs {A B C A' B' C' P} (f : A -> A') (g : B -> B') (h : C -> C')
+  (k : TriJoinRecData A' B' C' P)
+  : trijoin_rec k o functor_trijoin f g h
+    == trijoin_rec (trijoinrecdata_tricomp k f g h).
+Proof.
+  (* On the LHS, we use naturality of the [trijoin_rec] inside [functor_trijoin]: *)
+  refine ((trijoin_rec_nat _ _ _ _ _)^$ $@ _).
+  refine (fmap trijoin_rec _).
+  (* Just to clarify to the reader what is going on: *)
+  change (?L $-> ?R) with (trijoinrecdata_tricomp (trijoin_rec_inv (trijoin_rec k)) f g h $-> R).
+  exact (trijoinrecdata_tricomp_0fun (trijoin_rec_beta k) f g h).
+Defined.
+
+(** Naturality of [trijoin_twist].  This version uses [functor_trijoin] and simply combines the above. *)
+Definition trijoin_twist_nat' {A B C A' B' C'} (f : A -> A') (g : B -> B') (h : C -> C')
+  : trijoin_twist A' B' C' o functor_trijoin f g h
+    == functor_trijoin g f h o trijoin_twist A B C.
+Proof.
+  intro x.
+  rhs_V nrapply trijoin_twist_nat_rhs.
+  nrapply trijoin_twist_nat_lhs.
+Defined.
+
+(** And now a version using [functor_join]. *)
+Definition trijoin_twist_nat {A B C A' B' C'} (f : A -> A') (g : B -> B') (h : C -> C')
+  : trijoin_twist A' B' C' o functor_join f (functor_join g h)
+    == functor_join g (functor_join f h) o trijoin_twist A B C.
+Proof.
+  intro x.
+  lhs nrefine (ap _ (functor_trijoin_as_functor_join f g h x)).
+  rhs nrapply functor_trijoin_as_functor_join.
+  apply trijoin_twist_nat'.
+Defined.
+
+(** ** Naturality of [join_assoc] *)
+
+Definition join_assoc_nat {A B C A' B' C'} (f : A -> A') (g : B -> B') (h : C -> C')
+  : join_assoc A' B' C' o functor_join f (functor_join g h)
+    == functor_join (functor_join f g) h o join_assoc A B C.
+Proof.
+  (* Since [join_assoc] is a composite of [trijoin_twist] and [join_sym], we just use their naturality. We'll work from right to left, as it is easier to work near the head of a term. *)
+  intro x.
+  unfold join_assoc; simpl.
+  (* First we pass the [functor_joins]s through the outer [join_sym]. *)
+  rhs_V nrapply join_sym_nat.
+  (* Strip off the outer [join_sym]. *)
+  apply (ap _).
+  (* Next we pass the [functor_join]s through [trijoin_twist]. *)
+  rhs_V nrapply trijoin_twist_nat.
+  (* Strip off the [trijoin_twist]. *)
+  apply (ap _).
+  (* Finally, we pass the [functor_join]s through the inner [join_sym]. *)
+  lhs_V nrapply functor_join_compose.
+  rhs_V nrapply functor_join_compose.
+  apply functor2_join.
+  - reflexivity.
+  - apply join_sym_nat.
 Defined.

--- a/theories/Homotopy/Join/TriJoin.v
+++ b/theories/Homotopy/Join/TriJoin.v
@@ -651,7 +651,7 @@ Defined.
 
 (** It will be handy to name the inverse natural equivalence. *)
 Definition trijoin_rec_natequiv (A B C : Type)
-  := natequiv_inverse _ _ (trijoin_rec_inv_natequiv A B C).
+  := natequiv_inverse (trijoin_rec_inv_natequiv A B C).
 
 (** [trijoin_rec_natequiv A B C P] is an equivalence of 0-groupoids whose underlying function is definitionally [trijoin_rec]. *)
 Local Definition trijoin_rec_natequiv_check (A B C P : Type)

--- a/theories/WildCat/Adjoint.v
+++ b/theories/WildCat/Adjoint.v
@@ -146,9 +146,9 @@ Section AdjunctionData.
     intros y y' f.
     apply GpdHom_path.
     refine (_^ @ _ @ _).
-    1: exact (is1natural_natequiv _ _ (natequiv_inverse _ _
+    1: exact (is1natural_natequiv (natequiv_inverse
         (natequiv_adjunction_l _)) (G y') _ (fmap G f) _).
-    2: exact (is1natural_natequiv _ _ (natequiv_inverse _ _
+    2: exact (is1natural_natequiv (natequiv_inverse
         (natequiv_adjunction_r _)) _ _ _ (Id _)).
     simpl.
     apply equiv_ap_inv'.
@@ -166,8 +166,8 @@ Section AdjunctionData.
   Lemma triangle_helper2 x y g
     : (equiv_adjunction adj x y)^-1 g = adjunction_unit y $o fmap F g.
   Proof.
-    epose (n1 := is1natural_natequiv _ _
-      (natequiv_inverse _ _ (natequiv_adjunction_l _)) _ _ _ _).
+    epose (n1 := is1natural_natequiv
+      (natequiv_inverse (natequiv_adjunction_l _)) _ _ _ _).
     clearbody n1; cbv in n1.
     refine (_ @ n1).
     by rewrite cat_idl_strong.
@@ -221,7 +221,7 @@ Proof.
   snrapply Build_Adjunction.
   1: exact (fun x => e x).
   1: exact is1nat_e.
-  intros x; apply (is1natural_natequiv _ _ (e x)).
+  intros x; apply (is1natural_natequiv (e x)).
 Defined.
 
 (** A natural equivalence between functors [C^op -> Type] which is also natural in the left. *)
@@ -235,7 +235,7 @@ Definition Build_Adjunction_natequiv_nat_right
 Proof.
   snrapply Build_Adjunction.
   1: exact (fun x y => e y x).
-  1: intros y; apply (is1natural_natequiv _ _ (e y)).
+  1: intros y; apply (is1natural_natequiv (e y)).
   exact is1nat_e.
 Defined.
 
@@ -288,7 +288,7 @@ Section UnitCounitAdjunction.
       (is0functor_G := is0functor_yon (G y))
       (fun x : C^op => γ x y).
   Proof.
-    nrapply (is1natural_natequiv (yon y o F) (yon (G y)) (natequiv_inverse _ _
+    nrapply (is1natural_natequiv (natequiv_inverse
       (Build_NatEquiv (yon (G y)) (yon y o F) (fun x => (γ x y)^-1$) _))).
     nrapply is1natural_yoneda.
     nrapply is1functor_compose.
@@ -336,9 +336,9 @@ Proof.
       exact (nattrans_prewhisker (adjunction_unit adj) K).
     + intros K K' θ j.
       apply GpdHom_path.
-      refine (_ @ is1natural_natequiv _ _ (natequiv_inverse _ _
+      refine (_ @ is1natural_natequiv (natequiv_inverse
         (natequiv_adjunction_r adj _)) _ _ _ _).
-      refine ((is1natural_natequiv _ _ (natequiv_inverse _ _
+      refine ((is1natural_natequiv (natequiv_inverse
         (natequiv_adjunction_l adj _)) _ _ _ _)^ @ _).
       cbn; rapply ap.
       refine(cat_idl_strong _ @ _^).
@@ -348,9 +348,9 @@ Proof.
       exact (nattrans_prewhisker (adjunction_counit adj) K).
     + intros K K' θ j.
       apply GpdHom_path.
-      refine (_ @ is1natural_natequiv _ _
+      refine (_ @ is1natural_natequiv
         (natequiv_adjunction_r adj _) _ _ _ _).
-      refine ((is1natural_natequiv _ _
+      refine ((is1natural_natequiv
         (natequiv_adjunction_l adj _) _ _ _ _)^ @ _).
       cbn; rapply ap.
       refine(cat_idl_strong _ @ _^).

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -26,12 +26,19 @@ Arguments Is1Natural {A B} {isgraph_A}
   F {is0functor_F} G {is0functor_G} alpha : rename.
 Arguments isnat {_ _ _ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
 
-Record NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
+Record NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} {F G : A -> B}
   {ff : Is0Functor F} {fg : Is0Functor G} :=
 {
   trans_nattrans : F $=> G ;
   is1natural_nattrans : Is1Natural F G trans_nattrans ;
 }.
+
+Arguments NatTrans {A B} {isgraph_A}
+  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
+  F G {is0functor_F} {is0functor_G} : rename.
+Arguments Build_NatTrans {A B} {isgraph_A}
+  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
+  F G {is0functor_F} {is0functor_G} alpha isnat_alpha: rename.
 
 Global Existing Instance is1natural_nattrans.
 Coercion trans_nattrans : NatTrans >-> Transformation.
@@ -159,7 +166,7 @@ Defined.
 (** Natural equivalences *)
 
 Record NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
-  (F G : A -> B) `{!Is0Functor F, !Is0Functor G} :=
+  {F G : A -> B} `{!Is0Functor F, !Is0Functor G} :=
 {
   cat_equiv_natequiv : forall a, F a $<~> G a ;
   is1natural_natequiv : Is1Natural F G (fun a => cat_equiv_natequiv a) ;
@@ -180,17 +187,23 @@ Global Existing Instance is1natural_natequiv.
 Coercion cat_equiv_natequiv : NatEquiv >-> Funclass.
 
 Lemma nattrans_natequiv {A B : Type} `{IsGraph A} `{HasEquivs B}
-  (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
+  {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   : NatEquiv F G -> NatTrans F G.
 Proof.
   intros alpha.
   nrapply Build_NatTrans.
-  rapply (is1natural_natequiv _ _ alpha).
+  rapply (is1natural_natequiv alpha).
 Defined.
 
 (** Throws a warning, but can probably be ignored. *)
 Global Set Warnings "-ambiguous-paths".
 Coercion nattrans_natequiv : NatEquiv >-> NatTrans.
+
+(** The above coercion doesn't trigger when it should, so we add the following. *)
+Definition isnat_natequiv {A B : Type} `{IsGraph A} `{HasEquivs B}
+  {F G : A -> B} `{!Is0Functor F, !Is0Functor G} (alpha : NatEquiv F G)
+  {a a' : A} (f : a $-> a')
+  := isnat (nattrans_natequiv alpha) f.
 
 Definition Build_NatEquiv' {A B : Type} `{IsGraph A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
@@ -228,7 +241,7 @@ Proof.
 Defined.
 
 Definition natequiv_inverse {A B : Type} `{IsGraph A} `{HasEquivs B}
-  (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
+  {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   : NatEquiv F G -> NatEquiv G F.
 Proof.
   intros [alpha I].

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -170,16 +170,13 @@ Definition opyon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
   : (opyon1 a $<~> opyon1 b) -> (b $<~> a).
 Proof.
   intros f.
-  refine (cate_adjointify (f a (Id a)) (f^-1$ b (Id b)) _ _) ;
-    apply GpdHom_path;
-      pose proof (is1natural_natequiv _ _ f);
-      pose proof (is1natural_natequiv _ _ f^-1$);
-      cbn in *.
-  - refine ((isnat (fun a => (f a)^-1$) (f a (Id a)) (Id b))^ @ _); cbn.
+  refine (cate_adjointify (f a (Id a)) (f^-1$ b (Id b)) _ _);
+    apply GpdHom_path; cbn in *.
+  - refine ((isnat_natequiv (natequiv_inverse f) (f a (Id a)) (Id b))^ @ _); cbn.
     refine (_ @ cate_issect (f a) (Id a)); cbn.
     apply ap.
     srapply cat_idr_strong.
-  - refine ((isnat (cat_equiv_natequiv _ _ f) (f^-1$ b (Id b)) (Id a))^ @ _); cbn.
+  - refine ((isnat_natequiv f (f^-1$ b (Id b)) (Id a))^ @ _); cbn.
     refine (_ @ cate_isretr (f b) (Id b)); cbn.
     apply ap.
     srapply cat_idr_strong.

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -101,6 +101,10 @@ Definition moveR_equiv_V_0gpd {G H : ZeroGpd} (f : G $<~> H) (x : H) (y : G) (p 
   : equiv_fun_0gpd f^-1$ x $== y
   := fmap (equiv_fun_0gpd f^-1$) p $@ cat_eissect f y.
 
+Definition moveL_equiv_V_0gpd {G H : ZeroGpd} (f : G $<~> H) (x : H) (y : G) (p : equiv_fun_0gpd f y $== x)
+  : y $== equiv_fun_0gpd f^-1$ x
+  := (cat_eissect f y)^$ $@ fmap (equiv_fun_0gpd f^-1$) p.
+
 (** ** [f] is an equivalence of 0-groupoids iff [IsSurjInj f]
 
   We now give a different characterization of the equivalences of 0-groupoids, as the injective split essentially surjective 0-functors, which are defined in EquivGpd.  Advantages of this logically equivalent formulation are that it tends to be easier to prove in examples and that in some cases it is definitionally equal to [ExtensionAlong], which is convenient.  See Homotopy/Suspension.v and Algebra/AbGroups/Abelianization for examples. Advantages of the bi-invertible definition are that it reproduces a definition that is equivalent to [IsEquiv] when applied to types, assuming [Funext].  It also works in any 1-category. *)


### PR DESCRIPTION
This proves that `trijoin_twist` is natural.  Combined with the naturality of `join_sym`, this gives the naturality of `join_assoc`.  Direct proofs seemed hard, but by phrasing things using a new `functor_trijoin` defined using `trijoin_rec` it was possible to make this fairly clean, using naturality of `trijoin_rec` and `trijoinrecdata_fun_twist`.  Along the way, I removed rarely used arguments to `is1natural_natequiv` and `is1natural_nattrans`, and added `isnat_natequiv`, which is needed because another ambiguous coercion doesn't work.
