### PR TITLE
Spaces/Torus/*: simplify and try to remove Funext

### DIFF
--- a/theories/Spaces/Torus/Torus.v
+++ b/theories/Spaces/Torus/Torus.v
@@ -85,6 +85,10 @@ Admitted.
 (** The torus is pointed. *)
 Global Instance ispointed_torus : IsPointed Torus := tbase.
 
+(** The loops commute. *)
+Definition loops_commute_torus : loop_a @ loop_b = loop_b @ loop_a
+  := equiv_sq_path^-1 surf.
+
 (* TODO:
 (* We ought to be able to prove the computation rules all at the same time *)
 (* This gives me the idea of writing all our computation rules as a

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -33,7 +33,7 @@ Qed.
 Local Notation T := ([Torus, _]).
 Local Notation S1 := ([Circle, _]).
 
-Lemma pequiv_torus_prod_circles `{Funext} : T  <~>* S1 * S1.
+Lemma pequiv_torus_prod_circles : T <~>* S1 * S1.
 Proof.
   srapply Build_pEquiv'.
   1: apply equiv_torus_prod_Circle.

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -33,28 +33,6 @@ Qed.
 Local Notation T := ([Torus, _]).
 Local Notation S1 := ([Circle, _]).
 
-(** Loop space of Torus *)
-Theorem loops_torus `{Univalence} : loops T <~>* Int * Int.
-Proof.
-  srefine (_ o*E _).
-  1: exact (loops (S1 * S1)).
-  1: rapply (emap loops).
-  { srapply Build_pEquiv.
-    1: srapply Build_pMap.
-    1: exact equiv_torus_prod_Circle.
-    1: reflexivity.
-    exact _. }
-  srefine (_ o*E _).
-  1: exact (loops S1 * loops S1).
-  1: apply loops_prod.
-  snrapply Build_pEquiv.
-  1: srapply Build_pMap.
-  { apply functor_prod.
-    1,2: apply equiv_loopCircle_int. }
-  1: reflexivity.
-  exact _.
-Defined.
-
 Lemma pequiv_torus_prod_circles `{Funext} : T  <~>* S1 * S1.
 Proof.
   srapply Build_pEquiv'.
@@ -67,10 +45,17 @@ Theorem Pi1Torus `{Univalence}
   : GroupIsomorphism (Pi 1 T) (grp_prod abgroup_Z abgroup_Z).
 Proof.
   etransitivity.
-  { apply groupiso_pi_functor.
-    apply pequiv_torus_prod_circles. }
+  1: exact (emap (Pi 1) pequiv_torus_prod_circles).
   etransitivity.
   1: apply grp_iso_pi_prod.
   apply grp_iso_prod.
   1,2: apply pi1_circle.
+Defined.
+
+(** Loop space of Torus *)
+Theorem loops_torus `{Univalence} : loops T <~>* Int * Int.
+Proof.
+  (* Since [T] is 1-truncated, [loops T] is 0-truncated, and is therefore equivalent to its 0-truncation. *)
+  refine (_ o*E pequiv_ptr (n:=0)).
+  nrapply Pi1Torus.
 Defined.


### PR DESCRIPTION
The first commit simplifies `loops_torus`.  The second just records that the loops commute.  These two commits can go in.

The third commit attempts to remove Funext from TorusEquivCircles.v, using the standard trick.  This goes fine, except for two things, which are closed with `Admitted.`  The first involves some "cube-algebra" that would now be different because Funext is gone.  I'm hoping it'll be a bit simpler, but I'm not good at working with cubes, so I was hoping @Alizter might take a look.

The second `Admitted` happens because a later `Defined` fails with `Error: Case analysis on private inductive GraphQuotient.GraphQuotient.GraphQuotient`.  I'm not sure what is up with that.

(It would also be possible to prove this equivalence using the 0-groupoid Yoneda lemma.  It would be a bit verbose, but I think it would be straightforward and would build quickly.)

I'll mark this as WIP for now.  If we can't solve those problems, I'll PR just the first two commits, along with removing the `Section` in TorusEquivCircles, to make it faster.