### PR TITLE
Basics/Overture: clarify things related to internal_paths_rew

### DIFF
--- a/test/bugs/github1794.v
+++ b/test/bugs/github1794.v
@@ -1,0 +1,6 @@
+From HoTT Require Import Basics.Overture.
+
+(** When [rewrite] is first used, it defines helper lemmas.  If the first use is in a Section that has universe variables, then these lemmas get unnecessary universe variables.  Overture uses [rewrite] outside of a section to ensure that they have the expected number of universe variables, and we test that here. *)
+
+Check internal_paths_rew@{u1 u2}.
+Check internal_paths_rew_r@{u1 u2}.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -328,6 +328,7 @@ Arguments transport {A}%type_scope P%function_scope {x y} p%path_scope u : simpl
 Notation "p # x" := (transport _ p x) (only parsing) : path_scope.
 
 (** The first time [rewrite] is used in each direction, it creates transport lemmas called [internal_paths_rew] and [internal_paths_rew_r].  See ../Tactics.v for how these compare to [transport].  We use [rewrite] here to trigger the creation of these lemmas.  This ensures that they are defined outside of sections, so they are not unnecessarily polymorphic.  The lemmas below are not used in the library. *)
+(** TODO: If Coq PR#18299 is merged (possibly in Coq 8.20), then we can instead register wrappers for [transport] to be used for rewriting.  See the comment by Dan Christensen in that PR for how to do this.  Then the tactics [internal_paths_rew_to_transport] and [rewrite_to_transport] can be removed from ../Tactics.v. *)
 Local Lemma define_internal_paths_rew A x y P (u : P x) (H : x = y :> A) : P y.
 Proof. rewrite <- H. exact u. Defined.
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -327,7 +327,7 @@ Arguments transport {A}%type_scope P%function_scope {x y} p%path_scope u : simpl
 (** Transport is very common so it is worth introducing a parsing notation for it.  However, we do not use the notation for output because it hides the fibration, and so makes it very hard to read involved transport expression. *)
 Notation "p # x" := (transport _ p x) (only parsing) : path_scope.
 
-(** The first time [rewrite] is used in each direction, it creates transport lemmas called [internal_paths_rew] and [internal_paths_rew_r].  [internal_paths_rew P u p] is definitionally equal to [transport P p u], but the more common [internal_paths_rew_r] is not definitionally equal to something defined using [transport].  We use [rewrite] here to trigger the creation of these lemmas.  This ensures that they are defined outside of sections, so they are not unnecessarily polymorphic. The lemmas below are not used in the library. *)
+(** The first time [rewrite] is used in each direction, it creates transport lemmas called [internal_paths_rew] and [internal_paths_rew_r].  See ../Tactics.v for how these compare to [transport].  We use [rewrite] here to trigger the creation of these lemmas.  This ensures that they are defined outside of sections, so they are not unnecessarily polymorphic.  The lemmas below are not used in the library. *)
 Local Lemma define_internal_paths_rew A x y P (u : P x) (H : x = y :> A) : P y.
 Proof. rewrite <- H. exact u. Defined.
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -223,16 +223,6 @@ Register paths_rect as core.identity.ind.
 Notation "x = y :> A" := (@paths A x y) : type_scope.
 Notation "x = y" := (x = y :>_) : type_scope.
 
-(** The first time [rewrite] is used in each direction, it creates transport lemmas called [internal_paths_rew] and [internal_paths_rew_r].  [internal_paths_rew P u p] is definitionally equal to [transport P p u], but the more common [internal_paths_rew_r] is not definitionally equal to something defined using [transport].  We use [rewrite] here to trigger the creation of these lemmas.  This ensures that they are defined outside of sections, so they are not unnecessarily polymorphic. The lemmas below are not used in the library. *)
-Local Lemma define_internal_paths_rew A x y P (u : P x) (H : x = y :> A) : P y.
-Proof. rewrite <- H. exact u. Defined.
-
-Local Lemma define_internal_paths_rew_r A x y P (u : P y) (H : x = y :> A) : P x.
-Proof. rewrite -> H. exact u. Defined.
-
-Arguments internal_paths_rew {A%type_scope} {a} P%function_scope f {a0} p.
-Arguments internal_paths_rew_r {A%type_scope} {a y} P%function_scope HC X.
-
 Register paths as core.identity.type.
 
 Global Instance reflexive_paths {A} : Reflexive (@paths A) | 0 := @idpath A.
@@ -317,7 +307,7 @@ Register concat as core.identity.trans.
 Notation "1" := idpath : path_scope.
 
 (** The composition of two paths. *)
-(** We put [p] and [q] in [path_scope] explcitly.  This is a partial work-around for https://coq.inria.fr/bugs/show_bug.cgi?id=3990, which is that implicitly bound scopes don't nest well. *)
+(** We put [p] and [q] in [path_scope] explicitly.  This is a partial work-around for https://coq.inria.fr/bugs/show_bug.cgi?id=3990, which is that implicitly bound scopes don't nest well. *)
 Notation "p @ q" := (concat p%path q%path) : path_scope.
 
 (** The inverse of a path. *)
@@ -327,27 +317,29 @@ Notation "p ^" := (inverse p%path) : path_scope.
 (** An alternative notation which puts each path on its own line, via the [format] specification in Notations.v.  Useful as a temporary device during proofs of equalities between very long composites; to turn it on inside a section, say [Open Scope long_path_scope]. *)
 Notation "p @' q" := (concat p q) : long_path_scope.
 
-
-(** An important instance of [paths_ind] is that given any dependent type, one can _transport_ elements of instances of the type along equalities in the base.
-
-   [transport P p u] transports [u : P x] to [P y] along [p : x = y]. *)
-Definition transport {A : Type} (P : A -> Type) {x y : A} (p : x = y) (u : P x) : P y :=
-  match p with idpath => u end.
+(** An important instance of [paths_ind] is that given any dependent type, one can _transport_ elements of instances of the type along equalities in the base:  [transport P p u] transports [u : P x] to [P y] along [p : x = y]. *)
+Definition transport {A : Type} (P : A -> Type) {x y : A} (p : x = y) (u : P x) : P y
+  := match p with idpath => u end.
 
 (** See above for the meaning of [simpl nomatch]. *)
 Arguments transport {A}%type_scope P%function_scope {x y} p%path_scope u : simpl nomatch.
 
-(** Transport is very common so it is worth introducing a parsing notation for it.  However, we do not use the notation for output because it hides the fibration, and so makes it very hard to read involved transport expression.*)
-
+(** Transport is very common so it is worth introducing a parsing notation for it.  However, we do not use the notation for output because it hides the fibration, and so makes it very hard to read involved transport expression. *)
 Notation "p # x" := (transport _ p x) (only parsing) : path_scope.
 
-(** Having defined transport, we can use it to talk about what a homotopy theorist might see as "paths in a fibration over paths in the base"; and what a type theorist might see as "heterogeneous equality in a dependent type".
+(** The first time [rewrite] is used in each direction, it creates transport lemmas called [internal_paths_rew] and [internal_paths_rew_r].  [internal_paths_rew P u p] is definitionally equal to [transport P p u], but the more common [internal_paths_rew_r] is not definitionally equal to something defined using [transport].  We use [rewrite] here to trigger the creation of these lemmas.  This ensures that they are defined outside of sections, so they are not unnecessarily polymorphic. The lemmas below are not used in the library. *)
+Local Lemma define_internal_paths_rew A x y P (u : P x) (H : x = y :> A) : P y.
+Proof. rewrite <- H. exact u. Defined.
 
-We will first see this appearing in the type of [apD]. *)
+Local Lemma define_internal_paths_rew_r A x y P (u : P y) (H : x = y :> A) : P x.
+Proof. rewrite -> H. exact u. Defined.
 
-(** Functions act on paths: if [f : A -> B] and [p : x = y] is a path in [A], then [ap f p : f x = f y].
+Arguments internal_paths_rew {A%type_scope} {a} P%function_scope f {a0} p.
+Arguments internal_paths_rew_r {A%type_scope} {a y} P%function_scope HC X.
 
-   We typically pronounce [ap] as a single syllable, short for "application"; but it may also be considered as an acronym, "action on paths". *)
+(** Having defined transport, we can use it to talk about what a homotopy theorist might see as "paths in a fibration over paths in the base"; and what a type theorist might see as "heterogeneous equality in a dependent type".  We will first see this appearing in the type of [apD]. *)
+
+(** Functions act on paths: if [f : A -> B] and [p : x = y] is a path in [A], then [ap f p : f x = f y].  We typically pronounce [ap] as a single syllable, short for "application"; but it may also be considered as an acronym, "action on paths". *)
 
 Definition ap {A B:Type} (f:A -> B) {x y:A} (p:x = y) : f x = f y
   := match p with idpath => idpath end.

--- a/theories/Tactics.v
+++ b/theories/Tactics.v
@@ -407,3 +407,20 @@ Ltac context_to_lambda G :=
                                 let ret := context G[k] in
                                 exact ret)) in
   (eval cbv zeta in ret).
+
+(** The [rewrite <-] tactic uses [internal_paths_rew], which is definitionally equal to [transport], except for the order of the arguments.  The following replaces the former with the latter. *)
+Ltac internal_paths_rew_to_transport :=
+  repeat match goal with |- context [ internal_paths_rew ?P ?u ?p ] =>
+                           change (internal_paths_rew P u p) with (transport P p u) end.
+
+(** Unfortunately, the more common [rewrite ->] uses [internal_paths_rew_r], which is not definitionally equal to something involving [transport].  However, we do have a propositional equality. The arguments here match the arguments that [internal_paths_rew_r] takes. *)
+Definition internal_paths_rew_r_to_transport {A : Type} {x y : A} (P : A -> Type) (u : P y) (p : x = y)
+  : internal_paths_rew_r P u p = transport P p^ u.
+Proof.
+  destruct p; reflexivity.
+Defined.
+
+(** This tactic replaces both [internal_paths_rew] and [internal_paths_rew_r] with [transport], using [rewrite] for the latter. *)
+Ltac rewrite_to_transport :=
+  internal_paths_rew_to_transport;
+  rewrite ! internal_paths_rew_r_to_transport.


### PR DESCRIPTION
The first commit:
- Explains more clearly why `paths_rew` and `paths_rew_r` are defined, even though they are never used.  It also renames them and makes them `Local`.
- It makes some arguments to `internal_paths_rew` (and `rew_r`) implicit.  Now these look just like `transport`, except for the argument order.
- I also added a remark that `internal_paths_rew` is in fact definitionally equal to `transport`.  It's too bad that it's `internal_paths_rew_r` that arises from the default direction of `rewrite`...
- I removed `paths_rect_r`, which is never used.  The comment suggests that in the past it was needed for `rewrite <-`?

The second commit just moves the `internal_paths_rew` stuff to be right near `transport`, and fixes some other whitespace issues.  So it's best to look at the first commit in isolation to see the substantial changes clearly.

I considered adding
```coq
Ltac paths_rew_to_transport :=
  repeat match goal with |- context [ internal_paths_rew ?P ?u ?p ] =>
                           change (internal_paths_rew P u p) with (transport P p u) end.
```
to Tactics.v, but since it's `rew_r` that is more common, this probably isn't that useful.

(It sure would be nice if we could register `transport` as the lemma that rewrite should use in one direction, and `fun ... => transport P p^ u` to be what to use in the other direction.  I may open a Coq issue suggesting this.)