### PR TITLE
put hor \/ notation in module

### DIFF
--- a/theories/Sets/AC.v
+++ b/theories/Sets/AC.v
@@ -4,6 +4,7 @@ From HoTT Require Import Spaces.Card.
 
 From HoTT.Sets Require Import Ordinals.
 
+Local Open Scope hprop_scope.
 
 (** * Set-theoretic formulation of the axiom of choice (AC) *)
 

--- a/theories/Sets/GCH.v
+++ b/theories/Sets/GCH.v
@@ -2,7 +2,8 @@ From HoTT Require Import TruncType abstract_algebra.
 From HoTT Require Import PropResizing.PropResizing.
 From HoTT Require Import Spaces.Nat.Core Spaces.Card.
 
-Open Scope type.
+Local Open Scope type.
+Local Open Scope hprop_scope.
 
 
 (** * Formulation of GCH *)

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -2,6 +2,8 @@ From HoTT Require Import TruncType ExcludedMiddle Modalities.ReflectiveSubuniver
 From HoTT Require Import PropResizing.PropResizing.
 From HoTT Require Import Colimits.Quotient.
 
+Local Open Scope hprop_scope.
+
 (** This file contains a definition of ordinals and some fundamental results,
     roughly following the presentation in the HoTT book. *)
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -190,7 +190,8 @@ Definition hexists {X} (P : X -> Type) : HProp := merely (sig P).
 
 Definition hor (P Q : Type) : HProp := merely (P + Q).
 
-Notation "A \/ B" := (hor A B) : type_scope.
+Declare Scope hprop_scope.
+Notation "A \/ B" := (hor A B) : hprop_scope.
 
 Definition himage {X Y} (f : X -> Y) := image (Tr (-1)) f.
 


### PR DESCRIPTION
This notation is a bit too global and conflicts with wedge sum notations we use later. We fix this by putting it behind a module and import it when it is used. (It isn't used enough to justify it being global).

I also don't think it should be in type_scope but I don't really want to spend time thinking about that right now.