### PR TITLE
Reduce universe variables and other clean-ups

### DIFF
--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -8,7 +8,11 @@ Require Import Algebra.AbGroups.AbelianGroup.
 
 Local Open Scope int_scope.
 
-Definition abgroup_Z : AbGroup.
+Section MinimizationToSet.
+
+Local Set Universe Minimization ToSet.
+
+Definition abgroup_Z@{} : AbGroup@{Set}.
 Proof.
   snrapply Build_AbGroup.
   - refine (Build_Group Int int_add 0 int_negation _); repeat split.
@@ -19,6 +23,8 @@ Proof.
     + exact int_add_negation_r.
   - exact int_add_comm.
 Defined.
+
+End MinimizationToSet.
 
 (** We can multiply by [n : Int] in any abelian group. *)
 Definition ab_mul (n : Int) {A : AbGroup} : GroupHomomorphism A A.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -252,6 +252,7 @@ Definition pequiv_groupisomorphism {A B : Group}
   := fun f => Build_pEquiv _ _ f _.
 
 Coercion equiv_groupisomorphism : GroupIsomorphism >-> Equiv.
+Coercion pequiv_groupisomorphism : GroupIsomorphism >-> pEquiv.
 
 Definition equiv_path_groupisomorphism `{F : Funext} {G H : Group}
   (f g : GroupIsomorphism G H)

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -6,12 +6,16 @@ Require Import Basics.Overture.
 
 (** This module implements various tactics used in the library. *)
 
-(** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [nat] or a [trunc_index].  The difference is that it produces proof terms involving [fix] explicitly rather than [nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. *)
+(** The following tactic is designed to be more or less interchangeable with [induction n as [ | n' IH ]] whenever [n] is a [nat] or a [trunc_index].  The difference is that it produces proof terms involving [fix] explicitly rather than [nat_ind] or [trunc_index_ind], and therefore does not introduce higher universe parameters. It works if [n] is in the context or in the goal. *)
 Ltac simple_induction n n' IH :=
-  generalize dependent n;
+  try generalize dependent n;
   fix IH 1;
   intros [| n'];
   [ clear IH | specialize (IH n') ].
+
+Ltac simple_induction' n :=
+  let IH := fresh "IH" in
+  simple_induction n n IH.
 
 (** Debugging tactics to show the goal during evaluation. *)
 

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -1049,10 +1049,7 @@ Global Instance Z_abs@{} : IntAbs@{UN UN UN UN UN
   UN UN UN UN UN
   UN UN UN UN UN
   UN UN} Z N
-  := ltac:(first [exact Z_abs'@{Ularge Ularge Ularge Ularge Ularge
-                                Ularge Ularge}|
-                  exact Z_abs'@{Ularge Ularge Ularge Ularge Ularge
-                                Ularge}]).
+  := Z_abs'.
 
 Notation n_to_z := (naturals_to_semiring N Z).
 

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -15,6 +15,7 @@ Local Set Universe Minimization ToSet.
 Section nat_lift.
 
 Universe N.
+(* It's important that the universe [N] be free.  Occasionally, Coq will choose universe variables in proofs that force [N] to be [Set].  To pinpoint where this happens, you can add the line [Constraint Set < N.] here, and see what fails below. *)
 
 Let natpaths := @paths@{N} nat.
 Infix "=N=" := natpaths.
@@ -425,7 +426,7 @@ Qed.
 
 Instance decidable_nat_apart x y : Decidable (nat_apart x y).
 Proof.
-  rapply decidable_sum; apply Nat.Core.decidable_lt.
+  rapply decidable_sum@{N N N}; apply Nat.Core.decidable_lt.
 Defined.
 
 Global Instance nat_trivial_apart : TrivialApart nat.

--- a/theories/Spaces/Finite/Fin.v
+++ b/theories/Spaces/Finite/Fin.v
@@ -5,6 +5,9 @@ Require Import HSet.
 Require Import Spaces.Nat.
 Require Import Equiv.PathSplit.
 
+(** By setting this, using [simple_induction] instead of [induction], and specifying universe variables in a couple of places, we can avoid all universe variables in this file.  Several results are confirmed to use no universe variables with an @{} annotation. *)
+Local Set Universe Minimization ToSet.
+
 Local Open Scope path_scope.
 Local Open Scope nat_scope.
 
@@ -38,10 +41,10 @@ Proof.
   exact (inl (inr tt)).
 Defined.
 
-Global Instance decidablepaths_fin (n : nat)
+Global Instance decidablepaths_fin@{} (n : nat)
 : DecidablePaths (Fin n).
 Proof.
-  induction n as [|n IHn]; simpl; exact _.
+  simple_induction n n IHn; simpl; exact _.
 Defined.
 
 Global Instance contr_fin1 : Contr (Fin 1).
@@ -81,31 +84,30 @@ Fixpoint fsucc {n : nat} : Fin n -> Fin n.+1 :=
   end.
 
 (** This injection is an injection/embedding *)
-Lemma isembedding_fsucc {n : nat} : IsEmbedding (@fsucc n).
+Lemma isembedding_fsucc@{} {n : nat} : IsEmbedding (@fsucc n).
 Proof.
   apply isembedding_isinj_hset.
-  induction n.
+  simple_induction n n IHn.
   - intro i. elim i.
   - intros [] []; intro p.
     + f_ap. apply IHn. eapply path_sum_inl. exact p.
     + destruct u. elim (inl_ne_inr _ _ p).
     + destruct u. elim (inr_ne_inl _ _ p).
     + destruct u, u0; reflexivity.
-Qed.
+Defined.
 
 Lemma path_fin_fsucc_incl {n : nat} : forall k : Fin n, fsucc (fin_incl k) = fin_incl (fsucc k).
 Proof.
   trivial.
-Qed.
+Defined.
 
-Lemma path_nat_fin_incl {n : nat} : forall k : Fin n, fin_to_nat (fin_incl k) = fin_to_nat k.
-Proof.
-  reflexivity.
-Qed.
+Definition path_nat_fin_incl {n : nat} (k : Fin n)
+  : fin_to_nat (fin_incl k) = fin_to_nat k
+  := 1.
 
-Lemma path_nat_fsucc {n : nat} : forall k : Fin n, fin_to_nat (fsucc k) = S (fin_to_nat k).
+Lemma path_nat_fsucc@{} {n : nat} : forall k : Fin n, fin_to_nat (fsucc k) = S (fin_to_nat k).
 Proof.
-  induction n as [|n' IHn].
+  simple_induction n n IHn.
   - intros [].
   - intros [k'|[]].
     + rewrite path_fin_fsucc_incl, path_nat_fin_incl.
@@ -113,17 +115,15 @@ Proof.
     + reflexivity.
 Defined.
 
-Lemma path_nat_fin_zero {n} : fin_to_nat (@fin_zero n) = 0.
+Lemma path_nat_fin_zero@{} {n} : fin_to_nat (@fin_zero n) = 0.
 Proof.
-  induction n as [|n' IHn].
+  simple_induction n n IHn.
   - reflexivity.
   - trivial.
 Defined.
 
-Lemma path_nat_fin_last {n} : fin_to_nat (@fin_last n) = n.
-Proof.
-  reflexivity.
-Qed.
+Definition path_nat_fin_last {n} : fin_to_nat (@fin_last n) = n
+  := 1.
 
 (** ** Transposition equivalences *)
 
@@ -132,7 +132,7 @@ Qed.
 (** *** Swap the last two elements. *)
 
 Definition fin_transpose_last_two (n : nat)
-: Fin n.+2 <~> Fin n.+2
+  : Fin n.+2 <~> Fin n.+2
   := ((equiv_sum_assoc _ _ _)^-1)
        oE (1 +E (equiv_sum_symm _ _))
        oE (equiv_sum_assoc _ _ _).
@@ -140,21 +140,21 @@ Definition fin_transpose_last_two (n : nat)
 Arguments fin_transpose_last_two : simpl nomatch.
 
 Definition fin_transpose_last_two_last (n : nat)
-: fin_transpose_last_two n (inr tt) = (inl (inr tt))
+  : fin_transpose_last_two n (inr tt) = (inl (inr tt))
   := 1.
 
 Definition fin_transpose_last_two_nextlast (n : nat)
-: fin_transpose_last_two n (inl (inr tt)) = (inr tt)
+  : fin_transpose_last_two n (inl (inr tt)) = (inr tt)
   := 1.
 
 Definition fin_transpose_last_two_rest (n : nat) (k : Fin n)
-: fin_transpose_last_two n (inl (inl k)) = (inl (inl k))
+  : fin_transpose_last_two n (inl (inl k)) = (inl (inl k))
   := 1.
 
 (** *** Swap the last element with [k]. *)
 
 Fixpoint fin_transpose_last_with (n : nat) (k : Fin n.+1)
-: Fin n.+1 <~> Fin n.+1.
+  : Fin n.+1 <~> Fin n.+1.
 Proof.
   destruct k as [k|].
   - destruct n as [|n].
@@ -170,44 +170,44 @@ Defined.
 
 Arguments fin_transpose_last_with : simpl nomatch.
 
-Definition fin_transpose_last_with_last (n : nat) (k : Fin n.+1)
-: fin_transpose_last_with n k (inr tt) = k.
+Definition fin_transpose_last_with_last@{} (n : nat) (k : Fin n.+1)
+  : fin_transpose_last_with n k (inr tt) = k.
 Proof.
   destruct k as [k|].
-  - induction n as [|n IH]; simpl.
+  - simple_induction n n IHn; intro k; simpl.
     + elim k.
     + destruct k as [k|].
-      * simpl. rewrite IH; reflexivity.
+      * simpl. rewrite IHn; reflexivity.
       * simpl. apply ap, ap, path_contr.
   - (** We have to destruct [n] since fixpoints don't reduce unless their argument is a constructor. *)
     destruct n; simpl.
     all:apply ap, path_contr.
 Qed.
 
-Definition fin_transpose_last_with_with (n : nat) (k : Fin n.+1)
-: fin_transpose_last_with n k k = inr tt.
+Definition fin_transpose_last_with_with@{} (n : nat) (k : Fin n.+1)
+  : fin_transpose_last_with n k k = inr tt.
 Proof.
   destruct k as [k|].
-  - induction n as [|n IH]; simpl.
+  - simple_induction n n IHn; intro k; simpl.
     + elim k.
     + destruct k as [|k]; simpl.
-      * rewrite IH; reflexivity.
+      * rewrite IHn; reflexivity.
       * apply ap, path_contr.
   - destruct n; simpl.
     all:apply ap, path_contr.
 Qed.
 
-Definition fin_transpose_last_with_rest (n : nat)
-           (k : Fin n.+1) (l : Fin n)
-           (notk : k <> inl l)
-: fin_transpose_last_with n k (inl l) = (inl l).
+Definition fin_transpose_last_with_rest@{} (n : nat)
+  (k : Fin n.+1) (l : Fin n)
+  (notk : k <> inl l)
+  : fin_transpose_last_with n k (inl l) = (inl l).
 Proof.
   destruct k as [k|].
-  - induction n as [|n IH]; simpl.
-    1:elim k.
+  - simple_induction n n IHn; intros k l notk; simpl.
+    1: elim k.
     destruct k as [k|]; simpl.
     { destruct l as [l|]; simpl.
-      - rewrite IH.
+      - rewrite IHn.
         + reflexivity.
         + exact (fun p => notk (ap inl p)).
       - reflexivity. }
@@ -215,16 +215,16 @@ Proof.
       - reflexivity.
       - elim (notk (ap inl (ap inr (path_unit _ _)))). }
   - destruct n; reflexivity.
-Qed.
+Defined.
 
 Definition fin_transpose_last_with_last_other (n : nat) (k : Fin n.+1)
-: fin_transpose_last_with n (inr tt) k = k.
+  : fin_transpose_last_with n (inr tt) k = k.
 Proof.
   destruct n; reflexivity.
-Qed.
+Defined.
 
 Definition fin_transpose_last_with_invol (n : nat) (k : Fin n.+1)
-: fin_transpose_last_with n k o fin_transpose_last_with n k == idmap.
+  : fin_transpose_last_with n k o fin_transpose_last_with n k == idmap.
 Proof.
   intros l.
   destruct l as [l|[]].
@@ -240,7 +240,7 @@ Proof.
       apply fin_transpose_last_with_last_other.
   - rewrite fin_transpose_last_with_last.
     apply fin_transpose_last_with_with.
-Qed.
+Defined.
 
 (** ** Equivalences between canonical finite sets *)
 
@@ -248,19 +248,18 @@ Qed.
 
 (** Here is the uncurried map that constructs an equivalence [Fin n.+1 <~> Fin m.+1]. *)
 Definition fin_equiv (n m : nat)
-           (k : Fin m.+1) (e : Fin n <~> Fin m)
-: Fin n.+1 <~> Fin m.+1
-  := (fin_transpose_last_with m k)
-       oE (e +E 1).
+  (k : Fin m.+1) (e : Fin n <~> Fin m)
+  : Fin n.+1 <~> Fin m.+1
+  := (fin_transpose_last_with m k) oE (e +E 1).
 
 (** Here is the curried version that we will prove to be an equivalence. *)
 Definition fin_equiv' (n m : nat)
-: ((Fin m.+1) * (Fin n <~> Fin m)) -> (Fin n.+1 <~> Fin m.+1)
+  : ((Fin m.+1) * (Fin n <~> Fin m)) -> (Fin n.+1 <~> Fin m.+1)
   := fun ke => fin_equiv n m (fst ke) (snd ke).
 
 (** We construct its inverse and the two homotopies first as versions using homotopies without funext (similar to [ExtendableAlong]), then apply funext at the end. *)
-Definition fin_equiv_hfiber (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
-: { kf : (Fin m.+1) * (Fin n <~> Fin m) & fin_equiv' n m kf == e }.
+Definition fin_equiv_hfiber@{} (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
+  : { kf : (Fin m.+1) * (Fin n <~> Fin m) & fin_equiv' n m kf == e }.
 Proof.
   simpl in e.
   refine (equiv_sigma_prod _ _).
@@ -268,7 +267,7 @@ Proof.
   assert (p' := (moveL_equiv_V _ _ p)^).
   exists y.
   destruct y as [y|[]].
-  + simple refine (equiv_unfunctor_sum_l
+  + simple refine (equiv_unfunctor_sum_l@{Set Set Set Set Set Set Set Set Set Set}
               (fin_transpose_last_with m (inl y) oE e)
               _ _ ; _).
     { intros a. ev_equiv.
@@ -287,7 +286,7 @@ Proof.
     * rewrite unfunctor_sum_l_beta.
       apply fin_transpose_last_with_invol.
     * refine (fin_transpose_last_with_last _ _ @ p^).
-  + simple refine (equiv_unfunctor_sum_l e _ _ ; _).
+  + simple refine (equiv_unfunctor_sum_l@{Set Set Set Set Set Set Set Set Set Set} e _ _ ; _).
     { intros a.
       destruct (is_inl_or_is_inr (e (inl a))) as [l|r].
       - exact l.
@@ -306,16 +305,16 @@ Proof.
 Qed.
 
 Definition fin_equiv_inv (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
-: (Fin m.+1) * (Fin n <~> Fin m)
+  : (Fin m.+1) * (Fin n <~> Fin m)
   := (fin_equiv_hfiber n m e).1.
 
 Definition fin_equiv_issect (n m : nat) (e : Fin n.+1 <~> Fin m.+1)
-: fin_equiv' n m (fin_equiv_inv n m e) == e
+  : fin_equiv' n m (fin_equiv_inv n m e) == e
   := (fin_equiv_hfiber n m e).2.
 
 Definition fin_equiv_inj_fst (n m : nat)
            (k l : Fin m.+1) (e f : Fin n <~> Fin m)
-: (fin_equiv n m k e == fin_equiv n m l f) -> (k = l).
+  : (fin_equiv n m k e == fin_equiv n m l f) -> (k = l).
 Proof.
   intros p.
   refine (_ @ p (inr tt) @ _); simpl;
@@ -324,7 +323,7 @@ Qed.
 
 Definition fin_equiv_inj_snd (n m : nat)
            (k l : Fin m.+1) (e f : Fin n <~> Fin m)
-: (fin_equiv n m k e == fin_equiv n m l f) -> (e == f).
+  : (fin_equiv n m k e == fin_equiv n m l f) -> (e == f).
 Proof.
   intros p.
   intros x. assert (q := p (inr tt)); simpl in q.
@@ -336,7 +335,7 @@ Qed.
 
 (** Now it's time for funext. *)
 Global Instance isequiv_fin_equiv `{Funext} (n m : nat)
-: IsEquiv (fin_equiv' n m).
+  : IsEquiv (fin_equiv' n m).
 Proof.
   refine (isequiv_pathsplit 0 _); split.
   - intros e; exists (fin_equiv_inv n m e).
@@ -350,29 +349,29 @@ Proof.
     + refine (fin_equiv_inj_fst n m k l e f p).
     + apply path_equiv, path_arrow.
       refine (fin_equiv_inj_snd n m k l e f p).
-Qed.
+Defined.
 
 Definition equiv_fin_equiv `{Funext} (n m : nat)
-: ((Fin m.+1) * (Fin n <~> Fin m)) <~> (Fin n.+1 <~> Fin m.+1)
+  : ((Fin m.+1) * (Fin n <~> Fin m)) <~> (Fin n.+1 <~> Fin m.+1)
   := Build_Equiv _ _ (fin_equiv' n m) _.
 
 (** In particular, this implies that if two canonical finite sets are equivalent, then their cardinalities are equal. *)
 Definition nat_eq_fin_equiv (n m : nat)
 : (Fin n <~> Fin m) -> (n = m).
 Proof.
-  revert m; induction n as [|n IHn]; induction m as [|m IHm]; intros e.
+  revert m; simple_induction n n IHn; intro m; simple_induction m m IHm; intros e.
   - exact idpath.
   - elim (e^-1 (inr tt)).
   - elim (e (inr tt)).
   - refine (ap S (IHn m _)).
     exact (snd (fin_equiv_inv n m e)).
-Qed.
+Defined.
 
 (** ** Initial segments of [nat] *)
 
 Definition nat_fin (n : nat) (k : Fin n) : nat.
 Proof.
-  induction n as [|n nf].
+  simple_induction n n nf; intro k.
   - contradiction.
   - destruct k as [k|_].
     + exact (nf k).
@@ -380,12 +379,12 @@ Proof.
 Defined.
 
 Definition nat_fin_inl (n : nat) (k : Fin n)
-: nat_fin n.+1 (inl k) = nat_fin n k
+  : nat_fin n.+1 (inl k) = nat_fin n k
   := 1.
 
 Definition nat_fin_compl (n : nat) (k : Fin n) : nat.
 Proof.
-  induction n as [|n nfc].
+  simple_induction n n nfc; intro k.
   - contradiction.
   - destruct k as [k|_].
     + exact (nfc k).+1.
@@ -393,20 +392,20 @@ Proof.
 Defined.
 
 Definition nat_fin_compl_compl n k
-: (nat_fin n k + nat_fin_compl n k).+1 = n.
+  : (nat_fin n k + nat_fin_compl n k).+1 = n.
 Proof.
-  induction n as [|n IH].
+  simple_induction n n IHn; intro k.
   - contradiction.
   - destruct k as [k|?]; simpl.
     + rewrite nat_add_comm.
-      specialize (IH k).
-      rewrite nat_add_comm in IH.
-      exact (ap S IH).
+      specialize (IHn k).
+      rewrite nat_add_comm in IHn.
+      exact (ap S IHn).
     + rewrite nat_add_comm; reflexivity.
 Qed.
 
 (** [fsucc_mod] is the successor function mod n *)
-Definition fsucc_mod {n : nat} : Fin n -> Fin n.
+Definition fsucc_mod@{} {n : nat} : Fin n -> Fin n.
 Proof.
   destruct n.
   1: exact idmap.

--- a/theories/Spaces/Finite/Fin.v
+++ b/theories/Spaces/Finite/Fin.v
@@ -34,15 +34,15 @@ Fixpoint fin_to_nat {n} : Fin n -> nat
          end
      end.
 
-Global Instance decidable_fin@{u} (n : nat)
-: Decidable@{u} (Fin n).
+Global Instance decidable_fin (n : nat)
+: Decidable (Fin n).
 Proof.
   destruct n as [|n]; try exact _.
   exact (inl (inr tt)).
 Defined.
 
-Global Instance decidablepaths_fin@{u} (n : nat)
-: DecidablePaths@{u} (Fin n).
+Global Instance decidablepaths_fin@{} (n : nat)
+: DecidablePaths (Fin n).
 Proof.
   simple_induction n n IHn; simpl; exact _.
 Defined.

--- a/theories/Spaces/Finite/Fin.v
+++ b/theories/Spaces/Finite/Fin.v
@@ -34,15 +34,15 @@ Fixpoint fin_to_nat {n} : Fin n -> nat
          end
      end.
 
-Global Instance decidable_fin (n : nat)
-: Decidable (Fin n).
+Global Instance decidable_fin@{u} (n : nat)
+: Decidable@{u} (Fin n).
 Proof.
   destruct n as [|n]; try exact _.
   exact (inl (inr tt)).
 Defined.
 
-Global Instance decidablepaths_fin@{} (n : nat)
-: DecidablePaths (Fin n).
+Global Instance decidablepaths_fin@{u} (n : nat)
+: DecidablePaths@{u} (Fin n).
 Proof.
   simple_induction n n IHn; simpl; exact _.
 Defined.

--- a/theories/Spaces/Int/Core.v
+++ b/theories/Spaces/Int/Core.v
@@ -1,6 +1,8 @@
 Require Import Basics.
 Require Import Spaces.Pos.
 
+Local Set Universe Minimization ToSet.
+
 (** * The Integers. *)
 
 Local Close Scope trunc_scope.

--- a/theories/Spaces/Int/Core.v
+++ b/theories/Spaces/Int/Core.v
@@ -228,7 +228,7 @@ Definition sgn z :=
 
 (* ** Decidable paths and truncation. *)
 
-Global Instance decpaths_int : DecidablePaths@{u} Int.
+Global Instance decpaths_int : DecidablePaths Int.
 Proof.
   intros [n | | n] [m | | m].
   + destruct (dec (n = m)) as [p | q].
@@ -247,4 +247,4 @@ Proof.
 Defined.
 
 (** Since integers have decidable paths they are a hset *)
-Global Instance hset_int : IsHSet@{u} Int | 0 := _.
+Global Instance hset_int : IsHSet Int | 0 := _.

--- a/theories/Spaces/Int/Core.v
+++ b/theories/Spaces/Int/Core.v
@@ -228,7 +228,7 @@ Definition sgn z :=
 
 (* ** Decidable paths and truncation. *)
 
-Global Instance decpaths_int : DecidablePaths Int.
+Global Instance decpaths_int : DecidablePaths@{u} Int.
 Proof.
   intros [n | | n] [m | | m].
   + destruct (dec (n = m)) as [p | q].
@@ -247,4 +247,4 @@ Proof.
 Defined.
 
 (** Since integers have decidable paths they are a hset *)
-Global Instance hset_int : IsHSet Int | 0 := _.
+Global Instance hset_int : IsHSet@{u} Int | 0 := _.

--- a/theories/Spaces/Int/LoopExp.v
+++ b/theories/Spaces/Int/LoopExp.v
@@ -26,6 +26,8 @@ Definition loopexp {A : Type} {x : A} (p : x = x) (z : Int) : (x = x)
        | pos n => loopexp_pos p n
      end.
 
+(** TODO: One can also define [loopexp] as [int_iter (equiv_concat_r p x) z idpath].  This has slightly different computational behaviour, e.g., it sends [1 : int] to [1 @ p] rather than [p].  But with this definition, some of the results below become special cases of results in Int.Equiv, and others could be generalized to results belonging in Int.Equiv.  It's probably worth investigating this. *)
+
 Lemma loopexp_pos_inv {A : Type} {x : A} (p : x = x) (n : Pos)
   : loopexp_pos p^ n = (loopexp_pos p n)^.
 Proof.
@@ -63,28 +65,6 @@ Proof.
     apply ap.
     apply ap_loopexp_pos.
   + apply ap_loopexp_pos.
-Qed.
-
-Lemma int_add_succ_l a b : int_succ a + b = int_succ (a + b).
-Proof.
-  rewrite <- int_add_assoc, (int_add_comm 1 b).
-  apply int_add_assoc.
-Qed.
-
-Lemma int_add_succ_r a b : a + int_succ b = int_succ (a + b).
-Proof.
-  apply int_add_assoc.
-Qed.
-
-Lemma int_add_pred_l a b : int_pred a + b = int_pred (a + b).
-Proof.
-  rewrite <- int_add_assoc, (int_add_comm (-1) b).
-  apply int_add_assoc.
-Qed.
-
-Lemma int_add_pred_r a b : a + int_pred b = int_pred (a + b).
-Proof.
-  apply int_add_assoc.
 Qed.
 
 Lemma loopexp_pos_concat {A : Type} {x : A} (p : x = x) (a : Pos)

--- a/theories/Spaces/Int/Spec.v
+++ b/theories/Spaces/Int/Spec.v
@@ -2,6 +2,8 @@ Require Import Basics.
 Require Import Spaces.Pos.
 Require Import Spaces.Int.Core.
 
+Local Set Universe Minimization ToSet.
+
 Local Open Scope int_scope.
 
 (** ** Addition is commutative *)
@@ -132,6 +134,13 @@ Proof.
   1: apply pos_succ_pred_double.
   apply pos_pred_double_succ.
 Qed.
+
+(* ** The successor autoequivalence. *)
+Global Instance isequiv_int_succ : IsEquiv int_succ | 0
+  := isequiv_adjointify int_succ _ int_succ_pred int_pred_succ.
+
+Definition equiv_int_succ : Int <~> Int
+  := Build_Equiv _ _ _ isequiv_int_succ.
 
 (** ** Negation distributes over addition *)
 Lemma int_negation_add_distr n m : - (n + m) = - n + - m.
@@ -347,12 +356,28 @@ Proof.
   - apply int_add_assoc_pos.
 Qed.
 
-(* ** The successor autoequivalence. *)
-Global Instance isequiv_int_succ : IsEquiv int_succ | 0
-  := isequiv_adjointify int_succ _ int_succ_pred int_pred_succ.
+(** ** Relationship between [int_succ], [int_pred] and addition. *)
+Lemma int_add_succ_l a b : int_succ a + b = int_succ (a + b).
+Proof.
+  rewrite <- int_add_assoc, (int_add_comm 1 b).
+  apply int_add_assoc.
+Qed.
 
-Definition equiv_int_succ : Int <~> Int
-  := Build_Equiv _ _ _ isequiv_int_succ.
+Lemma int_add_succ_r a b : a + int_succ b = int_succ (a + b).
+Proof.
+  apply int_add_assoc.
+Qed.
+
+Lemma int_add_pred_l a b : int_pred a + b = int_pred (a + b).
+Proof.
+  rewrite <- int_add_assoc, (int_add_comm (-1) b).
+  apply int_add_assoc.
+Qed.
+
+Lemma int_add_pred_r a b : a + int_pred b = int_pred (a + b).
+Proof.
+  apply int_add_assoc.
+Qed.
 
 (** ** Commutativity of multiplication *)
 Lemma int_mul_comm n m : n * m = m * n.

--- a/theories/Spaces/Nat/Arithmetic.v
+++ b/theories/Spaces/Nat/Arithmetic.v
@@ -1,7 +1,9 @@
 Require Import Basics.
 Require Import Spaces.Nat.Core.
-Local Close Scope trunc_scope.
   
+Local Set Universe Minimization ToSet.
+
+Local Close Scope trunc_scope.
 Local Open Scope nat_scope.
 
 Ltac nat_absurd_trivial :=
@@ -37,7 +39,7 @@ Local Definition transitive_paths_nat (n m k : nat)
 Proposition assoc_nat_add (n m k : nat)
   : n + (m + k) = (n + m) + k.
 Proof.
-  revert m k; induction n.
+  revert m k; simple_induction n n IHn.
   - reflexivity.
   - intros m k. change (n.+1 + (m + k)) with (n + (m + k)).+1.
     apply (transitive_paths _ _ _ (nat_add_n_Sm _ _)).
@@ -167,7 +169,7 @@ Defined.
 
 Proposition sub_n_n (n : nat) : n - n = 0.
 Proof.
-  induction n.
+  simple_induction n n IHn.
   - reflexivity.
   - simpl; exact IHn.
 Defined.
@@ -194,10 +196,10 @@ Ltac rewrite_subnn :=
 Proposition add_n_sub_n_eq (m n : nat) : m + n - n = m.
 Proof.
   destruct m.
-  - induction n.
+  - simple_induction' n.
     + reflexivity.
     + assumption.
-  - induction n.
+  - simple_induction' n.
     + simpl. destruct (add_n_O m); reflexivity.
     + simpl. destruct (add_n_Sm m n). assumption.
 Defined.
@@ -226,17 +228,17 @@ Defined.
 
 Proposition n_leq_add_n_k (n m : nat) : n <= n + m.
 Proof.
-  induction n.
+  simple_induction n n IHn.
   - apply leq_0_n.
   - simpl; apply leq_S_n', IHn.
 Defined.
 
 Proposition n_leq_add_n_k' (n m : nat) : n <= m + n.
 Proof.
-  induction m.
+  simple_induction' m.
   - exact(leq_n n).
   - simpl. apply leq_S. assumption.
-Defined.    
+Defined.
 
 Proposition natineq0eq0 {n : nat} : n <= 0 -> n = 0.
 Proof.
@@ -247,9 +249,9 @@ Defined.
 
 Proposition subsubadd (n m k : nat) : n - (m + k) = n - m - k.
 Proof.
-  revert m k; induction n.
+  revert m k; simple_induction n n IHn.
   - reflexivity.
-  - intro m; induction m; intro k.
+  - intro m; destruct m; intro k.
     + change (0 + k) with k; reflexivity.
     + change (m.+1 + k) with (m + k).+1; apply IHn.
 Defined.
@@ -264,12 +266,12 @@ Defined.
 Definition nleqSm_dichot {n m : nat}
   : (n <= m.+1) -> sum (n <= m) (n = m.+1).
 Proof.
-  revert m; induction n.
+  revert m; simple_induction n n IHn.
   - intro. left. exact (leq_0_n m).
-  - induction m.
+  - destruct m.
     + intro l. apply leq_S_n, natineq0eq0 in l.
       right; apply ap; exact l.
-    + intro l. apply leq_S_n, IHn in l; induction l as [a | b].
+    + intro l. apply leq_S_n, IHn in l; destruct l as [a | b].
       * left. apply leq_S_n'; exact a.
       * right. apply ap; exact b.
 Defined.
@@ -288,7 +290,7 @@ Defined.
 
 Proposition sub_leq_0_converse (n m : nat) : n - m = 0 -> n <= m.
 Proof.
-  revert m; induction n.
+  revert m; simple_induction n n IHn.
   - auto with nat.
   - intros m eq. destruct m.
     + simpl in eq. apply symmetric_paths in eq.
@@ -306,9 +308,9 @@ Defined.
 
 Proposition lt_sub_gt_0 (n m : nat) : m < n -> 0 < n - m.
 Proof.
-  revert m; induction n.
+  revert m; simple_induction n n IHn.
   - intros m ineq. contradiction (not_lt_n_0 m).
-  - induction m.
+  - destruct m.
     + simpl. easy.
     + simpl. intro ineq. apply leq_S_n in ineq.
       now apply IHn in ineq.
@@ -317,10 +319,10 @@ Defined.
 Proposition natminuspluseq (n m : nat)
   : n <= m -> (m - n) + n = m.
 Proof.
-  revert m; induction n.
+  revert m; simple_induction n n IHn.
   - intros. destruct m; [reflexivity |]. simpl.
     apply (ap S), symmetric_paths, add_n_O.
-  - intros m l. induction m.
+  - intros m l. destruct m.
     + contradiction (not_leq_Sn_0 n).
     + simpl. apply leq_S_n, IHn in l.
       destruct (nat_add_n_Sm (m - n) n).
@@ -336,7 +338,7 @@ Proof.
   - apply n_lt_m_n_leq_m in g.
     now destruct (symmetric_paths _ _ (sub_leq_0 n m _)).
 Defined.
-    
+
 Proposition natminuspluseq' (n m : nat)
   : n <= m -> n + (m - n) = m.
 Proof.
@@ -363,7 +365,7 @@ Proposition nataddpreservesleq { n m k : nat }
   : n <= m -> n + k <= m + k.
 Proof.
   intro l.
-  induction k.
+  simple_induction k k IHk.
   - destruct (add_n_O n), (add_n_O m); exact l.
   - destruct (nat_add_n_Sm n k), (nat_add_n_Sm m k);
       apply leq_S_n'; exact IHk.
@@ -387,7 +389,7 @@ Proof.
   unfold "<".
   change (n + k).+1 with (n.+1 + k).
   generalize (n.+1). intros n' l.
-  induction k.
+  simple_induction k k IHk.
   - destruct (add_n_O n'), (add_n_O m); exact l.
   - destruct (nat_add_n_Sm n' k), (nat_add_n_Sm m k);
       apply leq_S_n'; exact IHk.
@@ -404,7 +406,7 @@ Defined.
 Proposition nataddreflectslt { n m k : nat }
   : n + k < m + k -> n < m.
 Proof.
-  induction k.
+  simple_induction k k IHk.
   - destruct (add_n_O n), (add_n_O m); trivial.
   - intro l. destruct (nat_add_n_Sm n k), (nat_add_n_Sm m k) in l.
     apply leq_S_n, IHk in l; exact l.
@@ -448,9 +450,9 @@ Defined.
 Proposition nataddsub_assoc_lemma {k m : nat}
   : (k <= m) -> m.+1 - k = (m - k).+1.
 Proof.
-  revert m; induction k.
+  revert m; simple_induction k k IHk.
   - intros m l; simpl. destruct m; reflexivity.
-  - induction m.
+  - destruct m.
     + simpl; intro g; contradiction (not_leq_Sn_0 _ g).
     + intro l; apply leq_S_n in l.
       change (m.+2 - k.+1) with (m.+1 - k).
@@ -461,7 +463,7 @@ Defined.
 Proposition nataddsub_assoc (n : nat) {m k : nat}
   : (k <= m) -> n + (m - k) = n + m - k.
 Proof.
-  revert m k. induction n.
+  revert m k. simple_induction n n IHn.
   - reflexivity.
   - intros m k l.
     change (n.+1 + (m - k)) with (n + (m - k)).+1;
@@ -492,9 +494,9 @@ Proposition nataddsub_comm_ineq_lemma (n m : nat)
   : n.+1 - m <= (n - m).+1.
 Proof.
   revert m.
-  induction n.
-  - induction m; [ apply leq_n | apply leq_S; apply leq_n ]. 
-  - intro m; induction m.
+  simple_induction n n IHn.
+  - simple_induction m m IHm; [ apply leq_n | apply leq_S; apply leq_n ]. 
+  - intro m; simple_induction m m IHm.
     + apply leq_n.
     + apply IHn.
 Defined.
@@ -502,7 +504,7 @@ Defined.
 Proposition nataddsub_comm_ineq (n m k : nat)
   : (n + k) - m <= (n - m) + k.
 Proof. 
-  induction k.
+  simple_induction k k IHk.
   - destruct (add_n_O n), (add_n_O (n - m)); constructor.
   - destruct (add_n_Sm n k).
     refine (leq_trans (nataddsub_comm_ineq_lemma (n+k) m) _).
@@ -524,9 +526,9 @@ Defined.
 Proposition i_lt_n_sum_m (n m i : nat)
   : i < n - m -> m <= n.
 Proof.
-  revert m i; induction n.
+  revert m i; simple_induction n n IHn.
   - intros m i l. simpl in l. contradiction (not_lt_n_0 _ _).
-  - intros m i l. induction m.
+  - intros m i l. destruct m.
     + apply leq_0_n.
     + apply leq_S_n'. simpl in l. apply (IHn m i l).
 Defined.
@@ -552,7 +554,7 @@ Defined.
 
 Proposition predeqminus1 { n : nat } : n - 1 = pred n.
 Proof.
-  induction n.
+  simple_induction' n.
   - reflexivity.
   - apply sub_n_0.
 Defined.
@@ -566,8 +568,7 @@ Defined.
 
 Proposition S_predn (n i: nat) : (i < n) -> S(pred n) = n.
 Proof.
-  intros l.
-  induction n.
+  simple_induction' n; intros l.
   - contradiction (not_lt_n_0 i).
   - reflexivity.
 Defined.
@@ -649,7 +650,7 @@ Defined.
 Proposition natsubpreservesleq { n m k : nat }
   : n <= m -> n - k <= m - k.
 Proof.
-  induction k.
+  simple_induction k k IHk.
   - destruct (symmetric_paths _ _ (sub_n_0 n)),
       (symmetric_paths _ _ (sub_n_0 m)); done.
   - intro l. change (k.+1) with (1 + k).
@@ -666,9 +667,9 @@ Defined.
 Proposition sub_less { n k : nat } : n - k <= n.
 Proof.
   revert k.
-  induction n.
+  simple_induction n n IHn.
   - intros; apply leq_0_n.
-  - induction k.
+  - destruct k.
     + apply leq_n.
     + simpl; apply (@leq_trans _ n _);
         [ apply IHn | apply leq_S, leq_n].
@@ -744,10 +745,10 @@ Defined.
 Proposition nat_add_bifunctor (n n' m m' : nat)
   : n <= m -> n' <= m' -> n + n' <= m + m'.
 Proof.
-  revert n' m m'; induction n.
+  revert n' m m'; simple_induction n n IHn.
   - intros n' m m' l l'. simpl.
     apply (leq_trans l'). exact (n_leq_add_n_k' m' m).
-  - intros n' m; induction m.
+  - intros n' m; destruct m.
     + intros. contradiction (not_leq_Sn_0 n).
     + intros m' l l'. apply leq_S_n in l. simpl.
       apply leq_S_n', IHn.
@@ -782,7 +783,7 @@ Proposition strong_induction (P : nat -> Type)
 Proof.
   intro a.
   assert (forall n m: nat, m < n -> P m) as X. {
-    induction n.
+    simple_induction n n IHn.
     - intros m l. contradiction (not_lt_n_0 m).
     - intros m l. apply leq_S_n in l.
       destruct l as [ | n].
@@ -816,9 +817,9 @@ Proof.
   - now constructor.
 Defined.
 
-Proposition increasing_geq_n_0 (n :nat) : increasing_geq n 0.
+Proposition increasing_geq_n_0 (n : nat) : increasing_geq n 0.
 Proof.
-  induction n.
+  simple_induction n n IHn.
   - constructor.
   - induction IHn.
     + constructor; now constructor.
@@ -828,7 +829,7 @@ Defined.
 Lemma increasing_geq_minus (n k : nat)
   : increasing_geq n (n - k).
 Proof.
-  induction k.
+  simple_induction k k IHk.
   - destruct (symmetric_paths _ _ (sub_n_0 n)); constructor.
   - destruct (@leq_dichot n k) as [l | g].
     + destruct (symmetric_paths _ _ (sub_leq_0 _ _ _)) in IHk.
@@ -854,7 +855,7 @@ Defined.
   
 Lemma ineq_sub (n m : nat) : n <= m -> m - (m - n) = n.
 Proof.
-  revert m; induction n.
+  revert m; simple_induction n n IHn.
   - intros. destruct (symmetric_paths _ _ (sub_n_0 m)),
       (symmetric_paths _ _ (sub_n_n m));
       reflexivity.

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -99,7 +99,7 @@ Definition x1_neq_x0 {z w : Pos} : x1 z <> x0 w
 
 (** * Positive binary integers have decidable paths *)
 
-Global Instance decpaths_pos : DecidablePaths Pos.
+Global Instance decpaths_pos : DecidablePaths@{u} Pos.
 Proof.
   intros n; induction n as [|zn|on];
   intros m; induction m as [|zm|om].
@@ -121,7 +121,7 @@ Proof.
 Defined.
 
 (** Decidable paths imply Pos is a hSet *)
-Global Instance ishset_pos : IsHSet Pos := _.
+Global Instance ishset_pos : IsHSet@{u} Pos := _.
 
 (** * Operations over positive numbers *)
 

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -1,6 +1,8 @@
 Require Import Basics.Overture Basics.Tactics Basics.Decidable
   Spaces.Nat.Core.
 
+Local Set Universe Minimization ToSet.
+
 (** * Binary Positive Integers *)
 
 (** Most of this file has been adapted from the coq standard library for positive binary integers. *)
@@ -14,7 +16,7 @@ Inductive Pos : Type0 :=
 Declare Scope positive_scope.
 Delimit Scope positive_scope with pos.
 
-(** Here are some notations that let us right binary positive integers more easily. *)
+(** Here are some notations that let us write binary positive integers more easily. *)
 Notation "1" := xH : positive_scope.
 Notation "p ~ 1" := (x1 p) : positive_scope.
 Notation "p ~ 0" := (x0 p) : positive_scope.

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -99,7 +99,7 @@ Definition x1_neq_x0 {z w : Pos} : x1 z <> x0 w
 
 (** * Positive binary integers have decidable paths *)
 
-Global Instance decpaths_pos : DecidablePaths@{u} Pos.
+Global Instance decpaths_pos : DecidablePaths Pos.
 Proof.
   intros n; induction n as [|zn|on];
   intros m; induction m as [|zm|om].
@@ -121,7 +121,7 @@ Proof.
 Defined.
 
 (** Decidable paths imply Pos is a hSet *)
-Global Instance ishset_pos : IsHSet@{u} Pos := _.
+Global Instance ishset_pos : IsHSet Pos := _.
 
 (** * Operations over positive numbers *)
 

--- a/theories/Spaces/Pos/Spec.v
+++ b/theories/Spaces/Pos/Spec.v
@@ -1,6 +1,8 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import Pos.Core.
 
+Local Set Universe Minimization ToSet.
+
 Local Open Scope positive_scope.
 
 (** ** Specification of [succ] in term of [add] *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -9,6 +9,9 @@ Require Export Modalities.Modality.        (* [Export] since the actual definiti
 Require Import Modalities.Descent.
 Require Import Truncations.Core Truncations.SeparatedTrunc.
 
+(** This reduces universe variables in [conn_pointed_type] and [conn_point_elim], which refer to [Unit]. *)
+Local Set Universe Minimization ToSet.
+
 Local Open Scope path_scope.
 Local Open Scope trunc_scope.
 
@@ -63,25 +66,20 @@ Defined.
 (** The connectivity of a pointed type and (the inclusion of) its point are intimately connected. *)
 
 (** We can't make both of these [Instance]s, as that would result in infinite loops. *)
+
 Global Instance conn_pointed_type@{u} {n : trunc_index} {A : Type@{u}} (a0:A)
-       `{IsConnMap n _ _ (unit_name a0)}
+  `{IsConnMap n _ _ (unit_name a0)}
   : IsConnected n.+1 A | 1000.
 Proof.
   apply isconnected_conn_map_to_unit.
-  (* Coq can find [conn_map_to_unit_isconnected] and [isconnected_contr] via typeclass search, but we manually pose them to get rid of an unneeded universe variable. *)
-  pose conn_map_to_unit_isconnected@{u u}.
-  pose isconnected_contr@{u u}.
-  apply (OO_cancelR_conn_map@{u u u u} (Tr n.+1) (Tr n) (unit_name a0) (const_tt A)).
+  apply (OO_cancelR_conn_map (Tr n.+1) (Tr n) (unit_name a0) (const_tt A)).
 Defined.
 
-Definition conn_point_incl `{Univalence} {n : trunc_index} {A : Type@{u}} (a0:A)
-           `{IsConnected n.+1 A}
+Definition conn_point_incl `{Univalence} {n : trunc_index} {A : Type} (a0:A)
+  `{IsConnected n.+1 A}
   : IsConnMap n (unit_name a0).
 Proof.
-  (* Coq can find [conn_map_to_unit_isconnected] and [isconnected_contr] via typeclass search, but we manually pose them to get rid of an unneeded universe variable. *)
-  pose conn_map_to_unit_isconnected@{u u}.
-  pose isconnected_contr@{u u}.
-  rapply (OO_cancelL_conn_map@{u u u u} (Tr n.+1) (Tr n) (unit_name a0) (const_tt A)).
+  rapply (OO_cancelL_conn_map (Tr n.+1) (Tr n) (unit_name a0) (const_tt A)).
   apply O_lex_leq_Tr.
 Defined.
 

--- a/theories/Types/Empty.v
+++ b/theories/Types/Empty.v
@@ -2,6 +2,9 @@
 (** * Theorems about the empty type *)
 
 Require Import Basics.Overture Basics.Equivalences Basics.Trunc.
+
+Local Set Universe Minimization ToSet.
+
 Local Open Scope path_scope.
 
 (** ** Unpacking *)
@@ -12,37 +15,37 @@ Local Open Scope path_scope.
 (** ** Equivalences *)
 (** ** Universal mapping properties *)
 
-Global Instance contr_from_Empty {_ : Funext} (A : Empty -> Type) :
-  Contr (forall x:Empty, A x).
+Global Instance contr_from_Empty@{u} {_ : Funext} (A : Empty -> Type@{u})
+  : Contr@{u} (forall x:Empty, A x).
 Proof.
-  refine (Build_Contr _ (Empty_ind A) _).
-  intros f; apply path_forall; intros x; elim x.
+  refine (Build_Contr@{u} _ (Empty_ind A) _).
+  intros f; apply path_forall@{Set u u}; intros x; elim x.
 Defined.
 
 Lemma Empty_rec {T : Type} (falso: Empty) : T.
 Proof. case falso. Defined.
 
-Global Instance isequiv_empty_rec `{Funext} (A : Type)
-: IsEquiv (fun (_ : Unit) => @Empty_rec A) | 0
-  := isequiv_adjointify _
+Global Instance isequiv_empty_rec@{u} `{Funext} (A : Type@{u})
+  : IsEquiv@{Set u} (fun (_ : Unit) => @Empty_rec A) | 0
+  := isequiv_adjointify@{Set u} _
   (fun _ => tt)
-  (fun f => path_forall _ _ (fun x => Empty_rec x))
+  (fun f => path_forall@{Set u u} _ _ (fun x => Empty_rec x))
   (fun x => match x with tt => idpath end).
 
-Definition equiv_empty_rec `{Funext} (A : Type)
-  : Unit <~> (Empty -> A)
-  := (Build_Equiv _ _ (fun (_ : Unit) => @Empty_rec A) _).
+Definition equiv_empty_rec@{u} `{Funext} (A : Type@{u})
+  : Unit <~> ((Empty -> A) : Type@{u})
+  := (Build_Equiv@{Set u} _ _ (fun (_ : Unit) => @Empty_rec A) _).
 
 (** ** Behavior with respect to truncation *)
 
-Global Instance istrunc_Empty (n : trunc_index) : IsTrunc n.+1 Empty.
+Global Instance istrunc_Empty@{} (n : trunc_index) : IsTrunc n.+1 Empty.
 Proof.
   refine (@istrunc_leq (-1)%trunc n.+1 tt _ _).
   apply istrunc_S.
   intros [].
 Defined.
 
-Global Instance all_to_empty_isequiv (T : Type) (f : T -> Empty) : IsEquiv f.
+Global Instance isequiv_all_to_empty (T : Type) (f : T -> Empty) : IsEquiv f.
 Proof.
   refine (Build_IsEquiv _ _ _ 
     (Empty_ind (fun _ => T))                (* := equiv_inf *)


### PR DESCRIPTION
When dealing with types defined to land in `Set` (aka `Type0`), such as `abgroup_Z`, `Pos`, `Int` and `Fin n`, it makes sense to use `Local Set Universe Minimization ToSet.` as otherwise free universe variables are created that are not matched when using the results.  By doing this and being careful to use `simple_induction`, many universe variables are eliminated.  For example, `abgroup_Z` goes from 25 to 0, `fsucc_mod` goes from 9 to 0, and `stratified_succ` goes from 17 to 1.

There are other improvements mixed in, such as making use of `nat_iter`.   I also cleaned up various comments and fixed indentation.