### PR TITLE
characterize fiber of loop-susp counit

### DIFF
--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -146,12 +146,12 @@ Proof.
   funext q.
   simpl.
   lhs rapply (transport_equiv (merid p) _ q).
+  simpl.
   rewrite transport_paths_Fl.
   rewrite ap_V.
   rewrite inv_V.
   rewrite Susp_rec_beta_merid.
   rewrite transport_idmap_ap.
-  simpl.
   rewrite ap_compose.
   rewrite functor_susp_beta_merid.
   rewrite Susp_rec_beta_merid.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -1,6 +1,6 @@
 Require Import Types Basics Pointed Truncations.
 Require Import HSpace Suspension ExactSequence HomotopyGroup.
-Require Import WildCat.Core WildCat.Universe  WildCat.Equiv Modalities.ReflectiveSubuniverse Modalities.Descent.
+Require Import WildCat.Core WildCat.Universe WildCat.Equiv Modalities.ReflectiveSubuniverse Modalities.Descent.
 Require Import HSet Spaces.Nat.Core.
 Require Import Homotopy.Join Colimits.Pushout Colimits.PushoutFlattening.
 
@@ -129,16 +129,8 @@ Proof.
   rapply freudenthal_hspace.
 Defined.
 
-(** A version that shows that the underlying functions are equal. *)
-Definition transport_equiv' {A : Type} {B C : A -> Type}
-  {x1 x2 : A} (p : x1 = x2) (f : B x1 <~> C x1)
-  : transport (fun x => B x <~> C x) p f = (equiv_transport _ p) oE f oE (equiv_transport _ p^) :> (B x2 -> C x2).
-Proof.
-  destruct p; auto.
-Defined.
-
-(** We can use the Hopf construction to show that the fiber of the loop-susp counit is equivalent to the join of the loop spaces. *)
-(* TODO: use explicit path algebra once [equiv_hopf_total_join] is computable and make this poitned. *)
+(** Since [loops X] is an H-space, the Hopf construction provides a map [Join (loops X) (loops X) -> Susp (loops X)].  We show that this map is equivalent to the fiber of [loop_susp_counit X : Susp (loops X) -> X] over the base point, up to the automorphism of [Susp (loops X)] induced by inverting loops. *)
+(* TODO: use explicit path algebra once [equiv_hopf_total_join] is computable and make this pointed. *)
 Definition equiv_pfiber_loops_susp_counit_join `{Univalence} (X : pType)
   : pfiber (loop_susp_counit X) <~> pjoin (loops X) (loops X).
 Proof.
@@ -152,9 +144,8 @@ Proof.
   intros p.
   nrapply path_equiv.
   funext q.
-  unfold emap.
   simpl.
-  lhs rapply transport_equiv.
+  lhs rapply (transport_equiv (merid p) _ q).
   rewrite transport_paths_Fl.
   rewrite ap_V.
   rewrite inv_V.
@@ -165,6 +156,16 @@ Proof.
   rewrite functor_susp_beta_merid.
   rewrite Susp_rec_beta_merid.
   rewrite transport_path_universe.
-  apply moveR_Vp.
-  reflexivity.
+  apply concat_V_pp.
+Defined.
+
+(** As a corollary we get 2n-connectivity of [loop_susp_counit X] for an n-connected [X]. *)
+Global Instance conn_map_loop_susp_counit `{Univalence}
+  {n : trunc_index} (X : pType) `{IsConnected n.+2 X}
+  : IsConnMap (n.+1 +2+ n.+1)%nat (loop_susp_counit X).
+Proof.
+  rapply (conn_point_elim (-1)).
+  1: exact (isconnected_pred_add' n 0 _).
+  nrapply (isconnected_equiv' _ _ (equiv_pfiber_loops_susp_counit_join X)^-1).
+  rapply isconnected_join.
 Defined.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -166,8 +166,9 @@ Global Instance conn_map_loop_susp_counit `{Univalence}
 Proof.
   destruct n.
   - intro x; hnf; exact _.
-  - rapply (conn_point_elim (-1)).
-    1: exact (isconnected_pred_add' n 0 _).
-    nrapply (isconnected_equiv' _ _ (equiv_pfiber_loops_susp_counit_join X)^-1).
-    rapply isconnected_join.
+  - snrapply (conn_point_elim (-1)).
+    + exact (isconnected_pred_add' n 0 _).
+    + exact _.
+    + nrapply (isconnected_equiv' _ _ (equiv_pfiber_loops_susp_counit_join X)^-1).
+      nrapply isconnected_join; exact _.
 Defined.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -161,11 +161,13 @@ Defined.
 
 (** As a corollary we get 2n-connectivity of [loop_susp_counit X] for an n-connected [X]. *)
 Global Instance conn_map_loop_susp_counit `{Univalence}
-  {n : trunc_index} (X : pType) `{IsConnected n.+2 X}
-  : IsConnMap (n.+1 +2+ n.+1)%nat (loop_susp_counit X).
+  {n : trunc_index} (X : pType) `{IsConnected n.+1 X}
+  : IsConnMap (n +2+ n) (loop_susp_counit X).
 Proof.
-  rapply (conn_point_elim (-1)).
-  1: exact (isconnected_pred_add' n 0 _).
-  nrapply (isconnected_equiv' _ _ (equiv_pfiber_loops_susp_counit_join X)^-1).
-  rapply isconnected_join.
+  destruct n.
+  - intro x; hnf; exact _.
+  - rapply (conn_point_elim (-1)).
+    1: exact (isconnected_pred_add' n 0 _).
+    nrapply (isconnected_equiv' _ _ (equiv_pfiber_loops_susp_counit_join X)^-1).
+    rapply isconnected_join.
 Defined.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -1,6 +1,6 @@
 Require Import Types Basics Pointed Truncations.
 Require Import HSpace Suspension ExactSequence HomotopyGroup.
-Require Import WildCat.Core Modalities.ReflectiveSubuniverse Modalities.Descent.
+Require Import WildCat.Core WildCat.Universe  WildCat.Equiv Modalities.ReflectiveSubuniverse Modalities.Descent.
 Require Import HSet Spaces.Nat.Core.
 Require Import Homotopy.Join Colimits.Pushout Colimits.PushoutFlattening.
 
@@ -47,7 +47,7 @@ Proof.
   - reflexivity.
 Defined. 
 
-(** *** Miscellaneous lemmas and corollaries about the Hopf construction *)
+(** ** Miscellaneous lemmas and corollaries about the Hopf construction *)
 
 Lemma transport_hopf_construction `{Univalence} {X : pType}
   `{IsHSpace X} `{forall a, IsEquiv (a *.)}
@@ -127,4 +127,43 @@ Proof.
   refine (_ o*E pequiv_ptr (n:=k)).
   nrefine (pequiv_O_inverts k (loop_susp_unit X)).
   rapply freudenthal_hspace.
+Defined.
+
+(** A version that shows that the underlying functions are equal. *)
+Definition transport_equiv' {A : Type} {B C : A -> Type}
+  {x1 x2 : A} (p : x1 = x2) (f : B x1 <~> C x1)
+  : transport (fun x => B x <~> C x) p f = (equiv_transport _ p) oE f oE (equiv_transport _ p^) :> (B x2 -> C x2).
+Proof.
+  destruct p; auto.
+Defined.
+
+(** We can use the Hopf construction to show that the fiber of the loop-susp counit is equivalent to the join of the loop spaces. *)
+Definition equiv_pfiber_loops_susp_counit_join `{Univalence} (X : pType)
+  : pfiber (loop_susp_counit X) <~> pjoin (loops X) (loops X).
+Proof.
+  snrefine (equiv_hopf_total_join (loops X) oE _).
+  1: rapply ishspace_loops.
+  1,2: exact _.
+  snrapply equiv_functor_sigma'.
+  1: exact (emap psusp (equiv_path_inverse _ _)).
+  snrapply Susp_ind; hnf.
+  1,2: reflexivity.
+  intros p.
+  nrapply path_equiv.
+  funext q.
+  unfold emap.
+  simpl.
+  lhs rapply transport_equiv.
+  rewrite transport_paths_Fl.
+  rewrite ap_V.
+  rewrite inv_V.
+  rewrite Susp_rec_beta_merid.
+  rewrite transport_idmap_ap.
+  simpl.
+  rewrite ap_compose.
+  rewrite functor_susp_beta_merid.
+  rewrite Susp_rec_beta_merid.
+  rewrite transport_path_universe.
+  apply moveR_Vp.
+  reflexivity.
 Defined.

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -138,6 +138,7 @@ Proof.
 Defined.
 
 (** We can use the Hopf construction to show that the fiber of the loop-susp counit is equivalent to the join of the loop spaces. *)
+(* TODO: use explicit path algebra once [equiv_hopf_total_join] is computable and make this poitned. *)
 Definition equiv_pfiber_loops_susp_counit_join `{Univalence} (X : pType)
   : pfiber (loop_susp_counit X) <~> pjoin (loops X) (loops X).
 Proof.

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -112,6 +112,14 @@ Proof.
   destruct p; simpl; auto.
 Defined.
 
+(** This is an improvement to [transport_arrow_toconst].  That result shows that the functions are homotopic, but even without funext, we can prove that these functions are equal. *)
+Definition transport_arrow_toconst' {A : Type} {B : A -> Type} {C : Type}
+  {x1 x2 : A} (p : x1 = x2) (f : B x1 -> C)
+  : transport (fun x => B x -> C) p f = f o transport B p^.
+Proof.
+  destruct p; auto.
+Defined.
+
 Definition transport_arrow_fromconst {A B : Type} {C : A -> Type}
   {x1 x2 : A} (p : x1 = x2) (f : B -> C x1) (y : B)
   : (transport (fun x => B -> C x) p f) y  =  p # (f y).

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -97,6 +97,14 @@ Proof.
   destruct p; simpl; auto.
 Defined.
 
+(** This is an improvement to [transport_arrow].  That result only shows that the functions are homotopic, but even without funext, we can prove that these functions are equal. *)
+Definition transport_arrow' {A : Type} {B C : A -> Type}
+  {x1 x2 : A} (p : x1 = x2) (f : B x1 -> C x1)
+  : transport (fun x => B x -> C x) p f = transport _ p o f o transport _ p^.
+Proof.
+  destruct p; auto.
+Defined.
+
 Definition transport_arrow_toconst {A : Type} {B : A -> Type} {C : Type}
   {x1 x2 : A} (p : x1 = x2) (f : B x1 -> C) (y : B x2)
   : (transport (fun x => B x -> C) p f) y  =  f (p^ # y).

--- a/theories/Types/Equiv.v
+++ b/theories/Types/Equiv.v
@@ -202,3 +202,28 @@ End AssumeFunext.
 
 (** We make this a global hint outside of the section. *)
 #[export] Hint Immediate isequiv_contr_map : typeclass_instances.
+
+(** This is like [transport_arrow], but for a family of equivalence types. It just shows that the functions are homotopic. *)
+Definition transport_equiv {A : Type} {B C : A -> Type}
+  {x1 x2 : A} (p : x1 = x2) (f : B x1 <~> C x1) (y : B x2)
+  : (transport (fun x => B x <~> C x) p f) y = p # (f (p^ # y)).
+Proof.
+  destruct p; auto.
+Defined.
+
+(** A version that shows that the underlying functions are equal. *)
+Definition transport_equiv' {A : Type} {B C : A -> Type}
+  {x1 x2 : A} (p : x1 = x2) (f : B x1 <~> C x1)
+  : transport (fun x => B x <~> C x) p f = (equiv_transport _ p) oE f oE (equiv_transport _ p^) :> (B x2 -> C x2).
+Proof.
+  destruct p; auto.
+Defined.
+
+(** A version that shows that the equivalences are equal.  Here we do need [Funext], for [path_equiv]. *)
+Definition transport_equiv'' `{Funext} {A : Type} {B C : A -> Type}
+  {x1 x2 : A} (p : x1 = x2) (f : B x1 <~> C x1)
+  : transport (fun x => B x <~> C x) p f = (equiv_transport _ p) oE f oE (equiv_transport _ p^).
+Proof.
+  apply path_equiv.
+  destruct p; auto.
+Defined.


### PR DESCRIPTION
We characterize the fiber of the loop-susp counit. We can't make it a pointed equivalence just yet as we are missing pointedness of the Hopf construction. Interestingly we have to twist the first component when we try to show the sigma types are equivalent.

I've also gone ahead and added the lemmas in #1841 as we use one of these.