### PR TITLE
Join: prove unitors, triangle law, and hexagon law

### DIFF
--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -558,6 +558,18 @@ Section FunctorJoin.
   Definition equiv_functor_join {A B C D} (f : A <~> C) (g : B <~> D)
     : Join A B <~> Join C D := Build_Equiv _ _ (functor_join f g) _.
 
+  Global Instance isbifunctor_join : IsBifunctor Join.
+  Proof.
+    snrapply Build_IsBifunctor.
+    - intro A; snrapply Build_Is0Functor; intros B D g.
+      exact (functor_join idmap g).
+    - intro B; snrapply Build_Is0Functor; intros A C f.
+      exact (functor_join f idmap).
+    - intros A C f B D g x.
+      lhs_V nrapply functor_join_compose.
+      nrapply functor_join_compose.
+  Defined.
+
 End FunctorJoin.
 
 (** * Symmetry of Join
@@ -666,6 +678,9 @@ Section JoinSym.
     := equiv_homotopic_inverse (equiv_join_sym' A B)
                               (join_sym_homotopic A B)
                               (join_sym_homotopic B A).
+
+  Global Instance isequiv_join_sym A B : IsEquiv (join_sym A B)
+    := equiv_isequiv (equiv_join_sym A B).
 
   (** It's also straightforward to directly prove that [join_sym] is an equivalence.  The above approach is meant to illustrate the Yoneda lemma.  In the case of [equiv_trijoin_twist], the Yoneda approach seems to be more straightforward. *)
   Definition join_sym_inv A B : join_sym A B o join_sym B A == idmap.
@@ -795,19 +810,45 @@ End JoinTrunc.
 (** Join with Empty *)
 Section JoinEmpty.
 
-  Definition equiv_join_empty A : Join A Empty <~> A.
+  Definition equiv_join_empty_right A : Join A Empty <~> A.
   Proof.
     snrapply equiv_adjointify.
-    - srapply (Join_rec idmap); contradiction.
+    - apply join_rec; snrapply (Build_JoinRecData idmap); contradiction.
     - exact joinl.
     - reflexivity.
     - snrapply Join_ind; [reflexivity| |]; contradiction.
   Defined.
 
-  Definition equiv_join_empty' A : Join Empty A <~> A
-    := equiv_join_empty _ oE equiv_join_sym _ _.
+  Definition equiv_join_empty_left A : Join Empty A <~> A
+    := equiv_join_empty_right _ oE equiv_join_sym _ _.
+
+  Global Instance join_right_unitor : RightUnitor Type Join Empty.
+  Proof.
+    snrapply Build_NatEquiv.
+    - apply equiv_join_empty_right.
+    - intros A B f.
+      cbn -[equiv_join_empty_right].
+      snrapply Join_ind_FlFr.
+      + intro a.
+        reflexivity.
+      + intros [].
+      + intros a [].
+  Defined.
+
+  Global Instance join_left_unitor : LeftUnitor Type Join Empty.
+  Proof.
+    snrapply Build_NatEquiv.
+    - apply equiv_join_empty_left.
+    - intros A B f x.
+      cbn -[equiv_join_empty_right].
+      rhs_V rapply (isnat_natequiv join_right_unitor).
+      cbn -[equiv_join_empty_right].
+      apply ap, join_sym_nat.
+  Defined.
 
 End JoinEmpty.
+
+Arguments equiv_join_empty_right : simpl never.
 
 (** Iterated Join powers of a type. *)
 Section JoinPower.
@@ -823,7 +864,7 @@ Section JoinPower.
   Definition equiv_join_powers (A : Type) (n : nat) : join_power A n.+1 <~> iterated_join A n.
   Proof.
     induction n as [|n IHn]; simpl.
-    - exact (equiv_join_empty A).
+    - exact (equiv_join_empty_right A).
     - exact (equiv_functor_join equiv_idmap IHn).
   Defined.
 

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -158,7 +158,7 @@ Corollary join_join_power A n m
   : Join (join_power A n) (join_power A m) <~> join_power A (n + m)%nat.
 Proof.
   induction n as [|n IHn].
-  1: exact (equiv_join_empty' _).
+  1: exact (equiv_join_empty_left _).
   simpl. refine (_ oE (join_assoc _ _ _)^-1%equiv).
   exact (equiv_functor_join equiv_idmap IHn).
 Defined.

--- a/theories/Homotopy/Join/TriJoin.v
+++ b/theories/Homotopy/Join/TriJoin.v
@@ -67,6 +67,25 @@ Proof.
   nrapply ap_trijoin_general_transport.
 Defined.
 
+Definition ap_trijoin_general_V {J W P : Type} (f : J -> P)
+  (a : J) (jr : W -> J) (jg : forall w, a = jr w)
+  {b c : W} (p : b = c)
+  : ap_trijoin_general f a jr jg p^
+     = (1 @@ (ap (ap f) (ap_V jr p) @ ap_V f _)) @ moveR_pV _ _ _ (ap_trijoin_general f a jr jg p)^.
+Proof.
+  induction p.
+  unfold ap_trijoin_general; cbn.
+  by induction (jg b).
+Defined.
+
+Definition ap_trijoin_V {A B C P : Type} (f : TriJoin A B C -> P)
+  (a : A) (b : B) (c : C)
+  : ap_triangle f (triangle_v' a (jglue b c)^)
+     = (1 @@ (ap (ap f) (ap_V joinr _) @ ap_V f _)) @ moveR_pV _ _ _ (ap_trijoin f a b c)^.
+Proof.
+  nrapply ap_trijoin_general_V.
+Defined.
+
 (** ** The induction principle for the triple join *)
 
 (** A lemma that handles the path algebra in the final step. *)
@@ -198,11 +217,11 @@ Proof.
   (* Change [ap (transport __) _] on LHS. *)
   rewrite (concat_p_pp _ (transport_paths_Fr (jglue b c) (j12 f a b)) _).
   rewrite (concat_Ap (transport_paths_Fr (jglue b c))).
-  (* [trijoin_rec_beta_join23] expands to something of the form [p^ @ r], so that's what is in the lemma.  One can unfold it to see this, but the [Qed] is a bit faster without this.
-  unfold trijoin_rec_beta_join23. *)
+  (* Everything that remains is pure path algebra. *)
+  (* [trijoin_rec_beta_join23] expands to something of the form [p^ @ r], so that's what is in the lemma.  One can unfold it to see this, but the [Qed] is a bit faster without this: *)
+  (* unfold trijoin_rec_beta_join23. *)
   (* Note that one of the [ap]s on the LHS computes to [u @@ 1], so that's what is in the lemma: *)
   (* change (ap (fun q => q @ ?x) ?u) with (u @@ @idpath _ x). *)
-  (* Everything that remains is pure path algebra. *)
   nrapply trijoin_rec_beta_join123_helper.
 Qed.
 
@@ -673,6 +692,19 @@ Proof.
   exact (isnat (trijoin_rec_natequiv A B C) g f).
 Defined.
 
+(** It is also useful to record this. *)
+Definition issect_trijoin_rec_inv {A B C P : Type} (f : TriJoin A B C -> P)
+  : trijoin_rec (trijoin_rec_inv f) $== f
+  := cate_issect (trijoin_rec_inv_natequiv A B C P) f.
+
+(** This comes up a lot as well, and if you inline the proof, you get an ugly goal. *)
+Definition moveR_trijoin_rec {A B C P : Type} {f : TriJoinRecData A B C P} {g : TriJoin A B C -> P}
+  (p : f $== trijoin_rec_inv g)
+  : trijoin_rec f == g.
+Proof.
+  exact (moveR_equiv_V_0gpd (trijoin_rec_inv_natequiv A B C P) _ _ p).
+Defined.
+
 (** * Functoriality of the triple join *)
 
 (** ** Precomposition of [TriJoinRecData] *)
@@ -749,7 +781,7 @@ Defined.
 Definition functor_trijoin_idmap {A B C}
   : functor_trijoin idmap idmap idmap == (idmap : TriJoin A B C -> TriJoin A B C).
 Proof.
-  refine (moveR_equiv_V_0gpd (trijoin_rec_inv_natequiv A B C _) _ _ _).
+  apply moveR_trijoin_rec.
   change (trijoinrecdata_trijoin A B C $== trijoinrecdata_fun idmap (trijoinrecdata_trijoin A B C)).
   symmetry.
   exact (fmap_id (trijoinrecdata_0gpd A B C) _ (trijoinrecdata_trijoin A B C)).

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -11,6 +11,7 @@ Require Export WildCat.Yoneda.
 Require Export WildCat.Square.
 Require Export WildCat.PointedCat.
 Require Export WildCat.Bifunctor.
+Require Export WildCat.Monoidal.
 
 (* See also contrib/SetoidRewrite.v for tools that can be used for rewriting in wild categories. *)
 

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -129,6 +129,25 @@ Proof.
   exact (fmap_comp F g f x).
 Defined.
 
+(** This is form of injectivity of [opyoneda]. *)
+Definition opyoneda_isinj {A : Type} `{Is1Cat A} (a : A)
+  (F : A -> Type) `{!Is0Functor F, !Is1Functor F}
+  (x x' : F a) (p : forall b, opyoneda a F x b == opyoneda a F x' b)
+  : x = x'.
+Proof.
+  refine ((fmap_id F a x)^ @ _ @ fmap_id F a x').
+  cbn in p.
+  exact (p a (Id a)).
+Defined.
+
+(** This says that [opyon] is faithful, although we haven't yet defined a graph structure on natural transformations to express this in that way.  This follows from the previous result, but then would need [HasMorExt A], since the previous result assumes that [F] is a 1-functor, which is stronger than what is needed.  The direct proof below only needs the weaker assumption [Is1Cat_Strong A]. *)
+Definition opyon_faithful {A : Type} `{Is1Cat_Strong A}
+  (a b : A) (f g : b $-> a)
+  (p : forall (c : A) (h : a $-> c), h $o f = h $o g)
+  : f = g
+  := (cat_idl_strong f)^ @ p a (Id a) @ cat_idl_strong g.
+
+(** The composite in one direction is the identity map. *)
 Definition opyoneda_issect {A : Type} `{Is1Cat A} (a : A)
            (F : A -> Type) `{!Is0Functor F, !Is1Functor F}
            (x : F a)
@@ -149,7 +168,7 @@ Proof.
   exact (cat_idr_strong f).
 Defined.
 
-(** Specialization to "full-faithfulness" of the Yoneda embedding.  (In quotes because, again, incoherence means we can't recover the witness of naturality.)  *)
+(** A natural transformation between representable functors induces a map between the representing objects. *)
 Definition opyon_cancel {A : Type} `{Is01Cat A} (a b : A)
   : (opyon a $=> opyon b) -> (b $-> a)
   := un_opyoneda a (opyon b).
@@ -164,7 +183,7 @@ Proof.
   rapply (Build_Fun11 _ _ (opyon a)).
 Defined.
 
-(** We can also deduce "full-faithfulness" on equivalences. *)
+(** An equivalence between representable functors induces an equivalence between the representing objects. *)
 Definition opyon_equiv {A : Type} `{HasEquivs A} `{!Is1Cat_Strong A}
            {a b : A}
   : (opyon1 a $<~> opyon1 b) -> (b $<~> a).
@@ -192,6 +211,8 @@ Proof.
     exact (equiv_precompose_cat_equiv e).
   - rapply is1natural_opyoneda.
 Defined.
+
+(** ** The covariant Yoneda lemma using 0-groupoids *)
 
 (** We repeat the above, regarding [opyon] as landing in 0-groupoids, using the 1-category structure on [ZeroGpd] in [ZeroGroupoid.v].  This has many advantages.  It avoids [HasMorExt], which means that we don't need [Funext] in many examples.  It also avoids [Is1Cat_Strong], which means the results all have the same hypotheses, namely that [A] is a 1-category.  This allows us to simplify the proof of [opyon_equiv_0gpd], making use of [opyoneda_isretr_0gpd]. *)
 
@@ -242,17 +263,35 @@ Proof.
   exact (fmap_comp F g f x).
 Defined.
 
+(** This is form of injectivity of [opyoneda_0gpd]. *)
+Definition opyoneda_isinj_0gpd {A : Type} `{Is1Cat A} (a : A)
+  (F : A -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  (x x' : F a) (p : forall b : A, opyoneda_0gpd a F x b $== opyoneda_0gpd a F x' b)
+  : x $== x'.
+Proof.
+  refine ((fmap_id F a x)^$ $@ _ $@ fmap_id F a x').
+  cbn in p.
+  exact (p a (Id a)).
+Defined.
+
+(** This says that [opyon_0gpd] is faithful, although we haven't yet defined a graph structure on natural transformations to express this in that way. *)
+Definition opyon_faithful_0gpd {A : Type} `{Is1Cat A} (a b : A)
+  (f g : b $-> a) (p : forall (c : A) (h : a $-> c), h $o f $== h $o g)
+  : f $== g
+  := opyoneda_isinj_0gpd a _ f g p.
+
+(** The composite in one direction is the identity map. *)
 Definition opyoneda_issect_0gpd {A : Type} `{Is1Cat A} (a : A)
-           (F : A -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
-           (x : F a)
+  (F : A -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  (x : F a)
   : un_opyoneda_0gpd a F (opyoneda_0gpd a F x) $== x
   := fmap_id F a x.
 
-(** Note that we do not in general recover the witness of 1-naturality.  Indeed, if [A] is fully coherent, then a transformation of the form [opyoneda a F x] is always also fully coherently natural, so an incoherent witness of 1-naturality could not be recovered in this way.  *)
+(** For the other composite, note that we do not in general recover the witness of 1-naturality.  Indeed, if [A] is fully coherent, then a transformation of the form [opyoneda a F x] is always also fully coherently natural, so an incoherent witness of 1-naturality could not be recovered in this way.  *)
 Definition opyoneda_isretr_0gpd {A : Type} `{Is1Cat A} (a : A)
-           (F : A -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
-           (alpha : opyon_0gpd a $=> F) {alnat : Is1Natural (opyon_0gpd a) F alpha}
-           (b : A)
+  (F : A -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  (alpha : opyon_0gpd a $=> F) {alnat : Is1Natural (opyon_0gpd a) F alpha}
+  (b : A)
   : opyoneda_0gpd a F (un_opyoneda_0gpd a F alpha) b $== alpha b.
 Proof.
   unfold opyoneda, un_opyoneda, opyon; intros f.
@@ -262,8 +301,8 @@ Proof.
   exact (cat_idr f).
 Defined.
 
-(** Specialization to "full-faithfulness" of the Yoneda embedding.  (In quotes because, again, incoherence means we can't recover the witness of naturality.)  *)
-Definition opyon_0gpd_cancel {A : Type} `{Is1Cat A} (a b : A)
+(** A natural transformation between representable functors induces a map between the representing objects. *)
+Definition opyon_cancel_0gpd {A : Type} `{Is1Cat A} (a b : A)
   : (opyon_0gpd a $=> opyon_0gpd b) -> (b $-> a)
   := un_opyoneda_0gpd a (opyon_0gpd b).
 
@@ -271,8 +310,8 @@ Definition opyon_0gpd_cancel {A : Type} `{Is1Cat A} (a b : A)
 Definition opyon1_0gpd {A : Type} `{Is1Cat A} (a : A) : Fun11 A ZeroGpd
   := Build_Fun11 _ _ (opyon_0gpd a).
 
-(** We can also deduce "full-faithfulness" on equivalences.  We explain how this compares to [opyon_equiv] above.  Instead of assuming that each [f c : (a $-> c) -> (b $-> c)] is an equivalence of types, it only needs to be an equivalence of 0-groupoids.  For example, this means that we have a map [g c : (b $-> c) -> (a $-> c)] such that for each [k : a $-> c], [g c (f c k) $== k], rather than [g c (f c k) = k] as the version with types requires.  Similarly, the naturality is up to 2-cells, instead of up to paths.  This allows us to avoid [Funext] and [HasMorExt] when using this result.  As a side benefit, we also don't require that [A] is strong. The proof is also simpler, since we can re-use the work done in [opyoneda_isretr_0gpd]. *)
-Definition opyon_equiv_0gpd {A : Type} `{HasEquivs A} `{!Is1Cat A}
+(** An equivalence between representable functors induces an equivalence between the representing objects.  We explain how this compares to [opyon_equiv] above.  Instead of assuming that each [f c : (a $-> c) -> (b $-> c)] is an equivalence of types, it only needs to be an equivalence of 0-groupoids.  For example, this means that we have a map [g c : (b $-> c) -> (a $-> c)] such that for each [k : a $-> c], [g c (f c k) $== k], rather than [g c (f c k) = k] as the version with types requires.  Similarly, the naturality is up to 2-cells, instead of up to paths.  This allows us to avoid [Funext] and [HasMorExt] when using this result.  As a side benefit, we also don't require that [A] is strong. The proof is also simpler, since we can re-use the work done in [opyoneda_isretr_0gpd]. *)
+Definition opyon_equiv_0gpd {A : Type} `{HasEquivs A}
   {a b : A} (f : opyon1_0gpd a $<~> opyon1_0gpd b)
   : b $<~> a.
 Proof.
@@ -337,6 +376,18 @@ Global Instance is1natural_yoneda {A : Type} `{Is1Cat A} (a : A)
   : Is1Natural (yon a) F (yoneda a F x)
   := is1natural_opyoneda (A:=A^op) a F x.
 
+Definition yoneda_isinj {A : Type} `{Is1Cat A} (a : A)
+  (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F}
+  (x x' : F a) (p : forall b, yoneda a F x b == yoneda a F x' b)
+  : x = x'
+  := opyoneda_isinj (A:=A^op) a F x x' p.
+
+Definition yon_faithful {A : Type} `{Is1Cat_Strong A}
+  (a b : A) (f g : b $-> a)
+  (p : forall (c : A) (h : c $-> b), f $o h = g $o h)
+  : f = g
+  := opyon_faithful (A:=A^op) b a f g p.
+
 Definition yoneda_issect {A : Type} `{Is1Cat A} (a : A)
            (F : A^op -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : un_yoneda a F (yoneda a F x) = x
@@ -371,15 +422,71 @@ Definition natequiv_yon_equiv {A : Type} `{HasEquivs A}
   : (a $<~> b) -> (yon1 a $<~> yon1 b)
   := natequiv_opyon_equiv (A:=A^op).
 
-Definition yon1_0gpd {A : Type} `{Is1Cat A} (a : A) : Fun01 A^op ZeroGpd
+(** ** The contravariant Yoneda lemma using 0-groupoids *)
+
+Definition yon_0gpd {A : Type} `{Is1Cat A} (a : A) : A^op -> ZeroGpd
+  := opyon_0gpd (A:=A^op) a.
+
+Global Instance is0functor_yon_0gpd {A : Type} `{Is1Cat A} (a : A)
+  : Is0Functor (yon_0gpd a)
+  := is0functor_opyon_0gpd (A:=A^op) a.
+
+Global Instance is1functor_yon_0gpd {A : Type} `{Is1Cat A} (a : A)
+  : Is1Functor (yon_0gpd a)
+  := is1functor_opyon_0gpd (A:=A^op) a.
+
+Definition yoneda_0gpd {A : Type} `{Is1Cat A} (a : A)
+  (F : A^op -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  : F a -> (yon_0gpd a $=> F)
+  := opyoneda_0gpd (A:=A^op) a F.
+
+Definition un_yoneda_0gpd {A : Type} `{Is1Cat A}
+  (a : A) (F : A^op -> ZeroGpd) {ff : Is0Functor F}
+  : (yon_0gpd a $=> F) -> F a
+  := un_opyoneda_0gpd (A:=A^op) a F.
+
+Global Instance is1natural_yoneda_0gpd {A : Type} `{Is1Cat A}
+  (a : A) (F : A^op -> ZeroGpd) `{!Is0Functor F, !Is1Functor F} (x : F a)
+  : Is1Natural (yon_0gpd a) F (yoneda_0gpd a F x)
+  := is1natural_opyoneda_0gpd (A:=A^op) a F x.
+
+Definition yoneda_isinj_0gpd {A : Type} `{Is1Cat A} (a : A)
+  (F : A^op -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  (x x' : F a) (p : forall b : A, yoneda_0gpd a F x b $== yoneda_0gpd a F x' b)
+  : x $== x'
+  := opyoneda_isinj_0gpd (A:=A^op) a F x x' p.
+
+Definition yon_faithful_0gpd {A : Type} `{Is1Cat A} (a b : A)
+  (f g : b $-> a) (p : forall (c : A) (h : c $-> b), f $o h $== g $o h)
+  : f $== g
+  := opyon_faithful_0gpd (A:=A^op) b a f g p.
+
+Definition yoneda_issect_0gpd {A : Type} `{Is1Cat A} (a : A)
+  (F : A^op -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  (x : F a)
+  : un_yoneda_0gpd a F (yoneda_0gpd a F x) $== x
+  := opyoneda_issect_0gpd (A:=A^op) a F x.
+
+Definition yoneda_isretr_0gpd {A : Type} `{Is1Cat A} (a : A)
+  (F : A^op -> ZeroGpd) `{!Is0Functor F, !Is1Functor F}
+  (alpha : yon_0gpd a $=> F) {alnat : Is1Natural (yon_0gpd a) F alpha}
+  (b : A)
+  : yoneda_0gpd a F (un_yoneda_0gpd a F alpha) b $== alpha b
+  := opyoneda_isretr_0gpd (A:=A^op) a F alpha b.
+
+Definition yon_cancel_0gpd {A : Type} `{Is1Cat A} (a b : A)
+  : (yon_0gpd a $=> yon_0gpd b) -> (a $-> b)
+  := opyon_cancel_0gpd (A:=A^op) a b.
+
+Definition yon1_0gpd {A : Type} `{Is1Cat A} (a : A) : Fun11 A^op ZeroGpd
   := opyon1_0gpd (A:=A^op) a.
 
 Definition yon_equiv_0gpd {A : Type} `{HasEquivs A}
-  {a b : A}
-  : yon1_0gpd a $<~> yon1_0gpd b -> a $<~> b
-  := opyon_equiv_0gpd (A:=A^op).
+  {a b : A} (f : yon1_0gpd a $<~> yon1_0gpd b)
+  : a $<~> b
+  := opyon_equiv_0gpd (A:=A^op) f.
 
 Definition natequiv_yon_equiv_0gpd {A : Type} `{HasEquivs A}
-  {a b : A}
-  : a $<~> b -> yon1_0gpd a $<~> yon1_0gpd b
-  := natequiv_opyon_equiv_0gpd (A:=A^op).
+  {a b : A} (e : a $<~> b)
+  : yon1_0gpd (A:=A) a $<~> yon1_0gpd b
+  := natequiv_opyon_equiv_0gpd (A:=A^op) (e : CatEquiv (A:=A^op) b a).


### PR DESCRIPTION
The first commit adds faithfulness of the Yoneda embedding, which is used in the next parts.  It also adds duals for the 0gpd results, which I hadn't added before.

The next two commits make progress towards showing that the join gives a symmetric monoidal structure.  I think all that is missing is the pentagon.
