### PR TITLE
remove rewrite

### DIFF
--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -168,7 +168,10 @@ Section Flattening.
     : ap (flatten_rec Qgq Qgqglue) (flatten_gqglue s x) = Qgqglue a b s x.
   Proof.
     lhs nrapply ap_sig_rec_path_sigma; cbn.
-    rewrite GraphQuotient_ind_beta_gqglue.
+    lhs nrapply (ap (fun x => x @ _)).
+    { nrapply ap.
+      nrapply (ap01 (fun x => ap10 x _)).
+      nrapply GraphQuotient_ind_beta_gqglue. }
     apply moveR_pM.
     apply moveL_pM.
     lhs nrapply concat_pp_p.

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -171,14 +171,27 @@ Section Flattening.
     rewrite GraphQuotient_ind_beta_gqglue.
     apply moveR_pM.
     apply moveL_pM.
-    rewrite 3 concat_pp_p.
+    lhs nrapply concat_pp_p.
+    lhs nrapply concat_pp_p.
+    lhs nrapply concat_pp_p.
     apply moveR_Vp.
-    rewrite (ap10_dpath_arrow DGraphQuotient (fun _ => Q) (gqglue s)).
-    hott_simpl.
+    lhs nrapply ap.
+    1: nrapply ap.
+    1: nrapply (ap (fun x => x @ _)).
+    1: nrapply (ap10_dpath_arrow DGraphQuotient (fun _ => Q) (gqglue s)).
+    lhs nrapply ap.
+    1: nrapply ap.
+    1: lhs nrapply concat_pp_p.
+    1: nrapply concat_pp_p.
+    lhs nrapply ap.
+    1: nrapply concat_V_pp.
+    lhs nrapply concat_V_pp.
+    lhs nrapply concat_pp_p.
+    f_ap.
     lhs nrapply concat_pp_p.
     apply moveR_Mp.
     rhs nrapply concat_Vp.
-    apply moveR_pM.
+    apply moveR_pV.
     rhs nrapply concat_1p.
     nrapply ap_V.
   Defined.

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -174,20 +174,14 @@ Section Flattening.
       nrapply GraphQuotient_ind_beta_gqglue. }
     apply moveR_pM.
     apply moveL_pM.
-    lhs nrapply concat_pp_p.
-    lhs nrapply concat_pp_p.
-    lhs nrapply concat_pp_p.
+    do 3 lhs nrapply concat_pp_p.
     apply moveR_Vp.
-    lhs nrapply ap.
-    1: nrapply ap.
-    1: nrapply (ap (fun x => x @ _)).
+    lhs refine (1 @@ (1 @@ (_ @@ 1))).
     1: nrapply (ap10_dpath_arrow DGraphQuotient (fun _ => Q) (gqglue s)).
-    lhs nrapply ap.
-    1: nrapply ap.
-    1: lhs nrapply concat_pp_p.
-    1: nrapply concat_pp_p.
-    lhs nrapply ap.
-    1: nrapply concat_V_pp.
+    lhs refine (1 @@ (1 @@ _)).
+    { lhs nrapply concat_pp_p.
+      nrapply concat_pp_p. }
+    lhs nrapply (1 @@ concat_V_pp _ _).
     lhs nrapply concat_V_pp.
     lhs nrapply concat_pp_p.
     f_ap.


### PR DESCRIPTION
@jdchristensen This is a followup to #1851, it removes all the rewrites in the proof. The reason I used rewrite in the first place was because it was convenient and we seldom have to reason about the computation rules themselves (+ laziness).

I rewrote it using explicit path algebra so it can be reasoned about in the future if we ever have to. Another advantage is that Coq won't be slow when it tries to unfold these terms.