### PR TITLE
wildcat: binary products

### DIFF
--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -4,6 +4,7 @@ Require Import Spaces.List.
 Require Import Colimits.Pushout.
 Require Import Truncations.Core Truncations.SeparatedTrunc.
 Require Import Algebra.Groups.Group.
+Require Import WildCat.
 
 Local Open Scope list_scope.
 Local Open Scope mc_scope.
@@ -679,6 +680,8 @@ Section FreeProduct.
 
 End FreeProduct.
 
+Arguments amal_eta {G H K f g} x.
+
 Definition FreeProduct (G H : Group) : Group
   := AmalgamatedFreeProduct grp_trivial G H (grp_trivial_rec _) (grp_trivial_rec _).
 
@@ -708,4 +711,32 @@ Proof.
   intros []; apply contr_inhab_prop.
   apply tr.
   refine (grp_homo_unit _ @ (grp_homo_unit _)^).
+Defined.
+
+(** The freeproduct is the coproduct in the category of groups. *)
+Global Instance hasbinarycoproducts : HasBinaryCoproducts Group.
+Proof.
+  snrapply Build_HasBinaryCoproducts.
+  intros G H.
+  snrapply Build_BinaryCoproduct.
+  - exact (FreeProduct G H).
+  - exact freeproduct_inl.
+  - exact freeproduct_inr.
+  - exact (FreeProduct_rec G H).
+  - intros Z f g x; simpl.
+    rapply right_identity.
+  - intros Z f g x; simpl.
+    rapply right_identity.
+  - intros Z f g p q.
+    srapply amal_type_ind_hprop; simpl.
+    intros w.
+    induction w as [|gh].
+    1: exact (grp_homo_unit _ @ (grp_homo_unit _)^).
+    Local Notation "[ x ]" := (cons x nil).
+    change (f (amal_eta [gh] * amal_eta w) = g (amal_eta [gh] * amal_eta w)).
+    refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
+    f_ap; clear IHw w.
+    destruct gh as [g' | h].
+    + exact (p g').
+    + exact (q h).
 Defined.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -714,17 +714,18 @@ Global Instance issurj_grp_prod_pr2 {G H : Group}
 Global Instance hasbinaryproducts_group : HasBinaryProducts Group.
 Proof.
   snrapply Build_HasBinaryProducts.
-  - exact grp_prod.
-  - exact @grp_prod_pr1.
-  - exact @grp_prod_pr2.
-  - exact @grp_prod_corec.
-  - intros x y z f g.
+  intros G H.
+  snrapply Build_BinaryProduct.
+  - exact (grp_prod G H).
+  - exact grp_prod_pr1.
+  - exact grp_prod_pr2.
+  - intros K.
+    exact grp_prod_corec.
+  - intros K f g.
     exact (Id _).
-  - intros x y z f g.
+  - intros K f g.
     exact (Id _).
-  - intros x y z f g.
-    apply eta_prod.
-  - intros x y z f f' g g' p q a.
+  - intros K f g p q a.
     exact (path_prod' (p a) (q a)).
 Defined.
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -711,6 +711,23 @@ Global Instance issurj_grp_prod_pr2 {G H : Group}
   : IsSurjection (@grp_prod_pr2 G H)
   := issurj_retr grp_prod_inr (fun _ => idpath).
 
+Global Instance hasbinaryproducts_group : HasBinaryProducts Group.
+Proof.
+  snrapply Build_HasBinaryProducts.
+  - exact grp_prod.
+  - exact @grp_prod_pr1.
+  - exact @grp_prod_pr2.
+  - exact @grp_prod_corec.
+  - intros x y z f g.
+    exact (Id _).
+  - intros x y z f g.
+    exact (Id _).
+  - intros x y z f g.
+    apply eta_prod.
+  - intros x y z f f' g g' p q a.
+    exact (path_prod' (p a) (q a)).
+Defined.
+
 (** *** Properties of maps to and from the trivial group *)
 
 Global Instance isinitial_grp_trivial : IsInitial grp_trivial.

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -1,6 +1,7 @@
-Require Import Basics.
+Require Import Basics Types.Paths.
 Require Import Pointed.Core.
 Require Import Colimits.Pushout.
+Require Import WildCat.
 
 (* Here we define the Wedge sum of two pointed types *)
 
@@ -11,9 +12,93 @@ Definition Wedge (X Y : pType) : pType
 
 Notation "X \/ Y" := (Wedge X Y) : pointed_scope.
 
+Definition wedge_inl {X Y} : X $-> X \/ Y.
+Proof.
+  snrapply Build_pMap.
+  - exact (fun x => pushl x).
+  - reflexivity.
+Defined.
+
+Definition wedge_inr {X Y} : Y $-> X \/ Y.
+Proof.
+  snrapply Build_pMap.
+  - exact (fun x => pushr x).
+  - symmetry.
+    by rapply pglue.
+Defined.
+
 Definition wglue {X Y : pType}
   : pushl (point X) = (pushr (point Y) : X \/ Y) := pglue tt.
+
+Definition wedge_rec {X Y Z : pType} (f : X $-> Z) (g : Y $-> Z)
+  : X \/ Y $-> Z.
+Proof.
+  snrapply Build_pMap.
+  - snrapply Pushout_rec.
+    + exact f.
+    + exact g.
+    + by pelim f g.
+  - exact (point_eq f).
+Defined.
 
 Definition wedge_incl {X Y : pType} : X \/ Y -> X * Y :=
  Pushout_rec _ (fun x => (x, point Y)) (fun y => (point X, y)) 
   (fun _ : Unit => idpath).
+
+(** 1-universal property of wedge. *)
+(** TODO: remove rewrites. For some reason pelim is not able to immediately abstract the goal so some shuffling around is necessery. *)
+Lemma wedge_up X Y Z (f g : X \/ Y $-> Z)
+  : f $o wedge_inl $== g $o wedge_inl
+  -> f $o wedge_inr $== g $o wedge_inr
+  -> f $== g.
+Proof.
+  intros p q.
+  snrapply Build_pHomotopy.
+  - snrapply (Pushout_ind _ p q).
+    intros [].
+    simpl.
+    refine (transport_paths_FlFr _ _ @ _).
+    refine (concat_pp_p _ _ _ @ _).
+    apply moveR_Vp.
+    refine (whiskerR (dpoint_eq p) _ @ _).
+    refine (_ @ whiskerL _ (dpoint_eq q)^).
+    clear p q.
+    simpl.
+    apply moveL_Mp.
+    rewrite ? ap_V.
+    rewrite ? inv_pp.
+    hott_simpl.
+  - simpl; pelim p q.
+    hott_simpl.
+Defined.
+
+Global Instance hasbinarycoproducts : HasBinaryCoproducts pType.
+Proof.
+  snrapply Build_HasBinaryCoproducts.
+  intros X Y.
+  snrapply Build_BinaryCoproduct.
+  - exact (X \/ Y).
+  - exact wedge_inl.
+  - exact wedge_inr.
+  - intros Z f g.
+    by apply wedge_rec.
+  - intros Z f g.
+    snrapply Build_pHomotopy.
+    1: reflexivity.
+    by simpl; pelim f.
+  - intros Z f g.
+    snrapply Build_pHomotopy.
+    1: reflexivity.
+    simpl.
+    apply moveL_pV.
+    apply moveL_pM.
+    refine (_ @ (ap_V _ (pglue tt))^).
+    apply moveR_Mp.
+    apply moveL_pV.
+    apply moveR_Vp.
+    refine (Pushout_rec_beta_pglue _ f g _ _  @ _).
+    simpl.  
+    by pelim f g.
+  - intros Z f g p q.
+    by apply wedge_up.
+Defined.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -627,6 +627,40 @@ Proof.
   + intros. reflexivity.
 Defined.
 
+(** pType has binary products *)
+Global Instance hasbinaryproducts_ptype : HasBinaryProducts pType.
+Proof.
+  snrapply Build_HasBinaryProducts.
+  - exact (fun X Y => X * Y).
+  - intros x y; exact pfst.
+  - intros x y; exact psnd.
+  - intros x y z f g.
+    snrapply Build_pMap.
+    1: exact (fun w => (f w, g w)).
+    apply path_prod'; cbn; apply point_eq.
+  - intros x y z f g.
+    snrapply Build_pHomotopy.
+    1: reflexivity.
+    by pelim f g.
+  - intros x y z f g.
+    snrapply Build_pHomotopy.
+    1: reflexivity.
+    by pelim f g.
+  - intros x y z f.
+    snrapply Build_pHomotopy.
+    1: reflexivity.
+    by pelim f.
+  - intros x y z f f' g g' p q.
+    simpl.
+    snrapply Build_pHomotopy.
+    { intros a.
+      apply path_prod'; cbn.
+      - exact (p a).
+      - exact (q a). }
+    simpl.
+    by pelim p q f f' g g'.
+Defined.
+
 (** Some higher homotopies *)
 
 (** Horizontal composition of homotopies. *)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -631,26 +631,24 @@ Defined.
 Global Instance hasbinaryproducts_ptype : HasBinaryProducts pType.
 Proof.
   snrapply Build_HasBinaryProducts.
-  - exact (fun X Y => X * Y).
-  - intros x y; exact pfst.
-  - intros x y; exact psnd.
-  - intros x y z f g.
+  intros X Y.
+  snrapply Build_BinaryProduct.
+  - exact (X * Y).
+  - exact pfst.
+  - exact psnd.
+  - intros Z f g.
     snrapply Build_pMap.
     1: exact (fun w => (f w, g w)).
     apply path_prod'; cbn; apply point_eq.
-  - intros x y z f g.
+  - intros Z f g.
     snrapply Build_pHomotopy.
     1: reflexivity.
     by pelim f g.
-  - intros x y z f g.
+  - intros Z f g.
     snrapply Build_pHomotopy.
     1: reflexivity.
     by pelim f g.
-  - intros x y z f.
-    snrapply Build_pHomotopy.
-    1: reflexivity.
-    by pelim f.
-  - intros x y z f f' g g' p q.
+  - intros Z f g p q.
     simpl.
     snrapply Build_pHomotopy.
     { intros a.
@@ -658,7 +656,7 @@ Proof.
       - exact (p a).
       - exact (q a). }
     simpl.
-    by pelim p q f f' g g'.
+    by pelim p q f g.
 Defined.
 
 (** Some higher homotopies *)

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -13,6 +13,7 @@ Require Export WildCat.PointedCat.
 Require Export WildCat.Bifunctor.
 Require Export WildCat.Monoidal.
 Require Export WildCat.Products.
+Require Export WildCat.Coproducts.
 
 (* See also contrib/SetoidRewrite.v for tools that can be used for rewriting in wild categories. *)
 

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -12,6 +12,7 @@ Require Export WildCat.Square.
 Require Export WildCat.PointedCat.
 Require Export WildCat.Bifunctor.
 Require Export WildCat.Monoidal.
+Require Export WildCat.Products.
 
 (* See also contrib/SetoidRewrite.v for tools that can be used for rewriting in wild categories. *)
 

--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -1,4 +1,4 @@
-Require Import Basics EquivGpd Types.Prod.
+Require Import Basics EquivGpd Types.Prod Types.Sum.
 Require Import WildCat.Core WildCat.ZeroGroupoid WildCat.Equiv WildCat.Yoneda WildCat.Universe WildCat.NatTrans WildCat.Opposite WildCat.Products.
 
 (** * Categories with coproducts *)
@@ -127,3 +127,25 @@ Class HasBinaryCoproducts (A : Type) `{Is1Cat A} := {
 (** *** Coproduct functor *)
 
 (** TODO: The functoriality argument doesn't follow definitionally from the functoriality of [cat_prod], however after some modification it is close. We need to use appropriate lemmas for opposite functors. *) 
+
+(** *** Coproducts in Type *)
+
+(** [Type] has all binary coproducts *)
+Global Instance hasbinarycoproducts_type : HasBinaryCoproducts Type.
+Proof.
+  snrapply Build_HasBinaryCoproducts.
+  intros X Y.
+  snrapply Build_BinaryCoproduct.
+  - exact (X + Y).
+  - exact inl.
+  - exact inr.
+  - intros Z f g.
+    intros [x | y].
+    + exact (f x).
+    + exact (g y).
+  - reflexivity.
+  - reflexivity.
+  - intros Z f g p q [x | y].
+    + exact (p x).
+    + exact (q y).
+Defined.

--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -1,0 +1,129 @@
+Require Import Basics EquivGpd Types.Prod.
+Require Import WildCat.Core WildCat.ZeroGroupoid WildCat.Equiv WildCat.Yoneda WildCat.Universe WildCat.NatTrans WildCat.Opposite WildCat.Products.
+
+(** * Categories with coproducts *)
+
+Class BinaryCoproduct (A : Type) `{Is1Cat A} (x y : A) := Build_BinaryCoproduct' {
+  prod_co_coprod :: BinaryProduct (x : A^op) y
+}.
+
+Arguments Build_BinaryCoproduct' {_ _ _ _ _ x y} _.
+Arguments BinaryCoproduct {A _ _ _ _} x y.
+
+Definition cat_coprod {A : Type}  `{Is1Cat  A} (x y : A) `{!BinaryCoproduct x y} : A
+  := cat_prod (x : A^op) y.
+
+Definition cat_inl {A : Type} `{Is1Cat A} {x y : A} `{!BinaryCoproduct x y} : x $-> cat_coprod x y.
+Proof.
+  change (cat_prod (x : A^op) y $-> x).
+  exact cat_pr1.
+Defined.
+
+Definition cat_inr {A : Type} `{Is1Cat A} {x y : A} `{!BinaryCoproduct x y} : y $-> cat_coprod x y.
+Proof.
+  change (cat_prod (x : A^op) y $-> y).
+  exact cat_pr2.
+Defined.
+
+Definition Build_BinaryCoproduct {A : Type} `{Is1Cat A} {x y : A}
+  (cat_coprod : A) (cat_inl : x $-> cat_coprod) (cat_inr : y $-> cat_coprod)
+  (cat_coprod_rec : forall z : A, (x $-> z) -> (y $-> z) -> cat_coprod $-> z)
+  (cat_coprod_beta_inl : forall z (f : x $-> z) (g : y $-> z), cat_coprod_rec z f g $o cat_inl $== f)
+  (cat_coprod_beta_inr : forall z (f : x $-> z) (g : y $-> z), cat_coprod_rec z f g $o cat_inr $== g)
+  (cat_coprod_in_eta : forall z (f g : cat_coprod $-> z), f $o cat_inl $== g $o cat_inl -> f $o cat_inr $== g $o cat_inr -> f $== g)
+  : BinaryCoproduct x y
+  := Build_BinaryCoproduct'
+    (Build_BinaryProduct
+      (cat_coprod : A^op)
+      cat_inl
+      cat_inr
+      cat_coprod_rec
+      cat_coprod_beta_inl
+      cat_coprod_beta_inr
+      cat_coprod_in_eta).
+
+Section Lemmata.
+
+  Context {A : Type} {x y z : A} `{BinaryCoproduct _ x y}.
+
+  Definition cat_equiv_cat_coprod_rec_inv
+    : (opyon_0gpd (cat_coprod x y) z)
+    $<~> prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z)
+    := @cat_equiv_cat_prod_corec_inv A^op x y z _ _ _ _ _.
+
+  Definition cat_equiv_cat_coprod_rec
+    : prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z)
+    $<~> (opyon_0gpd (cat_coprod x y) z)
+    := @cat_equiv_cat_prod_corec A^op x y z _ _ _ _ _.
+
+  Definition cat_coprod_rec (f : x $-> z) (g : y $-> z) : cat_coprod x y $-> z
+    := @cat_prod_corec A^op x y z _ _ _ _ _ f g.
+  
+  Definition cat_coprod_beta_inl (f : x $-> z) (g : y $-> z)
+    : cat_coprod_rec f g $o cat_inl $== f
+    := @cat_prod_beta_pr1 A^op x y z _ _ _ _ _ f g.
+  
+  Definition cat_coprod_beta_inr (f : x $-> z) (g : y $-> z)
+    : cat_coprod_rec f g $o cat_inr $== g
+    := @cat_prod_beta_pr2 A^op x y z _ _ _ _ _ f g.
+  
+  Definition cat_coprod_eta (f : cat_coprod x y $-> z)
+    : cat_coprod_rec (f $o cat_inl) (f $o cat_inr) $== f
+    := @cat_prod_eta A^op x y z _ _ _ _ _ f.
+
+  (* TODO: decompose and move *)
+  Local Instance is0functor_coprod_0gpd_helper
+    : Is0Functor (fun z : A => prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z)).
+  Proof.
+    snrapply Build_Is0Functor.
+    intros a b f.
+    snrapply Build_Morphism_0Gpd.
+    - intros [g g'].
+      exact (f $o g, f $o g').
+    - snrapply Build_Is0Functor.
+      intros [g g'] [h h'] [p q].
+      split.
+      + exact (f $@L p).
+      + exact (f $@L q).
+  Defined.
+
+  (* TODO: decompose and move *)
+  Local Instance is1functor_coprod_0gpd_helper
+    : Is1Functor (fun z : A => prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z)).
+  Proof.
+    snrapply Build_Is1Functor.
+    - intros a b f g p [r_fst r_snd].
+      cbn; split.
+      + refine (_ $@R _).
+        apply p.
+      + refine (_ $@R _).
+        apply p.
+    - intros a [r_fst r_snd].
+      split; apply cat_idl.
+    - intros a b c f g [r_fst r_snd].
+      split; apply cat_assoc.
+  Defined.
+
+  Definition natequiv_cat_coprod_rec_inv
+    : NatEquiv (opyon_0gpd (cat_coprod x y)) (fun z => prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z))
+    := @natequiv_cat_prod_corec_inv A^op x y _ _ _ _ _.
+
+  Definition cat_coprod_rec_eta {f f' : x $-> z} {g g' : y $-> z}
+    : f $== f' -> g $== g' -> cat_coprod_rec f g $== cat_coprod_rec f' g'
+    := @cat_prod_corec_eta A^op x y z _ _ _ _ _ f f' g g'.
+  
+  Definition cat_coprod_in_eta {f f' : cat_coprod x y $-> z}
+    : f $o cat_inl $== f' $o cat_inl -> f $o cat_inr $== f' $o cat_inr -> f $== f'
+    := @cat_prod_pr_eta A^op x y z _ _ _ _ _ f f'.
+
+End Lemmata.
+
+(** *** Cateogires with binary coproducts *)
+
+Class HasBinaryCoproducts (A : Type) `{Is1Cat A} := {
+  binary_coproducts :: forall x y : A, BinaryCoproduct x y;
+}.
+
+(** *** Coproduct functor *)
+
+(** TODO: The functoriality argument doesn't follow definitionally from the functoriality of [cat_prod], however after some modification it is close. We need to use appropriate lemmas for opposite functors. *) 

--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -46,30 +46,30 @@ Section Lemmata.
 
   Context {A : Type} {x y z : A} `{BinaryCoproduct _ x y}.
 
-  Definition cat_equiv_cat_coprod_rec_inv
+  Definition cate_cat_coprod_rec_inv
     : (opyon_0gpd (cat_coprod x y) z)
     $<~> prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z)
-    := @cat_equiv_cat_prod_corec_inv A^op x y z _ _ _ _ _.
+    := @cate_cat_prod_corec_inv A^op x y _ _ _ _ _ _.
 
-  Definition cat_equiv_cat_coprod_rec
+  Definition cate_cat_coprod_rec
     : prod_0gpd (opyon_0gpd x z) (opyon_0gpd y z)
     $<~> (opyon_0gpd (cat_coprod x y) z)
-    := @cat_equiv_cat_prod_corec A^op x y z _ _ _ _ _.
+    := @cate_cat_prod_corec A^op x y _ _ _ _ _ _.
 
   Definition cat_coprod_rec (f : x $-> z) (g : y $-> z) : cat_coprod x y $-> z
-    := @cat_prod_corec A^op x y z _ _ _ _ _ f g.
+    := @cat_prod_corec A^op x y _ _ _ _ _ _ f g.
   
   Definition cat_coprod_beta_inl (f : x $-> z) (g : y $-> z)
     : cat_coprod_rec f g $o cat_inl $== f
-    := @cat_prod_beta_pr1 A^op x y z _ _ _ _ _ f g.
+    := @cat_prod_beta_pr1 A^op x y _ _ _ _ _ _ f g.
   
   Definition cat_coprod_beta_inr (f : x $-> z) (g : y $-> z)
     : cat_coprod_rec f g $o cat_inr $== g
-    := @cat_prod_beta_pr2 A^op x y z _ _ _ _ _ f g.
+    := @cat_prod_beta_pr2 A^op x y _ _ _ _ _ _ f g.
   
   Definition cat_coprod_eta (f : cat_coprod x y $-> z)
     : cat_coprod_rec (f $o cat_inl) (f $o cat_inr) $== f
-    := @cat_prod_eta A^op x y z _ _ _ _ _ f.
+    := @cat_prod_eta A^op x y _ _ _ _ _ _ f.
 
   (* TODO: decompose and move *)
   Local Instance is0functor_coprod_0gpd_helper
@@ -110,11 +110,11 @@ Section Lemmata.
 
   Definition cat_coprod_rec_eta {f f' : x $-> z} {g g' : y $-> z}
     : f $== f' -> g $== g' -> cat_coprod_rec f g $== cat_coprod_rec f' g'
-    := @cat_prod_corec_eta A^op x y z _ _ _ _ _ f f' g g'.
+    := @cat_prod_corec_eta A^op x y _ _ _ _ _ _ f f' g g'.
   
   Definition cat_coprod_in_eta {f f' : cat_coprod x y $-> z}
     : f $o cat_inl $== f' $o cat_inl -> f $o cat_inr $== f' $o cat_inr -> f $== f'
-    := @cat_prod_pr_eta A^op x y z _ _ _ _ _ f f'.
+    := @cat_prod_pr_eta A^op x y _ _ _ _ _ _ f f'.
 
 End Lemmata.
 

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -171,6 +171,8 @@ Class HasBinaryProducts (A : Type) `{Is1Cat A} := {
 (** *** Product functor *)
 
 (** Binary products are functorial in each argument. *)
+
+(* TODO: jdchristensen: Another approach to handling functoriality on the right is to first prove that products are symmetric. Then functoriality on the right follows from functoriality on the left... *)
 Global Instance is0functor_cat_prod_l {A : Type}
   `{HasBinaryProducts A} y
   : Is0Functor (fun x => cat_prod x y).

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -7,42 +7,42 @@ Require Import WildCat.Core.
 
 Class HasBinaryProducts (A : Type) `{Is1Cat A} := {
   (** A binary product is an object of a category given by a pair of objects. *)
-  product : A -> A -> A;
+  cat_prod : A -> A -> A;
 
   (** It comes equipped with two projection maps out of the product. *)
-  cat_pr1 : forall {x y : A}, product x y $-> x;
-  cat_pr2 : forall {x y : A}, product x y $-> y;
+  cat_pr1 : forall {x y : A}, cat_prod x y $-> x;
+  cat_pr2 : forall {x y : A}, cat_prod x y $-> y;
   
   (** Together with a pairing "corecursor" into the product. *)
-  product_corec : forall {x y z : A},
-    (z $-> x) -> (z $-> y) -> (z $-> product x y);
+  cat_prod_corec : forall {x y z : A},
+    (z $-> x) -> (z $-> y) -> (z $-> cat_prod x y);
 
   (** All this data satisifies certain equiations, leading to the unqiueness of the product_corec map. *)
 
   (** Applying the first projection after a map pariing gives the first map. *) 
-  product_beta_pr1 {x y z : A} (f : z $-> x) (g : z $-> y)
-    : cat_pr1 $o product_corec f g $== f;
+  cat_prod_beta_pr1 {x y z : A} (f : z $-> x) (g : z $-> y)
+    : cat_pr1 $o cat_prod_corec f g $== f;
   
   (** Applying the second projection after a map pariing gives the second map. *)
-  product_beta_pr2 {x y z : A} (f : z $-> x) (g : z $-> y)
-    : cat_pr2 $o product_corec f g $== g;
+  cat_prod_beta_pr2 {x y z : A} (f : z $-> x) (g : z $-> y)
+    : cat_pr2 $o cat_prod_corec f g $== g;
 
   (** The pairing map is the unique map that makes the following diagram commute. *)
-  product_eta {x y z : A} (f : z $-> product x y)
-    : product_corec (cat_pr1 $o f) (cat_pr2 $o f) $== f;
+  cat_prod_eta {x y z : A} (f : z $-> cat_prod x y)
+    : cat_prod_corec (cat_pr1 $o f) (cat_pr2 $o f) $== f;
   
-  (** Finally given any two [product_corec], they are uniquely identified by their components. (This introduces a 2-categorical notion of product, which for n-categorical universal properties will need (n+1) levels of cells. We therefore restrict to 1-categories for now). Without this condition, we would not be able to show the 2-functorial action of the product functor or even 1-functoriality in the second argument. *) 
-  product_corec_eta {x y z : A} {f f' : z $-> x} {g g' : z $-> y}
-    : f $== f' -> g $== g' -> product_corec f g $== product_corec f' g';
+  (** Finally given any two [cat_prod_corec], they are uniquely identified by their components. (This introduces a 2-categorical notion of product, which for n-categorical universal properties will need (n+1) levels of cells. We therefore restrict to 1-categories for now). Without this condition, we would not be able to show the 2-functorial action of the product functor or even 1-functoriality in the second argument. *) 
+  cat_prod_corec_eta {x y z : A} {f f' : z $-> x} {g g' : z $-> y}
+    : f $== f' -> g $== g' -> cat_prod_corec f g $== cat_prod_corec f' g';
 }.
 
-Lemma product_pr_eta {A} `{HasBinaryProducts A}
-  {x y z : A} {f f' : z $-> product x y}
+Lemma cat_prod_pr_eta {A} `{HasBinaryProducts A}
+  {x y z : A} {f f' : z $-> cat_prod x y}
   : cat_pr1 $o f $== cat_pr1 $o f' -> cat_pr2 $o f $== cat_pr2 $o f' -> f $== f'.
 Proof.
   intros fst snd.
-  refine ((product_eta _)^$ $@ _ $@ product_eta _).
-  by apply product_corec_eta.
+  refine ((cat_prod_eta _)^$ $@ _ $@ cat_prod_eta _).
+  by apply cat_prod_corec_eta.
 Defined.
 
 (** In general it's not possible to define a recursor for a product. It is possible if a category has an internal hom, but that is a very strong condition.  *)
@@ -51,99 +51,105 @@ Defined.
 
 
 (** Binary products are functorial in each argument. *)
-Global Instance is0functor_product_l {A : Type} `{Is1Cat A} `{HasBinaryProducts A} y
-  : Is0Functor (fun x => product x y).
+Global Instance is0functor_cat_prod_l {A : Type}
+  `{HasBinaryProducts A} y
+  : Is0Functor (fun x => cat_prod x y).
 Proof.
   snrapply Build_Is0Functor.
   intros a b f.
-  apply product_corec.
+  apply cat_prod_corec.
   - exact (f $o cat_pr1).
   - exact cat_pr2.
 Defined.
 
-Global Instance is1functor_product_l {A : Type} `{Is1Cat A} `{HasBinaryProducts A} y
-  : Is1Functor (fun x => product x y).
+Global Instance is1functor_cat_prod_l {A : Type}
+  `{HasBinaryProducts A} y
+  : Is1Functor (fun x => cat_prod x y).
 Proof.
   snrapply Build_Is1Functor.
   - intros a b f g p.
     simpl.
-    apply product_corec_eta.
+    apply cat_prod_corec_eta.
     2: apply Id.
     exact (p $@R cat_pr1).
   - intros x.
     simpl.
-    apply product_pr_eta.
-    + refine (product_beta_pr1 _ _ $@ _).
+    apply cat_prod_pr_eta.
+    + refine (cat_prod_beta_pr1 _ _ $@ _).
       exact (cat_idl _ $@ (cat_idr _)^$).
-    + refine (product_beta_pr2 _ _ $@ _).
+    + refine (cat_prod_beta_pr2 _ _ $@ _).
       exact (cat_idr _)^$.
   - intros x z w f g.
     simpl.
-    apply product_pr_eta.
-    + refine (product_beta_pr1 _ _ $@ _).
+    apply cat_prod_pr_eta.
+    + refine (cat_prod_beta_pr1 _ _ $@ _).
       refine (_ $@ cat_assoc _ _ _).
-      refine (_ $@ ((product_beta_pr1 _ _)^$ $@R _)).
+      refine (_ $@ ((cat_prod_beta_pr1 _ _)^$ $@R _)).
       refine (cat_assoc _ _ _ $@ (_ $@L _) $@ (cat_assoc _ _ _)^$).
-      exact (product_beta_pr1 _ _)^$.
-    + refine (product_beta_pr2 _ _ $@ _).
+      exact (cat_prod_beta_pr1 _ _)^$.
+    + refine (cat_prod_beta_pr2 _ _ $@ _).
       refine (_ $@ cat_assoc _ _ _).
-      refine (_ $@ ((product_beta_pr2 _ _)^$ $@R _)).
-      exact (product_beta_pr2 _ _)^$.
+      refine (_ $@ ((cat_prod_beta_pr2 _ _)^$ $@R _)).
+      exact (cat_prod_beta_pr2 _ _)^$.
 Defined.
 
-Global Instance is0functor_product_r {A : Type} `{Is1Cat A} `{HasBinaryProducts A} x
-  : Is0Functor (product x).
+Global Instance is0functor_cat_prod_r {A : Type}
+  `{HasBinaryProducts A} x
+  : Is0Functor (cat_prod x).
 Proof.
   snrapply Build_Is0Functor.
   intros a b f.
-  apply product_corec.
+  apply cat_prod_corec.
   - exact cat_pr1.
   - exact (f $o cat_pr2).
 Defined.
 
-Global Instance is1functor_product_r {A : Type} `{Is1Cat A} `{HasBinaryProducts A} x
-  : Is1Functor (product x).
+Global Instance is1functor_cat_prod_r {A : Type}
+  `{HasBinaryProducts A} x
+  : Is1Functor (cat_prod x).
 Proof.
   snrapply Build_Is1Functor.
   - intros y z f g p.
-    apply product_corec_eta.
+    apply cat_prod_corec_eta.
     1: apply Id.
     exact (p $@R cat_pr2).
   - intros y. simpl.
-    refine (_ $@ product_eta _).
-    apply product_corec_eta.
+    refine (_ $@ cat_prod_eta _).
+    apply cat_prod_corec_eta.
     + symmetry.
       apply cat_idr.
     + exact (cat_idl _ $@ (cat_idr _)^$).
   - intros y z w f g.
     simpl.
-    apply product_pr_eta.
-    + refine (product_beta_pr1 _ _ $@ _).
+    apply cat_prod_pr_eta.
+    + refine (cat_prod_beta_pr1 _ _ $@ _).
       refine (_ $@ cat_assoc _ _ _).
-      refine (_ $@ ((product_beta_pr1 _ _)^$ $@R _)).
-      exact (product_beta_pr1 _ _)^$.    
-    + refine (product_beta_pr2 _ _ $@ _).
+      refine (_ $@ ((cat_prod_beta_pr1 _ _)^$ $@R _)).
+      exact (cat_prod_beta_pr1 _ _)^$.    
+    + refine (cat_prod_beta_pr2 _ _ $@ _).
       refine (_ $@ cat_assoc _ _ _).
-      refine (_ $@ ((product_beta_pr2 _ _)^$ $@R _)).
+      refine (_ $@ ((cat_prod_beta_pr2 _ _)^$ $@R _)).
       refine (_ $@ (cat_assoc _ _ _)^$).
       refine (cat_assoc _ _ _ $@ _).
-      exact (_ $@L product_beta_pr2 _ _)^$.
+      exact (_ $@L cat_prod_beta_pr2 _ _)^$.
 Defined.
 
-(** [product_corec] is also functorial in each morphsism. *)
+(** [cat_prod_corec] is also functorial in each morphsism. *)
 
-Global Instance is0functor_product_corec_l {A : Type} `{Is1Cat A} `{HasBinaryProducts A} {x y z : A} (g : z $-> y)
-  : Is0Functor (fun f => @product_corec _ _ _ _ _ _ x y z f g).
+Global Instance is0functor_cat_prod_corec_l {A : Type}
+  `{HasBinaryProducts A} {x y z : A} (g : z $-> y)
+  : Is0Functor (fun f => @cat_prod_corec _ _ _ _ _ _ x y z f g).
 Proof.
   snrapply Build_Is0Functor.
   intros f f' p.
-  by apply product_corec_eta.
+  by apply cat_prod_corec_eta.
 Defined.
 
-Global Instance is0functor_product_corec_r {A : Type} `{Is1Cat A} `{HasBinaryProducts A} {x y z : A} (f : z $-> x)
-  : Is0Functor (@product_corec _ _ _ _ _ _ x y z f).
+Global Instance is0functor_cat_prod_corec_r {A : Type}
+  `{HasBinaryProducts A} {x y z : A} (f : z $-> x)
+  : Is0Functor (@cat_prod_corec _ _ _ _ _ _ x y z f).
 Proof.
   snrapply Build_Is0Functor.
   intros g h p.
-  by apply product_corec_eta.
+  by apply cat_prod_corec_eta.
 Defined.

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -1,0 +1,149 @@
+Require Import Basics.
+Require Import WildCat.Core.
+
+(** * Categories with products *)
+
+(** There is a lot of theory that can be developed about categories with certain limits. It can be very tempting to try to do this in full generality, but this often leads to the person doing the formalization getting lost down the rabbit hole. Therefore we try to keep things as direct as possible implementing only what we need for now. *)
+
+Class HasBinaryProducts (A : Type) `{Is1Cat A} := {
+  (** A binary product is an object of a category given by a pair of objects. *)
+  product : A -> A -> A;
+
+  (** It comes equipped with two projection maps out of the product. *)
+  cat_pr1 : forall {x y : A}, product x y $-> x;
+  cat_pr2 : forall {x y : A}, product x y $-> y;
+  
+  (** Together with a pairing "corecursor" into the product. *)
+  product_corec : forall {x y z : A},
+    (z $-> x) -> (z $-> y) -> (z $-> product x y);
+
+  (** All this data satisifies certain equiations, leading to the unqiueness of the product_corec map. *)
+
+  (** Applying the first projection after a map pariing gives the first map. *) 
+  product_beta_pr1 {x y z : A} (f : z $-> x) (g : z $-> y)
+    : cat_pr1 $o product_corec f g $== f;
+  
+  (** Applying the second projection after a map pariing gives the second map. *)
+  product_beta_pr2 {x y z : A} (f : z $-> x) (g : z $-> y)
+    : cat_pr2 $o product_corec f g $== g;
+
+  (** The pairing map is the unique map that makes the following diagram commute. *)
+  product_eta {x y z : A} (f : z $-> product x y)
+    : product_corec (cat_pr1 $o f) (cat_pr2 $o f) $== f;
+  
+  (** Finally given any two [product_corec], they are uniquely identified by their components. (This introduces a 2-categorical notion of product, which for n-categorical universal properties will need (n+1) levels of cells. We therefore restrict to 1-categories for now). Without this condition, we would not be able to show the 2-functorial action of the product functor or even 1-functoriality in the second argument. *) 
+  product_corec_eta {x y z : A} {f f' : z $-> x} {g g' : z $-> y}
+    : f $== f' -> g $== g' -> product_corec f g $== product_corec f' g';
+}.
+
+Lemma product_pr_eta {A} `{HasBinaryProducts A}
+  {x y z : A} {f f' : z $-> product x y}
+  : cat_pr1 $o f $== cat_pr1 $o f' -> cat_pr2 $o f $== cat_pr2 $o f' -> f $== f'.
+Proof.
+  intros fst snd.
+  refine ((product_eta _)^$ $@ _ $@ product_eta _).
+  by apply product_corec_eta.
+Defined.
+
+(** In general it's not possible to define a recursor for a product. It is possible if a category has an internal hom, but that is a very strong condition.  *)
+
+(** *** Product functor *)
+
+
+(** Binary products are functorial in each argument. *)
+Global Instance is0functor_product_l {A : Type} `{Is1Cat A} `{HasBinaryProducts A} y
+  : Is0Functor (fun x => product x y).
+Proof.
+  snrapply Build_Is0Functor.
+  intros a b f.
+  apply product_corec.
+  - exact (f $o cat_pr1).
+  - exact cat_pr2.
+Defined.
+
+Global Instance is1functor_product_l {A : Type} `{Is1Cat A} `{HasBinaryProducts A} y
+  : Is1Functor (fun x => product x y).
+Proof.
+  snrapply Build_Is1Functor.
+  - intros a b f g p.
+    simpl.
+    apply product_corec_eta.
+    2: apply Id.
+    exact (p $@R cat_pr1).
+  - intros x.
+    simpl.
+    apply product_pr_eta.
+    + refine (product_beta_pr1 _ _ $@ _).
+      exact (cat_idl _ $@ (cat_idr _)^$).
+    + refine (product_beta_pr2 _ _ $@ _).
+      exact (cat_idr _)^$.
+  - intros x z w f g.
+    simpl.
+    apply product_pr_eta.
+    + refine (product_beta_pr1 _ _ $@ _).
+      refine (_ $@ cat_assoc _ _ _).
+      refine (_ $@ ((product_beta_pr1 _ _)^$ $@R _)).
+      refine (cat_assoc _ _ _ $@ (_ $@L _) $@ (cat_assoc _ _ _)^$).
+      exact (product_beta_pr1 _ _)^$.
+    + refine (product_beta_pr2 _ _ $@ _).
+      refine (_ $@ cat_assoc _ _ _).
+      refine (_ $@ ((product_beta_pr2 _ _)^$ $@R _)).
+      exact (product_beta_pr2 _ _)^$.
+Defined.
+
+Global Instance is0functor_product_r {A : Type} `{Is1Cat A} `{HasBinaryProducts A} x
+  : Is0Functor (product x).
+Proof.
+  snrapply Build_Is0Functor.
+  intros a b f.
+  apply product_corec.
+  - exact cat_pr1.
+  - exact (f $o cat_pr2).
+Defined.
+
+Global Instance is1functor_product_r {A : Type} `{Is1Cat A} `{HasBinaryProducts A} x
+  : Is1Functor (product x).
+Proof.
+  snrapply Build_Is1Functor.
+  - intros y z f g p.
+    apply product_corec_eta.
+    1: apply Id.
+    exact (p $@R cat_pr2).
+  - intros y. simpl.
+    refine (_ $@ product_eta _).
+    apply product_corec_eta.
+    + symmetry.
+      apply cat_idr.
+    + exact (cat_idl _ $@ (cat_idr _)^$).
+  - intros y z w f g.
+    simpl.
+    apply product_pr_eta.
+    + refine (product_beta_pr1 _ _ $@ _).
+      refine (_ $@ cat_assoc _ _ _).
+      refine (_ $@ ((product_beta_pr1 _ _)^$ $@R _)).
+      exact (product_beta_pr1 _ _)^$.    
+    + refine (product_beta_pr2 _ _ $@ _).
+      refine (_ $@ cat_assoc _ _ _).
+      refine (_ $@ ((product_beta_pr2 _ _)^$ $@R _)).
+      refine (_ $@ (cat_assoc _ _ _)^$).
+      refine (cat_assoc _ _ _ $@ _).
+      exact (_ $@L product_beta_pr2 _ _)^$.
+Defined.
+
+(** [product_corec] is also functorial in each morphsism. *)
+
+Global Instance is0functor_product_corec_l {A : Type} `{Is1Cat A} `{HasBinaryProducts A} {x y z : A} (g : z $-> y)
+  : Is0Functor (fun f => @product_corec _ _ _ _ _ _ x y z f g).
+Proof.
+  snrapply Build_Is0Functor.
+  intros f f' p.
+  by apply product_corec_eta.
+Defined.
+
+Global Instance is0functor_product_corec_r {A : Type} `{Is1Cat A} `{HasBinaryProducts A} {x y z : A} (f : z $-> x)
+  : Is0Functor (@product_corec _ _ _ _ _ _ x y z f).
+Proof.
+  snrapply Build_Is0Functor.
+  intros g h p.
+  by apply product_corec_eta.
+Defined.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics Basics.Equivalences Basics.PathGroupoids.
-Require Import Types.Equiv.
-Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat.
+Require Import Types.Equiv Types.Prod.
+Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat WildCat.Products.
 
 (** ** The (1-)category of types *)
 
@@ -172,4 +172,19 @@ Proof.
     exact (concat_p1 _ @ (concat_1p _)^).
   - reflexivity.
   - reflexivity.
+Defined.
+
+Global Instance hasbinaryproducts_type : HasBinaryProducts Type.
+Proof.
+  srapply Build_HasBinaryProducts.
+  - exact prod.
+  - intros x y; exact fst.
+  - intros x y; exact snd.
+  - intros x y z f g.
+    exact (prod_coind f g).
+  - reflexivity.
+  - reflexivity.
+  - reflexivity.
+  - intros x y z f f' g g' p q a. 
+    exact (path_prod' (p a) (q a)).
 Defined.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics Basics.Equivalences Basics.PathGroupoids.
 Require Import Types.Equiv Types.Prod.
-Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat WildCat.Products.
+Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat.
 
 (** ** The (1-)category of types *)
 
@@ -172,19 +172,4 @@ Proof.
     exact (concat_p1 _ @ (concat_1p _)^).
   - reflexivity.
   - reflexivity.
-Defined.
-
-Global Instance hasbinaryproducts_type : HasBinaryProducts Type.
-Proof.
-  srapply Build_HasBinaryProducts.
-  - exact prod.
-  - intros x y; exact fst.
-  - intros x y; exact snd.
-  - intros x y z f g.
-    exact (prod_coind f g).
-  - reflexivity.
-  - reflexivity.
-  - reflexivity.
-  - intros x y z f f' g g' p q a. 
-    exact (path_prod' (p a) (q a)).
 Defined.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,5 +1,5 @@
 Require Import Basics.Overture Basics.Tactics Basics.Equivalences Basics.PathGroupoids.
-Require Import Types.Equiv Types.Prod.
+Require Import Types.Equiv.
 Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat.
 
 (** ** The (1-)category of types *)

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -1,5 +1,5 @@
 Require Import Basics.Overture Basics.Tactics.
-Require Import WildCat.Core WildCat.Equiv WildCat.EquivGpd.
+Require Import WildCat.Core WildCat.Equiv WildCat.EquivGpd WildCat.Prod.
 
 (** * The wild 1-category of 0-groupoids. *)
 
@@ -137,4 +137,9 @@ Proof.
   - cbn.  intro x.
     apply e1.
     apply e0.
+Defined.
+
+Definition prod_0gpd (G H : ZeroGpd) : ZeroGpd.
+Proof.
+  rapply (Build_ZeroGpd (G * H)).
 Defined.


### PR DESCRIPTION
We define what it means for a wild cat to have binary products and then show Type, pType and Group to have binary products. This notion of product is only 1-coherent as it will not be the correct notion of a product in a bicategory. But this doesn't matter for now as we haven't even defined a full bicategory yet.

AbGroup will be left out for now as a notion of biproduct will follow soon.

I've also defined binary coproducts as products in the opposite category and shown Type, pType and Group as examples of categories with binary coproducts.