### PR TITLE
New proof and generalization of Licata-Finster theorem

### DIFF
--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -220,6 +220,21 @@ Proof.
   by apply IHb.
 Defined.
 
+Definition trunc_index_leq_add@{} n m
+  : n <= m +2+ n.
+Proof.
+  simple_induction m m IHm.
+  - reflexivity.
+  - rapply trunc_index_leq_transitive.
+Defined.
+
+Definition trunc_index_leq_add'@{} n m
+  : n <= n +2+ m.
+Proof.
+  rewrite trunc_index_add_comm.
+  apply trunc_index_leq_add.
+Defined.
+
 Fixpoint trunc_index_min@{} (n m : trunc_index)
   : trunc_index.
 Proof.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -64,25 +64,24 @@ Section EilenbergMacLane.
   Defined.
 
   Lemma pequiv_loops_em_em (G : AbGroup) (n : nat)
-    : loops K(G, n.+1) <~>* K(G, n).
+    : K(G, n) <~>* loops K(G, n.+1).
   Proof.
     destruct n.
-    1: apply pequiv_loops_bg_g.
-    change (loops (pTr n.+2 (psusp (K(G, n.+1)))) <~>* K(G, n.+1)).
-    refine (_ o*E (ptr_loops _ _)^-1* ).
+    1: apply pequiv_g_loops_bg.
+    change (K(G, n.+1) <~>* loops (pTr n.+2 (psusp (K(G, n.+1))))).
+    refine (ptr_loops _ _ o*E _).
     destruct n.
-    { symmetry.
-      srapply (licata_finster (m:=-2)). }
-    refine ((pequiv_ptr (n:=n.+2))^-1* o*E _).
-    symmetry; rapply pequiv_ptr_loop_psusp'.
+    1: srapply (licata_finster (m:=-2)).
+    refine (_ o*E pequiv_ptr (n:=n.+2)).
+    rapply pequiv_ptr_loop_psusp'.
   Defined.
 
   Definition pequiv_loops_em_g (G : AbGroup) (n : nat)
-    : iterated_loops n K(G, n) <~>* G.
+    : G <~>* iterated_loops n K(G, n).
   Proof.
     induction n.
     - reflexivity.
-    - refine (IHn o*E _ o*E unfold_iterated_loops' _ _).
+    - refine ((unfold_iterated_loops' _ _)^-1* o*E _ o*E IHn).
       exact (emap (iterated_loops n) (pequiv_loops_em_em _ _)).
   Defined.
 
@@ -92,17 +91,16 @@ Section EilenbergMacLane.
   Proof.
     induction n.
     - apply grp_iso_g_pi1_bg.
-    - snrapply (transitive_groupisomorphism _ _ _ IHn).
-      symmetry.
-      snrapply (transitive_groupisomorphism _ _ _ (groupiso_pi_loops _ _)).
-      apply (groupiso_pi_functor _ (pequiv_loops_em_em _ _)).
+    - nrefine (grp_iso_compose _ IHn).
+      nrefine (grp_iso_compose _ (groupiso_pi_functor _ (pequiv_loops_em_em _ _))).
+      symmetry; apply (groupiso_pi_loops _ _).
   Defined.
 
   Definition iscohhspace_em `{Univalence} {G : AbGroup} (n : nat)
     : IsCohHSpace K(G, n).
   Proof.
     nrapply iscohhspace_equiv_cohhspace.
-    2: symmetry; apply pequiv_loops_em_em.
+    2: apply pequiv_loops_em_em.
     apply iscohhspace_loops.
   Defined.
 

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -7,6 +7,7 @@ Require Import Homotopy.ClassifyingSpace.
 Require Import Homotopy.HSpace.Core.
 Require Import Homotopy.HSpace.Coherent.
 Require Import Homotopy.HomotopyGroup.
+Require Import Homotopy.Hopf.
 Require Import TruncType.
 Require Import Truncations.Core Truncations.Connectedness.
 Require Import WildCat.
@@ -17,182 +18,6 @@ Local Open Scope pointed_scope.
 Local Open Scope nat_scope.
 Local Open Scope bg_scope.
 Local Open Scope mc_mult_scope.
-
-(** When X is 0-connected we see that Freudenthal doesn't let us characterise the loop space of a suspension. For this we need some extra assumptions about our space X.
-
-Suppose X is a 0-connected, 1-truncated coherent H-space, then
-
-  pTr 1 (loops (psusp X)) <~>* X
-
-By a coherent H-space we mean that the left and right identity laws at the unit are the same. *)
-
-Section LicataFinsterLemma.
-
-  Context `{Univalence} (X : pType)
-    `{IsConnected 0 X} `{IsTrunc 1 X} `{IsHSpace X}
-    {coh : IsCoherent X}.
-
-  (** This encode-decode style proof is detailed in Eilenberg-MacLane Spaces in Homotopy Type Theory by Dan Licata and Eric Finster. *)
-
-  Local Definition P : Susp X -> Type
-    := fun x => Tr 1 (North = x).
-
-  Local Definition codes : Susp X -> 1 -Type.
-  Proof.
-    srapply Susp_rec.
-    1: refine (Build_TruncType _ X).
-    1: refine (Build_TruncType _ X).
-    intro x.
-    apply path_trunctype.
-    apply (equiv_hspace_left_op x).
-  Defined.
-
-  Local Definition transport_codes_merid x y
-    : transport codes (merid x) y = x * y.
-  Proof.
-    unfold codes.
-    rewrite transport_idmap_ap.
-    rewrite ap_compose.
-    rewrite Susp_rec_beta_merid.
-    rewrite ap_trunctype.
-    by rewrite transport_path_universe_uncurried.
-  Defined.
-
-  Local Definition transport_codes_merid_V x
-    : transport codes (merid mon_unit)^ x = x.
-  Proof.
-    unfold codes.
-    rewrite transport_idmap_ap.
-    rewrite ap_V.
-    rewrite ap_compose.
-    rewrite Susp_rec_beta_merid.
-    rewrite ap_trunctype.
-    rewrite transport_path_universe_V_uncurried.
-    apply moveR_equiv_V.
-    symmetry.
-    cbn; apply left_identity.
-  Defined.
-
-  Local Definition encode : forall x, P x -> codes x.
-  Proof.
-    intro x.
-    srapply Trunc_rec.
-    intro p.
-    exact (transport codes p mon_unit).
-  Defined.
-
-  Local Definition decode' : X -> Tr 1 (@North X = North).
-  Proof.
-    intro x.
-    exact (tr (merid x @ (merid mon_unit)^)).
-  Defined.
-
-  Local Definition transport_decode' x y
-    : transport P (merid x) (decode' y)
-    = tr (merid y @ (merid mon_unit)^ @ merid x).
-  Proof.
-    unfold P.
-    unfold decode'.
-    rewrite transport_compose.
-    generalize (merid x).
-    generalize (merid y @ (merid mon_unit)^).
-    intros p [].
-    cbn; apply ap.
-    symmetry.
-    apply concat_p1.
-  Defined.
-
-  Local Definition encode_North_decode' x : encode North (decode' x) = x.
-  Proof.
-    cbn.
-    rewrite transport_idmap_ap.
-    rewrite ap_compose.
-    rewrite ap_pp.
-    rewrite ap_V.
-    rewrite 2 Susp_rec_beta_merid.
-    rewrite <- path_trunctype_V.
-    rewrite <- path_trunctype_pp.
-    rewrite ap_trunctype.
-    rewrite transport_path_universe_uncurried.
-    apply moveR_equiv_V; cbn.
-    exact (right_identity _ @ (left_identity _)^).
-  Defined.
-
-  Local Definition merid_mu (x y : X)
-    : tr (n:=1) (merid (x * y)) = tr (merid y @ (merid mon_unit)^ @ merid x).
-  Proof.
-    set (Q := fun a b : X => tr (n:=1) (merid (a * b))
-      = tr (merid b @ (merid mon_unit)^ @ merid a)).
-    srapply (@wedge_incl_elim_uncurried _ (-1) (-1) _
-      mon_unit _ _ mon_unit _ Q _ _ x y);
-    (* The try clause below is only needed for Coq <= 8.11 *)
-    try (intros a b; cbn; unfold Q; apply istrunc_paths; exact _).
-    unfold Q.
-    srefine (_;_;_).
-    { intro b.
-      apply ap.
-      symmetry.
-      refine (concat_pp_p _ _ _ @ _).
-      refine (ap _ (concat_Vp _) @ _).
-      refine (concat_p1 _ @ _).
-      apply ap.
-      exact (left_identity b)^. }
-    { intro a.
-      apply ap.
-      symmetry.
-      refine (ap (fun x => concat x (merid a)) (concat_pV _) @ _).
-      refine (concat_1p _ @ _).
-      apply ap.
-      exact (right_identity a)^. }
-    simpl.
-    apply ap, ap.
-    rewrite <- coh.
-    rewrite ? concat_p_pp.
-    apply whiskerR.
-    generalize (merid (mon_unit : X)).
-    by intros [].
-  Defined.
-
-  Local Definition decode : forall x, codes x -> P x.
-  Proof.
-    srapply Susp_ind; cbn.
-    1: apply decode'.
-    { intro x.
-      apply tr, merid, x. }
-    intro x.
-    srapply dp_path_transport^-1.
-    apply dp_arrow.
-    intro y.
-    apply dp_path_transport.
-    rewrite transport_codes_merid.
-    rewrite transport_decode'.
-    symmetry.
-    apply merid_mu.
-  Defined.
-
-  Local Definition decode_encode : forall x (p : P x),
-    decode x (encode x p) = p.
-  Proof.
-    intro x.
-    srapply Trunc_ind.
-    intro p.
-    destruct p; cbv.
-    apply ap, concat_pV.
-  Defined.
-
-  (** We could call this [pequiv_ptr_loop_psusp] but since we already used that for the Freudenthal case, it seems appropriate to use the name [licata_finster] for this case. *)
-  Lemma licata_finster : pTr 1 (loops (psusp X)) <~>* X.
-  Proof.
-    srapply Build_pEquiv'.
-    { srapply equiv_adjointify.
-      1: exact (encode North).
-      1: exact decode'.
-      1: intro; apply encode_North_decode'.
-      intro; apply decode_encode. }
-    reflexivity.
-  Defined.
-
-End LicataFinsterLemma.
 
 (** The definition of the Eilenberg-Mac Lane spaces.  Note that while we allow [G] to be non-abelian for [n > 1], later results will need to assume that [G] is abelian. *)
 Fixpoint EilenbergMacLane (G : Group) (n : nat) : pType
@@ -221,7 +46,7 @@ Section EilenbergMacLane.
   Global Instance is0connected_em {G : Group} (n : nat)
     : IsConnected 0 K(G, n.+1).
   Proof.
-    rapply (is0connected_isconnected n).
+    rapply (is0connected_isconnected n.-2).
   Defined.
 
   Local Open Scope trunc_scope.
@@ -246,9 +71,8 @@ Section EilenbergMacLane.
     change (loops (pTr n.+2 (psusp (K(G, n.+1)))) <~>* K(G, n.+1)).
     refine (_ o*E (ptr_loops _ _)^-1* ).
     destruct n.
-    { srapply licata_finster.
-      1: exact _.
-      reflexivity. }
+    { symmetry.
+      srapply (licata_finster (m:=-2)). }
     refine ((pequiv_ptr (n:=n.+2))^-1* o*E _).
     symmetry; rapply pequiv_ptr_loop_psusp'.
   Defined.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -1,6 +1,6 @@
 Require Import Types Basics Pointed Truncations.
 Require Import HSpace Suspension ExactSequence HomotopyGroup.
-Require Import WildCat Modalities.ReflectiveSubuniverse.
+Require Import WildCat Modalities.ReflectiveSubuniverse Modalities.Descent.
 Require Import HSet Spaces.Nat.
 
 Local Open Scope pointed_scope.
@@ -52,10 +52,10 @@ Proof.
   exact (right_identity _ @ (left_identity _)^).
 Defined.
 
-(** It follows from [hopf_retraction] and Freudenthal's theorem that [loop_susp_unit] induces an equivalence on [Pi (2n+1)] for [n]-connected H-spaces (with n >= 0). *)
-Proposition freudenthal_hspace `{Univalence}
-  {n : nat} {X : pType} `{IsConnected n X}
-  `{IsHSpace X} `{forall a, IsEquiv (a *.)}
+(** It follows from [hopf_retraction] and Freudenthal's theorem that [loop_susp_unit] induces an equivalence on [Pi (2n+1)] for [n]-connected H-spaces (with n >= 0). Note that [X] is automatically left-invertible. *)
+Proposition isequiv_Pi_connected_hspace `{Univalence}
+  {n : nat} (X : pType) `{IsConnected n X}
+  `{IsHSpace X}
   : IsEquiv (fmap (pPi (n + n).+1) (loop_susp_unit X)).
 Proof.
   nrapply isequiv_surj_emb.
@@ -64,6 +64,42 @@ Proof.
     + by apply (conn_map_loop_susp_unit (-1)).
     + rewrite <- trunc_index_add_nat_add.
       by apply (conn_map_loop_susp_unit).
-  - nrapply isembedding_pi_psect.
-    apply hopf_retraction.
+  - pose (is0connected_isconnected n.-2 _).
+    nrapply isembedding_pi_psect.
+    rapply hopf_retraction.
+Defined.
+
+(** By Freudenthal, [loop_susp_unit] induces an equivalence on lower homotopy groups as well, so it is a (2n+1)-equivalence.  We formalize it below with [m = n-1], and allow [n] to start at [-1].  We prove it using a more general result about reflective subuniverses, [OO_inverts_conn_map_factor_conn_map], but one could also use homotopy groups and the truncated Whitehead theorem. *)
+Definition freudenthal_hspace' `{Univalence}
+  {m : trunc_index} (X : pType) `{IsConnected m.+1 X}
+  `{IsHSpace X} `{forall a, IsEquiv (a *.)}
+  : O_inverts (Tr (m +2+ m).+1) (loop_susp_unit X).
+Proof.
+  set (r:=connecting_map_family (hopf_construction X)).
+  rapply (OO_inverts_conn_map_factor_conn_map _ (m +2+ m) _ r).
+  1: apply O_lex_leq_Tr.
+  rapply (conn_map_homotopic _ idmap).
+  symmetry.
+  nrapply hopf_retraction.
+Defined.
+
+(** Note that we don't really need the assumption that [X] is left-invertible in the previous result; for [m >= -1], it follows from connectivity.  And for [m = -2], the conclusion is trivial. Here we state the version for [m >= -1] without left-invertibility. *)
+Definition freudenthal_hspace `{Univalence}
+  {m : trunc_index} (X : pType) `{IsConnected m.+2 X}
+  `{IsHSpace X}
+  : O_inverts (Tr (m.+1 +2+ m.+1).+1) (loop_susp_unit X).
+Proof.
+  pose (is0connected_isconnected m _).
+  refine (freudenthal_hspace' (m:=m.+1) X).
+Defined.
+
+(** Here we give a generalization of a result from Eilenberg-MacLane Spaces in Homotopy Type Theory, Dan Licata and Eric Finster.  Their version corresponds to [m = -2] in our version.  Their encode-decode proof was formalized in this library in EMSpace.v until this shorter and more general approach was found. *)
+Definition licata_finster `{Univalence}
+  {m : trunc_index} (X : pType) `{IsConnected m.+2 X}
+  (k := (m.+1 +2+ m.+1).+1) `{IsHSpace X} `{IsTrunc k X}
+  : X <~>* pTr k (loops (psusp X)).
+Proof.
+  refine (_ o*E pequiv_ptr (n:=k)).
+  refine (pequiv_O_inverts k (loop_susp_unit X)).
+  rapply freudenthal_hspace.
 Defined.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -66,7 +66,7 @@ Proof.
       by apply (conn_map_loop_susp_unit).
   - pose (is0connected_isconnected n.-2 _).
     nrapply isembedding_pi_psect.
-    rapply hopf_retraction.
+    apply hopf_retraction.
 Defined.
 
 (** By Freudenthal, [loop_susp_unit] induces an equivalence on lower homotopy groups as well, so it is a (2n+1)-equivalence.  We formalize it below with [m = n-1], and allow [n] to start at [-1].  We prove it using a more general result about reflective subuniverses, [OO_inverts_conn_map_factor_conn_map], but one could also use homotopy groups and the truncated Whitehead theorem. *)
@@ -90,7 +90,7 @@ Definition freudenthal_hspace `{Univalence}
   : O_inverts (Tr (m.+1 +2+ m.+1).+1) (loop_susp_unit X).
 Proof.
   pose (is0connected_isconnected m _).
-  refine (freudenthal_hspace' (m:=m.+1) X).
+  exact (freudenthal_hspace' (m:=m.+1) X).
 Defined.
 
 (** Here we give a generalization of a result from Eilenberg-MacLane Spaces in Homotopy Type Theory, Dan Licata and Eric Finster.  Their version corresponds to [m = -2] in our version.  Their encode-decode proof was formalized in this library in EMSpace.v until this shorter and more general approach was found. *)
@@ -100,6 +100,6 @@ Definition licata_finster `{Univalence}
   : X <~>* pTr k (loops (psusp X)).
 Proof.
   refine (_ o*E pequiv_ptr (n:=k)).
-  refine (pequiv_O_inverts k (loop_susp_unit X)).
+  nrefine (pequiv_O_inverts k (loop_susp_unit X)).
   rapply freudenthal_hspace.
 Defined.

--- a/theories/Homotopy/PinSn.v
+++ b/theories/Homotopy/PinSn.v
@@ -5,8 +5,8 @@ Require Import Truncations.Core Truncations.Connectedness.
 Require Import Spaces.Int Spaces.Circle Spaces.Spheres.
 Require Import Algebra.AbGroups.
 Require Import Homotopy.HomotopyGroup.
-Require Import Homotopy.EMSpace.
 Require Import Homotopy.HSpaceS1.
+Require Import Homotopy.Hopf.
 
 (** * We show that the nth homotopy group of the n-sphere is the integers, for n >= 1. *)
 
@@ -51,7 +51,7 @@ Section Pi2S2.
 
   Definition ptr_loops_s2_s1 `{Univalence}
     : pTr 1 (loops (psphere 2)) <~>* psphere 1
-    := licata_finster (psphere 1).
+    := (licata_finster (psphere 1))^-1*.
 
   Definition pi2_s2 `{Univalence}
     : Pi 2 (psphere 2) $<~> abgroup_Z.

--- a/theories/Pointed/pModality.v
+++ b/theories/Pointed/pModality.v
@@ -69,3 +69,8 @@ Definition pto_O_natural `(O : ReflectiveSubuniverse) {X Y : pType}
 Proof.
   nrapply pO_rec_beta.
 Defined.
+
+Definition pequiv_O_inverts `(O : ReflectiveSubuniverse) {X Y : pType}
+  (f : X ->* Y) `{O_inverts O f}
+  : [O X, _] <~>* [O Y, _]
+  := Build_pEquiv _ _ (O_pfunctor O f) _.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -134,10 +134,10 @@ Definition merely_isconnected n A `{IsConnected n.+1 A}
   : merely A
   := @center _ (isconnected_pred_add' n (-1) A).
 
-(** And that an [n]-connected type, with [n >= 0], is [0]-connected. *)
-Definition is0connected_isconnected (n : nat) A `{IsConnected n A}
+(** And that an [n.+2]-connected type is [0]-connected. *)
+Definition is0connected_isconnected (n : trunc_index) A `{IsConnected n.+2 A}
   : IsConnected 0 A
-  := isconnected_pred_add' n.-2 0 A.
+  := isconnected_pred_add' n 0 A.
 
 Definition isconnmap_pred_add n m A B (f : A -> B) `{IsConnMap (n +2+ m) _ _ f}
   : IsConnMap m f.


### PR DESCRIPTION
With #1814 done, we knew we could give a new proof of the Licata-Finster theorem, while also generalizing it to any truncation level.  One way to do this would be to use homotopy groups and the truncated Whitehead theorem, but I noticed that one could use Prop 2.31 from CORS to prove the analogous result for any reflective subuniverse.  When I went to formalize it, I found that @mikeshulman had beat me to it almost four years ago with `OO_inverts_conn_map_factor_conn_map`!  So the additional work to prove Licata-Finster is just a few lines.

The first commit contains this, and removes the old encode-decode proof.  I'm happy to keep that proof around if people want.

The second commit cleans up EMSpace a bit by reversing some of the equivalences to be in the direction of the natural map, which avoids some inversions in other places.

The third commit contains two results about trunc indices that I didn't end up using but which will likely be useful to someone.