### PR TITLE
Speed up Colimit_Flattening

### DIFF
--- a/theories/Colimits/Colimit_Flattening.v
+++ b/theories/Colimits/Colimit_Flattening.v
@@ -114,7 +114,7 @@ Section Flattening.
       refine (_ @ concat_1p _).
       refine (concat_p_pp _ _ _ @ _).
       refine (_ @@ 1).
-      match goal with |- ap _ ?X @ _ = _ => set (p:=X) end.
+      match goal with |- ap _ ?X @ _ = _ => set (p := X) end.
       assert (r : transport_E'_V g x y = p^).
       { subst p.
         exact (moveL_transport_V_V E' _ _ _ _)^. }
@@ -158,7 +158,7 @@ Section Flattening.
       refine (_ @ concat_pp_p _ _ _).
       match goal with |- _ = (ap ?ff ?pp1 @ ?pp2) @ ?pp3
         => set (p1 := pp1) end.
-      assert (p1 = ap (transport E' (colimp i j g x)^)
+      assert (p1eq : p1 = ap (transport E' (colimp i j g x)^)
         (transport_pV E' (colimp i j g x) y)^).
       { subst p1; clear.
         etransitivity.
@@ -166,7 +166,7 @@ Section Flattening.
         etransitivity.
         1: nrapply inverse2; snrapply transport_VpV.
         symmetry; apply ap_V. }
-      rewrite X; clear X p1.
+      rewrite p1eq; clear p1eq p1.
       rewrite <- ap_compose; cbn.
       rewrite (ap_path_sigma (fun x => E (j; x))
         (fun x y => (colim j x; y))).
@@ -177,15 +177,15 @@ Section Flattening.
           change pp2 with (path_sigma' E' 1
                             (transport_E'_V g x
                                (transport E' (colimp i j g x) (transport E' (colimp i j g x)^ y)))) end.
-      assert (p1 = path_sigma' E' 1 (transport_Vp _ _ _)).
+      assert (p1eq : p1 = path_sigma' E' 1 (transport_Vp _ _ _)).
       { subst p1.
         rewrite <- ap_exist.
         rewrite (ap_compose (transport E' (colimp i j g x)^)
           (fun v => (colim j ((D _f g) x); v))).
-        f_ap; set (colimp i j g x).
+        f_ap; set (p := colimp i j g x).
         clear; symmetry.
         apply transport_VpV. }
-      rewrite X; clear p1 X.
+      rewrite p1eq; clear p1eq p1.
       rewrite <- !path_sigma_pp_pp'; f_ap.
       rewrite concat_p1, concat_pp_p.
       refine (1 @@ _).
@@ -198,7 +198,7 @@ Section Flattening.
       - f_ap.
         refine (1 @@ _).
         apply transport_VpV.
-      - set (transport E' (colimp i j g x)
+      - set (e := transport E' (colimp i j g x)
           (transport E' (colimp i j g x)^ y)).
         rewrite ap_pp, <- ap_compose.
         refine (_ @ (transport_E'_V_E' _ _ _)^).

--- a/theories/Colimits/Colimit_Flattening.v
+++ b/theories/Colimits/Colimit_Flattening.v
@@ -10,7 +10,7 @@ Local Open Scope path_scope.
 
 (** * Flattening lemma *)
 
-(** This file provide a proof of the flattening lemma for colimits. This lemma describes the type [sig E'] when [E' : colimit D -> Type] is a type family defined by recusrion on a colimit. *)
+(** This file provides a proof of the flattening lemma for colimits. This lemma describes the type [sig E'] when [E' : colimit D -> Type] is a type family defined by recursion on a colimit. *)
 (** The flattening lemma in the case of W-types is presented in section 6.12 of the HoTT book. *)
 (** A good intuition is given by the pushout's case (see above). *)
 
@@ -23,7 +23,7 @@ Section Flattening.
   Let E_f {i j : G} (g : G i j) (x : D i) : E (i; x) -> E (j; (D _f g) x)
       := @arr _ E (i; x) (j; D _f g x) (g; 1).
 
-  (** Now, given an equifibered diagram and using univalence, one can define a type family [E' : colimit D -> Type] by recusrion on the colimit. *)
+  (** Now, given an equifibered diagram and using univalence, one can define a type family [E' : colimit D -> Type] by recursion on the colimit. *)
 
   Definition E' : Colimit D -> Type.
   Proof.
@@ -79,15 +79,12 @@ Section Flattening.
       + apply transport_E'.
   Defined.
 
-  (** And we directly prove than it is universal. *)
+  (** And we directly prove that it is universal.  We break the proof into parts to slightly speed it up. *)
 
   Local Opaque path_sigma ap11.
 
-  (** TODO: Make this faster! *)
-  Global Instance unicocone_cocone_E' : UniversalCocone cocone_E'.
+  Local Definition cocone_extends Z: Cocone (diagram_sigma E) Z -> ((sig E') -> Z).
   Proof.
-    srapply Build_UniversalCocone.
-    intro Z; srapply isequiv_adjointify.
     - intros [q qq]; cbn in *.
       intros [x y]; revert x y.
       srapply Colimit_ind; cbn.
@@ -99,60 +96,66 @@ Section Flattening.
         cbn; f_ap.
         refine (path_sigma' _ 1 _); cbn.
         apply transport_E'_V.
+  Defined.
+
+  Local Definition cocone_isretr Z
+    : cocone_postcompose cocone_E' o cocone_extends Z == idmap.
+  Proof.
     - intros [q qq].
       srapply path_cocone.
       + intros i x; reflexivity.
       + intros i j g [x y].
         rewrite concat_1p, concat_p1.
         cbn; rewrite ap_path_sigma.
-        cbn; rewrite Colimit_ind_beta_colimp.
+        simpl.
+        rewrite Colimit_ind_beta_colimp.
         rewrite ap10_path_forall.
-        hott_simpl.
+        rewrite concat_pp_p, concat_V_pp.
         refine (_ @ concat_1p _).
+        refine (concat_p_pp _ _ _ @ _).
         refine (_ @@ 1).
-        match goal with |- ap _ ?X @ _ = _ => set X end.
-        assert (transport_E'_V g x y = p^).
+        match goal with |- ap _ ?X @ _ = _ => set (p:=X) end.
+        assert (r : transport_E'_V g x y = p^).
         { subst p.
           exact (moveL_transport_V_V E' _ _ _ _)^. }
-        rewrite X.
-        clearbody p; clear.
-        set (E_f g x y) in *.
+        rewrite r; clear r.
         destruct p.
         reflexivity.
-    - intro f.
+  Defined. (* 0.1s *)
+
+  Local Definition cocone_issect Z
+    : cocone_extends Z o cocone_postcompose cocone_E' == idmap.
+  Proof.
+      intro f.
       funext [x y].
-      revert x y; cbn.
-      srapply Colimit_ind; cbn.
-      + reflexivity.
+      revert x y.
+      srapply Colimit_ind.
+      + cbn; reflexivity.
       + intros i j g x; cbn.
         funext y.
-        rewrite transport_forall; cbn.
+        refine (transport_forall _ _ _ @ _).
         rewrite transport_paths_FlFr.
-        match goal with |- (_ @ ?pp) @ _ = _ => set pp end.
-        cbn in p.
-        assert (p = 1).
-        { subst p.
-          match goal with |- transportD E' ?C _ _ _ = _ => set (C2:=C) end.
-          rewrite (transportD_is_transport _ (fun w => C2 w.1 w.2)).
-          subst C2; cbn.
+        refine ((1 @@ _ @@ 1) @ (concat_p1 _ @@ 1) @ concat_Vp _).
+          match goal with |- transportD E' ?C _ _ _ = _ =>
+                            rewrite (transportD_is_transport _ (fun w => C w.1 w.2)) end.
           rewrite transport_paths_FlFr.
-          rewrite concat_p1.
+          lhs rapply concat_pp_p.
           apply moveR_Vp.
-          rewrite concat_p1.
+          apply equiv_1p_q1.
           rewrite ap_path_sigma.
-          cbn.
           rewrite Colimit_ind_beta_colimp.
           rewrite ap10_path_forall.
-          hott_simpl.
+          simpl.
+          rewrite concat_pp_p, concat_V_pp.
           rewrite ap11_is_ap10_ap01.
           cbn.
           rewrite concat_1p.
           rewrite (ap_compose (fun y => (colim j ((D _f g) x); y)) f).
-          cbn.
           rewrite (ap_compose (fun x0 : exists x0 : D j, E (j; x0)
             => (colim j (pr1 x0); pr2 x0)) f).
           rewrite <- ! (ap_pp f).
           apply (ap (ap f)).
+          refine (_ @ concat_pp_p _ _ _).
           match goal with |- _ = (ap ?ff ?pp1 @ ?pp2) @ ?pp3
             => set (p1 := pp1) end.
           assert (p1 = ap (transport E' (colimp i j g x)^)
@@ -161,8 +164,7 @@ Section Flattening.
             etransitivity.
             1: srapply moveL_transport_V_1.
             etransitivity.
-            { srapply inverse2.
-              2: srapply transport_VpV. }
+            1: nrapply inverse2; snrapply transport_VpV.
             symmetry; apply ap_V. }
           rewrite X; clear X p1.
           rewrite <- ap_compose; cbn.
@@ -171,9 +173,12 @@ Section Flattening.
           cbn; rewrite !concat_p1, concat_pp_p, ap_V.
           apply moveL_Vp.
           match goal with |- ?pp1 @ _ = ?pp2 @ _
-            => set (p1 := pp1); set (p2 := pp2) end; cbn in *.
+            => set (p1 := pp1);
+              change pp2 with (path_sigma' E' 1
+                                (transport_E'_V g x
+                                   (transport E' (colimp i j g x) (transport E' (colimp i j g x)^ y)))) end.
           assert (p1 = path_sigma' E' 1 (transport_Vp _ _ _)).
-          {  subst p1.
+          { subst p1.
             rewrite <- ap_exist.
             rewrite (ap_compose (transport E' (colimp i j g x)^)
               (fun v => (colim j ((D _f g) x); v))).
@@ -181,9 +186,6 @@ Section Flattening.
             clear; symmetry.
             apply transport_VpV. }
           rewrite X; clear p1 X.
-          assert (p2 = path_sigma' E' 1 (transport_E'_V _ _ _))
-            by reflexivity.
-          rewrite X; clear p2 X.
           rewrite <- !path_sigma_pp_pp'; f_ap.
           rewrite concat_p1, concat_pp_p.
           refine (1 @@ _).
@@ -205,8 +207,16 @@ Section Flattening.
             refine (_ @ (transport_pVp _ _ _)^).
             rewrite ap_compose.
             f_ap; symmetry.
-            apply transport_VpV. }
-        rewrite X; simpl; hott_simpl.
+            apply transport_VpV.
+  Defined. (* TODO: a little slow, 0.40s *)
+
+  Global Instance unicocone_cocone_E' : UniversalCocone cocone_E'.
+  Proof.
+    srapply Build_UniversalCocone.
+    intro Z; srapply isequiv_adjointify.
+    - exact (cocone_extends Z).
+    - exact (cocone_isretr Z).
+    - exact (cocone_issect Z).
   Defined.
 
   (** The flattening lemma follows by colimit unicity. *)
@@ -220,3 +230,4 @@ Section Flattening.
   Defined.
 
 End Flattening.
+(* TODO: ending the section is a bit slow (0.2s).  But simply removing the Section (and changing "Let" to "Local Definition") causes the whole file to be much slower.  It should be possible to remove the section without making the whole file slower. *)

--- a/theories/Colimits/Colimit_Flattening.v
+++ b/theories/Colimits/Colimit_Flattening.v
@@ -85,129 +85,129 @@ Section Flattening.
 
   Local Definition cocone_extends Z: Cocone (diagram_sigma E) Z -> ((sig E') -> Z).
   Proof.
-    - intros [q qq]; cbn in *.
-      intros [x y]; revert x y.
-      srapply Colimit_ind; cbn.
-      + intros i x y; exact (q i (x; y)).
-      + intros i j g x; cbn.
-        funext y.
-        refine (transport_arrow_toconst _ _ _ @ _).
-        refine (_ @ qq i j g (x; y)).
-        cbn; f_ap.
-        refine (path_sigma' _ 1 _); cbn.
-        apply transport_E'_V.
+    intros [q qq]; cbn in *.
+    intros [x y]; revert x y.
+    srapply Colimit_ind; cbn.
+    + intros i x y; exact (q i (x; y)).
+    + intros i j g x; cbn.
+      funext y.
+      refine (transport_arrow_toconst _ _ _ @ _).
+      refine (_ @ qq i j g (x; y)).
+      cbn; f_ap.
+      refine (path_sigma' _ 1 _); cbn.
+      apply transport_E'_V.
   Defined.
 
   Local Definition cocone_isretr Z
     : cocone_postcompose cocone_E' o cocone_extends Z == idmap.
   Proof.
-    - intros [q qq].
-      srapply path_cocone.
-      + intros i x; reflexivity.
-      + intros i j g [x y].
-        rewrite concat_1p, concat_p1.
-        cbn; rewrite ap_path_sigma.
-        simpl.
-        rewrite Colimit_ind_beta_colimp.
-        rewrite ap10_path_forall.
-        rewrite concat_pp_p, concat_V_pp.
-        refine (_ @ concat_1p _).
-        refine (concat_p_pp _ _ _ @ _).
-        refine (_ @@ 1).
-        match goal with |- ap _ ?X @ _ = _ => set (p:=X) end.
-        assert (r : transport_E'_V g x y = p^).
-        { subst p.
-          exact (moveL_transport_V_V E' _ _ _ _)^. }
-        rewrite r; clear r.
-        destruct p.
-        reflexivity.
+    intros [q qq].
+    srapply path_cocone.
+    + intros i x; reflexivity.
+    + intros i j g [x y].
+      rewrite concat_1p, concat_p1.
+      cbn; rewrite ap_path_sigma.
+      simpl.
+      rewrite Colimit_ind_beta_colimp.
+      rewrite ap10_path_forall.
+      rewrite concat_pp_p, concat_V_pp.
+      refine (_ @ concat_1p _).
+      refine (concat_p_pp _ _ _ @ _).
+      refine (_ @@ 1).
+      match goal with |- ap _ ?X @ _ = _ => set (p:=X) end.
+      assert (r : transport_E'_V g x y = p^).
+      { subst p.
+        exact (moveL_transport_V_V E' _ _ _ _)^. }
+      rewrite r; clear r.
+      destruct p.
+      reflexivity.
   Defined. (* 0.1s *)
 
   Local Definition cocone_issect Z
     : cocone_extends Z o cocone_postcompose cocone_E' == idmap.
   Proof.
-      intro f.
-      funext [x y].
-      revert x y.
-      srapply Colimit_ind.
-      + cbn; reflexivity.
-      + intros i j g x; cbn.
-        funext y.
-        refine (transport_forall _ _ _ @ _).
-        rewrite transport_paths_FlFr.
-        refine ((1 @@ _ @@ 1) @ (concat_p1 _ @@ 1) @ concat_Vp _).
-          match goal with |- transportD E' ?C _ _ _ = _ =>
-                            rewrite (transportD_is_transport _ (fun w => C w.1 w.2)) end.
-          rewrite transport_paths_FlFr.
-          lhs rapply concat_pp_p.
-          apply moveR_Vp.
-          apply equiv_1p_q1.
-          rewrite ap_path_sigma.
-          rewrite Colimit_ind_beta_colimp.
-          rewrite ap10_path_forall.
-          simpl.
-          rewrite concat_pp_p, concat_V_pp.
-          rewrite ap11_is_ap10_ap01.
-          cbn.
-          rewrite concat_1p.
-          rewrite (ap_compose (fun y => (colim j ((D _f g) x); y)) f).
-          rewrite (ap_compose (fun x0 : exists x0 : D j, E (j; x0)
-            => (colim j (pr1 x0); pr2 x0)) f).
-          rewrite <- ! (ap_pp f).
-          apply (ap (ap f)).
-          refine (_ @ concat_pp_p _ _ _).
-          match goal with |- _ = (ap ?ff ?pp1 @ ?pp2) @ ?pp3
-            => set (p1 := pp1) end.
-          assert (p1 = ap (transport E' (colimp i j g x)^)
-            (transport_pV E' (colimp i j g x) y)^).
-          { subst p1; clear.
-            etransitivity.
-            1: srapply moveL_transport_V_1.
-            etransitivity.
-            1: nrapply inverse2; snrapply transport_VpV.
-            symmetry; apply ap_V. }
-          rewrite X; clear X p1.
-          rewrite <- ap_compose; cbn.
-          rewrite (ap_path_sigma (fun x => E (j; x))
-            (fun x y => (colim j x; y))).
-          cbn; rewrite !concat_p1, concat_pp_p, ap_V.
-          apply moveL_Vp.
-          match goal with |- ?pp1 @ _ = ?pp2 @ _
-            => set (p1 := pp1);
-              change pp2 with (path_sigma' E' 1
-                                (transport_E'_V g x
-                                   (transport E' (colimp i j g x) (transport E' (colimp i j g x)^ y)))) end.
-          assert (p1 = path_sigma' E' 1 (transport_Vp _ _ _)).
-          { subst p1.
-            rewrite <- ap_exist.
-            rewrite (ap_compose (transport E' (colimp i j g x)^)
-              (fun v => (colim j ((D _f g) x); v))).
-            f_ap; set (colimp i j g x).
-            clear; symmetry.
-            apply transport_VpV. }
-          rewrite X; clear p1 X.
-          rewrite <- !path_sigma_pp_pp'; f_ap.
-          rewrite concat_p1, concat_pp_p.
-          refine (1 @@ _).
-          apply moveL_Mp.
-          rewrite <- ap_V, <- ap_pp.
-          srefine (_ @ _).
-          - refine (ap (transport E' (colimp i j g x)) _).
-            refine ((transport_E'_V _ _ _)^ @ _).
-            refine (ap _ (transport_pV _ _ _)).
-          - f_ap.
-            refine (1 @@ _).
-            apply transport_VpV.
-          - set (transport E' (colimp i j g x)
-              (transport E' (colimp i j g x)^ y)).
-            rewrite ap_pp, <- ap_compose.
-            refine (_ @ (transport_E'_V_E' _ _ _)^).
-            refine (1 @@ _).
-            subst e.
-            refine (_ @ (transport_pVp _ _ _)^).
-            rewrite ap_compose.
-            f_ap; symmetry.
-            apply transport_VpV.
+    intro f.
+    funext [x y].
+    revert x y.
+    srapply Colimit_ind.
+    + cbn; reflexivity.
+    + intros i j g x; cbn.
+      funext y.
+      refine (transport_forall _ _ _ @ _).
+      rewrite transport_paths_FlFr.
+      refine ((1 @@ _ @@ 1) @ (concat_p1 _ @@ 1) @ concat_Vp _).
+      match goal with |- transportD E' ?C _ _ _ = _ =>
+                        rewrite (transportD_is_transport _ (fun w => C w.1 w.2)) end.
+      rewrite transport_paths_FlFr.
+      lhs rapply concat_pp_p.
+      apply moveR_Vp.
+      apply equiv_1p_q1.
+      rewrite ap_path_sigma.
+      rewrite Colimit_ind_beta_colimp.
+      rewrite ap10_path_forall.
+      simpl.
+      rewrite concat_pp_p, concat_V_pp.
+      rewrite ap11_is_ap10_ap01.
+      cbn.
+      rewrite concat_1p.
+      rewrite (ap_compose (fun y => (colim j ((D _f g) x); y)) f).
+      rewrite (ap_compose (fun x0 : exists x0 : D j, E (j; x0)
+        => (colim j (pr1 x0); pr2 x0)) f).
+      rewrite <- ! (ap_pp f).
+      apply (ap (ap f)).
+      refine (_ @ concat_pp_p _ _ _).
+      match goal with |- _ = (ap ?ff ?pp1 @ ?pp2) @ ?pp3
+        => set (p1 := pp1) end.
+      assert (p1 = ap (transport E' (colimp i j g x)^)
+        (transport_pV E' (colimp i j g x) y)^).
+      { subst p1; clear.
+        etransitivity.
+        1: srapply moveL_transport_V_1.
+        etransitivity.
+        1: nrapply inverse2; snrapply transport_VpV.
+        symmetry; apply ap_V. }
+      rewrite X; clear X p1.
+      rewrite <- ap_compose; cbn.
+      rewrite (ap_path_sigma (fun x => E (j; x))
+        (fun x y => (colim j x; y))).
+      cbn; rewrite !concat_p1, concat_pp_p, ap_V.
+      apply moveL_Vp.
+      match goal with |- ?pp1 @ _ = ?pp2 @ _
+        => set (p1 := pp1);
+          change pp2 with (path_sigma' E' 1
+                            (transport_E'_V g x
+                               (transport E' (colimp i j g x) (transport E' (colimp i j g x)^ y)))) end.
+      assert (p1 = path_sigma' E' 1 (transport_Vp _ _ _)).
+      { subst p1.
+        rewrite <- ap_exist.
+        rewrite (ap_compose (transport E' (colimp i j g x)^)
+          (fun v => (colim j ((D _f g) x); v))).
+        f_ap; set (colimp i j g x).
+        clear; symmetry.
+        apply transport_VpV. }
+      rewrite X; clear p1 X.
+      rewrite <- !path_sigma_pp_pp'; f_ap.
+      rewrite concat_p1, concat_pp_p.
+      refine (1 @@ _).
+      apply moveL_Mp.
+      rewrite <- ap_V, <- ap_pp.
+      srefine (_ @ _).
+      - refine (ap (transport E' (colimp i j g x)) _).
+        refine ((transport_E'_V _ _ _)^ @ _).
+        refine (ap _ (transport_pV _ _ _)).
+      - f_ap.
+        refine (1 @@ _).
+        apply transport_VpV.
+      - set (transport E' (colimp i j g x)
+          (transport E' (colimp i j g x)^ y)).
+        rewrite ap_pp, <- ap_compose.
+        refine (_ @ (transport_E'_V_E' _ _ _)^).
+        refine (1 @@ _).
+        subst e.
+        refine (_ @ (transport_pVp _ _ _)^).
+        rewrite ap_compose.
+        f_ap; symmetry.
+        apply transport_VpV.
   Defined. (* TODO: a little slow, 0.40s *)
 
   Global Instance unicocone_cocone_E' : UniversalCocone cocone_E'.


### PR DESCRIPTION
On my machine, the time goes from 3.6s to 1.3s.  There are only two slow lines, both marked with TODO, but they are the tricky kind:  a Defined (0.4s), and the closing of the Section (0.2s).  Normally I would just remove the section, but if I simply remove it and leave the Context command, then the file becomes slower overall.  It might work to copy the Context to every definition, but I didn't think that was worth it for 0.2s.
