### PR TITLE
Makefile.coq.local: reduce long line warnings in alectryon build

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -172,7 +172,7 @@ alectryon-html/index.html alectryon-html/toc.html alectryon-html/coqdoc.css : al
 
 alectryon-html-done.timestamp: $(ALL_VOFILES) $(ALL_VFILES)
 	@ mkdir -p alectryon-html
-	$(TIMER) $(ALECTRYON) --frontend coq+rst --backend webpage --sertop-arg=--no_prelude --sertop-arg=--indices-matter $(COQLIBS_NOML) --output-directory alectryon-html --cache-directory alectryon-cache $(ALECTRYON_EXTRAFLAGS) $(ALL_VFILES)
+	$(TIMER) $(ALECTRYON) --frontend coq+rst --backend webpage --sertop-arg=--no_prelude --sertop-arg=--indices-matter $(COQLIBS_NOML) --output-directory alectryon-html --cache-directory alectryon-cache --long-line-threshold=999 $(ALECTRYON_EXTRAFLAGS) $(ALL_VFILES)
 	touch alectryon-html-done.timestamp
 
 alectryon-html:

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -172,7 +172,7 @@ alectryon-html/index.html alectryon-html/toc.html alectryon-html/coqdoc.css : al
 
 alectryon-html-done.timestamp: $(ALL_VOFILES) $(ALL_VFILES)
 	@ mkdir -p alectryon-html
-	$(TIMER) $(ALECTRYON) --frontend coq+rst --backend webpage --sertop-arg=--no_prelude --sertop-arg=--indices-matter $(COQLIBS_NOML) --output-directory alectryon-html --cache-directory alectryon-cache --long-line-threshold=999 $(ALECTRYON_EXTRAFLAGS) $(ALL_VFILES)
+	$(TIMER) $(ALECTRYON) --frontend coq+rst --backend webpage --sertop-arg=--no_prelude --sertop-arg=--indices-matter $(COQLIBS_NOML) --output-directory alectryon-html --cache-directory alectryon-cache --long-line-threshold=99999 $(ALECTRYON_EXTRAFLAGS) $(ALL_VFILES)
 	touch alectryon-html-done.timestamp
 
 alectryon-html:


### PR DESCRIPTION
It's not that important, but the alectryon builds spew out long line warnings because of our conventions on not having line breaks in comments, and I think this will get rid of them.  Let's see what happens when the CI runs.