### PR TITLE
Minor updates to Pointed/*, ReflectiveSubuniverse

### DIFF
--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -162,13 +162,12 @@ Class Reflects@{i} (O : Subuniverse@{i}) (T : Type@{i})
 Arguments extendable_to_O O {T _ _ Q Q_inO}.
 
 (** Here's a modified version that applies to types in possibly-smaller universes without collapsing those universes to [i]. *)
-Definition extendable_to_O'@{i j k} (O : Subuniverse@{i}) (T : Type@{j})
+Definition extendable_to_O'@{i j k | j <= i, k <= i} (O : Subuniverse@{i}) (T : Type@{j})
            `{Reflects O T} {Q : Type@{k}} {Q_inO : In O Q}
-  : ooExtendableAlong@{j i k i} (to O T) (fun _ => Q).
+  : ooExtendableAlong (to O T) (fun _ => Q).
 Proof.
-  assert (e := @extendable_to_O O T _ _ Q Q_inO).
-  apply (lift_ooextendablealong@{i j j i i i i k k i i}).
-  exact e.
+  apply lift_ooextendablealong.
+  rapply extendable_to_O.
 Defined.
 
 (** In particular, every type in the subuniverse automatically reflects into it. *)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -253,7 +253,7 @@ Definition issig_pequiv' (A B : pType)
 
 (** pForall can also be described as a type of extensions. *)
 Definition equiv_extension_along_pforall `{Funext} {A : pType} (P : pFam A)
-  : ExtensionAlong (unit_name (point A)) P (unit_name (dpoint P)) <~> pForall A P.
+  : ExtensionAlong@{Set _ _ _} (unit_name (point A)) P (unit_name (dpoint P)) <~> pForall A P.
 Proof.
   unfold ExtensionAlong.
   refine (issig_pforall A P oE _).

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -38,6 +38,8 @@ Definition Build_pEquiv' {A B : pType} (f : A <~> B)
   (p : f (point A) = point B)
   : A <~>* B := Build_pEquiv _ _ (Build_pMap _ _ f p) _.
 
+Arguments Build_pEquiv' & _ _ _ _.
+
 (* A version of equiv_adjointify for pointed equivalences where all data is pointed. There is a lot of unnecessary data here but sometimes it is easier to prove equivalences using this. *)
 Definition pequiv_adjointify {A B : pType} (f : A ->* B) (f' : B ->* A)
   (r : f o* f' ==* pmap_idmap) (s : f' o* f == pmap_idmap) : A <~>* B

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -103,9 +103,9 @@ Module Book_Loop_Susp_Adjunction.
   Definition loop_susp_adjoint_nat_r `{Funext} (A B B' : pType)
              (f : psusp A ->* B) (g : B ->* B')
   : loop_susp_adjoint A B' (g o* f)
-    ==* loops_functor g o* loop_susp_adjoint A B f.
+    ==* fmap loops g o* loop_susp_adjoint A B f.
   Proof.
-    pointed_reduce_rewrite.
+    pointed_reduce. (* Very slow for some reason. *)
     srefine (Build_pHomotopy _ _).
     - intros a. simpl.
       refine (_ @ (concat_1p _)^).
@@ -114,8 +114,9 @@ Module Book_Loop_Susp_Adjunction.
       rewrite !(transport_arrow_fromconst (B := A)).
       rewrite !transport_paths_Fr.
       rewrite !ap_V, !ap_pr1_path_basedpaths.
-      rewrite ap_pp, !(ap_compose f g), ap_V.
-      reflexivity.
+      Fail rewrite ap_pp, !(ap_compose f g), ap_V. (* This line fails with current versions of the library. *)
+      Fail reflexivity.
+      admit.
     - cbn.
       Fail reflexivity.
   Abort.

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -152,11 +152,11 @@ Defined.
 
 (** Buchholtz-van Doorn-Rijke, Theorem 4.2:  Let [j >= -1] and [n >= -2].  When [X] is [j]-connected and [Y] is a pointed family of [j+k+1]-truncated types, the type of pointed sections is [n]-truncated.  We formalize it with [j] replaced with a trunc index [m], and so there is a shift compared to the informal statement. This version also allows [n] to be one smaller than BvDR allow. *)
 Definition istrunc_pforall `{Univalence} {m n : trunc_index}
-  (X : pType) {iscX : IsConnected m.+1 X}
-  (Y : pFam X) {istY : forall x, IsTrunc (n +2+ m) (Y x)}
-  : IsTrunc n (pForall X Y).
+  (X : pType@{u}) {iscX : IsConnected m.+1 X}
+  (Y : pFam@{u v} X) {istY : forall x, IsTrunc (n +2+ m) (Y x)}
+  : IsTrunc@{w} n (pForall X Y).
 Proof.
-  nrapply (istrunc_equiv_istrunc _ (equiv_extension_along_pforall Y)).
+  nrapply (istrunc_equiv_istrunc _ (equiv_extension_along_pforall@{v w u} Y)).
   rapply (istrunc_extension_along_conn (n:=m) _ Y (HP:=istY)).
 Defined.
 

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -42,7 +42,7 @@ Lemma istrunc_extension_along_conn `{Univalence} {m n : trunc_index}
   (d : forall a:A, P (f a))
   : IsTrunc m (ExtensionAlong f P d).
 Proof.
-  revert P HP d. induction m as [ | m' IH]; intros P HP d; simpl in *.
+  revert P HP d. simple_induction m m' IH; intros P HP d; simpl in *.
   (* m = –2 *)
   - apply (Build_Contr _ (extension_conn_map_elim n f P d)).
     intros y. apply (allpath_extension_conn_map n); assumption.


### PR DESCRIPTION
The only non-trivial thing is an improvement to the universes in the result `istrunc_pmap` that I added recently.  When I went to use it in other code, I found that Coq had made some sub-optimal choices that meant I couldn't use it.