### PR TITLE
ReflectiveSubuniverse: simplify universe vars in conn_map_homotopic

### DIFF
--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1605,7 +1605,7 @@ Section ConnectedMaps.
   Proof.
     intros ? b.
     exact (isconnected_equiv O (hfiber@{i i} f b)
-                             (equiv_hfiber_homotopic f g h b) _).
+                             (equiv_hfiber_homotopic@{i i i} f g h b) _).
   Defined.
 
   (** The pullback of a connected map is connected *)


### PR DESCRIPTION
Tiny fix to get rid of a floating universe variable.