### PR TITLE
Displayed Wild Categories

### DIFF
--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -172,6 +172,14 @@ Reserved Infix "$@vL" (at level 34).
 Reserved Notation "s ^h$" (at level 20).
 Reserved Notation "s ^v$" (at level 20).
 
+(** Displayed wild cat *)
+Reserved Infix "$o'" (at level 40, left associativity).
+Reserved Infix "$@'" (at level 30).
+Reserved Infix "$@L'" (at level 30).
+Reserved Infix "$@R'" (at level 30).
+Reserved Infix "$@@'" (at level 30).
+Reserved Notation "f ^$'" (at level 3, format "f '^$''").
+
 (** Cubical *)
 Reserved Infix "@@h" (at level 30).
 Reserved Infix "@@v" (at level 30).

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -14,6 +14,7 @@ Require Export WildCat.Bifunctor.
 Require Export WildCat.Monoidal.
 Require Export WildCat.Products.
 Require Export WildCat.Coproducts.
+Require Export WildCat.Displayed.
 
 (* See also contrib/SetoidRewrite.v for tools that can be used for rewriting in wild categories. *)
 

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -4,10 +4,10 @@ Require Import Basics.Tactics.
 Require Import Types.Sigma.
 Require Import WildCat.Core.
 
-Class IsDGraph (A : Type) `{IsGraph A} (D : A -> Type)
+Class IsDGraph {A : Type} `{IsGraph A} (D : A -> Type)
   := DHom : forall {a b : A}, (a $-> b) -> D a -> D b -> Type.
 
-Class Is01DCat (A : Type) `{Is01Cat A} (D : A -> Type) `{!IsDGraph A D} :=
+Class Is01DCat {A : Type} `{Is01Cat A} (D : A -> Type) `{!IsDGraph D} :=
 {
   DId : forall {a : A} (a' : D a), DHom (Id a) a' a';
   dcat_comp : forall {a b c : A} {g : b $-> c} {f : a $-> b}
@@ -27,8 +27,8 @@ Definition dcat_precomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
   : forall (g : b $-> c), DHom g b' c' -> DHom (g $o f) a' c'
   := fun _ g' => g' $o' f'.
 
-Class Is0DGpd (A : Type) `{Is0Gpd A} (D : A -> Type)
-  `{!IsDGraph A D, !Is01DCat A D}
+Class Is0DGpd {A : Type} `{Is0Gpd A} (D : A -> Type)
+  `{!IsDGraph D, !Is01DCat D}
   := dgpd_rev : forall {a b : A} {f : a $== b} {a' : D a} {b' : D b},
                 DHom f a' b' -> DHom (f^$) b' a'.
 
@@ -63,20 +63,20 @@ Class Is0DFunctor {A : Type} {B : Type}
 
 Arguments dfmap {A B DA _ _ DB _ _} F {_} F' {_ _ _ _ _ _} f'.
 
-Class Is2DGraph (A : Type) `{Is2Graph A}
-  (D : A -> Type) `{!IsDGraph A D}
+Class Is2DGraph {A : Type} `{Is2Graph A}
+  (D : A -> Type) `{!IsDGraph D}
   := isdgraph_dhom : forall {a b} {a'} {b'},
-                    IsDGraph (a $-> b) (fun f => DHom f a' b').
+                      IsDGraph (fun (f:a $-> b) => DHom f a' b').
 
 Global Existing Instance isdgraph_dhom.
 #[global] Typeclasses Transparent Is2DGraph.
 
-Class Is1DCat (A : Type) `{Is2Graph A, !Is01Cat A, !Is1Cat A}
-  (D : A -> Type) `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} := {
+Class Is1DCat {A : Type} `{Is2Graph A, !Is01Cat A, !Is1Cat A}
+  (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} := {
     is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                    Is01DCat (a $-> b) (fun f => DHom f a' b');
+                    Is01DCat (fun f => DHom f a' b');
     is0dgpd_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                    Is0DGpd (a $-> b) (fun f => DHom f a' b');
+                    Is0DGpd (fun f => DHom f a' b');
     is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
                             {b' : D b} {c' : D c} (g' : DHom g b' c'),
                             Is0DFunctor (fun f => DHom f a' b')
@@ -222,14 +222,14 @@ Proof.
     apply Id.
 Defined.
 
-Class Is1DCat_Strong (A : Type) `{Is2Graph A, !Is01Cat A, !Is1Cat_Strong A}
+Class Is1DCat_Strong {A : Type} `{Is2Graph A, !Is01Cat A, !Is1Cat_Strong A}
   (D : A -> Type)
-  `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} :=
+  `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} :=
 {
   is01dcat_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
-                          Is01DCat (a $-> b) (fun f => DHom f a' b');
+                          Is01DCat (fun f => DHom f a' b');
   is0dgpd_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
-                        Is0DGpd (a $-> b) (fun f => DHom f a' b');
+                        Is0DGpd (fun f => DHom f a' b');
   is0dfunctor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
                                 {b' : D b} {c' : D c} (g' : DHom g b' c'),
                                 Is0DFunctor (fun f => DHom f a' b')
@@ -274,7 +274,7 @@ Proof.
 Defined.
 
 Global Instance is1dcat_is1dcatstrong {A : Type} (D : A -> Type)
-  `{Is1DCat_Strong A D} : Is1DCat A D.
+  `{Is1DCat_Strong A D} : Is1DCat D.
 Proof.
   srapply Build_Is1DCat.
   - intros a b c d f g h a' b' c' d' f' g' h'.
@@ -317,7 +317,7 @@ Defined.
 
 Section IdentityFunctor.
   Global Instance is0dfunctor_idmap {A : Type} `{Is01Cat A}
-    (DA : A -> Type) `{!IsDGraph A DA, !Is01DCat A DA}
+    (DA : A -> Type) `{!IsDGraph DA, !Is01DCat DA}
     : Is0DFunctor DA DA (idmap) (fun a a' => a').
   Proof.
     intros a b f a' b' f'.
@@ -325,7 +325,7 @@ Section IdentityFunctor.
   Defined.
 
   Global Instance is1dfunctor_idmap {A : Type} `{Is1Cat A} (DA : A -> Type)
-    `{!IsDGraph A DA, !Is2DGraph A DA, !Is01DCat A DA, !Is1DCat A DA}
+    `{!IsDGraph DA, !Is2DGraph DA, !Is01DCat DA, !Is1DCat DA}
     : Is1DFunctor DA DA (idmap) (fun a a' => a').
   Proof.
     apply Build_Is1DFunctor.
@@ -340,8 +340,8 @@ End IdentityFunctor.
 
 Section ConstantFunctor.
   Global Instance is0dfunctor_const {A : Type} `{IsGraph A}
-    {B : Type} `{Is01Cat B} (DA : A -> Type) `{!IsDGraph A DA}
-    (DB : B -> Type) `{!IsDGraph B DB, !Is01DCat B DB} (x : B) (x' : DB x)
+    {B : Type} `{Is01Cat B} (DA : A -> Type) `{!IsDGraph DA}
+    (DB : B -> Type) `{!IsDGraph DB, !Is01DCat DB} (x : B) (x' : DB x)
     : Is0DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
   Proof.
     intros a b f a' b' f'.
@@ -350,9 +350,9 @@ Section ConstantFunctor.
 
   Global Instance is1dfunctor_const {A : Type} `{Is1Cat A} {B : Type} `{Is1Cat B}
     (DA : A -> Type)
-    `{!IsDGraph A DA, !Is2DGraph A DA, !Is01DCat A DA, !Is1DCat A DA}
+    `{!IsDGraph DA, !Is2DGraph DA, !Is01DCat DA, !Is1DCat DA}
     (DB : B -> Type)
-    `{!IsDGraph B DB, !Is2DGraph B DB, !Is01DCat B DB, !Is1DCat B DB}
+    `{!IsDGraph DB, !Is2DGraph DB, !Is01DCat DB, !Is1DCat DB}
     (x : B) (x' : DB x)
     : Is1DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
   Proof.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -1,0 +1,367 @@
+Require Import Basics.Overture.
+Require Import Basics.PathGroupoids.
+Require Import Basics.Tactics.
+Require Import Types.
+Require Import WildCat.Core.
+
+Class IsDGraph (A : Type) `{IsGraph A} (D : A -> Type)
+  := dhom : forall {a b}, (a $-> b) -> D a -> D b -> Type.
+
+Class Is01DCat (A : Type) `{Is01Cat A} (D : A -> Type) `{!IsDGraph A D} :=
+{
+  did : forall {a : A} (a' : D a), dhom (Id a) a' a';
+  dcat_comp : forall {a b c} {g : b $-> c} {f : a $-> b} {a'} {b'} {c'},
+          dhom g b' c' -> dhom f a' b' -> dhom (g $o f) a' c';
+}.
+
+Notation "g '$o'' f" := (@dcat_comp _ _ _ _ _ _ _ _ _ _ _ _ _ _ g f).
+
+Definition dcat_postcomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
+  {g : b $-> c} {a' : D a} {b' : D b} {c' : D c} (g' : dhom g b' c')
+  : forall (f : a $-> b), dhom f a' b' -> dhom (g $o f) a' c'
+  := fun _ f' => g' $o' f'.
+
+Definition dcat_precomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
+  {f : a $-> b} {a' : D a} {b' : D b} {c' : D c} (f' : dhom f a' b')
+  : forall (g : b $-> c), dhom g b' c' -> dhom (g $o f) a' c'
+  := fun _ g' => g' $o' f'.
+
+Class Is0DGpd (A : Type) `{Is0Gpd A} (D : A -> Type)
+  `{!IsDGraph A D, !Is01DCat A D}
+  := dgpd_rev : forall {a b : A} {f : a $== b} {a' : D a} {b' : D b},
+                dhom f a' b' -> dhom (f^$) b' a'.
+
+Notation "p ^$'" := (dgpd_rev p).
+
+Definition dgpd_hom {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
+  (f : a $== b) (a' : D a) (b' : D b)
+  := dhom f a' b'.
+
+(* Diagrammatic order to match gpd_comp *)
+Definition dgpd_comp {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b c : A}
+  {f : a $== b} {g : b $== c} {a' : D a} {b' : D b} {c' : D c}
+  : dgpd_hom f a' b' -> dgpd_hom g b' c' -> dgpd_hom (g $o f) a' c'
+  := fun f' g' => g' $o' f'.
+
+Notation "p '$@'' q" := (dgpd_comp p q).
+
+Definition dgpd_hom_path {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
+  (p : a = b) {a' : D a} {b': D b} (p' : transport D p a' = b')
+  : dgpd_hom (GpdHom_path p) a' b'.
+Proof.
+  destruct p, p'.
+  apply did.
+Defined.
+
+(* A displayed 0-functor G over a 0-functor F acts on displayed objects and
+1-cells and satisfies no axioms. *)
+Class Is0DFunctor
+  {A : Type} `{IsGraph A} {B : Type} `{IsGraph B}
+  (DA : A -> Type) `{!IsDGraph A DA} (DB : B -> Type) `{!IsDGraph B DB}
+  (F : A -> B) `{!Is0Functor F} (G : forall (a : A), DA a -> DB (F a))
+  := dfmap : forall {a b : A} {f : a $-> b} {a' : DA a} {b' : DA b},
+              dhom f a' b' -> dhom (fmap F f) (G a a') (G b b').
+
+Arguments dfmap {A _ B _ DA _ DB _} F {_} G {_ _ _ _ _ _} f'.
+
+Class Is2DGraph (A : Type) `{IsGraph A, !Is2Graph A}
+  (D : A -> Type) `{!IsDGraph A D}
+  := isdgraph_dhom : forall {a b} {a'} {b'},
+                    IsDGraph (a $-> b) (fun f => dhom f a' b').
+
+Global Existing Instance isdgraph_dhom.
+#[global] Typeclasses Transparent Is2DGraph.
+
+Class Is1DCat (A : Type) `{IsGraph A, !Is2Graph A, !Is01Cat A, !Is1Cat A}
+  (D : A -> Type) `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} := {
+    is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
+                    Is01DCat (a $-> b) (fun f => dhom f a' b');
+    is0dgpd_dhom : forall {a b : A} {a' : D a} {b' : D b},
+                  Is0DGpd (a $-> b) (fun f => dhom f a' b');
+    is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
+                            {b' : D b} {c' : D c} (g' : dhom g b' c'),
+                            Is0DFunctor (fun f => dhom f a' b')
+                                        (fun gf => dhom gf a' c')
+                                        (cat_postcomp a g) (dcat_postcomp g');
+    is0dfunctor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
+                          {b' : D b} {c' : D c} (f' : dhom f a' b'),
+                            Is0DFunctor (fun g => dhom g b' c')
+                                        (fun gf => dhom gf a' c')
+                                        (cat_precomp c f) (dcat_precomp f');
+    dcat_assoc : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
+                  {a' : D a} {b' : D b} {c' : D c} {d' : D d}
+                  (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d'),
+                  dhom (cat_assoc f g h)
+                        ((h' $o' g') $o' f') (h' $o' (g' $o' f'));
+    dcat_idl : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
+                (f' : dhom f a' b'), dhom (cat_idl f) (did b' $o' f') f';
+    dcat_idr : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
+                (f' : dhom f a' b'), dhom (cat_idr f) (f' $o' did a') f';
+}.
+
+Global Existing Instance is01dcat_dhom.
+Global Existing Instance is0dgpd_dhom.
+Global Existing Instance is0dfunctor_postcomp.
+Global Existing Instance is0dfunctor_precomp.
+
+Definition dcat_assoc_opp {A : Type} (D : A -> Type) `{Is1DCat A D}
+  {a b c d : A}  {f : a $-> b} {g : b $-> c} {h : c $-> d}
+  {a' : D a} {b' : D b} {c' : D c} {d' : D d}
+  (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d')
+  : dhom (cat_assoc_opp f g h) (h' $o' (g' $o' f')) ((h' $o' g') $o' f')
+  := (dcat_assoc f' g' h')^$'.
+
+Definition dcat_postwhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
+  {a b c : A} {f g : a $-> b} {h : b $-> c} {p : f $== g}
+  {a' : D a} {b' : D b} {c' : D c} {f' : dhom f a' b'} {g' : dhom g a' b'}
+  (h' : dhom h b' c') (p' : dhom p f' g')
+  : dhom (h $@L p) (h' $o' f') (h' $o' g')
+  := dfmap (cat_postcomp a h) (dcat_postcomp h') p'.
+
+Notation "h $@L' p" := (dcat_postwhisker h p).
+
+Definition dcat_prewhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
+  {a b c : A} {f : a $-> b} {g h : b $-> c} {p : g $== h}
+  {a' : D a} {b' : D b} {c' : D c} {g' : dhom g b' c'} {h' : dhom h b' c'}
+  (p' : dhom p g' h') (f' : dhom f a' b')
+  : dhom (p $@R f) (g' $o' f') (h' $o' f')
+  := dfmap (cat_precomp c f) (dcat_precomp f') p'.
+
+Notation "p $@R' f" := (dcat_prewhisker p f).
+
+Definition dcat_comp2 {A : Type} {D : A -> Type} `{Is1DCat A D} {a b c : A}
+  {f g : a $-> b} {h k : b $-> c} {p : f $== g} {q : h $== k}
+  {a' : D a} {b' : D b} {c' : D c} {f' : dhom f a' b'} {g' : dhom g a' b'}
+  {h' : dhom h b' c'} {k' : dhom k b' c'}
+  (p' : dhom p f' g') (q' : dhom q h' k')
+  : dhom (p $@@ q) (h' $o' f') (k' $o' g')
+  :=  (k' $@L' p') $o' (q' $@R' f').
+
+Global Instance isgraph_sigma {A : Type} (D : A -> Type) `{IsDGraph A D}
+  : IsGraph (sig D).
+Proof.
+  srapply Build_IsGraph.
+  intros [a a'] [b b'].
+  exact {f : a $-> b & dhom f a' b'}.
+Defined.
+
+Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{Is01DCat A D}
+  : Is01Cat (sig D).
+Proof.
+  srapply Build_Is01Cat.
+  - intros [a a']. exact (Id a; did a').
+  - intros [a a'] [b b'] [c c'] [g g'] [f f']. exact (g $o f; g' $o' f').
+Defined.
+
+Global Instance is0gpd_sigma {A : Type} (D : A -> Type) `{Is0DGpd A D}
+  : Is0Gpd (sig D).
+Proof.
+  srapply Build_Is0Gpd.
+  intros [a a'] [b b'] [f f'].
+  exact (f^$; dgpd_rev f').
+Defined.
+
+Global Instance is0functor_pr1 {A : Type} (D : A -> Type) `{IsDGraph A D}
+  : Is0Functor (pr1 : (sig D) -> A).
+Proof.
+  srapply Build_Is0Functor.
+  intros [a a'] [b b'] [f f'].
+  exact f.
+Defined.
+
+Global Instance is2graph_sigma {A : Type} (D : A -> Type) `{Is2DGraph A D}
+  : Is2Graph (sig D).
+Proof.
+  intros [a a'] [b b'].
+  srapply Build_IsGraph.
+  intros [f f'] [g g'].
+  exact ({p : f $-> g & dhom p f' g'}).
+Defined.
+
+Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{Is01DCat A DA}
+  {B : Type} (DB : B -> Type) `{Is01DCat B DB} (F : A -> B) `{!Is0Functor F}
+  (G : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F G}
+  : Is0Functor (functor_sigma F G).
+Proof.
+  srapply Build_Is0Functor.
+  intros [a a'] [b b'].
+  intros [f f'].
+  exact (fmap F f; dfmap F G f').
+Defined.
+
+Global Instance is1cat_sigma {A : Type} (D : A -> Type) `{Is1DCat A D}
+  : Is1Cat (sig D).
+Proof.
+  srapply Build_Is1Cat.
+  - intros [a a'] [b b'] [c c'] [f f'].
+    apply Build_Is0Functor.
+    intros [g g'] [h h'] [p p'].
+    exact (f $@L p; f' $@L' p').
+  - intros [a a'] [b b'] [c c'] [f f'].
+    apply Build_Is0Functor.
+    intros [g g'] [h h'] [p p'].
+    exact (p $@R f; p' $@R' f').
+  - intros [a a'] [b b'] [c c'] [d d'] [f f'] [g g'] [h h'].
+    exact (cat_assoc f g h; dcat_assoc f' g' h').
+  - intros [a a'] [b b'] [f f'].
+    exact (cat_idl f; dcat_idl f').
+  - intros [a a'] [b b'] [f f'].
+    exact (cat_idr f; dcat_idr f').
+Defined.
+
+Global Instance is1functor_pr1 {A : Type} {D : A -> Type} `{Is1DCat A D}
+  : Is1Functor (pr1 : (sig D) -> A).
+Proof.
+  srapply Build_Is1Functor.
+  - intros [a a'] [b b'] [f f'] [g g'] [p p'].
+    exact p.
+  - intros [a a'].
+    apply Id.
+  - intros [a a'] [b b'] [c c'] [f f'] [g g'].
+    apply Id.
+Defined.
+
+Class Is1DCat_Strong (A : Type) `{IsGraph A, !Is2Graph A, !Is01Cat A, !Is1Cat_Strong A}
+  (D : A -> Type)
+  `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} :=
+{
+  is01dcat_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
+                          Is01DCat (a $-> b) (fun f => dhom f a' b');
+  is0dgpd_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
+                        Is0DGpd (a $-> b) (fun f => dhom f a' b');
+  is0dfunctor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
+                                {b' : D b} {c' : D c} (g' : dhom g b' c'),
+                                Is0DFunctor (fun f => dhom f a' b')
+                                            (fun gf => dhom gf a' c')
+                                            (cat_postcomp a g)
+                                            (dcat_postcomp g');
+  is0dfunctor_precomp_strong : forall {a b c : A} {f : a $-> b} {a' : D a}
+                                {b' : D b} {c' : D c} (f' : dhom f a' b'),
+                                Is0DFunctor (fun g => dhom g b' c')
+                                            (fun gf => dhom gf a' c')
+                                            (cat_precomp c f)
+                                            (dcat_precomp f');
+  dcat_assoc_strong : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
+                      {a' : D a} {b' : D b} {c' : D c} {d' : D d}
+                      (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d'),
+                      (transport (fun k => dhom k a' d') (cat_assoc_strong f g h)
+                      ((h' $o' g') $o' f')) = h' $o' (g' $o' f');
+  dcat_idl_strong : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
+                    (f' : dhom f a' b'),
+                    (transport (fun k => dhom k a' b') (cat_idl_strong f)
+                    (did b' $o' f')) = f';
+  dcat_idr_strong : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
+                    (f' : dhom f a' b'),
+                    (transport (fun k => dhom k a' b') (cat_idr_strong f)
+                    (f' $o' did a')) = f';
+}.
+
+Global Existing Instance is01dcat_dhom_strong.
+Global Existing Instance is0dgpd_dhom_strong.
+Global Existing Instance is0dfunctor_postcomp_strong.
+Global Existing Instance is0dfunctor_precomp_strong.
+
+Definition dcat_assoc_opp_strong {A : Type} (D : A -> Type) `{Is1DCat_Strong A D}
+  {a b c d : A}  {f : a $-> b} {g : b $-> c} {h : c $-> d}
+  {a' : D a} {b' : D b} {c' : D c} {d' : D d}
+  (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d')
+  : (transport (fun k => dhom k a' d') (cat_assoc_opp_strong f g h)
+                      (h' $o' (g' $o' f'))) = (h' $o' g') $o' f'.
+Proof.
+  apply (moveR_transport_V (fun k => dhom k a' d') (cat_assoc_strong f g h) _ _).
+  exact ((dcat_assoc_strong f' g' h')^).
+Defined.
+
+Global Instance is1dcat_is1dcatstrong {A : Type} (D : A -> Type)
+  `{Is1DCat_Strong A D} : Is1DCat A D.
+Proof.
+  srapply Build_Is1DCat.
+  - intros a b c d f g h a' b' c' d' f' g' h'.
+    exact (dgpd_hom_path (cat_assoc_strong f g h) (dcat_assoc_strong f' g' h')).
+  - intros a b f a' b' f'.
+    exact (dgpd_hom_path (cat_idl_strong f) (dcat_idl_strong f')).
+  - intros a b f a' b' f'.
+    exact (dgpd_hom_path (cat_idr_strong f) (dcat_idr_strong f')).
+Defined.
+
+Class Is1DFunctor
+  {A B : Type} (DA : A -> Type) `{Is1DCat A DA} (DB : B -> Type) `{Is1DCat B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (G : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F G} :=
+{
+  dfmap2 : forall {a b : A} {f g : a $-> b} {p : f $== g} {a' : DA a}
+            {b' : DA b} (f' : dhom f a' b') (g' : dhom g a' b'),
+            dhom p f' g' -> dhom (fmap2 F p) (dfmap F G f') (dfmap F G g');
+  dfmap_id : forall {a : A} (a' : DA a),
+              dhom (fmap_id F a) (dfmap F G (did a')) (did (G a a'));
+  dfmap_comp : forall {a b c : A} {f : a $-> b} {g : b $-> c} {a' : DA a}
+                {b' : DA b} {c' : DA c} (f' : dhom f a' b') (g' : dhom g b' c'),
+                dhom (fmap_comp F f g) (dfmap F G (g' $o' f'))
+                (dfmap F G g' $o' dfmap F G f');
+}.
+
+Global Instance is1functor_sigma {A B : Type} (DA : A -> Type) (DB : B -> Type)
+  (F : A -> B) (G : forall (a : A), DA a -> DB (F a)) `{Is1DFunctor A B DA DB F G}
+  : Is1Functor (functor_sigma F G).
+Proof.
+  srapply Build_Is1Functor.
+  - intros [a a'] [b b'] [f f'] [g g'] [p p'].
+    exists (fmap2 F p).
+    exact (dfmap2 f' g' p').
+  - intros [a a'].
+    exact (fmap_id F a; dfmap_id a').
+  - intros [a a'] [b b'] [c c'] [f f'] [g g'].
+    exact (fmap_comp F f g; dfmap_comp f' g').
+Defined.
+
+Section IdentityFunctor.
+  Global Instance is0dfunctor_idmap {A : Type} `{Is01Cat A}
+    (DA : A -> Type) `{!IsDGraph A DA, !Is01DCat A DA}
+    : Is0DFunctor DA DA (idmap) (fun a a' => a').
+  Proof.
+    intros a b f a' b' f'.
+    assumption.
+  Defined.
+
+  Global Instance is1dfunctor_idmap {A : Type} `{Is1Cat A} (DA : A -> Type)
+    `{!IsDGraph A DA, !Is2DGraph A DA, !Is01DCat A DA, !Is1DCat A DA}
+    : Is1DFunctor DA DA (idmap) (fun a a' => a').
+  Proof.
+    apply Build_Is1DFunctor.
+    - intros a b f g p a' b' f' g' p'.
+      assumption.
+    - intros a a'.
+      apply did.
+    - intros a b c f g a' b' c' f' g'.
+      apply did.
+  Defined.
+End IdentityFunctor.
+
+Section ConstantFunctor.
+  Global Instance is0dfunctor_const {A : Type} `{IsGraph A}
+    {B : Type} `{Is01Cat B} (DA : A -> Type) `{!IsDGraph A DA}
+    (DB : B -> Type) `{!IsDGraph B DB, !Is01DCat B DB} (x : B) (x' : DB x)
+    : Is0DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
+  Proof.
+    intros a b f a' b' f'.
+    apply did.
+  Defined.
+
+  Global Instance is1dfunctor_const {A : Type} `{Is1Cat A} {B : Type} `{Is1Cat B}
+    (DA : A -> Type)
+    `{!IsDGraph A DA, !Is2DGraph A DA, !Is01DCat A DA, !Is1DCat A DA}
+    (DB : B -> Type)
+    `{!IsDGraph B DB, !Is2DGraph B DB, !Is01DCat B DB, !Is1DCat B DB}
+    (x : B) (x' : DB x)
+    : Is1DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
+  Proof.
+    srapply Build_Is1DFunctor.
+    - intros a b f g p a' b' f' g' p'.
+      apply did.
+    - intros a a'.
+      apply did.
+    - intros a b c f g a' b' c' f' g'.
+      apply dgpd_rev.
+      apply dcat_idl.
+  Defined.
+End ConstantFunctor.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -73,30 +73,31 @@ Global Existing Instance isdgraph_dhom.
 #[global] Typeclasses Transparent Is2DGraph.
 
 Class Is1DCat {A : Type} `{Is1Cat A}
-  (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} := {
-    is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                    Is01DCat (fun f => DHom f a' b');
-    is0dgpd_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                    Is0DGpd (fun f => DHom f a' b');
-    is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
-                            {b' : D b} {c' : D c} (g' : DHom g b' c'),
-                            @Is0DFunctor _ _ (fun f => DHom f a' b')
-                            _ _ (fun gf => DHom gf a' c')
-                            _ _ (cat_postcomp a g) _ (dcat_postcomp g');
-    is0dfunctor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
-                          {b' : D b} {c' : D c} (f' : DHom f a' b'),
-                          @Is0DFunctor _ _ (fun g => DHom g b' c')
-                          _ _ (fun gf => DHom gf a' c')
-                          _ _ (cat_precomp c f) _ (dcat_precomp f');
-    dcat_assoc : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
-                  {a' : D a} {b' : D b} {c' : D c} {d' : D d}
-                  (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d'),
-                  DHom (cat_assoc f g h) ((h' $o' g') $o' f')
-                  (h' $o' (g' $o' f'));
-    dcat_idl : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
-                (f' : DHom f a' b'), DHom (cat_idl f) (DId b' $o' f') f';
-    dcat_idr : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
-                (f' : DHom f a' b'), DHom (cat_idr f) (f' $o' DId a') f';
+  (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} :=
+{
+  is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
+                  Is01DCat (fun f => DHom f a' b');
+  is0dgpd_dhom : forall {a b : A} {a' : D a} {b' : D b},
+                 Is0DGpd (fun f => DHom f a' b');
+  is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
+                         {b' : D b} {c' : D c} (g' : DHom g b' c'),
+                         @Is0DFunctor _ _ (fun f => DHom f a' b')
+                         _ _ (fun gf => DHom gf a' c')
+                         _ _ (cat_postcomp a g) _ (dcat_postcomp g');
+  is0dfunctor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
+                        {b' : D b} {c' : D c} (f' : DHom f a' b'),
+                        @Is0DFunctor _ _ (fun g => DHom g b' c')
+                        _ _ (fun gf => DHom gf a' c')
+                        _ _ (cat_precomp c f) _ (dcat_precomp f');
+  dcat_assoc : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
+               {a' : D a} {b' : D b} {c' : D c} {d' : D d}
+               (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d'),
+               DHom (cat_assoc f g h) ((h' $o' g') $o' f')
+               (h' $o' (g' $o' f'));
+  dcat_idl : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
+             (f' : DHom f a' b'), DHom (cat_idl f) (DId b' $o' f') f';
+  dcat_idr : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
+             (f' : DHom f a' b'), DHom (cat_idr f) (f' $o' DId a') f';
 }.
 
 Global Existing Instance is01dcat_dhom.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -212,7 +212,7 @@ Proof.
 Defined.
 
 Global Instance is1functor_pr1 {A : Type} {D : A -> Type} `{Is1DCat A D}
-  : Is1Functor (pr1 : (sig D) -> A).
+  : Is1Functor (pr1 : sig D -> A).
 Proof.
   srapply Build_Is1Functor.
   - intros [a a'] [b b'] [f f'] [g g'] [p p'].

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -5,69 +5,68 @@ Require Import Types.Sigma.
 Require Import WildCat.Core.
 
 Class IsDGraph (A : Type) `{IsGraph A} (D : A -> Type)
-  := dhom : forall {a b : A}, (a $-> b) -> D a -> D b -> Type.
+  := DHom : forall {a b : A}, (a $-> b) -> D a -> D b -> Type.
 
 Class Is01DCat (A : Type) `{Is01Cat A} (D : A -> Type) `{!IsDGraph A D} :=
 {
-  did : forall {a : A} (a' : D a), dhom (Id a) a' a';
+  DId : forall {a : A} (a' : D a), DHom (Id a) a' a';
   dcat_comp : forall {a b c : A} {g : b $-> c} {f : a $-> b}
               {a' : D a} {b' : D b} {c' : D c},
-              dhom g b' c' -> dhom f a' b' -> dhom (g $o f) a' c';
+              DHom g b' c' -> DHom f a' b' -> DHom (g $o f) a' c';
 }.
 
 Notation "g '$o'' f" := (dcat_comp g f).
 
 Definition dcat_postcomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
-  {g : b $-> c} {a' : D a} {b' : D b} {c' : D c} (g' : dhom g b' c')
-  : forall (f : a $-> b), dhom f a' b' -> dhom (g $o f) a' c'
+  {g : b $-> c} {a' : D a} {b' : D b} {c' : D c} (g' : DHom g b' c')
+  : forall (f : a $-> b), DHom f a' b' -> DHom (g $o f) a' c'
   := fun _ f' => g' $o' f'.
 
 Definition dcat_precomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
-  {f : a $-> b} {a' : D a} {b' : D b} {c' : D c} (f' : dhom f a' b')
-  : forall (g : b $-> c), dhom g b' c' -> dhom (g $o f) a' c'
+  {f : a $-> b} {a' : D a} {b' : D b} {c' : D c} (f' : DHom f a' b')
+  : forall (g : b $-> c), DHom g b' c' -> DHom (g $o f) a' c'
   := fun _ g' => g' $o' f'.
 
 Class Is0DGpd (A : Type) `{Is0Gpd A} (D : A -> Type)
   `{!IsDGraph A D, !Is01DCat A D}
   := dgpd_rev : forall {a b : A} {f : a $== b} {a' : D a} {b' : D b},
-                dhom f a' b' -> dhom (f^$) b' a'.
+                DHom f a' b' -> DHom (f^$) b' a'.
 
 Notation "p ^$'" := (dgpd_rev p).
 
-Definition dgpd_hom {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
+Definition DGpdHom {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
   (f : a $== b) (a' : D a) (b' : D b)
-  := dhom f a' b'.
+  := DHom f a' b'.
 
-(* Diagrammatic order to match gpd_comp *)
+(** Diagrammatic order to match gpd_comp *)
 Definition dgpd_comp {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b c : A}
   {f : a $== b} {g : b $== c} {a' : D a} {b' : D b} {c' : D c}
-  : dgpd_hom f a' b' -> dgpd_hom g b' c' -> dgpd_hom (g $o f) a' c'
+  : DGpdHom f a' b' -> DGpdHom g b' c' -> DGpdHom (g $o f) a' c'
   := fun f' g' => g' $o' f'.
 
 Notation "p '$@'' q" := (dgpd_comp p q).
 
-Definition dgpd_hom_path {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
+Definition DGpdHom_path {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
   (p : a = b) {a' : D a} {b': D b} (p' : transport D p a' = b')
-  : dgpd_hom (GpdHom_path p) a' b'.
+  : DGpdHom (GpdHom_path p) a' b'.
 Proof.
   destruct p, p'.
-  apply did.
+  apply DId.
 Defined.
 
-(* A displayed 0-functor G over a 0-functor F acts on displayed objects and
-1-cells and satisfies no axioms. *)
+(** A displayed 0-functor [F'] over a 0-functor [F] acts on displayed objects and 1-cells and satisfies no axioms. *)
 Class Is0DFunctor {A : Type} {B : Type}
   (DA : A -> Type) `{IsDGraph A DA} (DB : B -> Type) `{IsDGraph B DB}
-  (F : A -> B) `{!Is0Functor F} (G : forall (a : A), DA a -> DB (F a))
+  (F : A -> B) `{!Is0Functor F} (F' : forall (a : A), DA a -> DB (F a))
   := dfmap : forall {a b : A} {f : a $-> b} {a' : DA a} {b' : DA b},
-              dhom f a' b' -> dhom (fmap F f) (G a a') (G b b').
+              DHom f a' b' -> DHom (fmap F f) (F' a a') (F' b b').
 
-Arguments dfmap {A B DA _ _ DB _ _} F {_} G {_ _ _ _ _ _} f'.
+Arguments dfmap {A B DA _ _ DB _ _} F {_} F' {_ _ _ _ _ _} f'.
 
 Class Is2DGraph (A : Type) `{IsGraph A, !Is2Graph A}
   (D : A -> Type) `{!IsDGraph A D}
   := isdgraph_dhom : forall {a b} {a'} {b'},
-                    IsDGraph (a $-> b) (fun f => dhom f a' b').
+                    IsDGraph (a $-> b) (fun f => DHom f a' b').
 
 Global Existing Instance isdgraph_dhom.
 #[global] Typeclasses Transparent Is2DGraph.
@@ -75,28 +74,28 @@ Global Existing Instance isdgraph_dhom.
 Class Is1DCat (A : Type) `{IsGraph A, !Is2Graph A, !Is01Cat A, !Is1Cat A}
   (D : A -> Type) `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} := {
     is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                    Is01DCat (a $-> b) (fun f => dhom f a' b');
+                    Is01DCat (a $-> b) (fun f => DHom f a' b');
     is0dgpd_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                    Is0DGpd (a $-> b) (fun f => dhom f a' b');
+                    Is0DGpd (a $-> b) (fun f => DHom f a' b');
     is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
-                            {b' : D b} {c' : D c} (g' : dhom g b' c'),
-                            Is0DFunctor (fun f => dhom f a' b')
-                                        (fun gf => dhom gf a' c')
+                            {b' : D b} {c' : D c} (g' : DHom g b' c'),
+                            Is0DFunctor (fun f => DHom f a' b')
+                                        (fun gf => DHom gf a' c')
                                         (cat_postcomp a g) (dcat_postcomp g');
     is0dfunctor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
-                          {b' : D b} {c' : D c} (f' : dhom f a' b'),
-                          Is0DFunctor (fun g => dhom g b' c')
-                                      (fun gf => dhom gf a' c')
+                          {b' : D b} {c' : D c} (f' : DHom f a' b'),
+                          Is0DFunctor (fun g => DHom g b' c')
+                                      (fun gf => DHom gf a' c')
                                       (cat_precomp c f) (dcat_precomp f');
     dcat_assoc : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
                   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
-                  (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d'),
-                  dhom (cat_assoc f g h)
+                  (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d'),
+                  DHom (cat_assoc f g h)
                         ((h' $o' g') $o' f') (h' $o' (g' $o' f'));
     dcat_idl : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
-                (f' : dhom f a' b'), dhom (cat_idl f) (did b' $o' f') f';
+                (f' : DHom f a' b'), DHom (cat_idl f) (DId b' $o' f') f';
     dcat_idr : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
-                (f' : dhom f a' b'), dhom (cat_idr f) (f' $o' did a') f';
+                (f' : DHom f a' b'), DHom (cat_idr f) (f' $o' DId a') f';
 }.
 
 Global Existing Instance is01dcat_dhom.
@@ -107,34 +106,34 @@ Global Existing Instance is0dfunctor_precomp.
 Definition dcat_assoc_opp {A : Type} (D : A -> Type) `{Is1DCat A D}
   {a b c d : A}  {f : a $-> b} {g : b $-> c} {h : c $-> d}
   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
-  (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d')
-  : dhom (cat_assoc_opp f g h) (h' $o' (g' $o' f')) ((h' $o' g') $o' f')
+  (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d')
+  : DHom (cat_assoc_opp f g h) (h' $o' (g' $o' f')) ((h' $o' g') $o' f')
   := (dcat_assoc f' g' h')^$'.
 
 Definition dcat_postwhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
   {a b c : A} {f g : a $-> b} {h : b $-> c} {p : f $== g}
-  {a' : D a} {b' : D b} {c' : D c} {f' : dhom f a' b'} {g' : dhom g a' b'}
-  (h' : dhom h b' c') (p' : dhom p f' g')
-  : dhom (h $@L p) (h' $o' f') (h' $o' g')
+  {a' : D a} {b' : D b} {c' : D c} {f' : DHom f a' b'} {g' : DHom g a' b'}
+  (h' : DHom h b' c') (p' : DHom p f' g')
+  : DHom (h $@L p) (h' $o' f') (h' $o' g')
   := dfmap (cat_postcomp a h) (dcat_postcomp h') p'.
 
 Notation "h $@L' p" := (dcat_postwhisker h p).
 
 Definition dcat_prewhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
   {a b c : A} {f : a $-> b} {g h : b $-> c} {p : g $== h}
-  {a' : D a} {b' : D b} {c' : D c} {g' : dhom g b' c'} {h' : dhom h b' c'}
-  (p' : dhom p g' h') (f' : dhom f a' b')
-  : dhom (p $@R f) (g' $o' f') (h' $o' f')
+  {a' : D a} {b' : D b} {c' : D c} {g' : DHom g b' c'} {h' : DHom h b' c'}
+  (p' : DHom p g' h') (f' : DHom f a' b')
+  : DHom (p $@R f) (g' $o' f') (h' $o' f')
   := dfmap (cat_precomp c f) (dcat_precomp f') p'.
 
 Notation "p $@R' f" := (dcat_prewhisker p f).
 
 Definition dcat_comp2 {A : Type} {D : A -> Type} `{Is1DCat A D} {a b c : A}
   {f g : a $-> b} {h k : b $-> c} {p : f $== g} {q : h $== k}
-  {a' : D a} {b' : D b} {c' : D c} {f' : dhom f a' b'} {g' : dhom g a' b'}
-  {h' : dhom h b' c'} {k' : dhom k b' c'}
-  (p' : dhom p f' g') (q' : dhom q h' k')
-  : dhom (p $@@ q) (h' $o' f') (k' $o' g')
+  {a' : D a} {b' : D b} {c' : D c} {f' : DHom f a' b'} {g' : DHom g a' b'}
+  {h' : DHom h b' c'} {k' : DHom k b' c'}
+  (p' : DHom p f' g') (q' : DHom q h' k')
+  : DHom (p $@@ q) (h' $o' f') (k' $o' g')
   :=  (k' $@L' p') $o' (q' $@R' f').
 
 Global Instance isgraph_sigma {A : Type} (D : A -> Type) `{IsDGraph A D}
@@ -142,7 +141,7 @@ Global Instance isgraph_sigma {A : Type} (D : A -> Type) `{IsDGraph A D}
 Proof.
   srapply Build_IsGraph.
   intros [a a'] [b b'].
-  exact {f : a $-> b & dhom f a' b'}.
+  exact {f : a $-> b & DHom f a' b'}.
 Defined.
 
 Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{Is01DCat A D}
@@ -150,7 +149,7 @@ Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{Is01DCat A D}
 Proof.
   srapply Build_Is01Cat.
   - intros [a a'].
-    exact (Id a; did a').
+    exact (Id a; DId a').
   - intros [a a'] [b b'] [c c'] [g g'] [f f'].
     exact (g $o f; g' $o' f').
 Defined.
@@ -177,18 +176,18 @@ Proof.
   intros [a a'] [b b'].
   srapply Build_IsGraph.
   intros [f f'] [g g'].
-  exact ({p : f $-> g & dhom p f' g'}).
+  exact ({p : f $-> g & DHom p f' g'}).
 Defined.
 
 Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{Is01DCat A DA}
   {B : Type} (DB : B -> Type) `{Is01DCat B DB} (F : A -> B) `{!Is0Functor F}
-  (G : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F G}
-  : Is0Functor (functor_sigma F G).
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F F'}
+  : Is0Functor (functor_sigma F F').
 Proof.
   srapply Build_Is0Functor.
   intros [a a'] [b b'].
   intros [f f'].
-  exact (fmap F f; dfmap F G f').
+  exact (fmap F f; dfmap F F' f').
 Defined.
 
 Global Instance is1cat_sigma {A : Type} (D : A -> Type) `{Is1DCat A D}
@@ -228,34 +227,34 @@ Class Is1DCat_Strong (A : Type) `{IsGraph A, !Is2Graph A, !Is01Cat A, !Is1Cat_St
   `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} :=
 {
   is01dcat_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
-                          Is01DCat (a $-> b) (fun f => dhom f a' b');
+                          Is01DCat (a $-> b) (fun f => DHom f a' b');
   is0dgpd_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
-                        Is0DGpd (a $-> b) (fun f => dhom f a' b');
+                        Is0DGpd (a $-> b) (fun f => DHom f a' b');
   is0dfunctor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
-                                {b' : D b} {c' : D c} (g' : dhom g b' c'),
-                                Is0DFunctor (fun f => dhom f a' b')
-                                            (fun gf => dhom gf a' c')
+                                {b' : D b} {c' : D c} (g' : DHom g b' c'),
+                                Is0DFunctor (fun f => DHom f a' b')
+                                            (fun gf => DHom gf a' c')
                                             (cat_postcomp a g)
                                             (dcat_postcomp g');
   is0dfunctor_precomp_strong : forall {a b c : A} {f : a $-> b} {a' : D a}
-                                {b' : D b} {c' : D c} (f' : dhom f a' b'),
-                                Is0DFunctor (fun g => dhom g b' c')
-                                            (fun gf => dhom gf a' c')
+                                {b' : D b} {c' : D c} (f' : DHom f a' b'),
+                                Is0DFunctor (fun g => DHom g b' c')
+                                            (fun gf => DHom gf a' c')
                                             (cat_precomp c f)
                                             (dcat_precomp f');
   dcat_assoc_strong : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
                       {a' : D a} {b' : D b} {c' : D c} {d' : D d}
-                      (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d'),
-                      (transport (fun k => dhom k a' d') (cat_assoc_strong f g h)
+                      (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d'),
+                      (transport (fun k => DHom k a' d') (cat_assoc_strong f g h)
                       ((h' $o' g') $o' f')) = h' $o' (g' $o' f');
   dcat_idl_strong : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
-                    (f' : dhom f a' b'),
-                    (transport (fun k => dhom k a' b') (cat_idl_strong f)
-                    (did b' $o' f')) = f';
+                    (f' : DHom f a' b'),
+                    (transport (fun k => DHom k a' b') (cat_idl_strong f)
+                    (DId b' $o' f')) = f';
   dcat_idr_strong : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
-                    (f' : dhom f a' b'),
-                    (transport (fun k => dhom k a' b') (cat_idr_strong f)
-                    (f' $o' did a')) = f';
+                    (f' : DHom f a' b'),
+                    (transport (fun k => DHom k a' b') (cat_idr_strong f)
+                    (f' $o' DId a')) = f';
 }.
 
 Global Existing Instance is01dcat_dhom_strong.
@@ -266,11 +265,11 @@ Global Existing Instance is0dfunctor_precomp_strong.
 Definition dcat_assoc_opp_strong {A : Type} (D : A -> Type) `{Is1DCat_Strong A D}
   {a b c d : A}  {f : a $-> b} {g : b $-> c} {h : c $-> d}
   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
-  (f' : dhom f a' b') (g' : dhom g b' c') (h' : dhom h c' d')
-  : (transport (fun k => dhom k a' d') (cat_assoc_opp_strong f g h)
+  (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d')
+  : (transport (fun k => DHom k a' d') (cat_assoc_opp_strong f g h)
                       (h' $o' (g' $o' f'))) = (h' $o' g') $o' f'.
 Proof.
-  apply (moveR_transport_V (fun k => dhom k a' d') (cat_assoc_strong f g h) _ _).
+  apply (moveR_transport_V (fun k => DHom k a' d') (cat_assoc_strong f g h) _ _).
   exact ((dcat_assoc_strong f' g' h')^).
 Defined.
 
@@ -279,32 +278,32 @@ Global Instance is1dcat_is1dcatstrong {A : Type} (D : A -> Type)
 Proof.
   srapply Build_Is1DCat.
   - intros a b c d f g h a' b' c' d' f' g' h'.
-    exact (dgpd_hom_path (cat_assoc_strong f g h) (dcat_assoc_strong f' g' h')).
+    exact (DGpdHom_path (cat_assoc_strong f g h) (dcat_assoc_strong f' g' h')).
   - intros a b f a' b' f'.
-    exact (dgpd_hom_path (cat_idl_strong f) (dcat_idl_strong f')).
+    exact (DGpdHom_path (cat_idl_strong f) (dcat_idl_strong f')).
   - intros a b f a' b' f'.
-    exact (dgpd_hom_path (cat_idr_strong f) (dcat_idr_strong f')).
+    exact (DGpdHom_path (cat_idr_strong f) (dcat_idr_strong f')).
 Defined.
 
 Class Is1DFunctor
   {A B : Type} (DA : A -> Type) `{Is1DCat A DA} (DB : B -> Type) `{Is1DCat B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (G : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F G} :=
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F F'} :=
 {
   dfmap2 : forall {a b : A} {f g : a $-> b} {p : f $== g} {a' : DA a}
-            {b' : DA b} (f' : dhom f a' b') (g' : dhom g a' b'),
-            dhom p f' g' -> dhom (fmap2 F p) (dfmap F G f') (dfmap F G g');
+            {b' : DA b} (f' : DHom f a' b') (g' : DHom g a' b'),
+            DHom p f' g' -> DHom (fmap2 F p) (dfmap F F' f') (dfmap F F' g');
   dfmap_id : forall {a : A} (a' : DA a),
-              dhom (fmap_id F a) (dfmap F G (did a')) (did (G a a'));
+              DHom (fmap_id F a) (dfmap F F' (DId a')) (DId (F' a a'));
   dfmap_comp : forall {a b c : A} {f : a $-> b} {g : b $-> c} {a' : DA a}
-                {b' : DA b} {c' : DA c} (f' : dhom f a' b') (g' : dhom g b' c'),
-                dhom (fmap_comp F f g) (dfmap F G (g' $o' f'))
-                (dfmap F G g' $o' dfmap F G f');
+                {b' : DA b} {c' : DA c} (f' : DHom f a' b') (g' : DHom g b' c'),
+                DHom (fmap_comp F f g) (dfmap F F' (g' $o' f'))
+                (dfmap F F' g' $o' dfmap F F' f');
 }.
 
 Global Instance is1functor_sigma {A B : Type} (DA : A -> Type) (DB : B -> Type)
-  (F : A -> B) (G : forall (a : A), DA a -> DB (F a)) `{Is1DFunctor A B DA DB F G}
-  : Is1Functor (functor_sigma F G).
+  (F : A -> B) (F' : forall (a : A), DA a -> DB (F a)) `{Is1DFunctor A B DA DB F F'}
+  : Is1Functor (functor_sigma F F').
 Proof.
   srapply Build_Is1Functor.
   - intros [a a'] [b b'] [f f'] [g g'] [p p'].
@@ -333,9 +332,9 @@ Section IdentityFunctor.
     - intros a b f g p a' b' f' g' p'.
       assumption.
     - intros a a'.
-      apply did.
+      apply DId.
     - intros a b c f g a' b' c' f' g'.
-      apply did.
+      apply DId.
   Defined.
 End IdentityFunctor.
 
@@ -346,7 +345,7 @@ Section ConstantFunctor.
     : Is0DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
   Proof.
     intros a b f a' b' f'.
-    apply did.
+    apply DId.
   Defined.
 
   Global Instance is1dfunctor_const {A : Type} `{Is1Cat A} {B : Type} `{Is1Cat B}
@@ -359,9 +358,9 @@ Section ConstantFunctor.
   Proof.
     srapply Build_Is1DFunctor.
     - intros a b f g p a' b' f' g' p'.
-      apply did.
+      apply DId.
     - intros a a'.
-      apply did.
+      apply DId.
     - intros a b c f g a' b' c' f' g'.
       apply dgpd_rev.
       apply dcat_idl.
@@ -387,7 +386,7 @@ Section CompositeFunctor.
   Global Instance is1dfunctor_compose
     `{Is1DCat A DA} `{Is1DCat B DB} `{Is1DCat C DC}
     `{!Is0Functor F, !Is1Functor F} `{!Is0Functor G, !Is1Functor G}
-    `{!Is0DFunctor DA DB F F', !Is1DFunctor DA DB F F'} 
+    `{!Is0DFunctor DA DB F F', !Is1DFunctor DA DB F F'}
     `{!Is0DFunctor DB DC G G', !Is1DFunctor DB DC G G'}
     : Is1DFunctor DA DC (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
@@ -395,8 +394,8 @@ Section CompositeFunctor.
     - intros a b f g p a' b' f' g' p'.
       apply (dfmap2 _ _ (dfmap2 f' g' p')).
     - intros a a'.
-      apply (dgpd_comp (dfmap2 _ _ (dfmap_id a')) (dfmap_id _)).
+      apply (dfmap2 _ _ (dfmap_id a') $@' dfmap_id _).
     - intros a b c f g a' b' c' f' g'.
-      apply (dgpd_comp (dfmap2 _ _ (dfmap_comp f' g')) (dfmap_comp _ _)).
+      apply (dfmap2 _ _ (dfmap_comp f' g') $@' dfmap_comp _ _).
   Defined.
 End CompositeFunctor.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -57,7 +57,7 @@ Defined.
 
 (** A displayed 0-functor [F'] over a 0-functor [F] acts on displayed objects and 1-cells and satisfies no axioms. *)
 Class Is0DFunctor {A : Type} {B : Type}
-  (DA : A -> Type) `{IsDGraph A DA} (DB : B -> Type) `{IsDGraph B DB}
+  {DA : A -> Type} `{IsDGraph A DA} {DB : B -> Type} `{IsDGraph B DB}
   (F : A -> B) `{!Is0Functor F} (F' : forall (a : A), DA a -> DB (F a))
   := dfmap : forall {a b : A} {f : a $-> b} {a' : DA a} {b' : DA b},
               DHom f a' b' -> DHom (fmap F f) (F' a a') (F' b b').
@@ -80,19 +80,19 @@ Class Is1DCat {A : Type} `{Is1Cat A}
                     Is0DGpd (fun f => DHom f a' b');
     is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
                             {b' : D b} {c' : D c} (g' : DHom g b' c'),
-                            Is0DFunctor (fun f => DHom f a' b')
-                                        (fun gf => DHom gf a' c')
-                                        (cat_postcomp a g) (dcat_postcomp g');
+                            @Is0DFunctor _ _ (fun f => DHom f a' b')
+                            _ _ (fun gf => DHom gf a' c')
+                            _ _ (cat_postcomp a g) _ (dcat_postcomp g');
     is0dfunctor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
                           {b' : D b} {c' : D c} (f' : DHom f a' b'),
-                          Is0DFunctor (fun g => DHom g b' c')
-                                      (fun gf => DHom gf a' c')
-                                      (cat_precomp c f) (dcat_precomp f');
+                          @Is0DFunctor _ _ (fun g => DHom g b' c')
+                          _ _ (fun gf => DHom gf a' c')
+                          _ _ (cat_precomp c f) _ (dcat_precomp f');
     dcat_assoc : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
                   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
                   (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d'),
-                  DHom (cat_assoc f g h)
-                        ((h' $o' g') $o' f') (h' $o' (g' $o' f'));
+                  DHom (cat_assoc f g h) ((h' $o' g') $o' f')
+                  (h' $o' (g' $o' f'));
     dcat_idl : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
                 (f' : DHom f a' b'), DHom (cat_idl f) (DId b' $o' f') f';
     dcat_idr : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
@@ -164,7 +164,7 @@ Proof.
 Defined.
 
 Global Instance is0functor_pr1 {A : Type} (D : A -> Type) `{IsDGraph A D}
-  : Is0Functor (pr1 : (sig D) -> A).
+  : Is0Functor (pr1 : sig D -> A).
 Proof.
   srapply Build_Is0Functor.
   intros [a a'] [b b'] [f f'].
@@ -182,7 +182,7 @@ Defined.
 
 Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{Is01DCat A DA}
   {B : Type} (DB : B -> Type) `{Is01DCat B DB} (F : A -> B) `{!Is0Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F'}
   : Is0Functor (functor_sigma F F').
 Proof.
   srapply Build_Is0Functor.
@@ -233,16 +233,14 @@ Class Is1DCat_Strong {A : Type} `{Is1Cat_Strong A}
                         Is0DGpd (fun f => DHom f a' b');
   is0dfunctor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
                                 {b' : D b} {c' : D c} (g' : DHom g b' c'),
-                                Is0DFunctor (fun f => DHom f a' b')
-                                            (fun gf => DHom gf a' c')
-                                            (cat_postcomp a g)
-                                            (dcat_postcomp g');
+                                @Is0DFunctor _ _ (fun f => DHom f a' b')
+                                _ _ (fun gf => DHom gf a' c')
+                                _ _ (cat_postcomp a g) _ (dcat_postcomp g');
   is0dfunctor_precomp_strong : forall {a b c : A} {f : a $-> b} {a' : D a}
                                 {b' : D b} {c' : D c} (f' : DHom f a' b'),
-                                Is0DFunctor (fun g => DHom g b' c')
-                                            (fun gf => DHom gf a' c')
-                                            (cat_precomp c f)
-                                            (dcat_precomp f');
+                                @Is0DFunctor _ _ (fun g => DHom g b' c')
+                                _ _ (fun gf => DHom gf a' c')
+                                _ _ (cat_precomp c f) _ (dcat_precomp f');
   dcat_assoc_strong : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
                       {a' : D a} {b' : D b} {c' : D c} {d' : D d}
                       (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d'),
@@ -268,7 +266,7 @@ Definition dcat_assoc_opp_strong {A : Type} (D : A -> Type) `{Is1DCat_Strong A D
   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
   (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d')
   : (transport (fun k => DHom k a' d') (cat_assoc_opp_strong f g h)
-                      (h' $o' (g' $o' f'))) = (h' $o' g') $o' f'.
+    (h' $o' (g' $o' f'))) = (h' $o' g') $o' f'.
 Proof.
   apply (moveR_transport_V (fun k => DHom k a' d') (cat_assoc_strong f g h) _ _).
   exact ((dcat_assoc_strong f' g' h')^).
@@ -287,9 +285,9 @@ Proof.
 Defined.
 
 Class Is1DFunctor
-  {A B : Type} (DA : A -> Type) `{Is1DCat A DA} (DB : B -> Type) `{Is1DCat B DB}
+  {A B : Type} {DA : A -> Type} `{Is1DCat A DA} {DB : B -> Type} `{Is1DCat B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor DA DB F F'} :=
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F'} :=
 {
   dfmap2 : forall {a b : A} {f g : a $-> b} {p : f $== g} {a' : DA a}
             {b' : DA b} (f' : DHom f a' b') (g' : DHom g a' b'),
@@ -319,7 +317,7 @@ Defined.
 Section IdentityFunctor.
   Global Instance is0dfunctor_idmap {A : Type} `{Is01Cat A}
     (DA : A -> Type) `{!IsDGraph DA, !Is01DCat DA}
-    : Is0DFunctor DA DA (idmap) (fun a a' => a').
+    : Is0DFunctor (idmap) (fun a a' => a').
   Proof.
     intros a b f a' b' f'.
     assumption.
@@ -327,7 +325,7 @@ Section IdentityFunctor.
 
   Global Instance is1dfunctor_idmap {A : Type} (DA : A -> Type)
     `{Is1DCat A DA}
-    : Is1DFunctor DA DA (idmap) (fun a a' => a').
+    : Is1DFunctor (idmap) (fun a a' => a').
   Proof.
     apply Build_Is1DFunctor.
     - intros a b f g p a' b' f' g' p'.
@@ -343,7 +341,7 @@ Section ConstantFunctor.
   Global Instance is0dfunctor_const {A : Type} `{IsGraph A}
     {B : Type} `{Is01Cat B} (DA : A -> Type) `{!IsDGraph DA}
     (DB : B -> Type) `{!IsDGraph DB, !Is01DCat DB} (x : B) (x' : DB x)
-    : Is0DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
+    : Is0DFunctor (fun _ : A => x) (fun _ _ => x').
   Proof.
     intros a b f a' b' f'.
     apply DId.
@@ -355,7 +353,7 @@ Section ConstantFunctor.
     (DB : B -> Type)
     `{Is1DCat B DB}
     (x : B) (x' : DB x)
-    : Is1DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
+    : Is1DFunctor (fun _ => x) (fun _ _ => x').
   Proof.
     snrapply Build_Is1DFunctor.
     - intros a b f g p a' b' f' g' p'.
@@ -377,8 +375,8 @@ Section CompositeFunctor.
   Global Instance is0dfunctor_compose
     `{IsDGraph A DA} `{IsDGraph B DB} `{IsDGraph C DC}
     `{!Is0Functor F} `{!Is0Functor G}
-    `{!Is0DFunctor DA DB F F'} `{!Is0DFunctor DB DC G G'}
-    : Is0DFunctor DA DC (G o F) (fun a a' => (G' (F a) o (F' a)) a').
+    `{!Is0DFunctor F F'} `{!Is0DFunctor G G'}
+    : Is0DFunctor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
     intros a b f a' b' f'.
     exact (dfmap G G' (dfmap F F' f')).
@@ -387,11 +385,11 @@ Section CompositeFunctor.
   Global Instance is1dfunctor_compose
     `{Is1DCat A DA} `{Is1DCat B DB} `{Is1DCat C DC}
     `{!Is0Functor F, !Is1Functor F} `{!Is0Functor G, !Is1Functor G}
-    `{!Is0DFunctor DA DB F F', !Is1DFunctor DA DB F F'}
-    `{!Is0DFunctor DB DC G G', !Is1DFunctor DB DC G G'}
-    `{!Is1DFunctor DA DB F F'}
-    `{!Is1DFunctor DB DC G G'}
-    : Is1DFunctor DA DC (G o F) (fun a a' => (G' (F a) o (F' a)) a').
+    `{!Is0DFunctor F F', !Is1DFunctor F F'}
+    `{!Is0DFunctor G G', !Is1DFunctor G G'}
+    `{!Is1DFunctor F F'}
+    `{!Is1DFunctor G G'}
+    : Is1DFunctor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
     snrapply Build_Is1DFunctor.
     - intros a b f g p a' b' f' g' p'.
@@ -403,12 +401,12 @@ Section CompositeFunctor.
   Defined.
 End CompositeFunctor.
 
-Local Definition obwise_prod {A B : Type} (DA : A -> Type) (DB : B -> Type)
+Local Definition pointwise_prod {A B : Type} (DA : A -> Type) (DB : B -> Type)
   (x : A * B) := DA (fst x) * DB (snd x).
 
 Global Instance isdgraph_prod {A B : Type} (DA : A -> Type) `{IsDGraph A DA}
   (DB : B -> Type) `{IsDGraph B DB}
-  : IsDGraph (obwise_prod DA DB).
+  : IsDGraph (pointwise_prod DA DB).
 Proof.
   intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'].
   exact (DHom f a1' a2' * DHom g b1' b2').
@@ -416,7 +414,7 @@ Defined.
 
 Global Instance is01dcat_prod {A B : Type} (DA : A -> Type) `{Is01DCat A DA}
   (DB : B -> Type) `{Is01DCat B DB}
-  : Is01DCat (obwise_prod DA DB).
+  : Is01DCat (pointwise_prod DA DB).
 Proof.
   srapply Build_Is01DCat.
   - intros [a b] [a' b'].
@@ -428,7 +426,7 @@ Defined.
 
 Global Instance is0dgpd_prod {A B : Type} (DA : A -> Type) `{Is0DGpd A DA}
   (DB : B -> Type) `{Is0DGpd B DB}
-  : Is0DGpd (obwise_prod DA DB).
+  : Is0DGpd (pointwise_prod DA DB).
 Proof.
   intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
   exact (f'^$', g'^$').
@@ -436,7 +434,7 @@ Defined.
 
 Global Instance is2dgraph_prod {A B : Type} (DA : A -> Type) `{Is2DGraph A DA}
   (DB : B -> Type) `{Is2DGraph B DB}
-  : Is2DGraph (obwise_prod DA DB).
+  : Is2DGraph (pointwise_prod DA DB).
 Proof.
   intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
   srapply isdgraph_prod.
@@ -444,7 +442,7 @@ Defined.
 
 Global Instance is1dcat_prod {A B : Type} (DA : A -> Type) `{Is1DCat A DA}
   (DB : B -> Type) `{Is1DCat B DB}
-  : Is1DCat (obwise_prod DA DB).
+  : Is1DCat (pointwise_prod DA DB).
 Proof.
   snrapply Build_Is1DCat.
   - intros ab1 ab2 ab1' ab2'.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -3,6 +3,7 @@ Require Import Basics.PathGroupoids.
 Require Import Basics.Tactics.
 Require Import Types.Sigma.
 Require Import WildCat.Core.
+Require Import WildCat.Prod.
 
 Class IsDGraph {A : Type} `{IsGraph A} (D : A -> Type)
   := DHom : forall {a b : A}, (a $-> b) -> D a -> D b -> Type.
@@ -401,3 +402,66 @@ Section CompositeFunctor.
       apply (dfmap2 _ _ (dfmap_comp f' g') $@' dfmap_comp _ _).
   Defined.
 End CompositeFunctor.
+
+Local Definition obwise_prod {A B : Type} (DA : A -> Type) (DB : B -> Type)
+  (x : A * B) := DA (fst x) * DB (snd x).
+
+Global Instance isdgraph_prod {A B : Type} (DA : A -> Type) `{IsDGraph A DA}
+  (DB : B -> Type) `{IsDGraph B DB}
+  : IsDGraph (obwise_prod DA DB).
+Proof.
+  intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'].
+  exact (DHom f a1' a2' * DHom g b1' b2').
+Defined.
+
+Global Instance is01dcat_prod {A B : Type} (DA : A -> Type) `{Is01DCat A DA}
+  (DB : B -> Type) `{Is01DCat B DB}
+  : Is01DCat (obwise_prod DA DB).
+Proof.
+  srapply Build_Is01DCat.
+  - intros [a b] [a' b'].
+    exact (DId a', DId b').
+  - intros [a1 b1] [a2 b2] [a3 b3] [f2 g2] [f1 g1] [a1' b1'] [a2' b2'] [a3' b3'].
+    intros [f2' g2'] [f1' g1'].
+    exact (f2' $o' f1', g2' $o' g1').
+Defined.
+
+Global Instance is0dgpd_prod {A B : Type} (DA : A -> Type) `{Is0DGpd A DA}
+  (DB : B -> Type) `{Is0DGpd B DB}
+  : Is0DGpd (obwise_prod DA DB).
+Proof.
+  intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
+  exact (f'^$', g'^$').
+Defined.
+
+Global Instance is2dgraph_prod {A B : Type} (DA : A -> Type) `{Is2DGraph A DA}
+  (DB : B -> Type) `{Is2DGraph B DB}
+  : Is2DGraph (obwise_prod DA DB).
+Proof.
+  intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
+  srapply (isdgraph_prod _ _).
+Defined.
+
+Global Instance is1dcat_prod {A B : Type} (DA : A -> Type) `{Is1DCat A DA}
+  (DB : B -> Type) `{Is1DCat B DB}
+  : Is1DCat (obwise_prod DA DB).
+Proof.
+  srapply Build_Is1DCat.
+  - intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
+    srapply (is01dcat_prod _ _).
+  - intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
+    srapply (is0dgpd_prod _ _).
+  - intros [a1 b1] [a2 b2] [a3 b3] [f g] [a1' b1'] [a2' b2'] [a3' b3'] [f' g'].
+    intros [h1 k1] [h2 k2] [p q] [h1' k1'] [h2' k2'] [p' q'].
+    exact (f' $@L' p', g' $@L' q').
+  - intros [a1 b1] [a2 b2] [a3 b3] [f g] [a1' b1'] [a2' b2'] [a3' b3'] [f' g'].
+    intros [h1 k1] [h2 k2] [p q] [h1' k1'] [h2' k2'] [p' q'].
+    exact (p' $@R' f', q' $@R' g').
+  - intros [a1 b1] [a2 b2] [a3 b3] [a4 b4] [f1 g1] [f2 g2] [f3 g3].
+    intros [a1' b1'] [a2' b2'] [a3' b3'] [a4' b4'] [f1' g1'] [f2' g2'] [f3' g3'].
+    exact (dcat_assoc f1' f2' f3', dcat_assoc g1' g2' g3').
+  - intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
+    exact (dcat_idl f', dcat_idl g').
+  - intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
+    exact (dcat_idr f', dcat_idr g').
+Defined.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -357,7 +357,7 @@ Section ConstantFunctor.
     (x : B) (x' : DB x)
     : Is1DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
   Proof.
-    srapply Build_Is1DFunctor.
+    snrapply Build_Is1DFunctor.
     - intros a b f g p a' b' f' g' p'.
       apply DId.
     - intros a a'.
@@ -393,7 +393,7 @@ Section CompositeFunctor.
     `{!Is1DFunctor DB DC G G'}
     : Is1DFunctor DA DC (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
-    srapply Build_Is1DFunctor.
+    snrapply Build_Is1DFunctor.
     - intros a b f g p a' b' f' g' p'.
       apply (dfmap2 _ _ (dfmap2 f' g' p')).
     - intros a a'.
@@ -446,7 +446,7 @@ Global Instance is1dcat_prod {A B : Type} (DA : A -> Type) `{Is1DCat A DA}
   (DB : B -> Type) `{Is1DCat B DB}
   : Is1DCat (obwise_prod DA DB).
 Proof.
-  srapply Build_Is1DCat.
+  snrapply Build_Is1DCat.
   - intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
     srapply (is01dcat_prod _ _).
   - intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -439,7 +439,7 @@ Global Instance is2dgraph_prod {A B : Type} (DA : A -> Type) `{Is2DGraph A DA}
   : Is2DGraph (obwise_prod DA DB).
 Proof.
   intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
-  srapply (isdgraph_prod _ _).
+  srapply isdgraph_prod.
 Defined.
 
 Global Instance is1dcat_prod {A B : Type} (DA : A -> Type) `{Is1DCat A DA}
@@ -447,21 +447,21 @@ Global Instance is1dcat_prod {A B : Type} (DA : A -> Type) `{Is1DCat A DA}
   : Is1DCat (obwise_prod DA DB).
 Proof.
   snrapply Build_Is1DCat.
-  - intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
-    srapply (is01dcat_prod _ _).
-  - intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
+  - intros ab1 ab2 ab1' ab2'.
+    srapply is01dcat_prod.
+  - intros ab1 ab2 ab1' ab2'.
     srapply (is0dgpd_prod _ _).
-  - intros [a1 b1] [a2 b2] [a3 b3] [f g] [a1' b1'] [a2' b2'] [a3' b3'] [f' g'].
-    intros [h1 k1] [h2 k2] [p q] [h1' k1'] [h2' k2'] [p' q'].
+  - intros ab1 ab2 ab3 fg ab1' ab2' ab3' [f' g'].
+    intros hk1 hk2 pq hk1' hk2' [p' q'].
     exact (f' $@L' p', g' $@L' q').
-  - intros [a1 b1] [a2 b2] [a3 b3] [f g] [a1' b1'] [a2' b2'] [a3' b3'] [f' g'].
-    intros [h1 k1] [h2 k2] [p q] [h1' k1'] [h2' k2'] [p' q'].
+  - intros ab1 ab2 ab3 fg ab1' ab2' ab3' [f' g'].
+    intros hk1 hk2 pq hk1' hk2' [p' q'].
     exact (p' $@R' f', q' $@R' g').
-  - intros [a1 b1] [a2 b2] [a3 b3] [a4 b4] [f1 g1] [f2 g2] [f3 g3].
-    intros [a1' b1'] [a2' b2'] [a3' b3'] [a4' b4'] [f1' g1'] [f2' g2'] [f3' g3'].
+  - intros ab1 ab2 ab3 ab4 fg1 fg2 fg3.
+    intros ab1' ab2' ab3' ab4' [f1' g1'] [f2' g2'] [f3' g3'].
     exact (dcat_assoc f1' f2' f3', dcat_assoc g1' g2' g3').
-  - intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
+  - intros ab1 ab2 fg ab1' ab2' [f' g'].
     exact (dcat_idl f', dcat_idl g').
-  - intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
+  - intros ab1 ab2 fg ab1' ab2' [f' g'].
     exact (dcat_idr f', dcat_idr g').
 Defined.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -388,8 +388,6 @@ Section CompositeFunctor.
     `{!Is0Functor F, !Is1Functor F} `{!Is0Functor G, !Is1Functor G}
     `{!Is0DFunctor F F', !Is1DFunctor F F'}
     `{!Is0DFunctor G G', !Is1DFunctor G G'}
-    `{!Is1DFunctor F F'}
-    `{!Is1DFunctor G G'}
     : Is1DFunctor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
     snrapply Build_Is1DFunctor.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -63,7 +63,7 @@ Class Is0DFunctor {A : Type} {B : Type}
 
 Arguments dfmap {A B DA _ _ DB _ _} F {_} F' {_ _ _ _ _ _} f'.
 
-Class Is2DGraph (A : Type) `{IsGraph A, !Is2Graph A}
+Class Is2DGraph (A : Type) `{Is2Graph A}
   (D : A -> Type) `{!IsDGraph A D}
   := isdgraph_dhom : forall {a b} {a'} {b'},
                     IsDGraph (a $-> b) (fun f => DHom f a' b').
@@ -71,7 +71,7 @@ Class Is2DGraph (A : Type) `{IsGraph A, !Is2Graph A}
 Global Existing Instance isdgraph_dhom.
 #[global] Typeclasses Transparent Is2DGraph.
 
-Class Is1DCat (A : Type) `{IsGraph A, !Is2Graph A, !Is01Cat A, !Is1Cat A}
+Class Is1DCat (A : Type) `{Is2Graph A, !Is01Cat A, !Is1Cat A}
   (D : A -> Type) `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} := {
     is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
                     Is01DCat (a $-> b) (fun f => DHom f a' b');
@@ -222,7 +222,7 @@ Proof.
     apply Id.
 Defined.
 
-Class Is1DCat_Strong (A : Type) `{IsGraph A, !Is2Graph A, !Is01Cat A, !Is1Cat_Strong A}
+Class Is1DCat_Strong (A : Type) `{Is2Graph A, !Is01Cat A, !Is1Cat_Strong A}
   (D : A -> Type)
   `{!IsDGraph A D, !Is2DGraph A D, !Is01DCat A D} :=
 {
@@ -369,9 +369,9 @@ End ConstantFunctor.
 
 Section CompositeFunctor.
   Context {A B C : Type} {DA : A -> Type} {DB : B -> Type} {DC : C -> Type}
-  (F : A -> B) (G : B -> C)
-  (F' : forall (a : A), DA a -> DB (F a))
-  (G' : forall (b : B), DB b -> DC (G b)).
+    (F : A -> B) (G : B -> C)
+    (F' : forall (a : A), DA a -> DB (F a))
+    (G' : forall (b : B), DB b -> DC (G b)).
 
   Global Instance is0dfunctor_compose
     `{IsDGraph A DA} `{IsDGraph B DB} `{IsDGraph C DC}
@@ -388,6 +388,8 @@ Section CompositeFunctor.
     `{!Is0Functor F, !Is1Functor F} `{!Is0Functor G, !Is1Functor G}
     `{!Is0DFunctor DA DB F F', !Is1DFunctor DA DB F F'}
     `{!Is0DFunctor DB DC G G', !Is1DFunctor DB DC G G'}
+    `{!Is1DFunctor DA DB F F'}
+    `{!Is1DFunctor DB DC G G'}
     : Is1DFunctor DA DC (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
     srapply Build_Is1DFunctor.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -72,7 +72,7 @@ Class Is2DGraph {A : Type} `{Is2Graph A}
 Global Existing Instance isdgraph_dhom.
 #[global] Typeclasses Transparent Is2DGraph.
 
-Class Is1DCat {A : Type} `{Is2Graph A, !Is01Cat A, !Is1Cat A}
+Class Is1DCat {A : Type} `{Is1Cat A}
   (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} := {
     is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
                     Is01DCat (fun f => DHom f a' b');
@@ -223,7 +223,7 @@ Proof.
     apply Id.
 Defined.
 
-Class Is1DCat_Strong {A : Type} `{Is2Graph A, !Is01Cat A, !Is1Cat_Strong A}
+Class Is1DCat_Strong {A : Type} `{Is1Cat_Strong A}
   (D : A -> Type)
   `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} :=
 {
@@ -325,8 +325,8 @@ Section IdentityFunctor.
     assumption.
   Defined.
 
-  Global Instance is1dfunctor_idmap {A : Type} `{Is1Cat A} (DA : A -> Type)
-    `{!IsDGraph DA, !Is2DGraph DA, !Is01DCat DA, !Is1DCat DA}
+  Global Instance is1dfunctor_idmap {A : Type} (DA : A -> Type)
+    `{Is1DCat A DA}
     : Is1DFunctor DA DA (idmap) (fun a a' => a').
   Proof.
     apply Build_Is1DFunctor.
@@ -349,11 +349,11 @@ Section ConstantFunctor.
     apply DId.
   Defined.
 
-  Global Instance is1dfunctor_const {A : Type} `{Is1Cat A} {B : Type} `{Is1Cat B}
+  Global Instance is1dfunctor_const {A : Type} {B : Type}
     (DA : A -> Type)
-    `{!IsDGraph DA, !Is2DGraph DA, !Is01DCat DA, !Is1DCat DA}
+    `{Is1DCat A DA}
     (DB : B -> Type)
-    `{!IsDGraph DB, !Is2DGraph DB, !Is01DCat DB, !Is1DCat DB}
+    `{Is1DCat B DB}
     (x : B) (x' : DB x)
     : Is1DFunctor DA DB (fun _ : A => x) (fun _ _ => x').
   Proof.


### PR DESCRIPTION
This is a refresh of work by @emilyriehl and others that can be found [here](https://github.com/mikeshulman/Coq-HoTT/blob/1f2bff43ccfe4a392cadfcca8104e58f30ca0d75/theories/WildCat/Displayed.v). The ultimate direction is still unclear, so any thoughts to that effect are appreciated. 

A few arbitrary conventions that are up for debate:
- Where possible, anything that exists in [WildCat/Core](https://github.com/HoTT/Coq-HoTT/blob/master/theories/WildCat/Core.v) retains the same name prefixed appropriately by d (or D). For example, `Is1DCat` and `dcat_comp`.
- A single tick indicates that an object or structure lives in a displayed category over the underlying object or structure. For example, if `a : A` then `a' : D a`, and composition in displayed categories is denoted `g' $o' f'` over `g $o f`.