### PR TITLE
Reduce dependencies, especially for Classes

### DIFF
--- a/theories/Classes/implementations/family_prod.v
+++ b/theories/Classes/implementations/family_prod.v
@@ -1,5 +1,5 @@
 Require Import
-  HoTT.Utf8
+  HoTT.Utf8Minimal
   HoTT.Basics.Overture Types.Unit
   HoTT.Classes.implementations.list.
 

--- a/theories/Classes/implementations/ne_list.v
+++ b/theories/Classes/implementations/ne_list.v
@@ -1,5 +1,5 @@
 Require Import
-  HoTT.Utf8
+  HoTT.Utf8Minimal
   HoTT.Classes.implementations.list
   HoTT.Basics.Overture
   HoTT.Spaces.Nat.

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -1,7 +1,7 @@
 (** This file defines [Algebra]. *)
 
 Require Export
-  HoTT.Utf8
+  HoTT.Utf8Minimal
   HoTT.Basics
   HoTT.Classes.implementations.ne_list
   HoTT.Classes.implementations.family_prod.

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -1,5 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
-Require Import Basics Types WildCat.
+Require Import Basics Types WildCat.Core WildCat.Universe.
 Require Export Colimits.Coeq.
 Local Open Scope path_scope.
 

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -1,7 +1,7 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
 Require Import Spaces.Int Spaces.Circle.
-Require Import Colimits.Coeq HIT.Flattening Truncations.
+Require Import Colimits.Coeq HIT.Flattening Truncations.Core Truncations.Connectedness.
 
 Local Open Scope path_scope.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -521,7 +521,7 @@ Section Reflective_Subuniverse.
     : IsEquiv (to O T) -> In O T
     := fun _ => inO_equiv_inO (O T) (to O T)^-1.
 
-    (* We don't make this an ordinary instance, but we allow it to solve [In O] constraints if we already have [IsEquiv] as a hypothesis.  *)
+    (** We don't make this an ordinary instance, but we allow it to solve [In O] constraints if we already have [IsEquiv] as a hypothesis.  *)
     #[local]
     Hint Immediate inO_isequiv_to_O : typeclass_instances.
 
@@ -541,6 +541,18 @@ Section Reflective_Subuniverse.
       - refine (O_indpaths (to O T o mu) idmap _).
         intros x; exact (ap (to O T) (H x)).
       - exact H.
+    Defined.
+
+    (** It follows that reflective subuniverses are closed under retracts. *)
+    Definition inO_retract_inO (A B : Type) `{In O B} (s : A -> B) (r : B -> A)
+      (K : r o s == idmap)
+      : In O A.
+    Proof.
+      nrapply (inO_to_O_retract A (r o (to O B)^-1 o (O_functor s))).
+      intro a.
+      lhs exact (ap (r o (to O B)^-1) (to_O_natural s a)).
+      lhs nrefine (ap r (eissect _ (s a))).
+      apply K.
     Defined.
 
   End Replete.

--- a/theories/Projective.v
+++ b/theories/Projective.v
@@ -1,8 +1,7 @@
-Require Import Basics Types HSet.
+Require Import Basics Types.
 Require Import Truncations.Core Truncations.SeparatedTrunc.
-Require Import Modalities.Modality Modalities.Separated Modalities.Identity.
+Require Import Modalities.Modality Modalities.Identity.
 Require Import Limits.Pullback.
-
 
 (** * Projective types *)
 
@@ -51,7 +50,6 @@ Corollary equiv_isoprojective_surjections_split
 Proof.
   exact (equiv_iff_hprop_uncurried (iff_isoprojective_surjections_split O X)).
 Defined.
-
 
 (** ** Projectivity and the axiom of choice *)
 
@@ -171,10 +169,7 @@ Section AC_oo_neg1.
       pose proof (projective_cover_AC X) as P; strip_truncations.
       destruct P as [P [p issurj_p]].
       pose proof (isprojX P _ X _ idmap p issurj_p) as S; strip_truncations.
-      destruct S as [s h].
-      rapply (istrunc_embedding_trunc s).
-      apply isembedding_isinj_hset.
-      exact (isinj_section h).
+      exact (inO_retract_inO (Tr 0) X P S.1 p S.2).
     - intro ishsetX.
       apply (equiv_isoprojective_hasochoice purely X)^-1.
       rapply AC.

--- a/theories/Utf8.v
+++ b/theories/Utf8.v
@@ -1,22 +1,11 @@
 Require Export HoTT.Basics.Utf8.
+Require Export HoTT.Utf8Minimal.
 Require Import HoTT.Basics HoTT.Types.
 Require Import Modalities.Identity.
 Require Import Spaces.Circle Spaces.TwoSphere HoTT.Truncations Homotopy.Suspension.
 
-(* Logic *)
-Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..) : type_scope.
-Notation "∃  x .. y , P" := (exists x, .. (exists y, P) ..) : type_scope.
+(** Some unicode symbols that we don't use within the library.  See also Utf8Minimal.v for a small number of symbols uses in the Classes library. *)
 
-Notation "x ∧ y" := (x /\ y) : type_scope.
-Notation "x → y" := (x -> y) : type_scope.
-
-Notation "x ↔ y" := (x <-> y) : type_scope.
-(*Notation "¬ x" := (not x) : type_scope.*)
-(*Notation "x ≠ y" := (x <> y) : type_scope.*)
-
-(* Abstraction *)
-Notation "'λ'  x .. y , t" := (fun x => .. (fun y => t) ..).
-  
 Notation Type₀ := Type0.
 Notation pr₁ := pr1.
 Notation pr₂ := pr2.

--- a/theories/Utf8Minimal.v
+++ b/theories/Utf8Minimal.v
@@ -1,0 +1,18 @@
+Require Export HoTT.Basics.Utf8.
+Require Import HoTT.Basics.Overture.
+
+(** * Just enough Utf8/unicode for the Classes library to build, without depending on everything that HoTT.Utf8 depends on. *)
+
+(* Logic *)
+Notation "∀  x .. y , P" := (forall x, .. (forall y, P) ..) : type_scope.
+Notation "∃  x .. y , P" := (exists x, .. (exists y, P) ..) : type_scope.
+
+Notation "x ∧ y" := (x /\ y) : type_scope.
+Notation "x → y" := (x -> y) : type_scope.
+
+Notation "x ↔ y" := (x <-> y) : type_scope.
+(*Notation "¬ x" := (not x) : type_scope.*)
+(*Notation "x ≠ y" := (x <> y) : type_scope.*)
+
+(* Abstraction *)
+Notation "'λ'  x .. y , t" := (fun x => .. (fun y => t) ..).


### PR DESCRIPTION
It turns out that the Classes library was depending on WildCat, Cubical, Modalities, Homotopy.Suspension, etc, all because it uses some unicode symbols defined in Utf8.v.  I separated that small subset into a new file Utf8Minimal.v, which greatly reduces the dependencies and speeds up a parallel build by about 2%.  I also reduced a few other dependencies.  I noticed these because so much of the library was getting rebuilt when WildCat/Induced.v was changed.

The commits are independent, except that the fourth one depends on the third one.