### PR TITLE
flattening for pushouts + total space of Hopf construction

### DIFF
--- a/contrib/HoTTBook.v
+++ b/contrib/HoTTBook.v
@@ -59,7 +59,7 @@
 
 From HoTT Require Import Basics Truncations.
 From HoTT Require Idempotents Spaces.Spheres Spaces.No.
-From HoTT Require HIT.V HIT.Flattening Homotopy.WhiteheadsPrinciple.
+From HoTT Require HIT.V HIT.Flattening Homotopy.WhiteheadsPrinciple Homotopy.Hopf.
 From HoTT Require Categories.
 From HoTT Require Metatheory.IntervalImpliesFunext Metatheory.UnivalenceImpliesFunext.
 From HoTT Require Classes.theory.premetric.
@@ -1325,7 +1325,8 @@ Definition Book_7_6_2 := @HoTT.HFiber.equiv_istruncmap_ap.
 (* ================================================== lem:hopf-construction *)
 (** Lemma 8.5.7 *)
 
-
+Definition Book_8_5_6 := @HoTT.Homotopy.Hopf.hopf_construction.
+Definition Book_8_5_7 := @HoTT.Homotopy.Hopf.equiv_hopf_total_join.
 
 (* ================================================== lem:hspace-S1 *)
 (** Lemma 8.5.8 *)

--- a/theories/Colimits/Colimit_Pushout.v
+++ b/theories/Colimits/Colimit_Pushout.v
@@ -188,4 +188,30 @@ Section is_PO_pushout.
     eapply iscolimit_colimit.
   Defined.
 
+  Definition equiv_pushout_PO_beta_pglue (a : A)
+    : ap equiv_pushout_PO (pglue a) = popp a.
+  Proof.
+    cbn.
+    refine (_ @ _).
+    1: nrapply Pushout_rec_beta_pglue.
+    unfold popp'; cbn.
+    rewrite 2 concat_1p.
+    reflexivity.
+  Defined.
+
+  Definition Pushout_rec_PO_rec (P : Type) (pushb : B -> P) (pushc : C -> P)
+    (pusha : forall a : A, pushb (f a) = pushc (g a))
+    : Pushout_rec P pushb pushc pusha == PO_rec P pushb pushc pusha o equiv_pushout_PO.
+  Proof.
+    snrapply Pushout_ind.
+    1, 2: reflexivity.
+    intro a; cbn beta.
+    nrapply transport_paths_FlFr'; apply equiv_p1_1q.
+    lhs exact (Pushout_rec_beta_pglue P pushb pushc pusha a).
+    symmetry.
+    lhs nrapply (ap_compose equiv_pushout_PO _ (pglue a)).
+    lhs nrapply (ap _ (equiv_pushout_PO_beta_pglue a)).
+    nrapply PO_rec_beta_pp.
+  Defined.
+
 End is_PO_pushout.

--- a/theories/Colimits/Colimit_Pushout_Flattening.v
+++ b/theories/Colimits/Colimit_Pushout_Flattening.v
@@ -10,7 +10,7 @@ Require Import Colimits.Colimit_Flattening.
 
 (** * Pushout case *)
 
-(** We show the flattening lemma in the case of the pushout. *)
+(** We show the flattening lemma in the case of the pushout. This pushout is defined as the colimit of a span and is not the pushout that apepars elsehwere in the library. The flattening lemma here however can be used to derive the flattening lemma there and this is done in Colimits/PushoutFlattening.v. *)
 
 Section POCase.
   Context `{Univalence} {A B C} {f: A -> B} {g: A -> C}.

--- a/theories/Colimits/Colimit_Pushout_Flattening.v
+++ b/theories/Colimits/Colimit_Pushout_Flattening.v
@@ -10,7 +10,7 @@ Require Import Colimits.Colimit_Flattening.
 
 (** * Pushout case *)
 
-(** We show the flattening lemma in the case of the pushout. This pushout is defined as the colimit of a span and is not the pushout that apepars elsehwere in the library. The flattening lemma here however can be used to derive the flattening lemma there and this is done in Colimits/PushoutFlattening.v. *)
+(** We show the flattening lemma in the case of the pushout. This pushout is defined as the colimit of a span and is not the pushout that appears elsewhere in the library. The flattening lemma here however can be used to derive the flattening lemma there and this is done in Colimits/PushoutFlattening.v. *)
 
 Section POCase.
   Context `{Univalence} {A B C} {f: A -> B} {g: A -> C}.

--- a/theories/Colimits/Colimit_Pushout_Flattening.v
+++ b/theories/Colimits/Colimit_Pushout_Flattening.v
@@ -49,31 +49,31 @@ Section POCase.
   Definition PO_flattening
     : PO (functor_sigma f f0) (functor_sigma g g0) <~> exists x, POCase_P x.
   Proof.
-    assert (PO (functor_sigma f f0) (functor_sigma g g0)
-            = Colimit (diagram_sigma POCase_E)). {
+    transitivity (Colimit (diagram_sigma POCase_E)).
+    { apply equiv_path.
       unfold PO; apply ap.
       srapply path_diagram; cbn.
       - intros [|[]]; cbn. all: reflexivity.
       - intros [[]|[]] [[]|[]] [] x; cbn in *.
         all: reflexivity. }
-    rewrite X; clear X.
     transitivity (exists x, E' (span f g) POCase_E POCase_HE x).
     - apply flattening_lemma.
     - apply equiv_functor_sigma_id.
       intro x.
-      assert (E' (span f g) POCase_E POCase_HE x = POCase_P x). {
-        unfold E', POCase_P, PO_rec.
-        f_ap. srapply path_cocone.
-        - intros [[]|[]] y; cbn.
-          1: apply path_universe_uncurried; apply g0.
-          all: reflexivity.
-        - intros [[]|[]] [[]|[]] []; cbn.
-          + intro y; simpl; hott_simpl.
-            unfold path_universe.
-            rewrite <- path_universe_V_uncurried.
-            refine (path_universe_compose (f0 y)^-1 (g0 y))^. 
-          + intros; apply concat_Vp. }
-      rewrite X. reflexivity.
+      apply equiv_path.
+      unfold E', POCase_P, PO_rec.
+      f_ap. srapply path_cocone.
+      + intros [[]|[]] y; cbn.
+        1: apply path_universe_uncurried; apply g0.
+        all: reflexivity.
+      + intros [[]|[]] [[]|[]] []; cbn.
+        * intro y. simpl.
+          rhs nrapply concat_1p.
+          unfold path_universe.
+          lhs nrapply (ap (fun x => x @ _) _^).
+          1: nrapply path_universe_V_uncurried.
+          exact (path_universe_compose (f0 y)^-1 (g0 y))^. 
+        * intros; apply concat_Vp.
   Defined.
 
 End POCase.

--- a/theories/Colimits/PushoutFlattening.v
+++ b/theories/Colimits/PushoutFlattening.v
@@ -18,81 +18,6 @@ Section Flattening.
     exact _.
   Defined.
 
-  Lemma flattening_coh
-    : forall x, pushout_flattening_fam x <~> POCase_P A0 B0 C0 f0 g0 (equiv_pushout_PO x).
-  Proof.
-    (** Proving that the type families are equivalent takes some work but is mostly trivial. We don't know how to transport over families of equivalences yet, so we use univalence to turn it into a transport over a family of paths. *)
-    snrapply Pushout_ind.
-    1,2: hnf; reflexivity.
-    intros a.
-    hnf.
-    lhs nrapply transport_idmap_ap.
-    unshelve erewrite ap_homotopic.
-    2: {
-      intros w.
-      rapply path_universe_uncurried.
-      apply equiv_path_universe. }
-    rewrite 2 transport_pp.
-    rewrite transport_path_universe_uncurried.
-    rewrite transport_path_universe_V.
-    apply moveR_equiv_V.
-    change (?x = path_universe_uncurried 1) with (x = path_universe equiv_idmap).
-    rewrite path_universe_1.
-    lhs nrapply (transport_idmap_ap _ _ _)^.
-    rewrite transport_paths_FlFr.
-    rewrite Pushout_rec_beta_pglue.
-    rewrite concat_pp_p.
-    apply moveR_Vp.
-    rewrite concat_p1.
-    rewrite ap_compose.
-    rewrite Pushout_rec_beta_pglue.
-    unfold popp'.
-    simpl.
-    rewrite 2 concat_1p.
-    change(path_universe 1%equiv @
-      ap (Colimit_Pushout_Flattening.POCase_P A0 B0 C0 f0 g0)
-      (popp a) = path_universe (g0 a oE (f0 a)^-1)).
-    rewrite PO_rec_beta_pp.
-    rewrite path_universe_1.
-    rewrite concat_1p.
-    reflexivity.
-  Defined.
-
-  Lemma flattening_coh_2
-    : forall x, pushout_flattening_fam x <~> POCase_P A0 B0 C0 f0 g0 (equiv_pushout_PO x).
-  Proof.
-    intros x.
-    snrapply Build_Equiv.
-    - revert x.
-      snrapply Pushout_ind.
-      1,2: intros x; exact idmap.
-      intros x.
-      rapply dpath_arrow.
-      intros y.
-      lhs nrapply transport_compose.
-      lhs nrapply transport2.
-      1: apply Pushout_rec_beta_pglue.
-      unfold popp'.
-      simpl.
-      rewrite 2 concat_1p.
-      lhs nrapply (transport_compose idmap (POCase_P A0 B0 C0 f0 g0) (popp x)).
-      lhs nrapply ap011.
-      1: reflexivity.
-      1: nrapply PO_rec_beta_pp.
-      rhs nrapply (transport_idmap_ap _ (pglue x) _).
-      lhs nrapply transport_path_universe_uncurried.
-      rhs nrapply ap011.
-      2: reflexivity.
-      2: apply Pushout_rec_beta_pglue.
-      rhs nrapply transport_path_universe_uncurried.
-      reflexivity.
-    - revert x.
-      snrapply Pushout_ind.
-      1,2: intro; exact (isequiv_idmap _).
-      intros a.
-      apply path_ishprop.
-  Defined.
-
   Definition pushout_flattening
     : Pushout (functor_sigma f f0) (functor_sigma g g0)
       <~> exists x, pushout_flattening_fam x.
@@ -102,7 +27,9 @@ Section Flattening.
     symmetry.
     snrapply equiv_functor_sigma'.
     1: apply equiv_pushout_PO.
-    apply flattening_coh_2.
+    intro x.
+    apply equiv_path.
+    nrapply Pushout_rec_PO_rec.
   Defined.
 
 End Flattening.

--- a/theories/Colimits/PushoutFlattening.v
+++ b/theories/Colimits/PushoutFlattening.v
@@ -2,7 +2,7 @@ Require Import Basics Types Colimits.Pushout Colimits.Colimit_Pushout Colimits.C
 
 (** * Flattening for pushouts *)
 
-(** We derive flattening for pushouts using the flattening lemma for colimits. Most of the work has already been done. What is left is to transport the result along the appropriate equivalences. *)
+(** We derive flattening for pushouts using the flattening lemma for colimits. Most of the work has already been done in Colimits/Colimit_Pushout_Flattening.v. The pushout there is defined as a colimit of a span whereas the pushout we use elsewhere is defined as a coequalizer. What is left is to transport the result along the appropriate equivalences. *)
 
 Section Flattening.
   Context `{Univalence} {A B C} {f : A -> B} {g : A -> C}

--- a/theories/Colimits/PushoutFlattening.v
+++ b/theories/Colimits/PushoutFlattening.v
@@ -1,0 +1,67 @@
+Require Import Basics Types Colimits.Pushout Colimits.Colimit_Pushout Colimits.Colimit_Pushout_Flattening.
+
+(** * Flattening for pushouts *)
+
+(** We derrive flattening for pushouts using the flattening lemma for colimits. Most of the work has already been done, what is left is to transport the result along the appropriate equivalences. *)
+
+Section Flattening.
+  Context `{Univalence} {A B C} {f : A -> B} {g : A -> C}.
+
+  Context (A0 : A -> Type) (B0 : B -> Type) (C0 : C -> Type)
+          (f0 : forall x, A0 x <~> B0 (f x)) (g0 : forall x, A0 x <~> C0 (g x)).
+
+  Definition POCase_P : Pushout f g -> Type.
+  Proof.
+    nrefine (Pushout_rec Type B0 C0 _).
+    cbn; intro x.
+    snrapply path_universe.
+    1: exact ((g0 x) oE (f0 x)^-1%equiv).
+    exact _.
+  Defined.
+
+  Definition PO_flattening
+    : Pushout (functor_sigma f f0) (functor_sigma g g0) <~> exists x, POCase_P x.
+  Proof.
+    snrefine (_ oE equiv_pushout_PO). 
+    snrefine (_ oE PO_flattening A0 B0 C0 f0 g0).
+    symmetry.
+    snrapply equiv_functor_sigma'.
+    1: apply equiv_pushout_PO.
+    (** Proving that the type families are equivalent takes some work but is mostly trivial. We don't know how to transport over families of equivlences yet, so we use univalence to turn it into a transportation over a family of paths. *)
+    snrapply Pushout_ind.
+    1,2: hnf; reflexivity.
+    intros a.
+    hnf.
+    lhs nrapply transport_idmap_ap.
+    unshelve erewrite ap_homotopic.
+    2: {
+      intros w.
+      rapply path_universe_uncurried.
+      apply equiv_path_universe. }
+    rewrite 2 transport_pp.
+    rewrite transport_path_universe_uncurried.
+    rewrite transport_path_universe_V.
+    apply moveR_equiv_V.
+    change (?x = path_universe_uncurried 1) with (x = path_universe equiv_idmap).
+    rewrite path_universe_1.
+    lhs nrapply (transport_idmap_ap _ _ _)^.
+    rewrite transport_paths_FlFr.
+    rewrite Pushout_rec_beta_pglue.
+    rewrite concat_pp_p.
+    apply moveR_Vp.
+    rewrite concat_p1.
+    rewrite ap_compose.
+    rewrite Pushout_rec_beta_pglue.
+    unfold popp'.
+    simpl.
+    rewrite 2 concat_1p.
+    change(path_universe 1%equiv @
+      ap (Colimit_Pushout_Flattening.POCase_P A0 B0 C0 f0 g0)
+      (popp a) = path_universe (g0 a oE (f0 a)^-1)).
+    rewrite PO_rec_beta_pp.
+    rewrite path_universe_1.
+    rewrite concat_1p.
+    reflexivity.
+  Defined.
+
+End Flattening.

--- a/theories/Colimits/PushoutFlattening.v
+++ b/theories/Colimits/PushoutFlattening.v
@@ -5,28 +5,22 @@ Require Import Basics Types Colimits.Pushout Colimits.Colimit_Pushout Colimits.C
 (** We derrive flattening for pushouts using the flattening lemma for colimits. Most of the work has already been done, what is left is to transport the result along the appropriate equivalences. *)
 
 Section Flattening.
-  Context `{Univalence} {A B C} {f : A -> B} {g : A -> C}.
+  Context `{Univalence} {A B C} {f : A -> B} {g : A -> C}
+    (A0 : A -> Type) (B0 : B -> Type) (C0 : C -> Type)
+    (f0 : forall x, A0 x <~> B0 (f x)) (g0 : forall x, A0 x <~> C0 (g x)).
 
-  Context (A0 : A -> Type) (B0 : B -> Type) (C0 : C -> Type)
-          (f0 : forall x, A0 x <~> B0 (f x)) (g0 : forall x, A0 x <~> C0 (g x)).
-
-  Definition POCase_P : Pushout f g -> Type.
+  Definition pushout_flattening_fam : Pushout f g -> Type.
   Proof.
     nrefine (Pushout_rec Type B0 C0 _).
     cbn; intro x.
     snrapply path_universe.
-    1: exact ((g0 x) oE (f0 x)^-1%equiv).
+    1: exact ((g0 x) o (f0 x)^-1).
     exact _.
   Defined.
 
-  Definition PO_flattening
-    : Pushout (functor_sigma f f0) (functor_sigma g g0) <~> exists x, POCase_P x.
+  Lemma flattening_coh
+    : forall x, pushout_flattening_fam x <~> POCase_P A0 B0 C0 f0 g0 (equiv_pushout_PO x).
   Proof.
-    snrefine (_ oE equiv_pushout_PO). 
-    snrefine (_ oE PO_flattening A0 B0 C0 f0 g0).
-    symmetry.
-    snrapply equiv_functor_sigma'.
-    1: apply equiv_pushout_PO.
     (** Proving that the type families are equivalent takes some work but is mostly trivial. We don't know how to transport over families of equivlences yet, so we use univalence to turn it into a transportation over a family of paths. *)
     snrapply Pushout_ind.
     1,2: hnf; reflexivity.
@@ -62,6 +56,18 @@ Section Flattening.
     rewrite path_universe_1.
     rewrite concat_1p.
     reflexivity.
+  Defined.
+
+  Definition pushout_flattening
+    : Pushout (functor_sigma f f0) (functor_sigma g g0)
+      <~> exists x, pushout_flattening_fam x.
+  Proof.
+    snrefine (_ oE equiv_pushout_PO). 
+    snrefine (_ oE PO_flattening A0 B0 C0 f0 g0).
+    symmetry.
+    snrapply equiv_functor_sigma'.
+    1: apply equiv_pushout_PO.
+    apply flattening_coh.
   Defined.
 
 End Flattening.

--- a/theories/Colimits/PushoutFlattening.v
+++ b/theories/Colimits/PushoutFlattening.v
@@ -2,7 +2,7 @@ Require Import Basics Types Colimits.Pushout Colimits.Colimit_Pushout Colimits.C
 
 (** * Flattening for pushouts *)
 
-(** We derrive flattening for pushouts using the flattening lemma for colimits. Most of the work has already been done, what is left is to transport the result along the appropriate equivalences. *)
+(** We derive flattening for pushouts using the flattening lemma for colimits. Most of the work has already been done. What is left is to transport the result along the appropriate equivalences. *)
 
 Section Flattening.
   Context `{Univalence} {A B C} {f : A -> B} {g : A -> C}
@@ -21,7 +21,7 @@ Section Flattening.
   Lemma flattening_coh
     : forall x, pushout_flattening_fam x <~> POCase_P A0 B0 C0 f0 g0 (equiv_pushout_PO x).
   Proof.
-    (** Proving that the type families are equivalent takes some work but is mostly trivial. We don't know how to transport over families of equivlences yet, so we use univalence to turn it into a transportation over a family of paths. *)
+    (** Proving that the type families are equivalent takes some work but is mostly trivial. We don't know how to transport over families of equivalences yet, so we use univalence to turn it into a transport over a family of paths. *)
     snrapply Pushout_ind.
     1,2: hnf; reflexivity.
     intros a.
@@ -58,6 +58,41 @@ Section Flattening.
     reflexivity.
   Defined.
 
+  Lemma flattening_coh_2
+    : forall x, pushout_flattening_fam x <~> POCase_P A0 B0 C0 f0 g0 (equiv_pushout_PO x).
+  Proof.
+    intros x.
+    snrapply Build_Equiv.
+    - revert x.
+      snrapply Pushout_ind.
+      1,2: intros x; exact idmap.
+      intros x.
+      rapply dpath_arrow.
+      intros y.
+      lhs nrapply transport_compose.
+      lhs nrapply transport2.
+      1: apply Pushout_rec_beta_pglue.
+      unfold popp'.
+      simpl.
+      rewrite 2 concat_1p.
+      lhs nrapply (transport_compose idmap (POCase_P A0 B0 C0 f0 g0) (popp x)).
+      lhs nrapply ap011.
+      1: reflexivity.
+      1: nrapply PO_rec_beta_pp.
+      rhs nrapply (transport_idmap_ap _ (pglue x) _).
+      lhs nrapply transport_path_universe_uncurried.
+      rhs nrapply ap011.
+      2: reflexivity.
+      2: apply Pushout_rec_beta_pglue.
+      rhs nrapply transport_path_universe_uncurried.
+      reflexivity.
+    - revert x.
+      snrapply Pushout_ind.
+      1,2: intro; exact (isequiv_idmap _).
+      intros a.
+      apply path_ishprop.
+  Defined.
+
   Definition pushout_flattening
     : Pushout (functor_sigma f f0) (functor_sigma g g0)
       <~> exists x, pushout_flattening_fam x.
@@ -67,7 +102,7 @@ Section Flattening.
     symmetry.
     snrapply equiv_functor_sigma'.
     1: apply equiv_pushout_PO.
-    apply flattening_coh.
+    apply flattening_coh_2.
   Defined.
 
 End Flattening.

--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -160,6 +160,7 @@ Require Export HoTT.Homotopy.HSpaceS1.
 Require Export HoTT.Homotopy.Bouquet.
 Require Export HoTT.Homotopy.EncodeDecode.
 Require Export HoTT.Homotopy.Syllepsis.
+Require Export HoTT.Homotopy.Hopf.
 
 Require Export HoTT.Spectra.Spectrum.
 

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -11,9 +11,7 @@ Local Open Scope mc_mult_scope.
 
 (** * The Hopf construction *)
 
-(** We define the Hopf construction associated to a left-invertible H-space, and use it to prove that H-spaces satisfy a strengthened version of Freudenthal's theorem (see [freudenthal_hspace] below).
-
-We have not yet included various standard results about the Hopf construction, such as the total space being the join of the fibre. *)
+(** We define the Hopf construction associated to a left-invertible H-space, and use it to prove that H-spaces satisfy a strengthened version of Freudenthal's theorem (see [freudenthal_hspace] below). *)
 
 (** The Hopf construction associated to a left-invertible H-space (Definition 8.5.6 in the HoTT book). *)
 Definition hopf_construction `{Univalence} (X : pType)
@@ -26,6 +24,30 @@ Proof.
     exact (fun x => path_universe ((x *.) o equiv_idmap^-1%equiv)).
   - simpl. exact pt.
 Defined.
+
+(** *** Total space of the Hopf construction *)
+
+(** The total space of the Hopf construction on [Susp X] is the join of [X] with itself. Note that we need both left and right multiplication to be equivalences. This is true when [X] is a 0-connected H-space for example. *)
+(* TODO: Show that this is a pointed equivalence. We cannot yet do this as we cannot compute with the flattening lemma due to the massive size of the proof. *)
+Definition equiv_hopf_total_join `{Univalence} (X : pType)
+  `{IsHSpace X} `{forall a, IsEquiv (a *.)} `{forall a, IsEquiv (.* a)}
+  : psigma (hopf_construction X) <~> pjoin X X.
+Proof.
+  snrefine (_ oE (pushout_flattening (f:=const_tt X) (g:=const_tt X) _
+    (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X)) (fun _ => equiv_idmap)
+    (fun x => Build_Equiv _ _ (x *.) (H1 x)))^-1%equiv).
+  snrapply equiv_pushout.
+  - cbn. refine (equiv_sigma_prod0 _ _ oE _ oE equiv_sigma_symm0 _ _).
+    snrapply equiv_functor_sigma_id.
+    intros x.
+    exact (Build_Equiv _ _ (.* x) _).
+  - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
+  - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
+  - reflexivity.
+  - reflexivity.
+Defined. 
+
+(** *** Miscellaneous lemmas and corollaries about the Hopf construction *)
 
 Lemma transport_hopf_construction `{Univalence} {X : pType}
   `{IsHSpace X} `{forall a, IsEquiv (a *.)}
@@ -105,25 +127,3 @@ Proof.
   nrefine (pequiv_O_inverts k (loop_susp_unit X)).
   rapply freudenthal_hspace.
 Defined.
-
-(** *** Total space of the Hopf construction *)
-
-(** The total space of the Hopf construction on [Susp X] is the join of [X] with itself. Note that we need both left and right multiplication to be equivalences. This is true when [X] is a 0-connected H-space for example. *)
-(* TODO: Show that this is a pointed equivalence. We cannot yet do this as we cannot compute with the flattening lemma due to the massive size of the proof. *)
-Definition equiv_hopf_total_join `{Univalence} (X : pType)
-  `{IsHSpace X} `{forall a, IsEquiv (a *.)} `{forall a, IsEquiv (.* a)}
-  : psigma (hopf_construction X) <~> pjoin X X.
-Proof.
-  snrefine (_ oE (pushout_flattening (f:=const_tt X) (g:=const_tt X) _
-    (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X)) (fun _ => equiv_idmap)
-    (fun x => Build_Equiv _ _ (x *.) (H1 x)))^-1%equiv).
-  snrapply equiv_pushout.
-  - cbn. refine (equiv_sigma_prod0 _ _ oE _ oE equiv_sigma_symm0 _ _).
-    snrapply equiv_functor_sigma_id.
-    intros x.
-    exact (Build_Equiv _ _ (.* x) _).
-  - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
-  - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
-  - reflexivity.
-  - reflexivity.
-Defined. 

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -23,7 +23,7 @@ Proof.
   srapply Build_pFam.
   - apply (Susp_rec (Y:=Type) X X).
     (** In order to use the flattening lemma for colimits to show that the total space is a join, we need for this equivalence to be a composition with the inverted identity equivalence so that the fiber is definitionally equivalent to the flattening lemma sigma type. This doesn't change anything elsewhere, but saves us having to rewrite an IsEquiv witness. *)
-    exact (fun x => path_universe ((x *.) o equiv_idmap)).
+    exact (fun x => path_universe ((x *.) o equiv_idmap^-1%equiv)).
   - simpl. exact pt.
 Defined.
 
@@ -116,16 +116,14 @@ Definition equiv_hopf_total_join `{Univalence} (X : pType)
 Proof.
   snrefine (_ oE (pushout_flattening (f:=const_tt X) (g:=const_tt X) _
     (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X)) (fun _ => equiv_idmap)
-    (fun x => Build_Equiv _ _ (fun y => sg_op x y) (H1 x)))^-1%equiv).
+    (fun x => Build_Equiv _ _ (x *.) (H1 x)))^-1%equiv).
   snrapply equiv_pushout.
-  - refine (equiv_sigma_prod0 _ _ oE _ oE equiv_sigma_symm0 _ _).
+  - cbn. refine (equiv_sigma_prod0 _ _ oE _ oE equiv_sigma_symm0 _ _).
     snrapply equiv_functor_sigma_id.
     intros x.
-    snrapply Build_Equiv.
-    + exact (.* x).
-    + exact _.
+    exact (Build_Equiv _ _ (.* x) _).
   - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
   - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
-  - hnf; reflexivity.
-  - hnf; reflexivity.
+  - reflexivity.
+  - reflexivity.
 Defined. 

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -23,7 +23,7 @@ Proof.
   srapply Build_pFam.
   - apply (Susp_rec (Y:=Type) X X).
     (** In order to use the flattening lemma for colimits to show that the total space is a join, we need for this equivalence to be a composition with the inverted identity equivalence so that the fiber is definitionally equivalent to the flattening lemma sigma type. This doesn't change anything elsewhere, but saves us having to rewrite an IsEquiv witness. *)
-    exact (fun x => path_universe ((x *.) o equiv_idmap^-1)).
+    exact (fun x => path_universe ((x *.) o equiv_idmap)).
   - simpl. exact pt.
 Defined.
 
@@ -106,14 +106,18 @@ Proof.
   rapply freudenthal_hspace.
 Defined.
 
-(** *** Total space of the Hopf fibration *)
+(** *** Total space of the Hopf construction *)
 
-(** The total space of the Hopf fibration on [Susp X] is the join of [X] with itself. Note that we need both left and right multiplication to be equivalences. This is true when [X] is a 0-connected H-space for example. *)
+(** The total space of the Hopf construction on [Susp X] is the join of [X] with itself. Note that we need both left and right multiplication to be equivalences. This is true when [X] is a 0-connected H-space for example. *)
 (* TODO: Show that this is a pointed equivalence. We cannot yet do this as we cannot compute with the flattening lemma due to the massive size of the proof. *)
 Definition equiv_hopf_total_join `{Univalence} (X : pType)
   `{IsHSpace X} `{forall a, IsEquiv (a *.)} `{forall a, IsEquiv (.* a)}
-  : psigma (hopf_construction X) <~> pjoin X X.
+  : psigma (hopf_construction X) <~>* pjoin X X.
 Proof.
+  symmetry.
+  snrapply Build_pEquiv'.
+  2: shelve.
+  symmetry.
   snrefine (_ oE (pushout_flattening (f:=const_tt X) (g:=const_tt X) _
     (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X)) (fun _ => equiv_idmap)
     (fun x => Build_Equiv _ _ (fun y => sg_op x y) (H1 x)))^-1%equiv).
@@ -124,11 +128,31 @@ Proof.
     snrapply Build_Equiv.
     + exact (.* x).
     + exact _.
-  - rapply equiv_sigma_unit_ind.
-  - rapply equiv_sigma_unit_ind.
-  - simpl.
-    hnf.
-    reflexivity.
-  - intros [x y].
-    reflexivity.
-Defined.
+  - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
+  - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
+  - hnf; reflexivity.
+  - hnf; reflexivity.
+  Unshelve.
+  unfold "pt".
+  Opaque pushout_flattening.
+  simpl.
+  Transparent pushout_flattening.
+  unfold pushout_flattening.
+  unfold "pt".
+  rapply (moveR_equiv_V' (equiv_functor_sigma' _ _)). 
+  Opaque Colimit_Pushout_Flattening.PO_flattening.
+  Opaque flattening_coh_2.
+  simpl.
+  unfold functor_sigma.
+  simpl.
+  unfold Colimit.functor_colimit.
+  simpl.
+  unfold Colimit.cocone_postcompose_inv.
+  unfold Cocone.cocone_postcompose.
+  simpl.
+  apply moveR_equiv_M'.
+
+
+    
+Admitted.
+     

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -112,12 +112,8 @@ Defined.
 (* TODO: Show that this is a pointed equivalence. We cannot yet do this as we cannot compute with the flattening lemma due to the massive size of the proof. *)
 Definition equiv_hopf_total_join `{Univalence} (X : pType)
   `{IsHSpace X} `{forall a, IsEquiv (a *.)} `{forall a, IsEquiv (.* a)}
-  : psigma (hopf_construction X) <~>* pjoin X X.
+  : psigma (hopf_construction X) <~> pjoin X X.
 Proof.
-  symmetry.
-  snrapply Build_pEquiv'.
-  2: shelve.
-  symmetry.
   snrefine (_ oE (pushout_flattening (f:=const_tt X) (g:=const_tt X) _
     (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X)) (fun _ => equiv_idmap)
     (fun x => Build_Equiv _ _ (fun y => sg_op x y) (H1 x)))^-1%equiv).
@@ -132,27 +128,4 @@ Proof.
   - exact (equiv_contr_sigma (Unit_ind (pointed_type X))).
   - hnf; reflexivity.
   - hnf; reflexivity.
-  Unshelve.
-  unfold "pt".
-  Opaque pushout_flattening.
-  simpl.
-  Transparent pushout_flattening.
-  unfold pushout_flattening.
-  unfold "pt".
-  rapply (moveR_equiv_V' (equiv_functor_sigma' _ _)). 
-  Opaque Colimit_Pushout_Flattening.PO_flattening.
-  Opaque flattening_coh_2.
-  simpl.
-  unfold functor_sigma.
-  simpl.
-  unfold Colimit.functor_colimit.
-  simpl.
-  unfold Colimit.cocone_postcompose_inv.
-  unfold Cocone.cocone_postcompose.
-  simpl.
-  apply moveR_equiv_M'.
-
-
-    
-Admitted.
-     
+Defined. 

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -27,7 +27,7 @@ Defined.
 
 (** *** Total space of the Hopf construction *)
 
-(** The total space of the Hopf construction on [Susp X] is the join of [X] with itself. Note that we need both left and right multiplication to be equivalences. This is true when [X] is a 0-connected H-space for example. *)
+(** The total space of the Hopf construction on [Susp X] is the join of [X] with itself. Note that we need both left and right multiplication to be equivalences. This is true when [X] is a 0-connected H-space for example. (This is lemma 8.5.7 in the HoTT book). *)
 (* TODO: Show that this is a pointed equivalence. We cannot yet do this as we cannot compute with the flattening lemma due to the massive size of the proof. *)
 Definition equiv_hopf_total_join `{Univalence} (X : pType)
   `{IsHSpace X} `{forall a, IsEquiv (a *.)} `{forall a, IsEquiv (.* a)}

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -117,3 +117,15 @@ Definition contr_equiv_unit (A : Type) (f : A <~> Unit) : Contr A
 
 (** The constant map to [Unit].  We define this so we can get rid of an unneeded universe variable that Coq generates when [const tt] is used in a context that doesn't have [Universe Minimization ToSet] as this file does. If we ever set that globally, then we could get rid of this and remove some imports of this file. *)
 Definition const_tt (A : Type) := @const A Unit tt.
+
+(** Families over Unit type are equivalent to the type at the base point. *)
+Lemma equiv_sigma_unit_ind (P : Unit -> Type)
+  : sig P <~> P tt.
+Proof.
+  simple refine (equiv_adjointify _ _ _ _).
+  - intros [[] p]; exact p.
+  - intros p; exists tt; exact p.
+  - reflexivity.
+  - intros [[] p].
+    reflexivity.
+Defined.

--- a/theories/Types/Unit.v
+++ b/theories/Types/Unit.v
@@ -117,15 +117,3 @@ Definition contr_equiv_unit (A : Type) (f : A <~> Unit) : Contr A
 
 (** The constant map to [Unit].  We define this so we can get rid of an unneeded universe variable that Coq generates when [const tt] is used in a context that doesn't have [Universe Minimization ToSet] as this file does. If we ever set that globally, then we could get rid of this and remove some imports of this file. *)
 Definition const_tt (A : Type) := @const A Unit tt.
-
-(** Families over Unit type are equivalent to the type at the base point. *)
-Lemma equiv_sigma_unit_ind (P : Unit -> Type)
-  : sig P <~> P tt.
-Proof.
-  simple refine (equiv_adjointify _ _ _ _).
-  - intros [[] p]; exact p.
-  - intros p; exists tt; exact p.
-  - reflexivity.
-  - intros [[] p].
-    reflexivity.
-Defined.


### PR DESCRIPTION
We use the colimits library to prove flattening for pushouts. The proof is a bit annoying as it doesn't compute well.

We use this to show that the Hopf construction has total space equivalent to a join. Because of the uncomputable nature of the flattening lemma we are unable to show that it preserves the base point.

This should be enough for something else I am working on. Corollaries like the Hopf fibrations for the spheres would ideally come once we sort out the computability.

I tried proving the flattening lemma directly for GraphQuotient and Pushout but I was not able to get around the difficult path algebra easily. The fact that this is done in the Colimits library is good and we should use it, however it is not as easy as I thought to transfer across equivalences in this case. Maybe I am missing something obvious?