### PR TITLE
Hartogs: improve speed, reorganize

### DIFF
--- a/theories/Sets/Hartogs.v
+++ b/theories/Sets/Hartogs.v
@@ -6,9 +6,61 @@ From HoTT.Sets Require Import Ordinals Powers.
 
 (** This file contains a construction of the Hartogs number. *)
 
+(** We begin with some results about changing the universe of a power set using propositional resizing. *)
+
+Definition power_inj `{PropResizing} {C : Type@{i}} (p : C -> HProp@{j})
+  : C -> HProp@{k}.
+Proof.
+  exact (fun a => Build_HProp (resize_hprop@{j k} (p a))).
+Defined.
+
+Lemma injective_power_inj `{PropResizing} {ua : Univalence} (C : Type@{i})
+  : IsInjective (@power_inj _ C).
+Proof.
+  intros p p'. unfold power_inj. intros q. apply path_forall. intros a. apply path_iff_hprop; intros Ha.
+  - eapply equiv_resize_hprop. change ((fun a => Build_HProp (resize_hprop (p' a))) a).
+    rewrite <- q. apply equiv_resize_hprop. apply Ha.
+  - eapply equiv_resize_hprop. change ((fun a => Build_HProp (resize_hprop (p a))) a).
+    rewrite q. apply equiv_resize_hprop. apply Ha.
+Qed.
+
+(* TODO: Could factor this as something keeping the [HProp] universe the same, followed by [power_inj]. *)
+Definition power_morph `{PropResizing} {ua : Univalence} {C B : Type@{i}} (f : C -> B)
+  : (C -> HProp) -> (B -> HProp).
+Proof.
+  intros p b. exact (Build_HProp (resize_hprop (forall a, f a = b -> p a))).
+Defined.
+
+Definition injective_power_morph `{PropResizing} {ua : Univalence} {C B : Type@{i}} (f : C -> B)
+  : IsInjective f -> IsInjective (@power_morph _ _ C B f).
+Proof.
+  intros Hf p p' q. apply path_forall. intros a. apply path_iff_hprop; intros Ha.
+  - enough (Hp : power_morph f p (f a)).
+    + rewrite q in Hp. apply equiv_resize_hprop in Hp. apply Hp. reflexivity.
+    + apply equiv_resize_hprop. intros a' -> % Hf. apply Ha.
+  - enough (Hp : power_morph f p' (f a)).
+    + rewrite <- q in Hp. apply equiv_resize_hprop in Hp. apply Hp. reflexivity.
+    + apply equiv_resize_hprop. intros a' -> % Hf. apply Ha.
+Qed.
+
+(** We'll also need this result. *)
+Lemma le_Cardinal_lt_Ordinal `{PropResizing} `{Univalence} (B C : Ordinal)
+  : B < C -> card B ≤ card C.
+Proof.
+  intros B_C. apply tr. cbn. rewrite (bound_property B_C).
+  exists out. apply isinjective_simulation. apply is_simulation_out.
+Qed.
+
 (** * Hartogs number *)
 
 Section Hartogs_Number.
+
+  Declare Scope Hartogs.
+  Open Scope Hartogs.
+
+  Notation "'𝒫'" := power_type (at level 30) : Hartogs.
+
+  Local Coercion subtype_as_type' {X} (Y : 𝒫 X) := { x : X & Y x }.
 
   Universe A.
   Context {univalence : Univalence}
@@ -16,15 +68,7 @@ Section Hartogs_Number.
           {lem: ExcludedMiddle}
           (A : HSet@{A}).
 
-  Lemma le_Cardinal_lt_Ordinal (B C : Ordinal)
-    : B < C -> card B ≤ card C.
-  Proof.
-    intros B_C. apply tr. cbn. rewrite (bound_property B_C).
-    exists out. apply isinjective_simulation. apply is_simulation_out.
-  Qed.
-
-  (* The Hartogs number of A consists of all ordinals that embed into A.
-     Note that this constructions necessarily increases the universe level. *)
+  (* The Hartogs number of [A] consists of all ordinals that embed into [A]. Note that this construction necessarily increases the universe level. *)
 
   Fail Check { B : Ordinal@{A _} | card B <= card A } : Type@{A}.
 
@@ -32,7 +76,6 @@ Section Hartogs_Number.
   Proof.
     set (carrier := {B : Ordinal@{A _} & card B <= card A}).
     set (relation := fun (B C : carrier) => B.1 < C.1).
-
     exists carrier relation. snrapply (isordinal_simulation pr1).
     1, 2, 3, 4: exact _.
     - apply isinj_embedding, (mapinO_pr1 (Tr (-1))). (* Faster than [exact _.] *)
@@ -47,25 +90,16 @@ Section Hartogs_Number.
         apply (isinjective_f x y). exact fx_fy.
   Defined.
 
-  Declare Scope Hartogs.
-  Open Scope Hartogs.
-
-  Notation "'𝒫'" := power_type (at level 30) : Hartogs.
-
-  Definition proper_subtype_inclusion {A} (U V : 𝒫 A)
-    := (forall a, U a -> V a) /\ merely (exists a : A, V a /\ ~U a).
-  Coercion subtype_as_type' {X} (Y : 𝒫 X) : Type
-    := { x : X & Y x }.
+  Definition proper_subtype_inclusion (U V : 𝒫 A)
+    := (forall a, U a -> V a) /\ merely (exists a : A, V a /\ ~(U a)).
 
   Infix "⊊" := proper_subtype_inclusion (at level 50) : Hartogs.
   Notation "(⊊)" := proper_subtype_inclusion : Hartogs.
 
-  (* The hartogs number of A embeds into the threefold power set of A.
-     This preliminary injection also increases the universe level though. *)
+  (* The hartogs number of [A] embeds into the threefold power set of [A].  This preliminary injection also increases the universe level though. *)
 
   Lemma hartogs_number'_injection
-    : exists f : hartogs_number' -> (𝒫 (𝒫 (𝒫 A)) : Type),
-        IsInjective f.
+    : exists f : hartogs_number' -> (𝒫 (𝒫 (𝒫 A))), IsInjective f.
   Proof.
     transparent assert (ϕ : (forall X : 𝒫 (𝒫 A), Lt X)). {
       intros X. intros x1 x2. exact (x1.1 ⊊ x2.1).
@@ -159,52 +193,17 @@ Section Hartogs_Number.
       rewrite <- H0. apply tr. exact iso.
   Qed.
 
-  (* Using hprop resizing, the threefold power set can be pushed to the same universe level as A. *)
+  (** Using hprop resizing, the threefold power set can be pushed to the same universe level as [A]. *)
 
-  Definition power_inj {pr : PropResizing} {C : Type@{i}} (p : C -> HProp) :
-    (C -> HProp : Type@{i}).
+  Definition uni_fix (X : 𝒫 (𝒫 (𝒫 A))) : ((𝒫 (𝒫 (𝒫 A))) : Type@{A}).
   Proof.
-    exact (fun a => Build_HProp (resize_hprop (p a))).
+    revert X.
+    nrapply power_morph.
+    nrapply power_morph.
+    nrapply power_inj.
   Defined.
 
-  Lemma injective_power_inj {pr : PropResizing} {ua : Univalence} (C : Type@{i}) :
-    IsInjective (@power_inj _ C).
-  Proof.
-    intros p p'. unfold power_inj. intros H. apply path_forall. intros a. apply path_iff_hprop; intros Ha.
-    - eapply equiv_resize_hprop. change ((fun a => Build_HProp (resize_hprop (p' a))) a).
-      rewrite <- H. apply equiv_resize_hprop. apply Ha.
-    - eapply equiv_resize_hprop. change ((fun a => Build_HProp (resize_hprop (p a))) a).
-      rewrite H. apply equiv_resize_hprop. apply Ha.
-  Qed.
-
-  Definition power_morph {pr : PropResizing} {ua : Univalence} {C B : Type@{i}} (f : C -> B) :
-    (C -> HProp) -> (B -> HProp).
-  Proof.
-    intros p b. exact (Build_HProp (resize_hprop (forall a, f a = b -> p a))).
-  Defined.
-
-  Definition injective_power_morph {pr : PropResizing} {ua : Univalence} {C B : Type@{i}} (f : C -> B) :
-    IsInjective f -> IsInjective (@power_morph _ _ C B f).
-  Proof.
-    intros Hf p p' H. apply path_forall. intros a. apply path_iff_hprop; intros Ha.
-    - enough (Hp : power_morph f p (f a)).
-      + rewrite H in Hp. apply equiv_resize_hprop in Hp. apply Hp. reflexivity.
-      + apply equiv_resize_hprop. intros a' -> % Hf. apply Ha.
-    - enough (Hp : power_morph f p' (f a)).
-      + rewrite <- H in Hp. apply equiv_resize_hprop in Hp. apply Hp. reflexivity.
-      + apply equiv_resize_hprop. intros a' -> % Hf. apply Ha.
-  Qed.
-
-  Definition uni_fix (X : 𝒫 (𝒫 (𝒫 A))) :
-    ((𝒫 (𝒫 (𝒫 A))) : Type@{i}).
-  Proof.
-    srapply power_morph. 3: apply X. intros P.
-    srapply power_morph. 3: apply P.
-    srapply power_inj.
-  Defined.
-
-  Lemma injective_uni_fix :
-    IsInjective uni_fix.
+  Lemma injective_uni_fix : IsInjective uni_fix.
   Proof.
     intros X Y. unfold uni_fix. intros H % injective_power_morph; trivial.
     intros P Q. intros H' % injective_power_morph; trivial.
@@ -213,11 +212,10 @@ Section Hartogs_Number.
 
   (* We can therefore resize the Hartogs number of A to the same universe level as A. *)
 
-  Definition hartogs_number_carrier : Type@{A} :=
-    {X : 𝒫 (𝒫 (𝒫 A)) | resize_hprop (merely (exists a, uni_fix (hartogs_number'_injection.1 a) = X))}.
+  Definition hartogs_number_carrier : Type@{A}
+    := {X : 𝒫 (𝒫 (𝒫 A)) | resize_hprop (merely (exists a, uni_fix (hartogs_number'_injection.1 a) = X))}.
 
-  Lemma hartogs_equiv :
-    hartogs_number_carrier <~> hartogs_number'.
+  Lemma hartogs_equiv : hartogs_number_carrier <~> hartogs_number'.
   Proof.
     apply equiv_inverse. unshelve eexists.
     - intros a. exists (uni_fix (hartogs_number'_injection.1 a)).
@@ -231,47 +229,20 @@ Section Hartogs_Number.
         intros H'. apply H' in H. now apply hartogs_number'_injection.2.
   Qed.
 
-  Definition resize_ordinal@{i j +} (B : Ordinal@{i _}) (C : Type@{j}) (g : C <~> B) :
-    Ordinal@{j _}.
-  Proof.
-    exists C (fun c1 c2 : C => resize_hprop (g c1 < g c2)).
-    snrapply (isordinal_simulation g). 2, 3, 4, 5: exact _.
-    - apply (istrunc_equiv_istrunc B (equiv_inverse g)).
-    - constructor.
-      + intros a a' a_a'. apply (equiv_resize_hprop _)^-1. exact a_a'.
-      + intros a b b_fa. apply tr. exists (g^-1 b). split.
-        * apply equiv_resize_hprop. rewrite eisretr. exact b_fa.
-        * apply eisretr.
-  Defined.
-
-  Definition hartogs_number : Ordinal@{A _} :=
-    resize_ordinal hartogs_number' hartogs_number_carrier hartogs_equiv.
+  Definition hartogs_number : Ordinal@{A _}
+    := resize_ordinal hartogs_number' hartogs_number_carrier hartogs_equiv.
 
   (* This final definition now satisfies the expected cardinality properties. *)
 
-  Lemma hartogs_number_injection :
-    exists f : hartogs_number -> 𝒫 (𝒫 (𝒫 A)), IsInjective f.
+  Lemma hartogs_number_injection
+    : exists f : hartogs_number -> 𝒫 (𝒫 (𝒫 A)), IsInjective f.
   Proof.  
     cbn. exists proj1. intros [X HX] [Y HY]. cbn. intros ->.
     apply ap. apply path_ishprop.
   Qed.
 
-  Lemma ordinal_initial (O : Ordinal) (a : O) :
-    Isomorphism O ↓a -> Empty.
-  Proof.
-    intros H % equiv_path_Ordinal.
-    enough (HO : O < O) by apply (irreflexive_ordinal_relation _ _ _ _ HO).
-    exists a. apply H.
-  Qed.
-
-  Lemma resize_ordinal_iso@{i j +} (B : Ordinal@{i _}) (C : Type@{j}) (g : C <~> B) :
-    Isomorphism (resize_ordinal B C g) B.
-  Proof.
-    exists g. intros a a'. cbn. split; apply equiv_resize_hprop.
-  Qed.
-
-  Lemma hartogs_number_no_injection :
-    ~ (exists f : hartogs_number -> A, IsInjective f).
+  Lemma hartogs_number_no_injection
+    : ~ (exists f : hartogs_number -> A, IsInjective f).
   Proof.
     cbn. intros [f Hf]. cbn in f.
     assert (HN : card hartogs_number <= card A). { apply tr. now exists f. }

--- a/theories/Sets/Hartogs.v
+++ b/theories/Sets/Hartogs.v
@@ -77,7 +77,7 @@ Section Hartogs_Number.
     set (carrier := {B : Ordinal@{A _} & card B <= card A}).
     set (relation := fun (B C : carrier) => B.1 < C.1).
     exists carrier relation. snrapply (isordinal_simulation pr1).
-    1, 2, 3, 4: exact _.
+    1-4: exact _.
     - apply isinj_embedding, (mapinO_pr1 (Tr (-1))). (* Faster than [exact _.] *)
     - constructor.
       + intros a a' a_a'. exact a_a'.

--- a/theories/Sets/Hartogs.v
+++ b/theories/Sets/Hartogs.v
@@ -6,7 +6,6 @@ From HoTT.Sets Require Import Ordinals Powers.
 
 (** This file contains a construction of the Hartogs number. *)
 
-
 (** * Hartogs number *)
 
 Section Hartogs_Number.
@@ -34,9 +33,9 @@ Section Hartogs_Number.
     set (carrier := {B : Ordinal@{A _} & card B <= card A}).
     set (relation := fun (B C : carrier) => B.1 < C.1).
 
-    exists carrier relation. srapply (isordinal_simulation pr1).
-    - exact _.
-    - exact _.
+    exists carrier relation. snrapply (isordinal_simulation pr1).
+    1, 2, 3, 4: exact _.
+    - apply isinj_embedding, (mapinO_pr1 (Tr (-1))). (* Faster than [exact _.] *)
     - constructor.
       + intros a a' a_a'. exact a_a'.
       + intros [B small_B] C C_B; cbn in *. apply tr.
@@ -83,8 +82,8 @@ Section Hartogs_Number.
           intros X. apply hprop_allpath; intros [b1 Hb1] [b2 Hb2].
           snrapply path_sigma_hprop; cbn.
           - intros b. snrapply istrunc_forall.
-            intros a. srapply istrunc_prod.
-            srapply istrunc_arrow.
+            intros a. snrapply istrunc_prod. 2: exact _.
+            snrapply istrunc_arrow.
             rapply ishprop_sigma_disjoint. intros b1' b2' [_ ->] [_ p].
             apply (injective_f). exact p.
           - apply extensionality. intros b'. split.
@@ -92,13 +91,13 @@ Section Hartogs_Number.
               specialize (Hb1 (f b')). apply snd in Hb1.
               specialize (Hb1 (b'; (b'_b1, idpath))).
               apply Hb2 in Hb1. destruct Hb1 as (? & H2 & H3).
-              apply injective in H3; try exact _. destruct H3.
+              apply injective in H3. 2: assumption. destruct H3.
               exact H2.
             + intros b'_b2.
               specialize (Hb2 (f b')). apply snd in Hb2.
               specialize (Hb2 (b'; (b'_b2, idpath))).
               apply Hb1 in Hb2. destruct Hb2 as (? & H2 & H3).
-              apply injective in H3; try exact _. destruct H3.
+              apply injective in H3. 2: assumption. destruct H3.
               exact H2.
         }
         exists (fun X : 𝒫 A =>
@@ -108,8 +107,9 @@ Section Hartogs_Number.
           - srapply equiv_adjointify.
             + intros [X [b _]]. exact b.
             + intros b.
-              unshelve eexists (fun a => Build_HProp (exists b', b' < b /\ a = f b'))
-              ; try exact _. {
+              unshelve eexists (fun a => Build_HProp (exists b', b' < b /\ a = f b')).
+              1: exact _.
+              {
                 apply hprop_allpath. intros [b1 [b1_b p]] [b2 [b2_b q]].
                 apply path_sigma_hprop; cbn. apply (injective f).
                 destruct p, q. reflexivity.
@@ -142,7 +142,7 @@ Section Hartogs_Number.
                 -- apply H'2. exists b1; auto.
                 -- intros X1_fb1. apply H'1 in X1_fb1. destruct X1_fb1 as [b' [b'_b1 fb1_fb']].
                    apply (injective f) in fb1_fb'. destruct fb1_fb'.
-                   apply irreflexivity in b'_b1; try exact _. assumption.
+                   apply irreflexivity in b'_b1. 2: exact _. assumption.
         }
       }
       assert (IsOrdinal X (ϕ X)) by exact (isordinal_simulation iso.1). 
@@ -151,7 +151,7 @@ Section Hartogs_Number.
         apply isomorphism_inverse. assumption.
       }
       enough (merely (Isomorphism (X : Type; ϕ X) C)). {
-        revert X1. rapply Trunc_rec. {
+        revert X1. nrapply Trunc_rec. {
           exact (ishprop_Isomorphism (Build_Ordinal X (ϕ X) _) C).
         }
         auto.
@@ -235,7 +235,7 @@ Section Hartogs_Number.
     Ordinal@{j _}.
   Proof.
     exists C (fun c1 c2 : C => resize_hprop (g c1 < g c2)).
-    srapply (isordinal_simulation g); try exact _.
+    snrapply (isordinal_simulation g). 2, 3, 4, 5: exact _.
     - apply (istrunc_equiv_istrunc B (equiv_inverse g)).
     - constructor.
       + intros a a' a_a'. apply (equiv_resize_hprop _)^-1. exact a_a'.
@@ -282,7 +282,7 @@ Section Hartogs_Number.
       unfold hartogs_number.
       exact (resize_ordinal_iso hartogs_number' hartogs_number_carrier hartogs_equiv).
     - assert (Isomorphism hartogs_number ↓hartogs_number) by apply isomorphism_to_initial_segment.
-      eapply transitive_Isomorphism; try apply X.
+      eapply transitive_Isomorphism. 1: exact X.
       unshelve eexists.
       + srapply equiv_adjointify.
         * intros [a Ha % equiv_resize_hprop]. unshelve eexists.
@@ -292,9 +292,9 @@ Section Hartogs_Number.
           -- apply equiv_resize_hprop. cbn. exact Ha.
         * intros [[a Ha] H % equiv_resize_hprop]. exists a.
           apply equiv_resize_hprop. apply H.
-        * intros [[a Ha] H]. apply path_sigma_hprop. apply path_sigma_hprop. reflexivity.
-        * intros [a Ha]. apply path_sigma_hprop. reflexivity.
-      + intros [[a Ha] H1] [[b H] H2]. cbn. reflexivity.
+        * intro a. apply path_sigma_hprop. apply path_sigma_hprop. reflexivity.
+        * intro a. apply path_sigma_hprop. reflexivity.
+      + reflexivity.
   Defined.
 
 End Hartogs_Number.

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -11,7 +11,6 @@ From HoTT Require Import Colimits.Quotient.
 Inductive Accessible {A} (R : Lt A) (a : A) :=
   acc : (forall b, b < a -> Accessible R b) -> Accessible R a.
 
-
 Global Instance ishprop_Accessible `{Funext} {A} (R : Lt A) (a : A) :
   IsHProp (Accessible R a).
 Proof.
@@ -22,10 +21,8 @@ Proof.
   apply IH.
 Qed.
 
-
 Class WellFounded {A} (R : Relation A) :=
   well_foundedness : forall a : A, Accessible R a.
-
 
 Global Instance ishprop_WellFounded `{Funext} {A} (R : Relation A) :
   IsHProp (WellFounded R).
@@ -35,9 +32,6 @@ Proof.
   apply path_ishprop.
 Qed.
 
-
-
-
 (** * Extensionality *)
 
 Class Extensional {A} (R : Lt A) :=
@@ -46,8 +40,6 @@ Class Extensional {A} (R : Lt A) :=
 Global Instance ishprop_Extensional `{Funext} {A} `{IsHSet A} (R : Relation A)
   : IsHProp (Extensional R).
 Proof. unfold Extensional. exact _. Qed.
-
-
 
 (** * Ordinals *)
 
@@ -74,7 +66,6 @@ Proof.
   unfold Transitive. exact _.
 Qed.
 
-
 Record Ordinal@{carrier relation +} :=
   { ordinal_carrier : Type@{carrier}
     ; ordinal_relation : Lt@{carrier relation} ordinal_carrier
@@ -86,8 +77,6 @@ Global Existing Instances ordinal_relation ordinal_property.
 Coercion ordinal_as_hset (A : Ordinal) : HSet
   := Build_HSet (ordinal_carrier A).
 
-
-
 Global Instance irreflexive_ordinal_relation A R
   : IsOrdinal A R -> Irreflexive R.
 Proof.
@@ -96,15 +85,11 @@ Proof.
   apply (IH a); assumption.
 Qed.
 
-
 Definition TypeWithRelation
   := { A : Type & Relation A }.
 
 Coercion ordinal_as_type_with_relation (A : Ordinal) : TypeWithRelation
   := (A : Type; (<)).
-
-
-
 
 (** * Paths in Ordinal *)
 
@@ -117,19 +102,15 @@ Proof.
   apply equiv_sigma_assoc'.
 Defined.
 
-
 Definition Isomorphism : TypeWithRelation -> TypeWithRelation -> Type
   := fun '(A; R__A) '(B; R__B) =>
        { f : A <~> B & forall a a', R__A a a' <-> R__B (f a) (f a') }.
-
 
 Global Instance isomorphism_id : Reflexive Isomorphism.
 Proof. intros A. exists equiv_idmap. cbn. intros a a'. reflexivity. Qed.
 
 Lemma isomorphism_inverse
-  : forall A B,
-    Isomorphism A B ->
-    Isomorphism B A.
+  : forall A B, Isomorphism A B -> Isomorphism B A.
 Proof.
   intros [A R__A] [B R__B] [f H].
   exists (equiv_inverse f).
@@ -143,10 +124,7 @@ Defined.
 
 (** We state this first without using [Transitive] to allow more general universe variables. *)
 Lemma transitive_Isomorphism
-  : forall A B C,
-    Isomorphism A B
-    -> Isomorphism B C
-    -> Isomorphism A C.
+  : forall A B C, Isomorphism A B -> Isomorphism B C -> Isomorphism A C.
 Proof.
   intros [A R__A] [B R__B] [C R__C].
   intros [f Hf] [g Hg].
@@ -157,8 +135,7 @@ Proof.
   - intros gfa_gfa'. apply Hf. apply Hg. exact gfa_gfa'.
 Defined.
 
-Global Instance isomorphism_compose_backwards
-  : Transitive Isomorphism
+Global Instance isomorphism_compose_backwards : Transitive Isomorphism
   := transitive_Isomorphism.
 
 Definition equiv_path_Ordinal `{Univalence} (A B : Ordinal)
@@ -203,12 +180,13 @@ Proof.
       repeat rewrite transport_pV in H0. exact H0.
 Qed.
 
-
 Lemma path_Ordinal `{Univalence} (A B : Ordinal)
   : forall f : A <~> B,
     (forall a a' : A, a < a' <-> f a < f a')
     -> A = B.
-Proof. intros f H0. apply equiv_path_Ordinal. exists f. exact H0. Qed.
+Proof.
+  intros f H0. apply equiv_path_Ordinal. exists f. exact H0.
+Qed.
 
 Lemma trichotomy_ordinal `{ExcludedMiddle} {A : Ordinal} (a b : A)
   : a < b \/ a = b \/ b < a.
@@ -243,8 +221,8 @@ Proof.
               ** apply tr. right. apply Empty_rec. exact (not_c_a c_a).
 Qed.
 
-Lemma ordinal_has_minimal_hsolutions {lem : ExcludedMiddle} (A : Ordinal) (P : A -> HProp) :
-  merely (exists a, P a) -> merely (exists a, P a /\ forall b, P b -> a < b \/ a = b).
+Lemma ordinal_has_minimal_hsolutions {lem : ExcludedMiddle} (A : Ordinal) (P : A -> HProp)
+  : merely (exists a, P a) -> merely (exists a, P a /\ forall b, P b -> a < b \/ a = b).
 Proof.
   intros H'. eapply merely_destruct; try apply H'.
   intros [a Ha]. induction (well_foundedness a) as [a _ IH].
@@ -259,8 +237,6 @@ Proof.
     apply Empty_rec, H, tr. exists b. now split.
 Qed.
 
-
-
 (** * Simulations *)
 
 (* We define the notion of simulations between arbitrary relations. For simplicity, most lemmas about simulations are formulated for ordinals only, even if they do not need all properties of ordinals. The only exception is isordinal_simulation which can be used to prove that a relation is an ordinal. *)
@@ -273,7 +249,6 @@ Class IsSimulation {A B : Type} {R__A : Lt A} {R__B : Lt B} (f : A -> B) :=
   }.
 Arguments simulation_is_hom {_ _ _ _} _ {_ _ _}.
 
-
 Global Instance ishprop_IsSimulation `{Funext}
          {A B : Ordinal} (f : A -> B) :
   IsHProp (IsSimulation f).
@@ -282,7 +257,6 @@ Proof.
   - issig.
   - exact _.
 Qed.
-
 
 Global Instance isinjective_simulation
          {A : Type} {R : Lt A} `{IsOrdinal A R}
@@ -492,16 +466,16 @@ Definition out
   : ↓a -> A
   := pr1.
 
-Definition initial_segment_property
-           `{PropResizing}
-           {A : Ordinal} {a : A}
+Definition initial_segment_property `{PropResizing}
+  {A : Ordinal} {a : A}
   : forall x : ↓a, out x < a.
-Proof. intros x. exact ((equiv_resize_hprop _)^-1 (proj2 x)). Defined.
+Proof.
+  intros x. exact ((equiv_resize_hprop _)^-1 (proj2 x)).
+Defined.
 
 
-Global Instance is_simulation_out
-         `{PropResizing}
-         {A : Ordinal} (a : A)
+Global Instance is_simulation_out `{PropResizing}
+  {A : Ordinal} (a : A)
   : IsSimulation (out : ↓a -> A).
 Proof.
   unfold out.
@@ -518,9 +492,8 @@ Proof.
 Qed.
 
 
-Global Instance isinjective_initial_segment `{Funext}
-         `{PropResizing}
-         (A : Ordinal)
+Global Instance isinjective_initial_segment `{Funext} `{PropResizing}
+  (A : Ordinal)
   : IsInjective (initial_segment : A -> Ordinal).
 Proof.
   enough (H1 : forall a1 a2 : A, ↓a1 = ↓a2 -> forall b : ↓a1, out b < a2). {
@@ -538,9 +511,6 @@ Proof.
   }
   rewrite transport_arrow_toconst. rewrite inv_V. apply initial_segment_property.
 Qed.
-
-
-
 
 Lemma equiv_initial_segment_simulation `{Univalence}
       `{PropResizing}
@@ -580,7 +550,6 @@ Proof.
       apply injective in p; try exact _. subst a'. exact a'_y.
 Qed.
 
-
 Lemma path_initial_segment_simulation `{Univalence}
       `{PropResizing}
       {A : Type} {R : Lt A} `{IsOrdinal A R}
@@ -591,16 +560,11 @@ Proof.
   apply equiv_path_Ordinal. apply (equiv_initial_segment_simulation f).
 Qed.
 
-
-
-
-
 (** * `Ordinal` is an ordinal *)
 
 Global Instance lt_Ordinal@{carrier relation +} `{PropResizing}
   : Lt Ordinal@{carrier relation}
   := fun A B => exists b : B, A = ↓b.
-
 
 Global Instance is_mere_relation_lt_on_Ordinal `{Univalence} `{PropResizing}
   : is_mere_relation Ordinal lt_Ordinal.
@@ -610,27 +574,21 @@ Proof.
   intros b b' -> p. apply (injective initial_segment). exact p.
 Qed.
 
-
-Definition bound
-           `{PropResizing}
-           {A B : Ordinal} (H : A < B)
+Definition bound `{PropResizing}
+  {A B : Ordinal} (H : A < B)
   : B
   := H.1.
 
 (* We use this notation to hide the proof of A < B that `bound` takes as an argument *)
 Notation "A ◁ B" := (@bound A B _) (at level 70) : Ordinals.
 
-
-Definition bound_property
-           `{PropResizing}
-           {A B : Ordinal} (H : A < B)
+Definition bound_property `{PropResizing}
+  {A B : Ordinal} (H : A < B)
   : A = ↓(bound H)
   := H.2.
 
-
-Lemma isembedding_initial_segment `{Univalence}
-      `{PropResizing}
-      {A : Ordinal} (a b : A)
+Lemma isembedding_initial_segment `{PropResizing} `{Univalence}
+  {A : Ordinal} (a b : A)
   : a < b <-> ↓a < ↓b.
 Proof.
   split.
@@ -646,9 +604,7 @@ Proof.
     apply initial_segment_property.
 Qed.
 
-
-Global Instance Ordinal_is_ordinal `{Univalence}
-         `{PropResizing}
+Global Instance Ordinal_is_ordinal `{PropResizing} `{Univalence}
   : IsOrdinal Ordinal (<).
 Proof.
   constructor.
@@ -694,7 +650,7 @@ Qed.
 
 (* This is analogous to the set-theoretic statement that an ordinal is the set of all smaller ordinals. *)
 Lemma isomorphism_to_initial_segment `{PropResizing} `{Univalence}
-      (B : Ordinal@{A _})
+  (B : Ordinal@{A _})
   : Isomorphism B ↓B.
 Proof.
   srapply exist.
@@ -710,9 +666,14 @@ Proof.
   - cbn. intros b b'. apply isembedding_initial_segment.
 Qed.
 
-
-
-
+(** But an ordinal isn't isomorphic to any initial segment of itself. *)
+Lemma ordinal_initial `{PropResizing} `{Univalence} (O : Ordinal) (a : O)
+  : Isomorphism O ↓a -> Empty.
+Proof.
+  intros p % equiv_path_Ordinal.
+  enough (HO : O < O) by apply (irreflexive_ordinal_relation _ _ _ _ HO).
+  exists a. apply p.
+Qed.
 
 (** * Ordinal successor *)
 
@@ -756,8 +717,7 @@ Proof.
 Defined.
 
 
-Lemma lt_successor `{Univalence} (A : Ordinal)
-      `{PropResizing}
+Lemma lt_successor `{PropResizing} `{Univalence} (A : Ordinal)
   : A < successor A.
 Proof.
   exists (inr tt).
@@ -777,9 +737,6 @@ Proof.
     + intros a. reflexivity.
   - cbn. intros a a'. reflexivity.
 Qed.
-
-
-
 
 (** * Ordinal limit *)
 
@@ -806,7 +763,6 @@ Definition image_rec {A} {B : HSet} (f : A -> B)
     -> image f -> C
   := Quotient_rec _ _ step.
 
-
 Definition factor2 {A} {B : HSet} (f : A -> B)
   : image f -> B
   := Quotient_rec _ _ f (fun a a' fa_fa' => fa_fa').
@@ -819,7 +775,6 @@ Proof.
   refine (Quotient_ind_hprop _ _ _); intros y; cbn.
   rapply qglue.
 Qed.
-
 
 Definition limit `{Univalence} `{PropResizing}
            {X : Type} (F : X -> Ordinal) : Ordinal.
@@ -849,12 +804,8 @@ Proof.
       * reflexivity.
 Defined.
 
-
-
-
 Global Instance le_on_Ordinal : Le Ordinal :=
   fun A B => exists f : A -> B, IsSimulation f.
-
 
 Definition limit_is_upper_bound `{Univalence} `{PropResizing}
            {X : Type} (F : X -> Ordinal)
@@ -873,4 +824,26 @@ Proof.
     + apply (injective (factor2 _)); simpl.
       rewrite (path_initial_segment_simulation out).
       symmetry. apply bound_property.
+Qed.
+
+(** Any type equivalent to an ordinal is an ordinal, and we can change the universe that the relation takes values in. *)
+
+(* TODO: Should factor this into two results:  (1) Anything equivalent to an ordinal is an ordinal (with the relation landing in the same universe for both).  (2) Under PropResizing, the universe that the relation takes values in can be changed. *)
+Definition resize_ordinal@{i j +} `{PropResizing} (B : Ordinal@{i _}) (C : Type@{j}) (g : C <~> B)
+  : Ordinal@{j _}.
+Proof.
+  exists C (fun c1 c2 : C => resize_hprop (g c1 < g c2)).
+  snrapply (isordinal_simulation g). 2, 3, 4, 5: exact _.
+  - apply (istrunc_equiv_istrunc B (equiv_inverse g)).
+  - constructor.
+    + intros a a' a_a'. apply (equiv_resize_hprop _)^-1. exact a_a'.
+    + intros a b b_fa. apply tr. exists (g^-1 b). split.
+      * apply equiv_resize_hprop. rewrite eisretr. exact b_fa.
+      * apply eisretr.
+Defined.
+
+Lemma resize_ordinal_iso@{i j +} `{PropResizing} (B : Ordinal@{i _}) (C : Type@{j}) (g : C <~> B)
+  : Isomorphism (resize_ordinal B C g) B.
+Proof.
+  exists g. intros a a'. cbn. split; apply equiv_resize_hprop.
 Qed.


### PR DESCRIPTION
There are two commits and they need to be read independently because the second one moves many things around.

The first one reduces the build time of Hartogs.v by 47%.

The second one moves things from inside the Hartogs Section to outside of it when they don't depend on the fixed type `A` and the universe variable `A` that are in the context.  Some are moved earlier in the file, and some are moved to Ordinals.v.  While editing, I changed lots of whitespace to match our conventions and made other minor fixes.
