### PR TITLE
1-category of successor structures

### DIFF
--- a/theories/Homotopy/SuccessorStructure.v
+++ b/theories/Homotopy/SuccessorStructure.v
@@ -1,17 +1,16 @@
 Require Import Basics.
 Require Import Spaces.Int.
 Require Import Spaces.Finite.Fin.
+Require Import WildCat.
 
 (** * Successor Structures. *)
 
 (** A successor structure is just a type with a endofunctor on it, called 'successor'. Typical examples include either the integers or natural numbers with the successor (or predecessor) operation. *)
 
 Record SuccStr : Type := {
-   ss_carrier : Type ;
+   ss_carrier :> Type ;
    ss_succ : ss_carrier -> ss_carrier ;
 }.
-
-Coercion ss_carrier : SuccStr >-> Sortclass.
 
 Declare Scope succ_scope.
 
@@ -72,3 +71,184 @@ Defined.
 Notation "'N3'" := (Stratified (+N) 3) : succ_scope.
 Notation "'Z3'" := (Stratified (+Z) 3) : succ_scope.
 
+(** ** Category of successor structures *)
+
+(** Inspired by the construction of the wildcat structure on pType, we can give SuccStr a wildcat structure in a similar manner (all the way up). *)
+
+Record ssFam (A : SuccStr) := {
+  ss_fam :> A -> Type;
+  dss_succ {x} : ss_fam x -> ss_fam (x.+1);
+}.
+  
+Arguments ss_fam {_ _} _.
+Arguments dss_succ {_ _ _}.
+
+Record ssForall {A : SuccStr} (B : ssFam A) := {
+  ss_fun :> forall x, B x;
+  ss_fun_succ : forall x, ss_fun x.+1 = dss_succ (ss_fun x); 
+}.
+
+Arguments ss_fun {_ _} _ _.
+Arguments ss_fun_succ {_ _} _ _.
+
+Definition ssfam_const {A : SuccStr} (B : SuccStr) : ssFam A
+  := Build_ssFam A (fun _ => B) (fun _ => ss_succ).
+
+Definition ssfam_sshomotopy {A : SuccStr} {P : ssFam A} (f g : ssForall P)
+  : ssFam A.
+Proof.
+  snrapply Build_ssFam.
+  1: exact (fun x => f x = g x).
+  cbn; intros x p.
+  refine (ss_fun_succ f x @ ap dss_succ p @ (ss_fun_succ g x)^).
+Defined.
+
+Definition ssHomotopy {A : SuccStr} {P : ssFam A} (f g : ssForall P)
+  := ssForall (ssfam_sshomotopy f g).
+
+Global Instance isgraph_ss : IsGraph SuccStr.
+Proof.
+  snrapply Build_IsGraph.
+  intros X Y.
+  exact (@ssForall X (ssfam_const Y)).
+Defined.
+
+Global Instance isgraph_ssforall {A : SuccStr} (P : ssFam A)
+  : IsGraph (ssForall P).
+Proof.
+  snrapply Build_IsGraph.
+  exact ssHomotopy.
+Defined.
+
+Global Instance is2graph_ssforall {A : SuccStr} (P : ssFam A)
+  : Is2Graph (ssForall P)
+  := {}.
+
+Global Instance is2graph_ss : Is2Graph SuccStr := {}.
+Global Instance is3graph_ss : Is3Graph SuccStr := {}.
+
+Ltac sselim_elim eq x :=
+  match type of (eq x) with
+  | ?lhs = _ =>
+    generalize dependent (eq x);
+    generalize dependent lhs
+  | _ => fail "sselim: no lhs found"
+  end.
+
+Ltac sselim f :=
+  let eq := fresh "eq" in
+  destruct f as [f eq];
+  cbn in *;
+  match type of eq with
+  | forall x : ?X, _ = _ =>
+    multimatch goal with
+    | x : X |- _ => sselim_elim eq x
+    | f : ?Y -> X |- _ =>
+      match goal with
+      | y : Y |- _ => sselim_elim eq (f y)
+      | g : ?Z -> Y |- _ =>
+        match goal with
+        | z : Z |- _ => sselim_elim eq (f (g z))
+        end
+      end
+    | _ => fail "sselim: no hyp found"
+    end
+  | _ => fail "sselim: no eq found"
+  end;  
+  nrapply paths_ind_r;
+  try clear eq;
+  try clear f.
+
+Tactic Notation "sselim" constr(x0) := sselim x0.
+Tactic Notation "sselim" constr(x0) constr(x1) := sselim x0; sselim x1.
+Tactic Notation "sselim" constr(x0) constr(x1) constr(x2) := sselim x0; sselim x1 x2.
+Tactic Notation "sselim" constr(x0) constr(x1) constr(x2) constr(x3) := sselim x0; sselim x1 x2 x3.
+Tactic Notation "sselim" constr(x0) constr(x1) constr(x2) constr(x3) constr(x4) := sselim x0; sselim x1 x2 x3 x4.
+Tactic Notation "sselim" constr(x0) constr(x1) constr(x2) constr(x3) constr(x4) constr(x5) := sselim x0; sselim x1 x2 x3 x4 x5.
+Tactic Notation "sselim" constr(x0) constr(x1) constr(x2) constr(x3) constr(x4) constr(x5) constr(x6) := sselim x0; sselim x1 x2 x3 x4 x5 x6.
+
+Global Instance is01cat_ss : Is01Cat SuccStr.
+Proof.
+  snrapply Build_Is01Cat.
+  - intro X.
+    snrapply Build_ssForall.
+    + exact (fun x => x).
+    + reflexivity.
+  - intros X Y Z f g.
+    snrapply Build_ssForall.
+    + intro x.
+      exact (f (g x)).
+    + intro x.
+      exact (ap f (ss_fun_succ g x) @ ss_fun_succ f (g x)).
+Defined.
+
+Global Instance is01cat_ssforall {A : SuccStr} (P : ssFam A)
+  : Is01Cat (ssForall P).
+Proof.
+  snrapply Build_Is01Cat.
+  - intro f.
+    snrapply Build_ssForall.
+    + reflexivity.
+    + intro x; simpl.
+      by destruct (ss_fun_succ f x).
+  - intros f g h p q.
+    snrapply Build_ssForall.
+    + intro x.
+      exact (q x @ p x).
+    + intro x; cbn.
+      sselim p q f g h. simpl.
+      by destruct (p x), (q x).
+Defined.
+
+Global Instance is0gpd_ssforall {A : SuccStr} (P : ssFam A)
+  : Is0Gpd (ssForall P).
+Proof.
+  snrapply Build_Is0Gpd.
+  intros f g p.
+  snrapply Build_ssForall.
+  - intro x.
+    exact (p x)^.
+  - intro x; cbn.
+    sselim p f g.
+    by destruct (p x).
+Defined.
+
+Global Instance is1cat_ss : Is1Cat SuccStr.
+Proof.
+  srapply Build_Is1Cat.
+  - intros X Y Z g.
+    snrapply Build_Is0Functor.
+    intros f h p.
+    snrapply Build_ssForall.
+    + intro x.
+      exact (ap g (p x)).
+    + intro x; cbn.
+      sselim p f h.
+      destruct (p x); clear p; simpl.
+      sselim g.
+      by destruct (eq (f x)).
+  - intros X Y Z g.
+    snrapply Build_Is0Functor.
+    intros f h q.
+    snrapply Build_ssForall.
+    + intros x.
+      apply q.
+    + intros x; cbn.
+      by sselim g q f h.
+  - intros X Y Z W f g h.
+    srapply Build_ssForall.
+    + intro x.
+      reflexivity.
+    + intro x; cbn.
+      by sselim f g h.
+  - intros X Y f.
+    srapply Build_ssForall.
+    1: reflexivity.
+    intros x.
+    by sselim f.
+  - intros X Y f.
+    srapply Build_ssForall.
+    1: reflexivity.
+    intros x.
+    by sselim f.
+Defined.


### PR DESCRIPTION
One of the nice things about pType is the potential to define the wildcat structure "all the way up". We don't actually do this, but because pHomotopy is defined as pForall we get all the higher morphisms "for free".

I was interested in working out what exactly makes a "forall" in a category tick. From what I could find, its not really a commonly studied phenomenon. Typically in category theory, such "forall" looking sets of dependent functions carry an extra structure of being internal. This is a strong requirement that makes it impossible to replicate in various categories (keep Spectra in mind). However the lesson to learn from pType is that we almost never care about ppForall but only pForall which has nothing to do with the internal (dependent) hom.

Therefore I was interested in seeing if we can push this idea in other categories, notably the category of spectra. That would allow us to have a very nice category to work with.

I believe this is possible but it will require a bit more work on understanding the exact definitions of family of spectra over a spectrum and how a hypothetical "sForall" might be constructed. The route of paramaterized spectra appears to somewhat be a red-herring and doesn't really gain us much.

Anyway, to give an initial proof-of-concept of the wider application of the pType-pforall technique, I decided to choose a structure which is not entirely trivial but still simple to work with. The toy example I chose in the end is the category of successor strucutres.

I don't believe that this work will lead to a deeper understanding of the theory of successor structures, however it does demonstrate that the forall-technique can be generalised.

The basic recipe is as follows:
- Start with a category C.
- Define a "displayed" version of the objects of C. Notably this should be a family over C.
- Define the homotopy family.
- Define foralls and higher homotopies between them using the family. 

Interesting things to note:

- My pelim tactic from before has an analogue here.
- The structure of SuccStr has a non-trivial endomap which can be "displayed" appropriately.
- We get a full 1-cat structure and 2-cat with some more work.

I would like to eventually try this technique on spectra once we work out what the correct way to have displayed spectra is. These are not parameterized spectra as the base space must also be a spectrum. It should probably consist of pFam for each pType in spextra and some how a displayed pointed map which I have yet to formulate.

I think that this work so far is harmless so I would advocate including it. It might be worth considering a way to axiomatize what a "forall" is in a category, but I think even just defining how to "display" things will be quite non-trivial.

cc @jdchristensen and @mikeshulman (who might be interested in the displayed part).
