### PR TITLE
use Quotient in ua library

### DIFF
--- a/theories/Classes/theory/ua_first_isomorphism.v
+++ b/theories/Classes/theory/ua_first_isomorphism.v
@@ -4,12 +4,12 @@
     identification theorem [id_first_isomorphism] follows. *)
 
 Require Import
-  HoTT.HSet
-  HoTT.HIT.quotient
-  HoTT.Classes.interfaces.canonical_names
-  HoTT.Classes.theory.ua_isomorphic
-  HoTT.Classes.theory.ua_subalgebra
-  HoTT.Classes.theory.ua_quotient_algebra.
+  HSet
+  Colimits.Quotient
+  Classes.interfaces.canonical_names
+  Classes.theory.ua_isomorphic
+  Classes.theory.ua_subalgebra
+  Classes.theory.ua_quotient_algebra.
 
 Import
   algebra_notations
@@ -118,7 +118,7 @@ Section first_isomorphism.
   Definition def_first_isomorphism (s : Sort σ)
     : (A / cong_ker f) s → (B && in_image_hom f) s.
   Proof.
-    refine (quotient_rec (cong_ker f s) (λ x, (f s x; tr (x; idpath))) _).
+    refine (Quotient_rec (cong_ker f s) _ (λ x, (f s x; tr (x; idpath))) _).
     intros x y p.
     now apply path_sigma_hprop.
   Defined.
@@ -136,10 +136,10 @@ Section first_isomorphism.
     induction w.
     - apply path_sigma_hprop.
       generalize dependent γ.
-      refine (quotient_ind_prop (cong_ker f t) _ _). intros x G.
+      refine (Quotient_ind_hprop (cong_ker f t) _ _). intros x G.
       destruct P.
-      apply (classes_eq_related (cong_ker f t) _ _ (G tt)).
-    - refine (quotient_ind_prop (cong_ker f t) _ _). intro x.
+      apply (related_quotient_paths (cong_ker f t) _ _ (G tt)).
+    - refine (Quotient_ind_hprop (cong_ker f t) _ _). intro x.
       apply (IHw (α x) (β (f t x)) (γ (class_of _ x))).
       + exact (P x).
       + intro a. exact (G (x,a)).
@@ -164,9 +164,9 @@ Section first_isomorphism.
     : IsEmbedding (hom_first_isomorphism s).
   Proof.
     apply isembedding_isinj_hset.
-    refine (quotient_ind_prop (cong_ker f s) _ _). intro x.
-    refine (quotient_ind_prop (cong_ker f s) _ _). intros y p.
-    apply related_classes_eq.
+    refine (Quotient_ind_hprop (cong_ker f s) _ _). intro x.
+    refine (Quotient_ind_hprop (cong_ker f s) _ _). intros y p.
+    apply qglue.
     exact (p..1).
   Qed.
 

--- a/theories/Classes/theory/ua_quotient_algebra.v
+++ b/theories/Classes/theory/ua_quotient_algebra.v
@@ -1,11 +1,11 @@
 Require Export HoTT.Classes.interfaces.ua_congruence.
 
 Require Import
-  HoTT.HSet
-  HoTT.HIT.quotient
-  HoTT.Classes.implementations.list
-  HoTT.Classes.interfaces.canonical_names
-  HoTT.Classes.theory.ua_homomorphism.
+  HSet
+  Colimits.Quotient
+  Classes.implementations.list
+  Classes.interfaces.canonical_names
+  Classes.theory.ua_homomorphism.
 
 Import algebra_notations ne_list.notations.
 
@@ -18,7 +18,7 @@ Section quotient_algebra.
     induced by [Φ]. *)
 
   Definition carriers_quotient_algebra : Carriers σ
-    := λ s, quotient (Φ s).
+    := λ s, Quotient (Φ s).
 
 (** Specialization of [quotient_ind_prop]. Suppose
     [P : FamilyProd carriers_quotient_algebra w → Type] and
@@ -35,7 +35,7 @@ Section quotient_algebra.
     := match w with
        | nil => λ P _ dclass 'tt, dclass tt
        | s :: w' => λ P _ dclass a,
-         quotient_ind_prop (Φ s) (λ a, ∀ b, P (a,b))
+         Quotient_ind_hprop (Φ s) (λ a, ∀ b, P (a,b))
            (λ a, quotient_ind_prop_family_prod
                   (λ c, P (class_of (Φ s) a, c)) (λ c, dclass (a, c)))
            (fst a) (snd a)
@@ -80,7 +80,7 @@ Section quotient_algebra.
     destruct (q _ _ (op_compatible_cons Φ s w f x P)) as [g1 P1].
     destruct (q _ _ (op_compatible_cons Φ s w f y P)) as [g2 P2].
     refine ((P1 a) @ _ @ (P2 a)^).
-    apply related_classes_eq.
+    apply qglue.
     exact (P (x,a) (y,a) (C, reflexive_for_all_2_family_prod A Φ a)).
   Defined.
 
@@ -111,7 +111,7 @@ Section quotient_algebra.
       match w return QuotOp w with
       | [:s:] => λ (f : A s) P, (class_of (Φ s) f; λ a, idpath)
       | s ::: w' => λ (f : A s → Operation A w') P,
-        (quotient_rec (Φ s)
+        (Quotient_rec (Φ s) _
           (λ (x : A s), op_qalg_cons op_quotient_algebra f P x)
           (op_quotient_algebra_well_def op_quotient_algebra s w' f P)
         ; _)
@@ -223,7 +223,7 @@ Section hom_quotient.
   Global Instance surjection_quotient
     : ∀ s, IsSurjection (hom_quotient s).
   Proof.
-    intro s. apply quotient_surjective.
+    intro s. apply issurj_class_of.
   Qed.
 End hom_quotient.
 
@@ -239,7 +239,7 @@ Proof.
   apply isequiv_surj_emb; [exact _ |].
   apply isembedding_isinj_hset.
   intros x y p.
-  by apply P, (classes_eq_related (Φ s)).
+  by apply P, (related_quotient_paths (Φ s)).
 Qed.
 
 (** This section develops the universal mapping property
@@ -262,7 +262,7 @@ Section ump_quotient_algebra.
 
     Definition def_hom_quotient_algebra_mapout
       : ∀ (s : Sort σ), (A/Φ) s → B s
-      := λ s, (quotient_ump (Φ s) (Build_HSet (B s)))^-1 (f s; R s).
+      := λ s, (equiv_quotient_ump (Φ s) (Build_HSet (B s)))^-1 (f s; R s).
 
     Lemma oppreserving_quotient_algebra_mapout {w : SymbolType σ}
       (g : Operation (A/Φ) w) (α : Operation A w) (β : Operation B w)
@@ -272,7 +272,7 @@ Section ump_quotient_algebra.
       unfold ComputeOpQuotient in G.
       induction w; cbn in *.
       - destruct (G tt)^. apply P.
-      - refine (quotient_ind_prop (Φ t) _ _). intro x.
+      - refine (Quotient_ind_hprop (Φ t) _ _). intro x.
         apply (IHw (g (class_of (Φ t) x)) (α x) (β (f t x))).
         + intro a. apply (G (x,a)).
         + apply P.
@@ -326,7 +326,7 @@ Section ump_quotient_algebra.
     exists (hom_quotient_algebra_mapin g).
     intros s x y E.
     exact (transport (λ z, g s (class_of (Φ s) x) = g s z)
-            (related_classes_eq (Φ s) E) idpath).
+            (qglue E) idpath).
   Defined.
 
 (** The universal mapping property of the quotient algebra. For each
@@ -349,7 +349,7 @@ Section ump_quotient_algebra.
     - intro G.
       apply path_hset_homomorphism.
       funext s.
-      exact (eissect (quotient_ump (Φ s) _) (G s)).
+      exact (eissect (equiv_quotient_ump (Φ s) _) (G s)).
     - intro F.
       apply path_sigma_hprop.
       by apply path_hset_homomorphism.

--- a/theories/Classes/theory/ua_second_isomorphism.v
+++ b/theories/Classes/theory/ua_second_isomorphism.v
@@ -1,12 +1,12 @@
 (** The second isomorphism theorem [isomorphic_second_isomorphism]. *)
 
 Require Import
-  HoTT.HSet
-  HoTT.HIT.quotient
-  HoTT.Classes.interfaces.canonical_names
-  HoTT.Classes.theory.ua_isomorphic
-  HoTT.Classes.theory.ua_subalgebra
-  HoTT.Classes.theory.ua_quotient_algebra.
+  HSet
+  Colimits.Quotient
+  Classes.interfaces.canonical_names
+  Classes.theory.ua_isomorphic
+  Classes.theory.ua_subalgebra
+  Classes.theory.ua_quotient_algebra.
 
 Import
   algebra_notations
@@ -93,12 +93,12 @@ Section is_subalgebra_class.
       exists (α; C).
       cbn in Q. destruct Q^.
       exact (EquivRel_Reflexive α).
-    - refine (quotient_ind_prop (Φ t) _ _). intro x.
+    - refine (Quotient_ind_hprop (Φ t) _ _). intro x.
       refine (Trunc_rec _).
       intros [y R].
       apply (IHw (γ (class_of (Φ t) x)) (α (i t y))).
       + intro a.
-        destruct (related_classes_eq (Φ t) R)^.
+        destruct (qglue R)^.
         apply (Q (i t y,a)).
       + apply C. exact y.2.
   Qed.
@@ -142,12 +142,12 @@ Section second_isomorphism.
 
   Definition def_second_isomorphism (s : Sort σ)
     : ((A&&P) / Ψ) s → ((A/Φ) && Q) s
-    := quotient_rec (Ψ s)
+    := Quotient_rec (Ψ s) _ 
         (λ (x : (A&&P) s),
          (class_of (Φ s) (i s x); tr (x; EquivRel_Reflexive x)))
         (λ (x y : (A&&P) s) (T : Ψ s x y),
          path_sigma_hprop (class_of (Φ s) (i s x); _)
-           (class_of (Φ s) (i s y); _) (related_classes_eq (Φ s) T)).
+           (class_of (Φ s) (i s y); _) (@qglue _ (Φ s) _ _ T)).
 
   Lemma oppreserving_second_isomorphism {w : SymbolType σ}
     (α : Operation A w) (γ : Operation (A/Φ) w)
@@ -160,8 +160,8 @@ Section second_isomorphism.
     induction w; cbn in *.
     - apply path_sigma_hprop.
       cbn. destruct (QB tt)^, (QA tt)^.
-      by apply related_classes_eq.
-    - refine (quotient_ind_prop (Ψ t) _ _). intro x.
+      by apply qglue.
+    - refine (Quotient_ind_hprop (Ψ t) _ _). intro x.
       apply (IHw (α (i t x)) (γ (class_of (Φ t) (i t x)))
               (ζ (class_of (Ψ t) x))
               (CA (class_of (Φ t) (i t x)) (tr (x; _)))
@@ -187,10 +187,10 @@ Section second_isomorphism.
     : IsEmbedding (hom_second_isomorphism s).
   Proof.
     apply isembedding_isinj_hset.
-    refine (quotient_ind_prop (Ψ s) _ _). intro x.
-    refine (quotient_ind_prop (Ψ s) _ _). intros y p.
-    apply related_classes_eq.
-    exact (classes_eq_related (Φ s) (i s x) (i s y) (p..1)).
+    refine (Quotient_ind_hprop (Ψ s) _ _). intro x.
+    refine (Quotient_ind_hprop (Ψ s) _ _). intros y p.
+    apply qglue.
+    exact (related_quotient_paths (Φ s) (i s x) (i s y) (p..1)).
   Qed.
 
   Global Instance surjection_second_isomorphism (s : Sort σ)
@@ -200,11 +200,11 @@ Section second_isomorphism.
     intros [y S].
     generalize dependent S.
     generalize dependent y.
-    refine (quotient_ind_prop (Φ s) _ _). intros y S.
+    refine (Quotient_ind_hprop (Φ s) _ _). intros y S.
     refine (Trunc_rec _ S). intros [y' S']. apply tr.
     exists (class_of _ y').
     apply path_sigma_hprop.
-    by apply related_classes_eq.
+    by apply qglue.
   Qed.
 
   Theorem is_isomorphism_second_isomorphism

--- a/theories/Classes/theory/ua_third_isomorphism.v
+++ b/theories/Classes/theory/ua_third_isomorphism.v
@@ -1,11 +1,11 @@
 (** This file proves the third isomorphism theorem,
     [isomorphic_third_isomorphism]. *)
 Require Import
-  HoTT.HIT.quotient
-  HoTT.Classes.interfaces.canonical_names
-  HoTT.Classes.theory.ua_quotient_algebra
-  HoTT.Classes.theory.ua_isomorphic
-  HoTT.Classes.theory.ua_first_isomorphism.
+  Colimits.Quotient
+  Classes.interfaces.canonical_names
+  Classes.theory.ua_quotient_algebra
+  Classes.theory.ua_isomorphic
+  Classes.theory.ua_first_isomorphism.
 
 Import algebra_notations quotient_algebra_notations isomorphic_notations.
 
@@ -29,16 +29,16 @@ Section cong_quotient.
     : EquivRel (cong_quotient subrel s).
   Proof.
     constructor.
-    - refine (quotient_ind_prop (Ψ s) _ _). intros x y z P Q.
+    - refine (Quotient_ind_hprop (Ψ s) _ _). intros x y z P Q.
       apply subrel.
       by transitivity x.
-    - refine (quotient_ind_prop (Ψ s) _ _). intro x1.
-      refine (quotient_ind_prop (Ψ s) _ _). intros x2 C y1 y2 P Q.
+    - refine (Quotient_ind_hprop (Ψ s) _ _). intro x1.
+      refine (Quotient_ind_hprop (Ψ s) _ _). intros x2 C y1 y2 P Q.
       symmetry.
       by apply C.
-    - refine (quotient_ind_prop (Ψ s) _ _). intro x1.
-      refine (quotient_ind_prop (Ψ s) _ _). intro x2.
-      refine (quotient_ind_prop (Ψ s) _ _). intros x3 C D y1 y2 P Q.
+    - refine (Quotient_ind_hprop (Ψ s) _ _). intro x1.
+      refine (Quotient_ind_hprop (Ψ s) _ _). intro x2.
+      refine (Quotient_ind_hprop (Ψ s) _ _). intros x3 C D y1 y2 P Q.
       transitivity x2.
       + exact (C y1 x2 P (EquivRel_Reflexive x2)).
       + exact (D x2 y2 (EquivRel_Reflexive x2) Q).
@@ -54,7 +54,7 @@ Section cong_quotient.
     - constructor.
     - destruct a as [x a], b as [y b], F as [Q F].
       split.
-      + apply Q; cbn; reflexivity.
+      + apply Q; simpl; reflexivity.
       + by apply IHw.
   Qed.
 
@@ -99,11 +99,11 @@ Section third_isomorphism.
     (x y : A s) (P : Ψ s x y)
     : class_of (Φ s) x = class_of (Φ s) y.
   Proof.
-    apply related_classes_eq. exact (subrel s x y P).
+    apply qglue. exact (subrel s x y P).
   Defined.
 
   Definition def_third_surjection (s : Sort σ) : (A/Ψ) s → (A/Φ) s
-    := quotient_rec (Ψ s) (class_of (Φ s)) (third_surjecton_well_def s).
+    := Quotient_rec (Ψ s) _ (class_of (Φ s)) (third_surjecton_well_def s).
 
   Lemma oppreserving_third_surjection {w : SymbolType σ} (f : Operation A w)
     : ∀ (α : Operation (A/Φ) w) (Qα : ComputeOpQuotient A Φ f α)
@@ -111,14 +111,14 @@ Section third_isomorphism.
       OpPreserving def_third_surjection β α.
   Proof.
     induction w.
-    - refine (quotient_ind_prop (Φ t) _ _). intros α Qα.
-      refine (quotient_ind_prop (Ψ t) _ _). intros β Qβ.
-      apply related_classes_eq.
+    - refine (Quotient_ind_hprop (Φ t) _ _). intros α Qα.
+      refine (Quotient_ind_hprop (Ψ t) _ _). intros β Qβ.
+      apply qglue.
       transitivity f.
-      + apply subrel. apply (classes_eq_related (Ψ t)). exact (Qβ tt).
-      + apply (classes_eq_related (Φ t)). symmetry. exact (Qα tt).
+      + apply subrel. apply (related_quotient_paths (Ψ t)). exact (Qβ tt).
+      + apply (related_quotient_paths (Φ t)). symmetry. exact (Qα tt).
     - intros α Qα β Qβ.
-      refine (quotient_ind_prop (Ψ t) _ _).
+      refine (Quotient_ind_hprop (Ψ t) _ _).
       intro x.
       exact (IHw (f x) (α (class_of (Φ t) x)) (λ a, Qα (x,a))
                (β (class_of (Ψ t) x)) (λ a, Qβ (x,a))).
@@ -138,7 +138,7 @@ Section third_isomorphism.
     : IsSurjection (hom_third_surjection s).
   Proof.
     apply BuildIsSurjection.
-    refine (quotient_ind_prop (Φ s) _ _).
+    refine (Quotient_ind_hprop (Φ s) _ _).
     intro x.
     apply tr.
     by exists (class_of (Ψ s) x).
@@ -151,16 +151,16 @@ Section third_isomorphism.
   Proof.
     apply path_quotient_algebra_iff. intros s x y.
     split; generalize dependent y; generalize dependent x;
-           refine (quotient_ind_prop (Ψ s) _ _); intro x;
-           refine (quotient_ind_prop (Ψ s) _ _); intro y.
+           refine (Quotient_ind_hprop (Ψ s) _ _); intro x;
+           refine (Quotient_ind_hprop (Ψ s) _ _); intro y.
     - intros K x' y' Cx Cy.
       apply subrel in Cx. apply subrel in Cy.
-      apply (classes_eq_related (Φ s)) in K.
+      apply (related_quotient_paths (Φ s)) in K.
       transitivity x.
       + by symmetry.
       + by transitivity y.
     - intro T.
-      apply related_classes_eq.
+      apply qglue.
       exact (T x y (EquivRel_Reflexive x) (EquivRel_Reflexive y)).
   Defined.
 


### PR DESCRIPTION
The use of quotient here was easy to replace. In a few places, cbn is replaced with simpl as Quotient interacts poorly with cbn, probably because of simpl never.