### PR TITLE
Colimits and Hopf: clean up and speed up

### DIFF
--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -100,9 +100,10 @@ Definition freudenthal_hspace' `{Univalence}
   : O_inverts (Tr (m +2+ m).+1) (loop_susp_unit X).
 Proof.
   set (r:=connecting_map_family (hopf_construction X)).
-  rapply (OO_inverts_conn_map_factor_conn_map _ (m +2+ m) _ r).
+  nrapply (OO_inverts_conn_map_factor_conn_map _ (m +2+ m) _ r).
+  2, 4: exact _.
   1: apply O_lex_leq_Tr.
-  rapply (conn_map_homotopic _ idmap).
+  rapply (conn_map_homotopic _ equiv_idmap (r o loop_susp_unit X)).
   symmetry.
   nrapply hopf_retraction.
 Defined.


### PR DESCRIPTION
Colimit_Pushout.v: The proof of `PO_ind` contained large subterms which needed to be reproduced in other proofs.  I factored those out, which makes many proof terms much smaller.  Also I avoided unnecessary uses of `destruct` (using the `[]` notation), which also made some proof terms larger than needed.  And I cleaned things up a bit.

Hopf.v: Just some minor things to avoid some fruitless typeclass search.
