### PR TITLE
Reduce universe variables, mainly in WildCat

### DIFF
--- a/test/bugs/github1791.v
+++ b/test/bugs/github1791.v
@@ -1,0 +1,21 @@
+From HoTT Require Import WildCat Join.
+
+(** PR #1791 reduced the number of universe variables for several definitions.  These tests ensure that they remain reduced. *)
+
+(** WildCat/Square.v: *)
+
+Check is0functor_idmap@{u1 u2}.
+Check vinverse@{u1 u2 u3 u4 u5}.
+Check transpose@{u1 u2 u3}.
+
+(** WildCat/Yoneda.v: *)
+
+Check opyon_equiv_0gpd@{u1 u2 u3 u4 u5 u6 u7 u8 u9}.
+
+(** Join/Core.v: *)
+
+Check equiv_join_sym@{u1 u2 u3 u4}.
+
+(** Join/JoinAssoc.v: *)
+
+Check join_assoc@{u1 u2 u3 u4 u5 u6 u7 u8}.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -602,16 +602,6 @@ Notation IsHSet := (IsTrunc minus_two.+2).
 #[export]
 Hint Extern 0 => progress change Contr_internal with Contr in * : typeclass_instances.
 
-(** *** Simple induction *)
-
-(** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [nat] or a [trunc_index].  The difference is that it produces proof terms involving [match] and [fix] explicitly rather than [nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. *)
-
-Ltac simple_induction n n' IH :=
-  generalize dependent n;
-  fix IH 1;
-  intros [| n'];
-  [ clear IH | specialize (IH n') ].
-
 (** *** Truncated relations  *)
 
 (** Hprop-valued relations.  Making this a [Notation] rather than a [Definition] enables typeclass resolution to pick it up easily.  We include the base type [A] in the notation since otherwise e.g. [forall (x y : A) (z : B x y), IsHProp (C x y z)] will get displayed as [forall (x : A), is_mere_relation (C x)].  *)

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -15,14 +15,6 @@ Ltac simple_induction n n' IH :=
   intros [| n'];
   [ clear IH | specialize (IH n') ].
 
-(** This should be equivalent to [induction p], except that it may leave additional things from the context reverted.  Using this avoids introducing extra universe variables. *)
-Ltac simple_path_induction p :=
-  match type of p with (_ = ?x) =>
-    move p at top; (* After the next line, we want the first two variables to be [x] and then [p]. *)
-    generalize dependent x;
-    refine (fun x p => match p with 1 => _ end);
-    clear x p end.
-
 (** Debugging tactics to show the goal during evaluation. *)
 
 Ltac show_goal := match goal with [ |- ?T ] => idtac T end.

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -1,8 +1,27 @@
 Require Import Basics.Overture.
 
-
 (** TODO: Clean up *)
-(** This module implements various tactics used to simplify the goals produced by Program, which are also generally useful. *)
+
+(** * Basic tactics *)
+
+(** This module implements various tactics used in the library. *)
+
+(** Simple induction *)
+
+(** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [nat] or a [trunc_index].  The difference is that it produces proof terms involving [fix] explicitly rather than [nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. *)
+Ltac simple_induction n n' IH :=
+  generalize dependent n;
+  fix IH 1;
+  intros [| n'];
+  [ clear IH | specialize (IH n') ].
+
+(** This should be equivalent to [induction p], except that it may leave additional things from the context reverted.  Using this avoids introducing extra universe variables. *)
+Ltac simple_path_induction p :=
+  match type of p with (_ = ?x) =>
+    move p at top; (* After the next line, we want the first two variables to be [x] and then [p]. *)
+    generalize dependent x;
+    refine (fun x p => match p with 1 => _ end);
+    clear x p end.
 
 (** Debugging tactics to show the goal during evaluation. *)
 

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -216,15 +216,18 @@ Ltac interval_ind f a b :=
 
 (** Similarly, for [h : JoinRecPath f g], if we have [a] and [b] and are trying to prove a goal only involving [h] and [g] evaluated at those points, we can assume that [g] is [f] and that [h] is "reflexivity".  For this, we first define a lemma that is like "path induction on h", and then a tactic that uses it. *)
 
-Definition square_ind {P : Type} (a b : P) (ab : a = b)
-  (Q : forall (a' b' : P) (ab' : a' = b') (ha : a = a') (hb : b = b') (k : ab @ hb = ha @ ab'), Type)
+Definition square_ind {P : Type@{u}} (a b : P) (ab : a = b)
+  (Q : forall (a' b' : P) (ab' : a' = b') (ha : a = a') (hb : b = b') (k : ab @ hb = ha @ ab'), Type@{v})
   (s : Q a b ab idpath idpath (equiv_p1_1q idpath))
   : forall a' b' ab' ha hb k, Q a' b' ab' ha hb k.
 Proof.
   intros.
-  induction ha, hb.
-  revert k; equiv_intro (equiv_p1_1q (p:=ab) (q:=ab')) k'; induction k'.
-  induction ab.
+  simple_path_induction ha.
+  simple_path_induction hb.
+  intro ab'; equiv_intro (equiv_p1_1q (p:=ab) (q:=ab')) k'.
+  simple_path_induction k'.
+  simple_path_induction ab.
+  intros Q s.
   exact s.
 Defined.
 

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -222,12 +222,9 @@ Definition square_ind {P : Type@{u}} (a b : P) (ab : a = b)
   : forall a' b' ab' ha hb k, Q a' b' ab' ha hb k.
 Proof.
   intros.
-  simple_path_induction ha.
-  simple_path_induction hb.
-  intro ab'; equiv_intro (equiv_p1_1q (p:=ab) (q:=ab')) k'.
-  simple_path_induction k'.
-  simple_path_induction ab.
-  intros Q s.
+  destruct ha, hb.
+  revert k; equiv_intro (equiv_p1_1q (p:=ab) (q:=ab')) k'; destruct k'.
+  destruct ab.
   exact s.
 Defined.
 
@@ -444,7 +441,7 @@ Section Triangle.
   Definition triangle_v_V (a : A) {b b' : B} (p : b = b')
     : triangle_v a p^ = (1 @@ ap_V joinr p) @ moveR_pV _ _ _ (triangle_v a p)^.
   Proof.
-    induction p; cbn.
+    destruct p; cbn.
     rhs nrapply concat_1p.
     symmetry; apply concat_pV_p.
   Defined.

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -216,8 +216,8 @@ Ltac interval_ind f a b :=
 
 (** Similarly, for [h : JoinRecPath f g], if we have [a] and [b] and are trying to prove a goal only involving [h] and [g] evaluated at those points, we can assume that [g] is [f] and that [h] is "reflexivity".  For this, we first define a lemma that is like "path induction on h", and then a tactic that uses it. *)
 
-Definition square_ind {P : Type@{u}} (a b : P) (ab : a = b)
-  (Q : forall (a' b' : P) (ab' : a' = b') (ha : a = a') (hb : b = b') (k : ab @ hb = ha @ ab'), Type@{v})
+Definition square_ind {P : Type} (a b : P) (ab : a = b)
+  (Q : forall (a' b' : P) (ab' : a' = b') (ha : a = a') (hb : b = b') (k : ab @ hb = ha @ ab'), Type)
   (s : Q a b ab idpath idpath (equiv_p1_1q idpath))
   : forall a' b' ab' ha hb k, Q a' b' ab' ha hb k.
 Proof.

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -281,19 +281,17 @@ Class Faithful {A B : Type} (F : A -> B) `{Is1Functor A B F} :=
 
 Section IdentityFunctor.
 
-  Context {A : Type} `{Is1Cat A}.
-
-  Global Instance is0functor_idmap : Is0Functor idmap.
+  Global Instance is0functor_idmap {A : Type} `{IsGraph A} : Is0Functor idmap.
   Proof.
     by apply Build_Is0Functor.
   Defined.
 
-  Global Instance is1functor_idmap : Is1Functor idmap.
+  Global Instance is1functor_idmap {A : Type} `{Is1Cat A} : Is1Functor idmap.
   Proof.
     by apply Build_Is1Functor.
   Defined.
 
-  #[export] Instance isFaithful_idmap : Faithful idmap.
+  #[export] Instance isFaithful_idmap {A : Type} `{Is1Cat A}: Faithful idmap.
   Proof.
     by unfold Faithful.
   Defined.

--- a/theories/WildCat/Square.v
+++ b/theories/WildCat/Square.v
@@ -8,9 +8,9 @@ Require Import WildCat.Equiv.
 
 (** A Square is a cubical 2-cell in a 1-category. The order of the arguments is left-right-top-bottom: [Square l r t b].  It is defined to be [r $o t $== b $o l]. *)
 
-Definition Square {A : Type} `{Is1Cat A} {x00 x20 x02 x22 : A}
+Definition Square@{u v w} {A : Type@{u}} `{Is1Cat@{u w v} A} {x00 x20 x02 x22 : A}
   (f01 : x00 $-> x02) (f21 : x20 $-> x22) (f10 : x00 $-> x20) (f12 : x02 $-> x22) 
-  : Type
+  : Type@{w}
   := f21 $o f10 $== f12 $o f01.
 
 
@@ -22,7 +22,7 @@ Section Squares.
     f03     f23     f43
     x04 f14 x24 f34 x44 
   All morphisms are pointed to the right or down. *)
-  Context {A : Type} `{HasEquivs A} {x x' x00 x20 x40 x02 x22 x42 x04 x24 x44 : A}
+  Context {A : Type} `{Is1Cat A} {x x' x00 x20 x40 x02 x22 x42 x04 x24 x44 : A}
     {f10 f10' : x00 $-> x20} {f30 : x20 $-> x40} 
     {f12 f12' : x02 $-> x22} {f32 : x22 $-> x42} 
     {f14 : x04 $-> x24} {f34 : x24 $-> x44}
@@ -55,7 +55,7 @@ Section Squares.
   := cat_assoc _ _ _ $@ (f23 $@L s) $@ (cat_assoc _ _ _)^$ $@ (t $@R f01) $@ cat_assoc _ _ _.
 
   (** If the horiztonal morphisms in a square are equivalences then we can flip the square by inverting them. *)
-  Definition hinverse (f10 : x00 $<~> x20) (f12 : x02 $<~> x22) (s : Square f01 f21 f10 f12)
+  Definition hinverse {HE : HasEquivs A} (f10 : x00 $<~> x20) (f12 : x02 $<~> x22) (s : Square f01 f21 f10 f12)
     : Square f21 f01 f10^-1$ f12^-1$
     := (cat_idl _)^$ $@ ((cate_issect f12)^$ $@R _) $@ cat_assoc _ _ _
       $@ (_ $@L ((cat_assoc _ _ _)^$ $@ (s^$ $@R _) $@ cat_assoc _ _ _
@@ -88,7 +88,7 @@ End Squares.
 Section Squares2.
 
   (** We declare the context again, now that we can reuse some declarations where the variables have been inserted. This would not need to be done if coq could generalize variables within sections. Currently this is possible in Lean and Agda. *)
-  Context {A B : Type} `{HasEquivs A} `{Is1Cat B}
+  Context {A : Type} `{HasEquivs A}
     {x x' x00 x20 x40 x02 x22 x42 x04 x24 x44 : A}
     {f10 f10' : x00 $-> x20} {f30 : x20 $-> x40} 
     {f12 f12' : x02 $-> x22} {f32 : x22 $-> x42} 
@@ -149,7 +149,7 @@ Section Squares2.
     : Square f01 f21' (f21 $o f10) f12
     := (cat_assoc _ _ _)^$ $@ s.
 
-  Definition fmap_square (f : A -> B) `{!Is0Functor f} `{!Is1Functor f}
+  Definition fmap_square {B : Type} `{Is1Cat B} (f : A -> B) `{!Is0Functor f} `{!Is1Functor f}
     (s : Square f01 f21 f10 f12)
     : Square (fmap f f01) (fmap f f21) (fmap f f10) (fmap f f12)
     := (fmap_comp f _ _)^$ $@ fmap2 f s $@ fmap_comp f _ _.


### PR DESCRIPTION
Because of [Coq issue 10513 ](https://github.com/coq/coq/issues/10513), unused `Context` variables introduce floating universe variables.  Floating universe variables are particularly annoying because they accumulate, as they are never forced to be equal to other variables.  The very small changes in the first commit cause an out-of-tree definition to go from having 623 universe variables to having 5 universe variables.

The second commit adds a tactic `simple_path_induction` which is to path induction as `simple_induction` is to induction over the naturals.  It avoids introducing universe variables in the induction.  I use this in Join/Core, as an example.  It turns out to not have been the cause of the blow up, but I think it's good to have.  I put this in Basics/Tactics, and moved `simple_induction` there as well.  (Overture.v should be the first file someone reads, and it has a lot of technical things that might be confusing for a beginning, so I'm keeping my eyes open for things that can be moved or removed.)

[Edit: `simple_path_induction` removed since `destruct p` accomplishes the same thing.]