### PR TITLE
Pullback, Lex: minor simplifications

### DIFF
--- a/theories/Limits/Pullback.v
+++ b/theories/Limits/Pullback.v
@@ -315,26 +315,28 @@ Proof.
   apply sq_1G.
 Defined.
 
+(** Maps into pullbacks are determined by their composites with the projections, and a coherence.  This can also be proved directly.  With [Funext], we could also prove an equivalence analogous to [equiv_path_pullback_rec_hset] below.  Not sure of the best name for this version. *)
+Definition pullback_homotopic {A B C D} {g : C -> D} {k : B -> D}
+           (f h : A -> Pullback k g)
+           (p1 : pullback_pr1 o f == pullback_pr1 o h)
+           (p2 : pullback_pr2 o f == pullback_pr2 o h)
+           (q : forall a, (ap k) (p1 a) @ (h a).2.2 = (f a).2.2 @ (ap g) (p2 a))
+  : f == h.
+Proof.
+  intro a.
+  apply equiv_path_pullback.
+  exists (p1 a).  exists (p2 a).
+  apply sq_path, q.
+Defined.
+
 (** When [A] is a set, the [PathSquare] becomes trivial. *)
 Definition equiv_path_pullback_hset {A B C} `{IsHSet A} (f : B -> A) (g : C -> A)
            (x y : Pullback f g)
   : (x.1 = y.1) * (x.2.1 = y.2.1) <~> (x = y).
 Proof.
-  refine (equiv_path_pullback f g x y oE _).
-  srapply equiv_adjointify.
-  - intros [p q].
-    refine (p; q; _).
-    apply (@center _ (istrunc_sq (-2))).
-  - intros [p [q _]].
-    exact (p, q).
-  - intros [p [q ?]].
-    srapply path_sigma'.
-    1: reflexivity.
-    refine (transport_sigma' _ _ @ _).
-    srapply path_sigma'.
-    1: reflexivity.
-    apply path_ishprop.
-  - reflexivity.
+  refine (equiv_path_pullback f g x y oE _^-1%equiv).
+  refine (_ oE equiv_sigma_prod (fun pq => PathSquare (ap f (fst pq)) (ap g (snd pq)) (x.2).2 (y.2).2)).
+  rapply equiv_sigma_contr. (* Uses [istrunc_sq]. *)
 Defined.
 
 Lemma equiv_path_pullback_rec_hset `{Funext} {A X Y Z : Type} `{IsHSet Z}

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -121,27 +121,31 @@ Section LexModality.
     nrapply (isequiv_homotopic
                (O_rec (functor_pullback _ _ _ _ _ _ _
                                         (to_O_natural O f) (to_O_natural O g)))).
-    1:apply isequiv_O_rec_O_inverts; exact _.
-    apply O_indpaths; intros [b [c e]].
-    refine (O_rec_beta _ _ @ _).
-    (** This *seems* like it ought to be the easier goal, but it turns out to involve lots of naturality wrangling.  If we ever want to make real use of this theorem, we might want to separate out this goal into an opaque lemma so we could make the main theorem transparent. *)
-    unfold functor_pullback, functor_sigma, pullback_corec; simpl.
-    refine (path_sigma' _ (to_O_natural O pullback_pr1 (b;(c;e)))^ _).
-    rewrite transport_sigma'; simpl.
-    refine (path_sigma' _ (to_O_natural O pullback_pr2 (b;(c;e)))^ _).
-    rewrite transport_paths_Fl.
-    rewrite transport_paths_Fr.
-    Open Scope long_path_scope.
-    unfold O_functor_square.
-    rewrite ap_V, inv_V, O_functor_homotopy_beta, !concat_p_pp.
-    unfold pullback_commsq; simpl.
-    rewrite to_O_natural_compose, !concat_pp_p.
-    do 3 apply whiskerL.
-    rewrite ap_V, <- inv_pp.
-    rewrite <- (inv_V (O_functor_compose _ _ _ _)), <- inv_pp.
-    apply inverse2, to_O_natural_compose.
-    Close Scope long_path_scope.
-  Qed.
+    1: apply isequiv_O_rec_O_inverts; exact _.
+    apply O_indpaths.
+    etransitivity.
+    1: intro x; apply O_rec_beta.
+    symmetry.
+    snrapply pullback_homotopic; intros [b [c e]]; cbn.
+    all: change (to (modality_subuniv O)) with (to O).
+    - nrapply (to_O_natural O).
+    - nrapply (to_O_natural O).
+    - Open Scope long_path_scope.
+      lhs nrapply concat_p_pp.
+      lhs nrapply (concat_p_pp _ _ _ @@ 1).
+      rewrite to_O_natural_compose.
+      unfold O_functor_square.
+      rewrite O_functor_homotopy_beta.
+      rewrite 6 concat_pp_p.
+      do 3 apply whiskerL.
+      rhs_V nrapply concat_pp_p.
+      apply moveL_pM.
+      lhs_V nrapply inv_pp.
+      rhs_V nrapply inv_Vp.
+      apply (ap inverse).
+      nrapply to_O_natural_compose.
+      Close Scope long_path_scope.
+  Defined.
 
   Definition diagonal_O_functor {A B : Type} (f : A -> B)
     : diagonal (O_functor O f) == equiv_O_pullback f f o O_functor O (diagonal f).


### PR DESCRIPTION
Add `pullback_homotopic` to Pullback.v, factoring out a bit of the argument from `O_functor_pullback` in Lex.v.  Also slightly simplify and speed up `O_functor_pullback`, and simplify `equiv_path_pullback_hset` in Pullback.v.