### PR TITLE
Wedge of a family of pType

### DIFF
--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -108,11 +108,8 @@ Defined.
 Definition FamilyWedge (I : Type) (X : I -> pType) : pType.
 Proof.
   snrapply Build_pType.
-  - srefine (Pushout (A := sig (fun _ : I => pUnit)) (B := sig X) (C := pUnit) _ _).
-    + snrapply functor_sigma.
-      1: exact idmap.
-      intros i.
-      exact (fun _ => pt).
+  - srefine (Pushout (A := I) (B := sig X) (C := pUnit) _ _).
+    + exact (fun i => (i; pt)).
     + exact (fun _ => pt).
   - apply pushr.
     exact pt.
@@ -124,7 +121,7 @@ Definition fwedge_in (I : pType) (X : I -> pType)
 Proof.
   snrapply Build_pMap.
   - exact pushl.
-  - exact (pglue (pt; pt)).
+  - exact (pglue pt).
 Defined.
 
 (** Recursion principle for the wedge of an indexed family of pointed types. *)
@@ -136,7 +133,7 @@ Proof.
   - snrapply Pushout_rec.
     + apply (sig_rec _ _ _ f).
     + exact pconst.
-    + intros [i ?].
+    + intros i.
       exact (point_eq (f i)).
   - exact idpath.
 Defined.

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -107,7 +107,7 @@ Defined.
 (** Note that the index type is not necesserily pointed. An empty wedge is the unit type which is the zero object in the category of pointed types. *)
 Definition FamilyWedge (I : Type) (X : I -> pType) : pType.
 Proof.
-  srefine ([_, _]).
+  snrapply Build_pType.
   - srefine (Pushout (A := sig (fun _ : I => pUnit)) (B := sig X) (C := pUnit) _ _).
     + snrapply functor_sigma.
       1: exact idmap.
@@ -118,7 +118,7 @@ Proof.
     exact pt.
 Defined.
 
-(** We can define an inclusion map if the index set is non-empty. In the empty case the wedge should be equivalent to the unit type anyway. *)
+(** We have an inclusion map [pushl : sig X -> FamilyWedge X].  When [I] is pointed, so is [sig X], and then this inclusion map is pointed. *)
 Definition fwedge_in (I : pType) (X : I -> pType)
   : psigma (pointed_fam X) $-> FamilyWedge I X.
 Proof.
@@ -136,31 +136,20 @@ Proof.
   - snrapply Pushout_rec.
     + apply (sig_rec _ _ _ f).
     + exact pconst.
-    + intros [i ].
+    + intros [i ?].
       exact (point_eq (f i)).
   - exact idpath.
 Defined.
 
-(** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge should land. This makes it somewhat awkward to define an indexed smash product.
-
-TODO: is this strictly necessary or are their weaker assumptions we can use? Can we remove funext? *)
+(** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge should land. This makes it somewhat awkward to work with, however in practice we typically only care about decidable index sets. *) 
 Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
   : FamilyWedge I X $-> pproduct X.
 Proof.
-  snrapply Build_pMap.
-  - snrapply Pushout_rec.
-    + intros [i x] a.
-      destruct (dec_paths i a).
-      * destruct p.
-        exact x.
-      * exact pt.
-    + exact (fun _ => pt).
-    + intros [i ].
-      simpl.
-      apply path_forall.
-      intros a.
-      destruct (dec_paths i a).
-      * by destruct p.
-      * reflexivity.
-  - exact idpath.
+  snrapply fwedge_rec.
+  intro i.
+  snrapply pproduct_corec.
+  intro a.
+  destruct (dec_paths i a).
+  - destruct p; exact pmap_idmap.
+  - exact pconst.
 Defined.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -158,6 +158,18 @@ Definition psigma {A : pType} (P : pFam A) : pType
 Definition pproduct {A : Type} (F : A -> pType) : pType
   := [forall (a : A), pointed_type (F a), ispointed_type o F].
 
+Definition pproduct_corec `{Funext} {A : Type} (F : A -> pType)
+  (X : pType) (f : forall a, X ->* F a)
+  : X ->* pproduct F.
+Proof.
+  snrapply Build_pMap.
+  - intros x a.
+    exact (f a x).
+  - cbn.
+    funext a.
+    apply point_eq.
+Defined.
+
 (** The following tactics often allow us to "pretend" that pointed maps and homotopies preserve basepoints strictly. *)
 
 (** First a version with no rewrites, which leaves some cleanup to be done but which can be used in transparent proofs. *)


### PR DESCRIPTION
We define wedges of families of pTypes.

Interestingly, we have to make some decidability assumptions on the indexing type in order to get the inclusion from wedge to product. This is also true for such colimits in a general pointed category.

I'm not sure if these assumptions are necessary, and in practice most index sets we will choose are decidable.

Once we have free products of abelian groups defined, we should be able to extend the PinSn result to wedges of spheres.