### PR TITLE
various improvements to wedge

### DIFF
--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -4,12 +4,14 @@ Require Import Colimits.Pushout.
 Require Import WildCat.
 Require Import Homotopy.Suspension.
 
-(* Here we define the Wedge sum of two pointed types *)
+Local Set Universe Minimization ToSet.
+
+(** * Wedge sums *)
 
 Local Open Scope pointed_scope.
 
-Definition Wedge@{u v} (X Y : pType@{u}) : pType@{v}
-  := [Pushout@{u u v v} (fun _ : Unit => point X) (fun _ => point Y), pushl (point X)].
+Definition Wedge (X Y : pType) : pType
+  := [Pushout (fun _ : Unit => point X) (fun _ => point Y), pushl (point X)].
 
 Notation "X \/ Y" := (Wedge X Y) : pointed_scope.
 
@@ -31,10 +33,10 @@ Defined.
 Definition wglue {X Y : pType}
   : pushl (point X) = (pushr (point Y)) :> (X \/ Y) := pglue tt.
 
-(** Wedge recursion into an unpointed type. We define this one separately as the universe variables need to be more general. *)
-Definition wedge_rec'@{i j v} {X Y : pType@{i}} {Z : Type@{v}}
+(** Wedge recursion into an unpointed type. *)
+Definition wedge_rec' {X Y : pType} {Z : Type}
   (f : X -> Z) (g : Y -> Z) (w : f pt = g pt)
-  : Wedge@{i j} X Y -> Z.
+  : Wedge X Y -> Z.
 Proof.
   snrapply Pushout_rec.
   - exact f.


### PR DESCRIPTION
These are some quality of life improvements for working with wedges. They consist of:
- <s>Adding explicit universe levels for wedges. Not sure if they need to be generalised further. I've opted for 2 levels for the source and target. I can't tell if having 3 will be useful at this point.</s> Universe levels are generalized correctly now.
- Generalising wedge_rec to target any type (in any universe) and naming that wedge_rec'. Then redefining wedge_rec as a special case of wedge_rec'.
- Using wild category notations for various arrows and homotopies so that fmap and friends work better.
- Add a computation rule for the wedge inclusion.