### PR TITLE
Equivalences clean up

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -256,6 +256,42 @@ Definition equiv_pr1 {A : Type} (P : A -> Type) `{forall x, Contr (P x)}
   : { x : A & P x } <~> A
   := Build_Equiv _ _ (@pr1 A P) _.
 
+(** Equivalences between path spaces *)
+
+(** If [f] is an equivalence, then so is [ap f].  We are lazy and use [adjointify]. *)
+Global Instance isequiv_ap `{IsEquiv A B f} (x y : A)
+  : IsEquiv (@ap A B f x y) | 1000
+  := isequiv_adjointify (ap f)
+  (fun q => (eissect f x)^  @  ap f^-1 q  @  eissect f y)
+  (fun q =>
+    ap_pp f _ _
+    @ whiskerR (ap_pp f _ _) _
+    @ ((ap_V f _ @ inverse2 (eisadj f _)^)
+      @@ (ap_compose f^-1 f _)^
+      @@ (eisadj f _)^)
+    @ concat_pA1_p (eisretr f) _ _
+    @ whiskerR (concat_Vp _) _
+    @ concat_1p _)
+  (fun p =>
+    whiskerR (whiskerL _ (ap_compose f f^-1 _)^) _
+    @ concat_pA1_p (eissect f) _ _
+    @ whiskerR (concat_Vp _) _
+    @ concat_1p _).
+
+Definition equiv_ap `(f : A -> B) `{IsEquiv A B f} (x y : A)
+  : (x = y) <~> (f x = f y)
+  := Build_Equiv _ _ (ap f) _.
+
+Global Arguments equiv_ap (A B)%type_scope f%function_scope _ _ _.
+
+Definition equiv_ap' `(f : A <~> B) (x y : A)
+  : (x = y) <~> (f x = f y)
+  := equiv_ap f x y.
+
+(* TODO: Is this really necessary? *)
+Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
+  : (f x = f y) -> (x = y)
+  := (ap f)^-1.
 
 (** Assuming function extensionality, composing with an equivalence is itself an equivalence *)
 
@@ -329,43 +365,6 @@ Definition isequiv_isequiv_postcompose {A B : Type} (f : A -> B)
   : IsEquiv f.
 (* TODO *)
 *)
-
-(** Equivalences between path spaces *)
-
-(** If [f] is an equivalence, then so is [ap f].  We are lazy and use [adjointify]. *)
-Global Instance isequiv_ap `{IsEquiv A B f} (x y : A)
-  : IsEquiv (@ap A B f x y) | 1000
-  := isequiv_adjointify (ap f)
-  (fun q => (eissect f x)^  @  ap f^-1 q  @  eissect f y)
-  (fun q =>
-    ap_pp f _ _
-    @ whiskerR (ap_pp f _ _) _
-    @ ((ap_V f _ @ inverse2 (eisadj f _)^)
-      @@ (ap_compose f^-1 f _)^
-      @@ (eisadj f _)^)
-    @ concat_pA1_p (eisretr f) _ _
-    @ whiskerR (concat_Vp _) _
-    @ concat_1p _)
-  (fun p =>
-    whiskerR (whiskerL _ (ap_compose f f^-1 _)^) _
-    @ concat_pA1_p (eissect f) _ _
-    @ whiskerR (concat_Vp _) _
-    @ concat_1p _).
-
-Definition equiv_ap `(f : A -> B) `{IsEquiv A B f} (x y : A)
-  : (x = y) <~> (f x = f y)
-  := Build_Equiv _ _ (ap f) _.
-
-Global Arguments equiv_ap (A B)%type_scope f%function_scope _ _ _.
-
-Definition equiv_ap' `(f : A <~> B) (x y : A)
-  : (x = y) <~> (f x = f y)
-  := equiv_ap f x y.
-
-(* TODO: Is this really necessary? *)
-Definition equiv_inj `(f : A -> B) `{IsEquiv A B f} {x y : A}
-  : (f x = f y) -> (x = y)
-  := (ap f)^-1.
 
 (** The inverse of an equivalence is an equivalence. *)
 Global Instance isequiv_inverse {A B : Type} (f : A -> B) {feq : IsEquiv f}

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -64,7 +64,7 @@ Definition equiv_compose' {A B C : Type} (g : B <~> C) (f : A <~> B)
   : A <~> C
   := equiv_compose g f.
 
-(** We put [g] and [f] in [equiv_scope] explicitly.  This is a partial work-around for https://coq.inria.fr/bugs/show_bug.cgi?id=3990, which is that implicitly bound scopes don't nest well. *)
+(** We put [g] and [f] in [equiv_scope] explicitly.  This is a partial work-around for https://github.com/coq/coq/issues/3990, which is that implicitly bound scopes don't nest well. *)
 Notation "g 'oE' f" := (equiv_compose' g%equiv f%equiv) : equiv_scope.
 
 (* The TypeClass [Transitive] has a different order of parameters than [equiv_compose].  Thus in declaring the instance we have to switch the order of arguments. *)


### PR DESCRIPTION
The first commit just moves `equiv_inj` a bit earlier in the file, with no changes.  Deselecting it makes the diff clearer.

The second commit cleans up a few things.  The proof of `isequiv_isequiv_precompose` is much shorter, and the dual is now proved.  The `ev_equiv` tactic is extended to do more tidying of goals involving `equiv_fun ...`.  Plus a few other minor things.