### PR TITLE
2-cat of pointed types

### DIFF
--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -200,7 +200,7 @@ Local Definition ext_cyclic_exact@{u v w +} `{Univalence}
          o* (pequiv_groupisomorphism (equiv_Z1_hom A))^-1*).
 Proof.
   (* we first move [equiv_Z1_hom] across the total space *)
-  apply moveL_isexact_equiv@{v v v w}.
+  apply moveL_isexact_equiv@{v w}.
   (* now we change the left map so as to apply exactness at iii from above *)
   snrapply (isexact_homotopic_i (Tr (-1))).
   1: exact (fmap10 (A:=Group^op) ab_hom (Z1_mul_nat n) A o*

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -81,14 +81,19 @@ Definition iscomplex_homotopic_f {F X Y : pType}
 
 Definition iscomplex_cancelR {F X Y Y' : pType}
   (i : F ->* X) (f : X ->* Y) (e : Y <~>* Y') (cx : IsComplex i (e o* f))
-  : IsComplex i f
-  := (compose_V_hh e (f o* i))^$ $@ cat_postwhisker _ ((cat_assoc i _ _)^$ $@ cx)
-       $@ precompose_pconst _.
+  : IsComplex i f.
+Proof.
+  refine (_ @* precompose_pconst e^-1*).
+  refine ((compose_V_hh e (f o* i))^$ $@ _).
+  refine (cat_postwhisker e^-1* _).
+  refine ((cat_assoc _ _ _)^$ $@ _).
+  exact cx.
+Defined.
 
 (** And likewise passage across squares with equivalences *)
 Definition iscomplex_equiv_i {F F' X X' Y : pType}
   (i : F ->* X) (i' : F' ->* X')
-  (g : F' <~>* F) (h : X' <~>* X) (p : Square g h i' i)
+  (g : F' $<~> F) (h : X' $<~> X) (p : Square g h i' i)
   (f : X ->* Y)
   (cx: IsComplex i f)
   : IsComplex i' (f o* h).
@@ -212,7 +217,7 @@ Defined.
 (** And also passage across squares with equivalences. *)
 Definition isexact_equiv_i n  {F F' X X' Y : pType}
   (i : F ->* X) (i' : F' ->* X')
-  (g : F' <~>* F) (h : X' <~>* X) (p : Square g h i' i)
+  (g : F' $<~> F) (h : X' $<~> X) (p : Square g h i' i)
   (f : X ->* Y) `{IsExact n F X Y i f}
   : IsExact n i' (f o* h).
 Proof.
@@ -259,7 +264,7 @@ Defined.
 Definition isexact_square_if n  {F F' X X' Y Y' : pType}
   {i : F ->* X} {i' : F' ->* X'}
   {f : X ->* Y} {f' : X' ->* Y'}
-  (g : F' <~>* F) (h : X' <~>* X) (k : Y' <~>* Y)
+  (g : F' $<~> F) (h : X' $<~> X) (k : Y' $<~> Y)
   (p : Square g h i' i) (q : Square h k f' f)
   `{IsExact n F X Y i f}
   : IsExact n i' f'.
@@ -267,7 +272,7 @@ Proof.
   pose (I := isexact_equiv_i n i i' g h p f).
   pose (I2 := isexact_homotopic_f n i' q).
   exists (iscomplex_cancelR i' f' k cx_isexact).
-  epose (e := (pequiv_pfiber (id_cate _) k (cat_idr (k o* f'))^$
+  epose (e := (pequiv_pfiber (id_cate _) k (cat_idr (k $o f'))^$
     : pfiber f' <~>* pfiber (k o* f'))).
   nrefine (cancelR_isequiv_conn_map n _ e).
   1: apply pointed_isequiv.
@@ -358,7 +363,7 @@ Defined.
 
 Definition pequiv_cxfib {F X Y : pType} {i : F ->* X} {f : X ->* Y}
   `{IsExact purely F X Y i f}
-  : F <~>* pfiber f
+  : F $<~> pfiber f
   := Build_pEquiv _ _ (cxfib cx_isexact) _.
 
 Definition fiberseq_isexact_purely {F X Y : pType} (i : F ->* X) (f : X ->* Y)

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -327,9 +327,10 @@ Definition joinrecdata_0gpd_fun (A B : Type) : Fun11 Type ZeroGpd
 (** By the Yoneda lemma, it follows from [JoinRecData] being a 1-functor that given [JoinRecData] in [J], we get a map [(J -> P) $-> (JoinRecData A B P)] of 0-groupoids which is natural in [P]. Below we will specialize to the case where [J] is [Join A B] with the canonical [JoinRecData]. *)
 Definition join_nattrans_recdata {A B J : Type} (f : JoinRecData A B J)
   : NatTrans (opyon_0gpd J) (joinrecdata_0gpd_fun A B).
-Proof.
-  srapply Build_NatTrans.  (* This finds the Yoneda lemma via typeclass search. Is that what we want? *)
-  Unshelve.
+Proof. 
+  snrapply Build_NatTrans.
+  1: rapply opyoneda_0gpd.
+  2: exact _.
   exact f.
 Defined.
 

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -261,8 +261,8 @@ Global Instance phomotopy_symmetric {A B} : Symmetric (@pHomotopy A B).
 Proof.
   intros f g p.
   snrefine (Build_pHomotopy _ _); cbn.
-  - intros x; exact ((p x)^).
-  - refine (inverse2 (dpoint_eq p) @ inv_pV _ _).
+  1: intros x; exact ((p x)^).
+  by pelim p f g.
 Defined.
 
 Notation "p ^*" := (phomotopy_symmetric _ _ p) : pointed_scope.
@@ -285,10 +285,8 @@ Definition pmap_postwhisker {A B C : pType} {f g : A ->* B}
   : h o* f ==* h o* g.
 Proof.
   snrefine (Build_pHomotopy _ _); cbn.
-  - exact (fun x => ap h (p x)).
-  - nrefine (ap _ (dpoint_eq p) @ ap_pp _ _ _ @ whiskerL _ (ap_V _ _) @ _^).
-    nrefine (whiskerL _ (inv_pp _ _) @ concat_pp_p _ _ _ @ _).
-    exact (whiskerL _ (concat_p_Vp _ _)).
+  1: exact (fun x => ap h (p x)).
+  by pelim p f g h. 
 Defined.
 
 Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
@@ -296,10 +294,8 @@ Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
   : g o* f ==* h o* f.
 Proof.
   snrefine (Build_pHomotopy _ _); cbn.
-  - exact (fun x => p (f x)).
-  - apply moveL_pV.
-    nrefine (concat_p_pp _ _ _ @ whiskerR (concat_Ap p (point_eq f))^ _ @ _).
-    exact (concat_pp_p _ _ _ @ whiskerL _ (point_htpy p)).
+  1: exact (fun x => p (f x)).
+  by pelim f p g h.
 Defined.
 
 (** ** 1-categorical properties of [pType]. *)
@@ -311,10 +307,7 @@ Definition pmap_compose_assoc {A B C D : pType} (h : C ->* D)
 Proof.
   snrapply Build_pHomotopy.
   1: reflexivity.
-  pointed_reduce_pmap f.
-  pointed_reduce_pmap g.
-  pointed_reduce_pmap h.
-  reflexivity.
+  by pelim f g h.
 Defined.
 
 (** precomposition of identity pointed map *)
@@ -323,8 +316,7 @@ Definition pmap_precompose_idmap {A B : pType} (f : A ->* B)
 Proof.
   snrapply Build_pHomotopy.
   1: reflexivity.
-  symmetry.
-  apply concat_pp_V.
+  by pelim f.
 Defined.
 
 (** postcomposition of identity pointed map *)
@@ -333,10 +325,7 @@ Definition pmap_postcompose_idmap {A B : pType} (f : A ->* B)
 Proof.
   snrapply Build_pHomotopy.
   1: reflexivity.
-  symmetry.
-  apply moveR_pV.
-  simpl.
-  apply equiv_p1_1q, ap_idmap.
+  by pelim f.
 Defined.
 
 (** ** Funext for pointed types and direct consequences. *)
@@ -575,46 +564,38 @@ Definition phomotopy_compose_p1 {A : pType} {P : pFam A} {f g : pForall A P}
 Proof.
   srapply Build_pHomotopy.
   1: intro; apply concat_p1.
-  pointed_reduce.
-  rewrite (concat_pp_V H (concat_p1 _))^. generalize (H @ concat_p1 _).
-  clear H. intros H. destruct H.
-  generalize (p point); generalize (g point).
-  intros x q. destruct q. reflexivity.
+  by pelim p f g.
 Defined.
 
 Definition phomotopy_compose_1p {A : pType} {P : pFam A} {f g : pForall A P}
  (p : f ==* g) : reflexivity f @* p ==* p.
 Proof.
   srapply Build_pHomotopy.
-  + intro x. apply concat_1p.
-  + pointed_reduce.
-    rewrite (concat_pp_V H (concat_p1 _))^. generalize (H @ concat_p1 _).
-    clear H. intros H. destruct H.
-    generalize (p point). generalize (g point).
-    intros x q. destruct q. reflexivity.
+  1: intro x; apply concat_1p.
+  by pelim p f g.
 Defined.
 
 Definition phomotopy_compose_pV {A : pType} {P : pFam A} {f g : pForall A P}
  (p : f ==* g) : p @* p ^* ==* phomotopy_reflexive f.
 Proof.
   srapply Build_pHomotopy.
-  + intro x. apply concat_pV.
-  + by pelim p f g.
+  1: intro x; apply concat_pV.
+  by pelim p f g.
 Defined.
 
 Definition phomotopy_compose_Vp {A : pType} {P : pFam A} {f g : pForall A P}
  (p : f ==* g) : p ^* @* p ==* phomotopy_reflexive g.
 Proof.
   srapply Build_pHomotopy.
-  + intro x. apply concat_Vp.
-  + by pelim p f g.
+  1: intro x; apply concat_Vp.
+  by pelim p f g.
 Defined.
 
 Definition equiv_phomotopy_concat_l `{Funext} {A B : pType}
   (f g h : A ->* B) (K : g ==* f)
   : f ==* h <~> g ==* h.
 Proof.
-  refine ((equiv_path_pforall _ _)^-1%equiv oE _ oE equiv_path_pforall _ _).
+refine ((equiv_path_pforall _ _)^-1%equiv oE _ oE equiv_path_pforall _ _).
   rapply equiv_concat_l.
   apply equiv_path_pforall.
   exact K.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -186,13 +186,13 @@ Ltac pointed_reduce_pmap f
     | _ ->* ?Y => let p := fresh in destruct Y as [Y ?], f as [f p]; cbn in *; destruct p; cbn
     end.
 
-(** General tactic to reduce any pointed equations of a pForall *)
+(** A general tactic to replace pointedness paths in a pForall with reflexivity.  It clears the function, so can only be applied once the function itself is not longer needed. *)
 Ltac pelim q :=
   destruct q as [q ?];
-  unfold pointed_fun, point_htpy in *;    
+  unfold pointed_fun, point_htpy in *;
   cbn;
   generalize dependent (q pt);
-  rapply paths_ind_r;
+  nrapply paths_ind_r;
   clear q.
 
 Tactic Notation "pelim" constr(x0) := pelim x0.
@@ -286,7 +286,7 @@ Definition pmap_postwhisker {A B C : pType} {f g : A ->* B}
 Proof.
   snrefine (Build_pHomotopy _ _); cbn.
   1: exact (fun x => ap h (p x)).
-  by pelim p f g h. 
+  by pelim p f g h.
 Defined.
 
 Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
@@ -440,10 +440,10 @@ Defined.
 
 (* A pointed equivalence is a section of its inverse *)
 Definition peissect {A B : pType} (f : A <~>* B)
-  : (pequiv_inverse f) o* f ==* pmap_idmap. 
+  : (pequiv_inverse f) o* f ==* pmap_idmap.
 Proof.
   srefine (Build_pHomotopy _ _).
-  1: apply (eissect f). 
+  1: apply (eissect f).
   simpl. unfold moveR_equiv_V.
   pointed_reduce.
   symmetry.
@@ -595,7 +595,7 @@ Definition equiv_phomotopy_concat_l `{Funext} {A B : pType}
   (f g h : A ->* B) (K : g ==* f)
   : f ==* h <~> g ==* h.
 Proof.
-refine ((equiv_path_pforall _ _)^-1%equiv oE _ oE equiv_path_pforall _ _).
+  refine ((equiv_path_pforall _ _)^-1%equiv oE _ oE equiv_path_pforall _ _).
   rapply equiv_concat_l.
   apply equiv_path_pforall.
   exact K.
@@ -758,38 +758,39 @@ Proof.
   + intros ? ? p. exact (phomotopy_compose_Vp p).
 Defined.
 
-Global Instance is3graph_ptype : Is3Graph pType := fun f g => _.
+Global Instance is3graph_ptype : Is3Graph pType
+  := fun f g => is2graph_pforall _ _.
 
 Global Instance is21cat_ptype : Is21Cat pType.
 Proof.
   unshelve econstructor.
-  1: exact _.
-  - intros f g h p; nrapply Build_Is1Functor.
-    + intros q r s t u.
+  - exact _.
+  - intros A B C f; nrapply Build_Is1Functor.
+    + intros g h p q r.
       srapply Build_pHomotopy.
-      1: exact (fun _ => ap _ (u _)).
-      by pelim u s t q r p.
-    + intros q.
+      1: exact (fun _ => ap _ (r _)).
+      by pelim r p q g h f.
+    + intros g.
       srapply Build_pHomotopy.
       1: reflexivity.
-      by pelim q p.
-    + intros a b c s t.
+      by pelim g f.
+    + intros g h i p q.
       srapply Build_pHomotopy.
       1: cbn; exact (fun _ => ap_pp _ _ _).
-      by pelim s t a b c p.
-  - intros f g h p; nrapply Build_Is1Functor.
-    + intros q r s t u.
+      by pelim p q g h i f.
+  - intros A B C f; nrapply Build_Is1Functor.
+    + intros g h p q r.
       srapply Build_pHomotopy.
-      1: intro; exact (u _).
-      by pelim p u s t q r.
-    + intros q.
-      srapply Build_pHomotopy.
-      1: reflexivity.
-      by pelim p q.
-    + intros a b c s t.
+      1: intro; exact (r _).
+      by pelim f r p q g h.
+    + intros g.
       srapply Build_pHomotopy.
       1: reflexivity.
-      by pelim p s t a b c.
+      by pelim f g.
+    + intros g h i p q.
+      srapply Build_pHomotopy.
+      1: reflexivity.
+      by pelim f p q i g h.
   - intros A B C D f g r1 r2 s1.
     srapply Build_pHomotopy.
     1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -193,7 +193,7 @@ Ltac pelim q :=
   cbn;
   generalize dependent (q pt);
   nrapply paths_ind_r;
-  clear q.
+  try clear q.
 
 Tactic Notation "pelim" constr(x0) := pelim x0.
 Tactic Notation "pelim" constr(x0) constr(x1) := pelim x0; pelim x1.

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -99,8 +99,9 @@ Defined.
 (** Loops is a pointed functor *)
 Global Instance ispointedfunctor_loops : IsPointedFunctor loops.
 Proof.
-  rapply Build_IsPointedFunctor'.
-  apply pequiv_loops_punit.
+  snrapply Build_IsPointedFunctor'.
+  1-4: exact _.
+  exact pequiv_loops_punit.
 Defined.
 
 Lemma fmap_loops_pconst {A B : pType} : fmap loops (@pconst A B) ==* pconst.
@@ -122,7 +123,7 @@ Global Instance is1functor_iterated_loops n : Is1Functor (iterated_loops n).
 Proof.
   induction n.
   1: exact _.
-  rapply is1functor_compose.
+  nrapply is1functor_compose; exact _.
 Defined.
 
 Lemma fmap_iterated_loops_pp {X Y : pType} (f : X ->* Y) n

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -84,7 +84,7 @@ Defined.
 Definition pequiv_pfiber {A B C D}
            {f : A ->* B} {g : C ->* D} (h : A <~>* C) (k : B <~>* D)
            (p : k o* f ==* g o* h)
-  : pfiber f <~>* pfiber g
+  : pfiber f $<~> pfiber g
   := Build_pEquiv _ _ (functor_pfiber p) _.
 
 Definition square_functor_pfiber {A B C D}

--- a/theories/Pointed/pHomotopy.v
+++ b/theories/Pointed/pHomotopy.v
@@ -25,26 +25,16 @@ Defined.
 
 (** ** Whiskering of pointed homotopies by pointed functions *)
 
-Definition pmap_postwhisker {A B C : pType} {f g : A ->* B}
-  (h : B ->* C) (p : f ==* g) : h o* f ==* h o* g.
+Definition pmap_postwhisker {A B C : pType} {f g : A $-> B}
+  (h : B $-> C) (p : f ==* g) : h o* f ==* h o* g.
 Proof.
-  snrapply Build_pHomotopy; cbn.
-  1: intros a; apply ap, p.
-  pointed_reduce.
-  symmetry.
-  simpl.
-  refine (concat_p1 _ @ concat_p1 _ @ ap _ _).
-  exact (concat_p1 _).
+  exact (h $@L p).
 Defined.
 
-Definition pmap_prewhisker {A B C : pType} (f : A ->* B)
-  {g h : B ->* C} (p : g ==* h) : g o* f ==* h o* f.
+Definition pmap_prewhisker {A B C : pType} (f : A $-> B)
+  {g h : B $-> C} (p : g $== h) : g o* f ==* h o* f.
 Proof.
-  snrapply Build_pHomotopy; cbn.
-  1: intros a; apply p.
-  pointed_reduce.
-  symmetry.
-  refine (concat_p1 _ @ concat_1p _ @ concat_p1 _).
+  exact (p $@R f).
 Defined.
 
 (** ** [phomotopy_path] respects 2-cells. *)


### PR DESCRIPTION
We show the (2,1)-category structure for pointed types. In order to do this easily, we introduce a new tactic called pelim which allows easy path induction on the pointed equation of various pointed structures. This is particularly useful in removing funext from various pType coherences.

Various places seemed to break from these changes, but could easily be fixed by replacing pointed notations with wildcat notations. This perhaps hints at a larger refactoring that should be done.

My motivation for showing these coherences is the need for 1-functoriality of pre/postcomposition for some unrelated work. Therefore it made sense to quickly generalize to the full 2-category while I was at it.