### PR TITLE
Updates to EMSpace, Join/Core, HSpaces/* and other things

### DIFF
--- a/test/Pointed/Core.v
+++ b/test/Pointed/Core.v
@@ -1,0 +1,19 @@
+From HoTT Require Import Basics.Overture Pointed.Core.
+
+(** Test pelim tactic. *)
+
+Open Scope pointed_scope.
+
+(** Check that it works for types with explicit base points. *)
+Definition test1 {X Y : Type} {x : X} {y : Y} (f : [X,x] ->* [Y,y]) : (f x = y) * (point_eq f = point_eq f).
+Proof.
+  pelim f.
+  split; reflexivity.
+Defined.
+
+(** Check that it works for pointed equivalences. *)
+Definition test2 {X Y : pType} (f : X <~>* Y) : (f pt = pt) * (point_eq f = point_eq f).
+Proof.
+  pelim f.
+  split; reflexivity.
+Defined.

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -354,7 +354,7 @@ Global Instance issurj_isabelianization {G : Group}
 Proof.
   intros k.
   pose (homotopic_isabelianization A (abel G) eta (abel_unit G)) as p.
-  refine (@cancelR_isequiv_conn_map _ _ _ _ _ _ _
+  refine (@cancelL_isequiv_conn_map _ _ _ _ _ _ _
     (conn_map_homotopic _ _ _ p _)).
 Defined.
 

--- a/theories/Algebra/AbSES/Pullback.v
+++ b/theories/Algebra/AbSES/Pullback.v
@@ -26,7 +26,7 @@ Proof.
     + snrapply phomotopy_homotopy_hset.
       * exact _.
       * reflexivity.
-    + nrefine (cancelR_equiv_conn_map
+    + nrefine (cancelL_equiv_conn_map
                  _ _ (hfiber_pullback_along_pointed f (projection _) (grp_homo_unit _))).
       nrefine (conn_map_homotopic _ _ _ _ (conn_map_isexact (IsExact:=isexact_inclusion_projection _))).
       intro a.

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -149,7 +149,7 @@ Proof.
     revert dependent F; nrapply (Trunc_ind (n:=0) (A:=AbSES B G)).
     (* [exact _.] works here, but is slow. *)
     { intro x; nrapply istrunc_forall.
-      intro y; rapply (istrunc_leq (trunc_index_leq_succ@{u} _)). }
+      intro y; rapply (istrunc_leq (trunc_index_leq_succ _)). }
     intro F.
     equiv_intros (equiv_path_Tr (n:=-1) (abses_pullback (projection E) F) pt) p.
     strip_truncations.

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -6,8 +6,6 @@ Require Import Basics.Overture.
 
 (** This module implements various tactics used in the library. *)
 
-(** Simple induction *)
-
 (** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [nat] or a [trunc_index].  The difference is that it produces proof terms involving [fix] explicitly rather than [nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. *)
 Ltac simple_induction n n' IH :=
   generalize dependent n;

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -120,6 +120,14 @@ Proof.
   all: assumption.
 Defined.
 
+Definition trunc_index_add_comm m n
+  : m +2+ n = n +2+ m.
+Proof.
+  induction n.
+  - apply trunc_index_add_minus_two.
+  - exact (trunc_index_add_succ _ _ @ ap trunc_S IHn).
+Defined.
+
 Fixpoint trunc_index_leq (m n : trunc_index) : Type0
   := match m, n with
        | -2, _ => Unit
@@ -147,6 +155,15 @@ Defined.
 
 Notation "n '.-1'" := (trunc_index_pred n) : trunc_scope.
 Notation "n '.-2'" := (n.-1.-1) : trunc_scope.
+
+Definition trunc_index_succ_pred (n : nat)
+  : (n.-1).+1 = n.
+Proof.
+  induction n as [|n IHn].
+  1: reflexivity.
+  unfold nat_to_trunc_index in *; cbn in *.
+  refine (ap trunc_S IHn).
+Defined.
 
 Definition trunc_index_leq_minus_two {n}
   : n <= -2 -> n = -2.

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -292,8 +292,8 @@ Section ImaginaroidHSpace.
     change (forall s : Susp A,
       Diamond (-mon_unit) s (mon_unit) s).
     srapply Susp_ind_dp; hnf.
-    1: by apply diamond_v.
-    1: by apply diamond_h.
+    1: by apply diamond_v_sq.
+    1: by apply diamond_h_sq.
     intro a.
     apply diamond_twist.
   Defined.

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -1,6 +1,6 @@
 Require Import Classes.interfaces.abstract_algebra.
 Require Import Cubical.
-Require Import Pointed.
+Require Import Pointed.Core Pointed.pSusp.
 Require Import Homotopy.HSpace.Core.
 Require Import Homotopy.Suspension.
 Require Import Homotopy.Join.Core.
@@ -34,7 +34,7 @@ Class CayleyDicksonSpheroid (X : pType) := {
   cds_swapop
   cds_factorneg_r.
 
-Section CayleyDicksonSpherioid_Properties.
+Section CayleyDicksonSpheroid_Properties.
 
   Context {X : pType} `(CayleyDicksonSpheroid X).
 
@@ -61,7 +61,7 @@ Section CayleyDicksonSpherioid_Properties.
     apply left_inverse.
   Defined.
 
-End CayleyDicksonSpherioid_Properties.
+End CayleyDicksonSpheroid_Properties.
 
 Global Instance conjugate_susp (A : Type) `(Negate A)
   : Conjugate (Susp A).
@@ -147,7 +147,7 @@ Proof.
   apply concat_pV.
 Defined.
 
-(** Every suspension of a Cayley-Dickson imaginaroid gives a Cayley-Dickson spherioid. *)
+(** Every suspension of a Cayley-Dickson imaginaroid gives a Cayley-Dickson spheroid. *)
 Global Instance cds_susp_cdi {A} `(CayleyDicksonImaginaroid A)
   : CayleyDicksonSpheroid (psusp A) := {}.
 

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -218,6 +218,12 @@ Section EilenbergMacLane.
     induction n; exact _.
   Defined.
 
+  Global Instance is0connected_em {G : Group} (n : nat)
+    : IsConnected 0 K(G, n.+1).
+  Proof.
+    rapply (is0connected_isconnected n).
+  Defined.
+
   Local Open Scope trunc_scope.
 
   (* This is a variant of [pequiv_ptr_loop_psusp] from pSusp.v. All we are really using is that [n.+2 <= n +2+ n], but because of the use of [isconnmap_pred_add], the proof is a bit more specific to this case. *)
@@ -266,6 +272,14 @@ Section EilenbergMacLane.
       symmetry.
       snrapply (transitive_groupisomorphism _ _ _ (groupiso_pi_loops _ _)).
       apply (groupiso_pi_functor _ (pequiv_loops_em_em _ _)).
+  Defined.
+
+  Definition iscohhspace_em `{Univalence} {G : AbGroup} (n : nat)
+    : IsCohHSpace K(G, n).
+  Proof.
+    nrapply iscohhspace_equiv_cohhspace.
+    2: symmetry; apply pequiv_loops_em_em.
+    apply iscohhspace_loops.
   Defined.
 
 End EilenbergMacLane.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -5,6 +5,7 @@ Require Import Algebra.AbGroups.
 Require Import Homotopy.Suspension.
 Require Import Homotopy.ClassifyingSpace.
 Require Import Homotopy.HSpace.Core.
+Require Import Homotopy.HSpace.Coherent.
 Require Import Homotopy.HomotopyGroup.
 Require Import TruncType.
 Require Import Truncations.Core Truncations.Connectedness.
@@ -17,23 +18,21 @@ Local Open Scope nat_scope.
 Local Open Scope bg_scope.
 Local Open Scope mc_mult_scope.
 
-
 (** When X is 0-connected we see that Freudenthal doesn't let us characterise the loop space of a suspension. For this we need some extra assumptions about our space X.
 
 Suppose X is a 0-connected, 1-truncated coherent H-space, then
 
   pTr 1 (loops (psusp X)) <~>* X
 
-By coherent H-space we mean that left and right identity laws at the unit are the same.
-*)
+By a coherent H-space we mean that the left and right identity laws at the unit are the same. *)
 
 Section LicataFinsterLemma.
 
   Context `{Univalence} (X : pType)
     `{IsConnected 0 X} `{IsTrunc 1 X} `{IsHSpace X}
-    {coh : left_identity mon_unit = right_identity mon_unit}.
+    {coh : IsCoherent X}.
 
-  (** This encode-decode style proof is detailed in Eilenberg-MacLane Spaces in Homotopy Type Theory by Dan Licata and Eric Finster *)
+  (** This encode-decode style proof is detailed in Eilenberg-MacLane Spaces in Homotopy Type Theory by Dan Licata and Eric Finster. *)
 
   Local Definition P : Susp X -> Type
     := fun x => Tr 1 (North = x).
@@ -181,7 +180,7 @@ Section LicataFinsterLemma.
     apply ap, concat_pV.
   Defined.
 
-  (* We could call this pequiv_ptr_loop_psusp but since we already used that for the Freudenthal case, it seems appropriate to name licata_finster for this one case *)
+  (* We could call this pequiv_ptr_loop_psusp but since we already used that for the Freudenthal case, it seems appropriate to use the name licata_finster for this one case. *)
   Lemma licata_finster : pTr 1 (loops (psusp X)) <~>* X.
   Proof.
     srapply Build_pEquiv'.
@@ -195,20 +194,20 @@ Section LicataFinsterLemma.
 
 End LicataFinsterLemma.
 
+(** The definition of the Eilenberg-Mac Lane spaces.  Note that while we allow [G] to be non-abelian for [n > 1], later results will need to assume that [G] is abelian. *)
+Fixpoint EilenbergMacLane (G : Group) (n : nat) : pType
+  := match n with
+      | 0    => G
+      | 1    => pClassifyingSpace G
+      | m.+1 => pTr m.+1 (psusp (EilenbergMacLane G m))
+     end.
+
+Notation "'K(' G , n )" := (EilenbergMacLane G n).
 
 Section EilenbergMacLane.
   Context `{Univalence}.
 
-  Fixpoint EilenbergMacLane (G : Group) (n : nat) : pType
-    := match n with
-        | 0    => G
-        | 1    => pClassifyingSpace G
-        | m.+1 => pTr m.+1 (psusp (EilenbergMacLane G m))
-       end.
-
-  Notation "'K(' G , n )" := (EilenbergMacLane G n).
-
-  Global Instance istrunc_em {G : Group}  {n : nat} : IsTrunc n K(G, n).
+  Global Instance istrunc_em {G : Group} {n : nat} : IsTrunc n K(G, n).
   Proof.
     destruct n as [|[]]; exact _.
   Defined.
@@ -242,6 +241,7 @@ Section EilenbergMacLane.
     refine (_ o*E (ptr_loops _ _)^-1* ).
     destruct n.
     { srapply licata_finster.
+      1: exact _.
       reflexivity. }
     refine ((pequiv_ptr (n:=n.+2))^-1* o*E _).
     symmetry; rapply pequiv_ptr_loop_psusp'.

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -79,7 +79,7 @@ Definition iscomplex_homotopic_f {F X Y : pType}
   : IsComplex i f'
   := pmap_prewhisker i ff @* cx.
 
-Definition iscomplex_cancelR {F X Y Y' : pType}
+Definition iscomplex_cancelL {F X Y Y' : pType}
   (i : F ->* X) (f : X ->* Y) (e : Y <~>* Y') (cx : IsComplex i (e o* f))
   : IsComplex i f.
 Proof.
@@ -206,7 +206,7 @@ Definition isexact_homotopic_f n  {F X Y : pType}
 Proof.
   exists (iscomplex_homotopic_f i ff cx_isexact).
   pose (e := equiv_hfiber_homotopic _ _ ff pt).
-  nrefine (cancelR_isequiv_conn_map n _ e).
+  nrefine (cancelL_isequiv_conn_map n _ e).
   1: apply equiv_isequiv.
   refine (conn_map_homotopic n (cxfib (cx_isexact)) _ _ _).
   intro u. simpl. srapply path_hfiber.
@@ -222,7 +222,7 @@ Definition isexact_equiv_i n  {F F' X X' Y : pType}
   : IsExact n i' (f o* h).
 Proof.
   exists (iscomplex_equiv_i i i' g h p f cx_isexact); cbn.
-  snrefine (cancelR_equiv_conn_map n (C := pfiber f) _ _).
+  snrefine (cancelL_equiv_conn_map n (C := pfiber f) _ _).
   - exact (@equiv_functor_hfiber _ _ _ _ (f o h) f h equiv_idmap
              (fun x => 1%path) (point Y)).
   - cbn; unfold functor_hfiber, functor_sigma; cbn.
@@ -271,10 +271,10 @@ Definition isexact_square_if n  {F F' X X' Y Y' : pType}
 Proof.
   pose (I := isexact_equiv_i n i i' g h p f).
   pose (I2 := isexact_homotopic_f n i' q).
-  exists (iscomplex_cancelR i' f' k cx_isexact).
+  exists (iscomplex_cancelL i' f' k cx_isexact).
   epose (e := (pequiv_pfiber (id_cate _) k (cat_idr (k $o f'))^$
     : pfiber f' <~>* pfiber (k o* f'))).
-  nrefine (cancelR_isequiv_conn_map n _ e).
+  nrefine (cancelL_isequiv_conn_map n _ e).
   1: apply pointed_isequiv.
   refine (conn_map_homotopic n (cxfib (cx_isexact)) _ _ _).
   intro u. srapply path_hfiber.

--- a/theories/Homotopy/Freudenthal.v
+++ b/theories/Homotopy/Freudenthal.v
@@ -28,6 +28,6 @@ Proof.
   exact ((concat_p1 _ @ concat_1p _)^).
 Defined.
 
-Definition freudenthal@{u v | u < v} := Eval unfold freudenthal' in @freudenthal'@{u u u u u v u u u u u}.
+Definition freudenthal@{u v | u < v} := Eval unfold freudenthal' in @freudenthal'@{u u u u u v u u u u u u}.
 
 Global Existing Instance freudenthal.

--- a/theories/Homotopy/Freudenthal.v
+++ b/theories/Homotopy/Freudenthal.v
@@ -28,6 +28,6 @@ Proof.
   exact ((concat_p1 _ @ concat_1p _)^).
 Defined.
 
-Definition freudenthal@{u v | u < v} := Eval unfold freudenthal' in @freudenthal'@{u u u u u v u u u u u u}.
+Definition freudenthal@{u v | u < v} := Eval unfold freudenthal' in @freudenthal'@{u u u u u v u u u u u}.
 
 Global Existing Instance freudenthal.

--- a/theories/Homotopy/Freudenthal.v
+++ b/theories/Homotopy/Freudenthal.v
@@ -13,7 +13,7 @@ Local Definition freudenthal' `{Univalence} (n : trunc_index)
            (X : Type) `{IsConnected n.+1 X}
   : IsConnMap (n +2+ n) (@merid X).
 Proof.
-  snrapply cancelR_equiv_conn_map.
+  snrapply cancelL_equiv_conn_map.
   2: { refine (equiv_ap' (B:=SPushout (fun (u v : Unit) => X)) _ North South).
        exact (equiv_pushout (equiv_contr_sigma (fun _ : Unit * Unit => X))^-1
                             (equiv_idmap Unit) (equiv_idmap Unit)

--- a/theories/Homotopy/HSpace/Coherent.v
+++ b/theories/Homotopy/HSpace/Coherent.v
@@ -1,13 +1,14 @@
-Require Import Basics HSpace.Core.
+Require Import Basics HSpace.Core Pointed.Core.
 
 Local Open Scope mc_mult_scope.
+Local Open Scope pointed_scope.
 
 (** ** Coherent H-space structures *)
 
 (** An H-space is coherent when the left and right identities agree at the base point. *)
 
 Class IsCoherent (X : pType) `{IsHSpace X} :=
-  iscoherent : left_identity _ = right_identity _.
+  iscoherent : left_identity pt = right_identity pt.
 
 Record IsCohHSpace (A : pType) := {
     ishspace_cohhspace : IsHSpace A;
@@ -17,9 +18,9 @@ Record IsCohHSpace (A : pType) := {
 
 Definition issig_iscohhspace (A : pType)
   : { hspace_op : SgOp A
-    & { hspace_left_identity : LeftIdentity hspace_op _
-    & { hspace_right_identity : RightIdentity hspace_op _
-    & hspace_left_identity (point _) = hspace_right_identity _ } } }
+    & { hspace_left_identity : LeftIdentity hspace_op pt
+    & { hspace_right_identity : RightIdentity hspace_op pt
+    & hspace_left_identity pt = hspace_right_identity pt } } }
       <~> IsCohHSpace A.
 Proof.
   transitivity { H : IsHSpace A & IsCoherent A }.

--- a/theories/Homotopy/HSpace/Coherent.v
+++ b/theories/Homotopy/HSpace/Coherent.v
@@ -1,4 +1,4 @@
-Require Import Basics HSpace.Core Pointed.Core.
+Require Import Basics HSpace.Core Pointed.Core Pointed.Loops.
 
 Local Open Scope mc_mult_scope.
 Local Open Scope pointed_scope.
@@ -27,4 +27,27 @@ Proof.
   2: issig.
   unfold IsCoherent.
   make_equiv.
+Defined.
+
+(** A type equivalent to a coherent H-space is a coherent H-space. *)
+Definition iscohhspace_equiv_cohhspace {X Y : pType} `{IsCohHSpace Y} (f : X <~>* Y)
+  : IsCohHSpace X.
+Proof.
+  snrapply Build_IsCohHSpace.
+  - rapply (ishspace_equiv_hspace f).
+    apply ishspace_cohhspace; assumption.
+  - unfold IsCoherent; cbn.
+    refine (_ @@ 1).
+    refine (ap (ap f^-1) _).
+    pointed_reduce_pmap f.
+    refine (1 @@ _).
+    exact (@iscoherent [Y, f pt] _ _).
+Defined.
+
+(** Every loop space is a coherent H-space. *)
+Definition iscohhspace_loops {X : pType} : IsCohHSpace (loops X).
+Proof.
+  snrapply Build_IsCohHSpace.
+  - apply ishspace_loops.
+  - reflexivity.
 Defined.

--- a/theories/Homotopy/HSpace/Coherent.v
+++ b/theories/Homotopy/HSpace/Coherent.v
@@ -39,9 +39,9 @@ Proof.
   - unfold IsCoherent; cbn.
     refine (_ @@ 1).
     refine (ap (ap f^-1) _).
-    pointed_reduce_pmap f.
+    pelim f.
     refine (1 @@ _).
-    exact (@iscoherent [Y, f pt] _ _).
+    apply iscoherent.
 Defined.
 
 (** Every loop space is a coherent H-space. *)

--- a/theories/Homotopy/HSpace/Core.v
+++ b/theories/Homotopy/HSpace/Core.v
@@ -90,7 +90,11 @@ Definition homogeneous_pt_id {A : pType} `{IsHomogeneous A}
   : forall a, A <~>* [A,a]
   := fun a => ishomogeneous a o*E (ishomogeneous (point A))^-1*.
 
-Definition homogeneous_pt_id_beta `{Funext} {A : pType} `{IsHomogeneous A}
+Definition homogeneous_pt_id_beta {A : pType} `{IsHomogeneous A}
+  : homogeneous_pt_id (point A) ==* pequiv_pmap_idmap
+  := peisretr _.
+
+Definition homogeneous_pt_id_beta' `{Funext} {A : pType} `{IsHomogeneous A}
   : homogeneous_pt_id (point A) = pequiv_pmap_idmap
   := ltac:(apply path_pequiv, peisretr).
 
@@ -102,12 +106,10 @@ Proof.
   - exact (fun a b => homogeneous_pt_id a b).
   - intro a; cbn.
     apply eisretr.
-  - intro a; cbn.
-    exact (ap _ (point_eq (ishomogeneous pt)^-1*)
-                   @ point_eq (ishomogeneous a)).
+  - intro a.  exact (point_eq (homogeneous_pt_id a)).
 Defined.
 
-(** Left-invertible H-spaces are homogeneous, giving a logical equivalence between left-invertible H-spaces and homogeneous types. (In fact, the type of homogeneous types with the base point sent to the pointed identity map is equivalent to the type of left-invertible coherent H-spaces, but we don't prove that here.) *)
+(** Left-invertible H-spaces are homogeneous, giving a logical equivalence between left-invertible H-spaces and homogeneous types. (In fact, the type of homogeneous types with the base point sent to the pointed identity map is equivalent to the type of left-invertible coherent H-spaces, but we don't prove that here.) See [equiv_iscohhspace_ptd_action] for a closely related result. *)
 Global Instance ishomogeneous_hspace {A : pType} `{IsHSpace A}
   `{forall a, IsEquiv (a *.)}
   : IsHomogeneous A
@@ -162,4 +164,31 @@ Proof.
   apply path_pforall, hspace_phomotopy_from_homotopy.
   apply (path_arrow _ _)^-1.
   exact K.
+Defined.
+
+(** A type equivalent to an H-space is an H-space. *)
+Definition ishspace_equiv_hspace {X Y : pType} `{IsHSpace Y} (f : X <~>* Y)
+  : IsHSpace X.
+Proof.
+  snrapply Build_IsHSpace.
+  - exact (fun a b => f^-1 (f a * f b)).
+  - intro b.
+    rhs_V nrapply (eissect f b).
+    apply ap.
+    lhs nrapply (ap (.* f b) (point_eq f)).
+    apply left_identity.
+  - intro a.
+    rhs_V nrapply (eissect f a).
+    apply ap.
+    lhs nrapply (ap (f a *.) (point_eq f)).
+    apply right_identity.
+Defined.
+
+(** Every loop space is an H-space. Making this an instance breaks CayleyDickson.v because Coq finds this instance rather than the expected one. *)
+Definition ishspace_loops {X : pType} : IsHSpace (loops X).
+Proof.
+  snrapply Build_IsHSpace.
+  - exact concat.
+  - exact concat_1p.
+  - exact concat_p1.
 Defined.

--- a/theories/Homotopy/HSpace/Pointwise.v
+++ b/theories/Homotopy/HSpace/Pointwise.v
@@ -64,10 +64,9 @@ Proof.
     snrapply Build_pHomotopy.
     + intro y; cbn.
       apply hspace_right_identity.
-    + cbn.
-      apply moveL_pV.
-      refine (concat_1p _ @ _ @ concat_A1p _ (dpoint_eq f))^; cbn.
-      apply whiskerL.
+    + pelim f; cbn.
+      symmetry.
+      lhs nrapply (concat_p1 _ @ concat_1p _ @ concat_1p _).
       apply iscoherent.
 Defined.
 

--- a/theories/Homotopy/HSpace/Pointwise.v
+++ b/theories/Homotopy/HSpace/Pointwise.v
@@ -5,8 +5,7 @@ Local Open Scope mc_mult_scope.
 
 (** * Pointwise H-space structures *)
 
-(** Whenever [X] is an H-space, so is any type of maps or pointed maps into [X]. *)
-
+(** Whenever [X] is an H-space, so is the type of maps into [X]. *)
 Global Instance ishspace_map `{Funext} (X : pType) (Y : Type)
   `{IsHSpace X} : IsHSpace [Y -> X, const pt].
 (* Note: When writing [f * g], Coq only finds this instance if [f] is explicitly in the pointed type [[Y -> X, const pt]]. *)
@@ -39,8 +38,8 @@ Proof.
            (g:=fun y gy => (f y) * gy)).
 Defined.
 
-(** For the type of pointed maps [Y ->** X], coherence of [X] is needed even to get a noncoherent H-space structure on [Y ->** X]. *)
 
+(** For the type of pointed maps [Y ->** X], coherence of [X] is needed even to get a noncoherent H-space structure on [Y ->** X]. *)
 Global Instance ishspace_pmap `{Funext} (X Y : pType) `{IsCoherent X}
   : IsHSpace (Y ->** X).
 Proof.
@@ -93,7 +92,7 @@ Proof.
     reflexivity.
 Defined.
 
-(** If the H-space structure on [X] is left-invertible, so is that one induced on [Y ->** X]. *)
+(** If the H-space structure on [X] is left-invertible, so is the one induced on [Y ->** X]. *)
 Global Instance isleftinvertible_hspace_pmap `{Funext} (X Y : pType)
   `{IsCoherent X} `{forall x, IsEquiv (x *.)}
   : forall f : Y ->** X, IsEquiv (f *.).

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -461,24 +461,34 @@ Section Diamond.
     := PathSquare (jglue a b) (jglue a' b')^ (jglue a b') (jglue a' b)^.
 
   Definition diamond_h {a a' : A} (b b' : B) (p : a = a')
-    : Diamond a a' b b'.
+    : jglue a b @ (jglue a' b)^ = jglue a b' @ (jglue a' b')^.
   Proof.
     destruct p.
-    apply sq_path.
     exact (concat_pV _ @ (concat_pV _)^).
   Defined.
 
-  Definition diamond_v (a a' : A) {b b' : B} (p : b = b')
+  Definition diamond_h_sq {a a' : A} (b b' : B) (p : a = a')
     : Diamond a a' b b'.
   Proof.
-    destruct p.
-    by apply sq_path.
+    by apply sq_path, diamond_h.
+  Defined.
+
+  Definition diamond_v (a a' : A) {b b' : B} (p : b = b')
+    : jglue a b @ (jglue a' b)^ = jglue a b' @ (jglue a' b')^.
+  Proof.
+    by destruct p.
+  Defined.
+
+  Definition diamond_v_sq (a a' : A) {b b' : B} (p : b = b')
+    : Diamond a a' b b'.
+  Proof.
+    by apply sq_path, diamond_v.
   Defined.
 
   Lemma diamond_symm (a : A) (b : B)
-    : diamond_v a a 1 = diamond_h b b 1.
+    : diamond_v_sq a a 1 = diamond_h_sq b b 1.
   Proof.
-    unfold diamond_v, diamond_h.
+    unfold diamond_v_sq, diamond_h_sq, diamond_v, diamond_h.
     symmetry; apply ap, concat_pV.
   Defined.
 
@@ -486,7 +496,7 @@ End Diamond.
 
 Definition diamond_twist {A : Type} {a a' : A} (p : a = a')
   : DPath (fun x => Diamond a' x a x) p
-    (diamond_v a' a 1) (diamond_h a a' 1).
+    (diamond_v_sq a' a 1) (diamond_h_sq a a' 1).
 Proof.
   destruct p.
   apply diamond_symm.

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1471,7 +1471,7 @@ Section ModalMaps.
     intros b; exact _.
   Defined.
 
-  (** Modal maps cancel on the left *)
+  (** Modal maps cancel on the left. *)
   Definition cancelL_mapinO {A B C : Type} (f : A -> B) (g : B -> C)
   : MapIn O g -> MapIn O (g o f) -> MapIn O f.
   Proof.
@@ -1479,7 +1479,22 @@ Section ModalMaps.
     refine (inO_equiv_inO _ (hfiber_hfiber_compose_map f g b)).
   Defined.
 
-  (** The pullback of a modal map is modal *)
+  (** Modal maps also cancel with equivalences on the other side. *)
+  Definition cancelR_isequiv_mapinO {A B C : Type} (f : A -> B) (g : B -> C)
+    `{IsEquiv _ _ f} `{MapIn O _ _ (g o f)}
+  : MapIn O g.
+  Proof.
+    intros b.
+    srefine (inO_equiv_inO' (hfiber (g o f) b) _).
+    exact (equiv_functor_sigma f (fun a => 1%equiv)).
+  Defined.
+
+  Definition cancelR_equiv_mapinO {A B C : Type} (f : A <~> B) (g : B -> C)
+    `{MapIn O _ _ (g o f)}
+  : MapIn O g
+  := cancelR_isequiv_mapinO f g.
+
+  (** The pullback of a modal map is modal. *)
   Global Instance mapinO_pullback {A B C}
          (f : B -> A) (g : C -> A) `{MapIn O _ _ g}
   : MapIn O (f^* g).
@@ -1748,7 +1763,7 @@ Section ConnectedMaps.
   Defined.
 
   (** Connected maps also cancel with equivalences on the other side. *)
-  Definition cancelR_isequiv_conn_map {A B C : Type} (f : A -> B) (g : B -> C)
+  Definition cancelL_isequiv_conn_map {A B C : Type} (f : A -> B) (g : B -> C)
          `{IsEquiv _ _ g} `{IsConnMap O _ _ (g o f)}
     : IsConnMap O f.
   Proof.
@@ -1757,10 +1772,10 @@ Section ConnectedMaps.
     exact (equiv_inverse (equiv_functor_sigma_id (fun a => equiv_ap g (f a) b))).
   Defined.
 
-  Definition cancelR_equiv_conn_map {A B C : Type} (f : A -> B) (g : B <~> C)
+  Definition cancelL_equiv_conn_map {A B C : Type} (f : A -> B) (g : B <~> C)
          `{IsConnMap O _ _ (g o f)}
     : IsConnMap O f
-    := cancelR_isequiv_conn_map f g.
+    := cancelL_isequiv_conn_map f g.
 
   (** The constant map to [Unit] is connected just when its domain is. *)
   Definition isconnected_conn_map_to_unit {A : Type}

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -186,14 +186,14 @@ Ltac pointed_reduce_pmap f
     | _ ->* ?Y => let p := fresh in destruct Y as [Y ?], f as [f p]; cbn in *; destruct p; cbn
     end.
 
-(** A general tactic to replace pointedness paths in a pForall with reflexivity.  Because it generalizes [f pt], it can usually only be applied once the function itself is not longer needed. *)
+(** A general tactic to replace pointedness paths in a pForall with reflexivity.  Because it generalizes [f pt], it can usually only be applied once the function itself is not longer needed.  Compared to [pointed_reduce], an advantage is that the pointed types do not need to be destructed. *)
 Ltac pelim f :=
   try match type of f with
     | pEquiv ?X ?Y => destruct f as [f ?iseq]
   end;
   destruct f as [f ?ptd];
   unfold pointed_fun, point_htpy in *;
-  cbn; cbn in f, ptd;
+  cbn in f, ptd |- *;
   match type of ptd with ?fpt = _ => generalize dependent fpt end;
   nrapply paths_ind_r;
   try clear f.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -186,14 +186,17 @@ Ltac pointed_reduce_pmap f
     | _ ->* ?Y => let p := fresh in destruct Y as [Y ?], f as [f p]; cbn in *; destruct p; cbn
     end.
 
-(** A general tactic to replace pointedness paths in a pForall with reflexivity.  It clears the function, so can only be applied once the function itself is not longer needed. *)
-Ltac pelim q :=
-  destruct q as [q ?];
+(** A general tactic to replace pointedness paths in a pForall with reflexivity.  Because it generalizes [f pt], it can usually only be applied once the function itself is not longer needed. *)
+Ltac pelim f :=
+  try match type of f with
+    | pEquiv ?X ?Y => destruct f as [f ?iseq]
+  end;
+  destruct f as [f ?ptd];
   unfold pointed_fun, point_htpy in *;
-  cbn;
-  generalize dependent (q pt);
+  cbn; cbn in f, ptd;
+  match type of ptd with ?fpt = _ => generalize dependent fpt end;
   nrapply paths_ind_r;
-  try clear q.
+  try clear f.
 
 Tactic Notation "pelim" constr(x0) := pelim x0.
 Tactic Notation "pelim" constr(x0) constr(x1) := pelim x0; pelim x1.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -111,15 +111,7 @@ Proof.
   refine (isconnected_elim n.+1 C f).
 Defined.
 
-(** By induction, an [n.+1]-connected type is also [-1]-connected. *)
-Definition merely_isconnected n A `{IsConnected n.+1 A}
-  : merely A.
-Proof.
-  induction n as [|n IHn].
-  - apply center; assumption.
-  - apply IHn, isconnected_pred; assumption.
-Defined.
-
+(** A [k]-connected type is [n]-connected, when [k >= n].  We constrain [k] by making it of the form [n +2+ m], which makes the induction go through smoothly. *)
 Definition isconnected_pred_add n m A `{H : IsConnected (n +2+ m) A}
   : IsConnected m A.
 Proof.
@@ -129,6 +121,24 @@ Proof.
   apply isconnected_pred.
   assumption.
 Defined.
+
+(** A version with the order of summands swapped, which is sometimes handy, e.g. in the next two results. *)
+Definition isconnected_pred_add' n m A `{H : IsConnected (m +2+ n) A}
+  : IsConnected m A.
+Proof.
+  rewrite trunc_index_add_comm in H.
+  apply (isconnected_pred_add n m); assumption.
+Defined.
+
+(** It follows that an [n.+1]-connected type is also [-1]-connected. *)
+Definition merely_isconnected n A `{IsConnected n.+1 A}
+  : merely A
+  := @center _ (isconnected_pred_add' n (-1) A).
+
+(** And that an [n]-connected type, with [n >= 0], is [0]-connected. *)
+Definition is0connected_isconnected (n : nat) A `{IsConnected n A}
+  : IsConnected 0 A
+  := isconnected_pred_add' n.-2 0 A.
 
 Definition isconnmap_pred_add n m A B (f : A -> B) `{IsConnMap (n +2+ m) _ _ f}
   : IsConnMap m f.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -126,8 +126,8 @@ Defined.
 Definition isconnected_pred_add' n m A `{H : IsConnected (m +2+ n) A}
   : IsConnected m A.
 Proof.
-  rewrite trunc_index_add_comm in H.
-  apply (isconnected_pred_add n m); assumption.
+  apply (isconnected_pred_add n m).
+  destruct (trunc_index_add_comm m n); assumption.
 Defined.
 
 (** It follows that an [n.+1]-connected type is also [-1]-connected. *)


### PR DESCRIPTION
Various things related to H-spaces, Eilenberg-Mac Lane spaces and loop spaces which helps WIP on bands, central types, Euler classes, etc.  The commit titles give a reasonable summary.  Many commits are independent, and the library builds after each commit.  I also improved the just-added `pelim` tactic and added tests.  I used `pelim` in a couple of places; there were other possible places too, but I left the explicit proofs in place.