### PR TITLE
Equivalences for displayed wild categories

### DIFF
--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -178,7 +178,9 @@ Reserved Infix "$@'" (at level 30).
 Reserved Infix "$@L'" (at level 30).
 Reserved Infix "$@R'" (at level 30).
 Reserved Infix "$@@'" (at level 30).
+Reserved Infix "$oE'" (at level 40, left associativity).
 Reserved Notation "f ^$'" (at level 3, format "f '^$''").
+Reserved Notation "f ^-1$'" (at level 3, format "f '^-1$''").
 
 (** Cubical *)
 Reserved Infix "@@h" (at level 30).

--- a/theories/WildCat.v
+++ b/theories/WildCat.v
@@ -15,6 +15,7 @@ Require Export WildCat.Monoidal.
 Require Export WildCat.Products.
 Require Export WildCat.Coproducts.
 Require Export WildCat.Displayed.
+Require Export WildCat.DisplayedEquiv.
 
 (* See also contrib/SetoidRewrite.v for tools that can be used for rewriting in wild categories. *)
 

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -8,7 +8,7 @@ Require Import WildCat.Prod.
 Class IsDGraph {A : Type} `{IsGraph A} (D : A -> Type)
   := DHom : forall {a b : A}, (a $-> b) -> D a -> D b -> Type.
 
-Class Is01DCat {A : Type} `{Is01Cat A} (D : A -> Type) `{!IsDGraph D} :=
+Class IsD01Cat {A : Type} `{Is01Cat A} (D : A -> Type) `{!IsDGraph D} :=
 {
   DId : forall {a : A} (a' : D a), DHom (Id a) a' a';
   dcat_comp : forall {a b c : A} {g : b $-> c} {f : a $-> b}
@@ -18,36 +18,36 @@ Class Is01DCat {A : Type} `{Is01Cat A} (D : A -> Type) `{!IsDGraph D} :=
 
 Notation "g '$o'' f" := (dcat_comp g f).
 
-Definition dcat_postcomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
+Definition dcat_postcomp {A : Type} {D : A -> Type} `{IsD01Cat A D} {a b c : A}
   {g : b $-> c} {a' : D a} {b' : D b} {c' : D c} (g' : DHom g b' c')
   : forall (f : a $-> b), DHom f a' b' -> DHom (g $o f) a' c'
   := fun _ f' => g' $o' f'.
 
-Definition dcat_precomp {A : Type} {D : A -> Type} `{Is01DCat A D} {a b c : A}
+Definition dcat_precomp {A : Type} {D : A -> Type} `{IsD01Cat A D} {a b c : A}
   {f : a $-> b} {a' : D a} {b' : D b} {c' : D c} (f' : DHom f a' b')
   : forall (g : b $-> c), DHom g b' c' -> DHom (g $o f) a' c'
   := fun _ g' => g' $o' f'.
 
-Class Is0DGpd {A : Type} `{Is0Gpd A} (D : A -> Type)
-  `{!IsDGraph D, !Is01DCat D}
+Class IsD0Gpd {A : Type} `{Is0Gpd A} (D : A -> Type)
+  `{!IsDGraph D, !IsD01Cat D}
   := dgpd_rev : forall {a b : A} {f : a $== b} {a' : D a} {b' : D b},
                 DHom f a' b' -> DHom (f^$) b' a'.
 
 Notation "p ^$'" := (dgpd_rev p).
 
-Definition DGpdHom {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
+Definition DGpdHom {A : Type} {D : A -> Type} `{IsD0Gpd A D} {a b : A}
   (f : a $== b) (a' : D a) (b' : D b)
   := DHom f a' b'.
 
 (** Diagrammatic order to match gpd_comp *)
-Definition dgpd_comp {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b c : A}
+Definition dgpd_comp {A : Type} {D : A -> Type} `{IsD0Gpd A D} {a b c : A}
   {f : a $== b} {g : b $== c} {a' : D a} {b' : D b} {c' : D c}
   : DGpdHom f a' b' -> DGpdHom g b' c' -> DGpdHom (g $o f) a' c'
   := fun f' g' => g' $o' f'.
 
 Notation "p '$@'' q" := (dgpd_comp p q).
 
-Definition DGpdHom_path {A : Type} {D : A -> Type} `{Is0DGpd A D} {a b : A}
+Definition DGpdHom_path {A : Type} {D : A -> Type} `{IsD0Gpd A D} {a b : A}
   (p : a = b) {a' : D a} {b': D b} (p' : transport D p a' = b')
   : DGpdHom (GpdHom_path p) a' b'.
 Proof.
@@ -55,16 +55,16 @@ Proof.
   apply DId.
 Defined.
 
-Global Instance reflexive_DHom {A} {D : A -> Type} `{Is01DCat A D} {a : A}
+Global Instance reflexive_DHom {A} {D : A -> Type} `{IsD01Cat A D} {a : A}
   : Reflexive (DHom (Id a))
   := fun a' => DId a'.
 
-Global Instance reflexive_DGpdHom {A} {D : A -> Type} `{Is0DGpd A D} {a : A}
+Global Instance reflexive_DGpdHom {A} {D : A -> Type} `{IsD0Gpd A D} {a : A}
   : Reflexive (DGpdHom (Id a))
   := fun a' => DId a'.
 
 (** A displayed 0-functor [F'] over a 0-functor [F] acts on displayed objects and 1-cells and satisfies no axioms. *)
-Class Is0DFunctor {A : Type} {B : Type}
+Class IsD0Functor {A : Type} {B : Type}
   {DA : A -> Type} `{IsDGraph A DA} {DB : B -> Type} `{IsDGraph B DB}
   (F : A -> B) `{!Is0Functor F} (F' : forall (a : A), DA a -> DB (F a))
   := dfmap : forall {a b : A} {f : a $-> b} {a' : DA a} {b' : DA b},
@@ -72,29 +72,29 @@ Class Is0DFunctor {A : Type} {B : Type}
 
 Arguments dfmap {A B DA _ _ DB _ _} F {_} F' {_ _ _ _ _ _} f'.
 
-Class Is2DGraph {A : Type} `{Is2Graph A}
+Class IsD2Graph {A : Type} `{Is2Graph A}
   (D : A -> Type) `{!IsDGraph D}
-  := isdgraph_dhom : forall {a b} {a'} {b'},
+  := isdgraph_hom : forall {a b} {a'} {b'},
                       IsDGraph (fun (f:a $-> b) => DHom f a' b').
 
-Global Existing Instance isdgraph_dhom.
-#[global] Typeclasses Transparent Is2DGraph.
+Global Existing Instance isdgraph_hom.
+#[global] Typeclasses Transparent IsD2Graph.
 
-Class Is1DCat {A : Type} `{Is1Cat A}
-  (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} :=
+Class IsD1Cat {A : Type} `{Is1Cat A}
+  (D : A -> Type) `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D} :=
 {
-  is01dcat_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                  Is01DCat (fun f => DHom f a' b');
-  is0dgpd_dhom : forall {a b : A} {a' : D a} {b' : D b},
-                 Is0DGpd (fun f => DHom f a' b');
-  is0dfunctor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
+  isd01cat_hom : forall {a b : A} {a' : D a} {b' : D b},
+                 IsD01Cat (fun f => DHom f a' b');
+  isd0gpd_hom : forall {a b : A} {a' : D a} {b' : D b},
+                IsD0Gpd (fun f => DHom f a' b');
+  isd0functor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
                          {b' : D b} {c' : D c} (g' : DHom g b' c'),
-                         @Is0DFunctor _ _ (fun f => DHom f a' b')
+                         @IsD0Functor _ _ (fun f => DHom f a' b')
                          _ _ (fun gf => DHom gf a' c')
                          _ _ (cat_postcomp a g) _ (dcat_postcomp g');
-  is0dfunctor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
+  isd0functor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
                         {b' : D b} {c' : D c} (f' : DHom f a' b'),
-                        @Is0DFunctor _ _ (fun g => DHom g b' c')
+                        @IsD0Functor _ _ (fun g => DHom g b' c')
                         _ _ (fun gf => DHom gf a' c')
                         _ _ (cat_precomp c f) _ (dcat_precomp f');
   dcat_assoc : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
@@ -108,19 +108,19 @@ Class Is1DCat {A : Type} `{Is1Cat A}
              (f' : DHom f a' b'), DHom (cat_idr f) (f' $o' DId a') f';
 }.
 
-Global Existing Instance is01dcat_dhom.
-Global Existing Instance is0dgpd_dhom.
-Global Existing Instance is0dfunctor_postcomp.
-Global Existing Instance is0dfunctor_precomp.
+Global Existing Instance isd01cat_hom.
+Global Existing Instance isd0gpd_hom.
+Global Existing Instance isd0functor_postcomp.
+Global Existing Instance isd0functor_precomp.
 
-Definition dcat_assoc_opp {A : Type} {D : A -> Type} `{Is1DCat A D}
+Definition dcat_assoc_opp {A : Type} {D : A -> Type} `{IsD1Cat A D}
   {a b c d : A}  {f : a $-> b} {g : b $-> c} {h : c $-> d}
   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
   (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d')
   : DHom (cat_assoc_opp f g h) (h' $o' (g' $o' f')) ((h' $o' g') $o' f')
   := (dcat_assoc f' g' h')^$'.
 
-Definition dcat_postwhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
+Definition dcat_postwhisker {A : Type} {D : A -> Type} `{IsD1Cat A D}
   {a b c : A} {f g : a $-> b} {h : b $-> c} {p : f $== g}
   {a' : D a} {b' : D b} {c' : D c} {f' : DHom f a' b'} {g' : DHom g a' b'}
   (h' : DHom h b' c') (p' : DHom p f' g')
@@ -129,7 +129,7 @@ Definition dcat_postwhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
 
 Notation "h $@L' p" := (dcat_postwhisker h p).
 
-Definition dcat_prewhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
+Definition dcat_prewhisker {A : Type} {D : A -> Type} `{IsD1Cat A D}
   {a b c : A} {f : a $-> b} {g h : b $-> c} {p : g $== h}
   {a' : D a} {b' : D b} {c' : D c} {g' : DHom g b' c'} {h' : DHom h b' c'}
   (p' : DHom p g' h') (f' : DHom f a' b')
@@ -138,7 +138,7 @@ Definition dcat_prewhisker {A : Type} {D : A -> Type} `{Is1DCat A D}
 
 Notation "p $@R' f" := (dcat_prewhisker p f).
 
-Definition dcat_comp2 {A : Type} {D : A -> Type} `{Is1DCat A D} {a b c : A}
+Definition dcat_comp2 {A : Type} {D : A -> Type} `{IsD1Cat A D} {a b c : A}
   {f g : a $-> b} {h k : b $-> c} {p : f $== g} {q : h $== k}
   {a' : D a} {b' : D b} {c' : D c} {f' : DHom f a' b'} {g' : DHom g a' b'}
   {h' : DHom h b' c'} {k' : DHom k b' c'}
@@ -150,13 +150,13 @@ Notation "q $@@' p" := (dcat_comp2 q p).
 
 (** Monomorphisms and epimorphisms. *)
 
-Definition DMonic {A} {D : A -> Type} `{Is1DCat A D} {b c : A}
+Definition DMonic {A} {D : A -> Type} `{IsD1Cat A D} {b c : A}
   {f : b $-> c} {mon : Monic f} {b' : D b} {c' : D c} (f' : DHom f b' c')
   := forall (a : A) (g h : a $-> b) (p : f $o g $== f $o h) (a' : D a)
       (g' : DHom g a' b') (h' : DHom h a' b'),
       DGpdHom p (f' $o' g') (f' $o' h') -> DGpdHom (mon a g h p) g' h'.
 
-Definition DEpic {A} {D : A -> Type} `{Is1DCat A D} {a b : A}
+Definition DEpic {A} {D : A -> Type} `{IsD1Cat A D} {a b : A}
   {f : a $-> b} {epi : Epic f} {a' : D a} {b' : D b} (f' : DHom f a' b')
   := forall (c : A) (g h : b $-> c) (p : g $o f $== h $o f) (c' : D c)
       (g' : DHom g b' c') (h' : DHom h b' c'),
@@ -170,7 +170,7 @@ Proof.
   exact {f : a $-> b & DHom f a' b'}.
 Defined.
 
-Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{Is01DCat A D}
+Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{IsD01Cat A D}
   : Is01Cat (sig D).
 Proof.
   srapply Build_Is01Cat.
@@ -180,7 +180,7 @@ Proof.
     exact (g $o f; g' $o' f').
 Defined.
 
-Global Instance is0gpd_sigma {A : Type} (D : A -> Type) `{Is0DGpd A D}
+Global Instance is0gpd_sigma {A : Type} (D : A -> Type) `{IsD0Gpd A D}
   : Is0Gpd (sig D).
 Proof.
   srapply Build_Is0Gpd.
@@ -196,7 +196,7 @@ Proof.
   exact f.
 Defined.
 
-Global Instance is2graph_sigma {A : Type} (D : A -> Type) `{Is2DGraph A D}
+Global Instance is2graph_sigma {A : Type} (D : A -> Type) `{IsD2Graph A D}
   : Is2Graph (sig D).
 Proof.
   intros [a a'] [b b'].
@@ -205,9 +205,9 @@ Proof.
   exact ({p : f $-> g & DHom p f' g'}).
 Defined.
 
-Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{Is01DCat A DA}
-  {B : Type} (DB : B -> Type) `{Is01DCat B DB} (F : A -> B) `{!Is0Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F'}
+Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{IsD01Cat A DA}
+  {B : Type} (DB : B -> Type) `{IsD01Cat B DB} (F : A -> B) `{!Is0Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F'}
   : Is0Functor (functor_sigma F F').
 Proof.
   srapply Build_Is0Functor.
@@ -216,7 +216,7 @@ Proof.
   exact (fmap F f; dfmap F F' f').
 Defined.
 
-Global Instance is1cat_sigma {A : Type} (D : A -> Type) `{Is1DCat A D}
+Global Instance is1cat_sigma {A : Type} (D : A -> Type) `{IsD1Cat A D}
   : Is1Cat (sig D).
 Proof.
   srapply Build_Is1Cat.
@@ -236,7 +236,7 @@ Proof.
     exact (cat_idr f; dcat_idr f').
 Defined.
 
-Global Instance is1functor_pr1 {A : Type} {D : A -> Type} `{Is1DCat A D}
+Global Instance is1functor_pr1 {A : Type} {D : A -> Type} `{IsD1Cat A D}
   : Is1Functor (pr1 : sig D -> A).
 Proof.
   srapply Build_Is1Functor.
@@ -248,22 +248,22 @@ Proof.
     apply Id.
 Defined.
 
-Class Is1DCat_Strong {A : Type} `{Is1Cat_Strong A}
+Class IsD1Cat_Strong {A : Type} `{Is1Cat_Strong A}
   (D : A -> Type)
-  `{!IsDGraph D, !Is2DGraph D, !Is01DCat D} :=
+  `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D} :=
 {
-  is01dcat_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
-                          Is01DCat (fun f => DHom f a' b');
-  is0dgpd_dhom_strong : forall {a b : A} {a' : D a} {b' : D b},
-                        Is0DGpd (fun f => DHom f a' b');
-  is0dfunctor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
+  isd01cat_hom_strong : forall {a b : A} {a' : D a} {b' : D b},
+                        IsD01Cat (fun f => DHom f a' b');
+  isd0gpd_hom_strong : forall {a b : A} {a' : D a} {b' : D b},
+                       IsD0Gpd (fun f => DHom f a' b');
+  isd0functor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
                                 {b' : D b} {c' : D c} (g' : DHom g b' c'),
-                                @Is0DFunctor _ _ (fun f => DHom f a' b')
+                                @IsD0Functor _ _ (fun f => DHom f a' b')
                                 _ _ (fun gf => DHom gf a' c')
                                 _ _ (cat_postcomp a g) _ (dcat_postcomp g');
-  is0dfunctor_precomp_strong : forall {a b c : A} {f : a $-> b} {a' : D a}
+  isd0functor_precomp_strong : forall {a b c : A} {f : a $-> b} {a' : D a}
                                 {b' : D b} {c' : D c} (f' : DHom f a' b'),
-                                @Is0DFunctor _ _ (fun g => DHom g b' c')
+                                @IsD0Functor _ _ (fun g => DHom g b' c')
                                 _ _ (fun gf => DHom gf a' c')
                                 _ _ (cat_precomp c f) _ (dcat_precomp f');
   dcat_assoc_strong : forall {a b c d : A} {f : a $-> b} {g : b $-> c} {h : c $-> d}
@@ -281,12 +281,12 @@ Class Is1DCat_Strong {A : Type} `{Is1Cat_Strong A}
                     (f' $o' DId a')) = f';
 }.
 
-Global Existing Instance is01dcat_dhom_strong.
-Global Existing Instance is0dgpd_dhom_strong.
-Global Existing Instance is0dfunctor_postcomp_strong.
-Global Existing Instance is0dfunctor_precomp_strong.
+Global Existing Instance isd01cat_hom_strong.
+Global Existing Instance isd0gpd_hom_strong.
+Global Existing Instance isd0functor_postcomp_strong.
+Global Existing Instance isd0functor_precomp_strong.
 
-Definition dcat_assoc_opp_strong {A : Type} {D : A -> Type} `{Is1DCat_Strong A D}
+Definition dcat_assoc_opp_strong {A : Type} {D : A -> Type} `{IsD1Cat_Strong A D}
   {a b c d : A}  {f : a $-> b} {g : b $-> c} {h : c $-> d}
   {a' : D a} {b' : D b} {c' : D c} {d' : D d}
   (f' : DHom f a' b') (g' : DHom g b' c') (h' : DHom h c' d')
@@ -297,10 +297,10 @@ Proof.
   exact ((dcat_assoc_strong f' g' h')^).
 Defined.
 
-Global Instance is1dcat_is1dcatstrong {A : Type} (D : A -> Type)
-  `{Is1DCat_Strong A D} : Is1DCat D.
+Global Instance isd1cat_isd1catstrong {A : Type} (D : A -> Type)
+  `{IsD1Cat_Strong A D} : IsD1Cat D.
 Proof.
-  srapply Build_Is1DCat.
+  srapply Build_IsD1Cat.
   - intros a b c d f g h a' b' c' d' f' g' h'.
     exact (DGpdHom_path (cat_assoc_strong f g h) (dcat_assoc_strong f' g' h')).
   - intros a b f a' b' f'.
@@ -310,7 +310,7 @@ Proof.
 Defined.
 
 Global Instance is1catstrong_sigma {A : Type}
-  (D : A -> Type) `{Is1DCat_Strong A D}
+  (D : A -> Type) `{IsD1Cat_Strong A D}
   : Is1Cat_Strong (sig D).
 Proof.
   srapply Build_Is1Cat_Strong.
@@ -323,10 +323,10 @@ Proof.
     exact (path_sigma' _ (cat_idr_strong f) (dcat_idr_strong f')).
 Defined.
 
-Class Is1DFunctor
-  {A B : Type} {DA : A -> Type} `{Is1DCat A DA} {DB : B -> Type} `{Is1DCat B DB}
+Class IsD1Functor
+  {A B : Type} {DA : A -> Type} `{IsD1Cat A DA} {DB : B -> Type} `{IsD1Cat B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F'} :=
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F'} :=
 {
   dfmap2 : forall {a b : A} {f g : a $-> b} {p : f $== g} {a' : DA a}
             {b' : DA b} (f' : DHom f a' b') (g' : DHom g a' b'),
@@ -347,7 +347,7 @@ Arguments dfmap_comp {A B DA _ _ _ _ _ _ _ _ DB _ _ _ _ _ _ _ _}
   F {_ _} F' {_ _ a b c f g a' b' c'} f' g'.
 
 Global Instance is1functor_sigma {A B : Type} (DA : A -> Type) (DB : B -> Type)
-  (F : A -> B) (F' : forall (a : A), DA a -> DB (F a)) `{Is1DFunctor A B DA DB F F'}
+  (F : A -> B) (F' : forall (a : A), DA a -> DB (F a)) `{IsD1Functor A B DA DB F F'}
   : Is1Functor (functor_sigma F F').
 Proof.
   srapply Build_Is1Functor.
@@ -361,19 +361,19 @@ Proof.
 Defined.
 
 Section IdentityFunctor.
-  Global Instance is0dfunctor_idmap {A : Type} `{Is01Cat A}
-    (DA : A -> Type) `{!IsDGraph DA, !Is01DCat DA}
-    : Is0DFunctor (idmap) (fun a a' => a').
+  Global Instance isd0functor_idmap {A : Type} `{Is01Cat A}
+    (DA : A -> Type) `{!IsDGraph DA, !IsD01Cat DA}
+    : IsD0Functor (idmap) (fun a a' => a').
   Proof.
     intros a b f a' b' f'.
     assumption.
   Defined.
 
-  Global Instance is1dfunctor_idmap {A : Type} (DA : A -> Type)
-    `{Is1DCat A DA}
-    : Is1DFunctor (idmap) (fun a a' => a').
+  Global Instance isd1functor_idmap {A : Type} (DA : A -> Type)
+    `{IsD1Cat A DA}
+    : IsD1Functor (idmap) (fun a a' => a').
   Proof.
-    apply Build_Is1DFunctor.
+    apply Build_IsD1Functor.
     - intros a b f g p a' b' f' g' p'.
       assumption.
     - intros a a'.
@@ -384,24 +384,24 @@ Section IdentityFunctor.
 End IdentityFunctor.
 
 Section ConstantFunctor.
-  Global Instance is0dfunctor_const {A : Type} `{IsGraph A}
+  Global Instance isd0functor_const {A : Type} `{IsGraph A}
     {B : Type} `{Is01Cat B} (DA : A -> Type) `{!IsDGraph DA}
-    (DB : B -> Type) `{!IsDGraph DB, !Is01DCat DB} (x : B) (x' : DB x)
-    : Is0DFunctor (fun _ : A => x) (fun _ _ => x').
+    (DB : B -> Type) `{!IsDGraph DB, !IsD01Cat DB} (x : B) (x' : DB x)
+    : IsD0Functor (fun _ : A => x) (fun _ _ => x').
   Proof.
     intros a b f a' b' f'.
     apply DId.
   Defined.
 
-  Global Instance is1dfunctor_const {A : Type} {B : Type}
+  Global Instance isd1functor_const {A : Type} {B : Type}
     (DA : A -> Type)
-    `{Is1DCat A DA}
+    `{IsD1Cat A DA}
     (DB : B -> Type)
-    `{Is1DCat B DB}
+    `{IsD1Cat B DB}
     (x : B) (x' : DB x)
-    : Is1DFunctor (fun _ => x) (fun _ _ => x').
+    : IsD1Functor (fun _ => x) (fun _ _ => x').
   Proof.
-    snrapply Build_Is1DFunctor.
+    snrapply Build_IsD1Functor.
     - intros a b f g p a' b' f' g' p'.
       apply DId.
     - intros a a'.
@@ -418,24 +418,24 @@ Section CompositeFunctor.
     (F' : forall (a : A), DA a -> DB (F a))
     (G' : forall (b : B), DB b -> DC (G b)).
 
-  Global Instance is0dfunctor_compose
+  Global Instance isd0functor_compose
     `{IsDGraph A DA} `{IsDGraph B DB} `{IsDGraph C DC}
     `{!Is0Functor F} `{!Is0Functor G}
-    `{!Is0DFunctor F F'} `{!Is0DFunctor G G'}
-    : Is0DFunctor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
+    `{!IsD0Functor F F'} `{!IsD0Functor G G'}
+    : IsD0Functor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
     intros a b f a' b' f'.
     exact (dfmap G G' (dfmap F F' f')).
   Defined.
 
-  Global Instance is1dfunctor_compose
-    `{Is1DCat A DA} `{Is1DCat B DB} `{Is1DCat C DC}
+  Global Instance isd1functor_compose
+    `{IsD1Cat A DA} `{IsD1Cat B DB} `{IsD1Cat C DC}
     `{!Is0Functor F, !Is1Functor F} `{!Is0Functor G, !Is1Functor G}
-    `{!Is0DFunctor F F', !Is1DFunctor F F'}
-    `{!Is0DFunctor G G', !Is1DFunctor G G'}
-    : Is1DFunctor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
+    `{!IsD0Functor F F', !IsD1Functor F F'}
+    `{!IsD0Functor G G', !IsD1Functor G G'}
+    : IsD1Functor (G o F) (fun a a' => (G' (F a) o (F' a)) a').
   Proof.
-    snrapply Build_Is1DFunctor.
+    snrapply Build_IsD1Functor.
     - intros a b f g p a' b' f' g' p'.
       apply (dfmap2 _ _ (dfmap2 F F' p')).
     - intros a a'.
@@ -456,11 +456,11 @@ Proof.
   exact (DHom f a1' a2' * DHom g b1' b2').
 Defined.
 
-Global Instance is01dcat_prod {A B : Type} (DA : A -> Type) `{Is01DCat A DA}
-  (DB : B -> Type) `{Is01DCat B DB}
-  : Is01DCat (pointwise_prod DA DB).
+Global Instance isd01cat_prod {A B : Type} (DA : A -> Type) `{IsD01Cat A DA}
+  (DB : B -> Type) `{IsD01Cat B DB}
+  : IsD01Cat (pointwise_prod DA DB).
 Proof.
-  srapply Build_Is01DCat.
+  srapply Build_IsD01Cat.
   - intros [a b] [a' b'].
     exact (DId a', DId b').
   - intros [a1 b1] [a2 b2] [a3 b3] [f2 g2] [f1 g1] [a1' b1'] [a2' b2'] [a3' b3'].
@@ -468,31 +468,31 @@ Proof.
     exact (f2' $o' f1', g2' $o' g1').
 Defined.
 
-Global Instance is0dgpd_prod {A B : Type} (DA : A -> Type) `{Is0DGpd A DA}
-  (DB : B -> Type) `{Is0DGpd B DB}
-  : Is0DGpd (pointwise_prod DA DB).
+Global Instance isd0gpd_prod {A B : Type} (DA : A -> Type) `{IsD0Gpd A DA}
+  (DB : B -> Type) `{IsD0Gpd B DB}
+  : IsD0Gpd (pointwise_prod DA DB).
 Proof.
   intros [a1 b1] [a2 b2] [f g] [a1' b1'] [a2' b2'] [f' g'].
   exact (f'^$', g'^$').
 Defined.
 
-Global Instance is2dgraph_prod {A B : Type} (DA : A -> Type) `{Is2DGraph A DA}
-  (DB : B -> Type) `{Is2DGraph B DB}
-  : Is2DGraph (pointwise_prod DA DB).
+Global Instance isd2graph_prod {A B : Type} (DA : A -> Type) `{IsD2Graph A DA}
+  (DB : B -> Type) `{IsD2Graph B DB}
+  : IsD2Graph (pointwise_prod DA DB).
 Proof.
   intros [a1 b1] [a2 b2] [a1' b1'] [a2' b2'].
   srapply isdgraph_prod.
 Defined.
 
-Global Instance is1dcat_prod {A B : Type} (DA : A -> Type) `{Is1DCat A DA}
-  (DB : B -> Type) `{Is1DCat B DB}
-  : Is1DCat (pointwise_prod DA DB).
+Global Instance isd1cat_prod {A B : Type} (DA : A -> Type) `{IsD1Cat A DA}
+  (DB : B -> Type) `{IsD1Cat B DB}
+  : IsD1Cat (pointwise_prod DA DB).
 Proof.
-  snrapply Build_Is1DCat.
+  snrapply Build_IsD1Cat.
   - intros ab1 ab2 ab1' ab2'.
-    srapply is01dcat_prod.
+    srapply isd01cat_prod.
   - intros ab1 ab2 ab1' ab2'.
-    srapply (is0dgpd_prod _ _).
+    srapply (isd0gpd_prod _ _).
   - intros ab1 ab2 ab3 fg ab1' ab2' ab3' [f' g'].
     intros hk1 hk2 pq hk1' hk2' [p' q'].
     exact (f' $@L' p', g' $@L' q').

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -1,5 +1,7 @@
 Require Import Basics.Overture.
 Require Import Basics.Tactics.
+Require Import Basics.Equivalences.
+Require Import Types.Sigma.
 Require Import WildCat.Core.
 Require Import WildCat.Displayed.
 Require Import WildCat.Equiv.
@@ -502,3 +504,22 @@ Definition dcat_path_equiv {A} {D : A -> Type} `{IsDUnivalent1Cat A D}
   {a b : A} (p : a = b) (a' : D a) (b' : D b)
   : DCatEquiv (cat_equiv_path a b p) a' b' -> transport D p a' = b'
   := (dcat_equiv_path p a' b')^-1.
+
+(** If [IsUnivalent1Cat A] and [IsDUnivalent1Cat D], then this is an equivalence by [isequiv_functor_sigma]. *)
+Definition dcat_equiv_path_sigma {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} (a' : D a) (b' : D b)
+  : {p : a = b & p # a' = b'} -> {e : a $<~> b & DCatEquiv e a' b'}
+  := functor_sigma (cat_equiv_path a b) (fun p => dcat_equiv_path p a' b').
+
+(** If the base category and the displayed category are both univalent, then the total category is univalent. *)
+Global Instance isunivalent1cat_sigma {A} `{IsUnivalent1Cat A} (D : A -> Type)
+  `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D, !IsD1Cat D, !DHasEquivs D}
+  `{!IsDUnivalent1Cat D}
+  : IsUnivalent1Cat (sig D).
+Proof.
+  snrapply Build_IsUnivalent1Cat.
+  intros aa' bb'.
+  apply (isequiv_homotopic
+          (dcat_equiv_path_sigma _ _ o (path_sigma_uncurried D aa' bb')^-1)).
+  intros []; reflexivity.
+Defined.

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -1,0 +1,504 @@
+Require Import Basics.Overture.
+Require Import Basics.Tactics.
+Require Import WildCat.Core.
+Require Import WildCat.Displayed.
+Require Import WildCat.Equiv.
+
+(** Equivalences in displayed wild categories *)
+Class DHasEquivs {A : Type} `{HasEquivs A}
+  (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D, !Is1DCat D} :=
+{
+  DCatEquiv : forall {a b}, (a $<~> b) -> D a -> D b -> Type;
+  DCatIsEquiv : forall {a b} {f : a $-> b} {fe : CatIsEquiv f} {a'} {b'},
+    DHom f a' b' -> Type;
+  dcate_fun : forall {a b} {f : a $<~> b} {a'} {b'},
+    DCatEquiv f a' b' -> DHom f a' b';
+  dcate_isequiv : forall {a b} {f : a $<~> b} {a'} {b'}
+    (f' : DCatEquiv f a' b'), DCatIsEquiv (dcate_fun f');
+  dcate_buildequiv : forall {a b} {f : a $-> b} `{!CatIsEquiv f} {a'} {b'}
+    (f' : DHom f a' b') {fe' : DCatIsEquiv f'},
+    DCatEquiv (Build_CatEquiv f) a' b';
+  dcate_buildequiv_fun : forall {a b} {f : a $-> b} `{!CatIsEquiv f}
+    {a'} {b'} (f' : DHom f a' b') {fe' : DCatIsEquiv f'},
+    DGpdHom (cate_buildequiv_fun f)
+    (dcate_fun (dcate_buildequiv f' (fe':=fe'))) f';
+  dcate_inv' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
+    DHom (cate_inv' _ _ f) b' a';
+  dcate_issect' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
+    DGpdHom (cate_issect' _ _ f) (dcate_inv' f' $o' dcate_fun f') (DId a');
+  dcate_isretr' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
+    DGpdHom (cate_isretr' _ _ f) (dcate_fun f' $o' dcate_inv' f') (DId b');
+  dcatie_adjointify : forall {a b} {f : a $-> b} {g : b $-> a}
+    {r : f $o g $== Id b} {s : g $o f $== Id a} {a'} {b'} (f' : DHom f a' b')
+    (g' : DHom g b' a') (r' : DGpdHom r (f' $o' g') (DId b'))
+    (s' : DGpdHom s (g' $o' f') (DId a')),
+    @DCatIsEquiv _ _ _ (catie_adjointify f g r s) _ _ f';
+}.
+
+(** Being an equivalence is a typeclass. *)
+Existing Class DCatIsEquiv.
+Global Existing Instance dcate_isequiv.
+
+Coercion dcate_fun : DCatEquiv >-> DHom.
+
+Definition Build_DCatEquiv {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $-> b} `{!CatIsEquiv f} {a' : D a} {b' : D b}
+  (f' : DHom f a' b') {fe' : DCatIsEquiv f'}
+  : DCatEquiv (Build_CatEquiv f) a' b'
+  := dcate_buildequiv f' (fe':=fe').
+
+(** Construct [DCatEquiv] via adjointify. *)
+Definition dcate_adjointify {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $-> b} {g : b $-> a}
+  {r : f $o g $== Id b} {s : g $o f $== Id a} {a'} {b'}
+  (f' : DHom f a' b') (g' : DHom g b' a') (r' : DHom r (f' $o' g') (DId b'))
+  (s' : DHom s (g' $o' f') (DId a'))
+  : DCatEquiv (cate_adjointify f g r s) a' b'
+  := Build_DCatEquiv f' (fe':=dcatie_adjointify f' g' r' s').
+
+(** Construct the entire inverse equivalence *)
+Definition dcate_inv {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b} {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
+  : DCatEquiv (f^-1$) b' a'.
+Proof.
+  snrapply dcate_adjointify.
+  - exact (dcate_inv' f').
+  - exact f'.
+  - exact (dcate_issect' f').
+  - exact (dcate_isretr' f').
+Defined.
+
+Notation "f ^-1$'" := (dcate_inv f).
+
+(** Witness that [f'] is a section of [dcate_inv f'] in addition to [dcate_inv' f']. *)
+Definition dcate_issect {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b} {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
+  : DGpdHom (cate_issect f) (dcate_fun f'^-1$' $o' f') (DId a').
+Proof.
+  refine (_ $@' dcate_issect' f').
+  refine (_ $@R' (dcate_fun f')).
+  apply dcate_buildequiv_fun.
+Defined.
+
+(** Witness that [f'] is a retraction of [dcate_inv f'] in addition to [dcate_inv' f']. *)
+Definition dcate_isretr {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b} {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
+  : DGpdHom (cate_isretr f) (dcate_fun f' $o' f'^-1$') (DId b').
+Proof.
+  refine (_ $@' dcate_isretr' f').
+  refine (dcate_fun f' $@L' _).
+  apply dcate_buildequiv_fun.
+Defined.
+
+(** If [g'] is a section of an equivalence, then it is the inverse. *)
+Definition dcate_inverse_sect {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b} {g : b $-> a} {p : f $o g $== Id b}
+  {a' : D a} {b' : D b} (f' : DCatEquiv f a' b') (g' : DHom g b' a')
+  (p' : DGpdHom p (dcate_fun f' $o' g') (DId b'))
+  : DGpdHom (cate_inverse_sect f g p) (dcate_fun f'^-1$') g'.
+Proof.
+  refine ((dcat_idr _)^$' $@' _).
+  refine ((_ $@L' p'^$') $@' _).
+  1: exact is0dgpd_dhom.
+  refine (dcat_assoc_opp _ _ _ $@' _).
+  refine (dcate_issect f' $@R' _ $@' _).
+  apply dcat_idl.
+Defined.
+
+(** If [g'] is a retraction of an equivalence, then it is the inverse. *)
+Definition dcate_inverse_retr {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b} {g : b $-> a} {p : g $o f $== Id a}
+  {a' : D a} {b' : D b} (f' : DCatEquiv f a' b') (g' : DHom g b' a')
+  (p' : DGpdHom p (g' $o' f') (DId a'))
+  : DGpdHom (cate_inverse_retr f g p) (dcate_fun f'^-1$') g'.
+Proof.
+  refine ((dcat_idl _)^$' $@' _).
+  refine ((p'^$' $@R' _) $@' _).
+  1: exact is0dgpd_dhom.
+  refine (dcat_assoc _ _ _ $@' _).
+  refine (_ $@L' dcate_isretr f' $@' _).
+  apply dcat_idr.
+Defined.
+
+(** It follows that the inverse of the equivalence you get by adjointification is homotopic to the inverse [g'] provided. *)
+Definition dcate_inv_adjointify {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $-> b} {g : b $-> a} {r : f $o g $== Id b}
+  {s : g $o f $== Id a} {a' : D a} {b' : D b} (f' : DHom f a' b')
+  (g' : DHom g b' a') (r' : DGpdHom r (f' $o' g') (DId b'))
+  (s' : DGpdHom s (g' $o' f') (DId a'))
+  : DGpdHom (cate_inv_adjointify f g r s)
+    (dcate_fun (dcate_adjointify f' g' r' s')^-1$') g'.
+Proof.
+  apply dcate_inverse_sect.
+  exact ((dcate_buildequiv_fun f' $@R' _) $@' r').
+Defined.
+
+(** If the base category has equivalences and the displayed category has displayed equivalences, then the total category has equivalences. *)
+Global Instance hasequivs_sigma {A} (D : A -> Type) `{DHasEquivs A D}
+  : HasEquivs (sig D).
+Proof.
+  snrapply Build_HasEquivs.
+  1:{ intros [a a'] [b b']. exact {f : a $<~> b & DCatEquiv f a' b'}. }
+  all: intros aa' bb' [f f'].
+  - exact {fe : CatIsEquiv f & DCatIsEquiv f'}.
+  - exists f. exact f'.
+  - exact (cate_isequiv f; dcate_isequiv f').
+  - intros [fe fe'].
+    exact (Build_CatEquiv f (fe:=fe); Build_DCatEquiv f' (fe':=fe')).
+  - intros ?; exists (cate_buildequiv_fun f).
+    exact (dcate_buildequiv_fun f').
+  - exists (f^-1$). exact (f'^-1$').
+  - exact (cate_issect f; dcate_issect f').
+  - exact (cate_isretr f; dcate_isretr f').
+  - intros [g g'] [r r'] [s s'].
+    exact (catie_adjointify f g r s; dcatie_adjointify f' g' r' s').
+Defined.
+
+(** The identity morphism is an equivalence *)
+Global Instance dcatie_id {A} {D : A -> Type} `{DHasEquivs A D}
+  {a : A} (a' : D a)
+  : DCatIsEquiv (DId a')
+  := dcatie_adjointify (DId a') (DId a') (dcat_idl (DId a')) (dcat_idl (DId a')).
+
+Definition id_dcate {A} {D : A -> Type} `{DHasEquivs A D}
+  {a : A} (a' : D a)
+  : DCatEquiv (id_cate a) a' a'
+  := Build_DCatEquiv (DId a').
+
+Global Instance reflexive_dcate {A} {D : A -> Type} `{DHasEquivs A D} {a : A}
+  : Reflexive (DCatEquiv (id_cate a))
+  := id_dcate.
+
+(** Equivalences can be composed. *)
+Global Instance compose_dcatie {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
+  (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
+  : DCatIsEquiv (dcate_fun g' $o' f').
+Proof.
+  snrapply dcatie_adjointify.
+  - exact (dcate_fun f'^-1$' $o' g'^-1$').
+  - refine (dcat_assoc _ _ _ $@' _).
+    refine (_ $@L' dcat_assoc_opp _ _ _ $@' _).
+    refine (_ $@L' (dcate_isretr _ $@R' _) $@' _).
+    refine (_ $@L' dcat_idl _ $@' _).
+    apply dcate_isretr.
+  - refine (dcat_assoc _ _ _ $@' _).
+    refine (_ $@L' dcat_assoc_opp _ _ _ $@' _).
+    refine (_ $@L' (dcate_issect _ $@R' _) $@' _).
+    refine (_ $@L' dcat_idl _ $@' _).
+    apply dcate_issect.
+Defined.
+
+Definition compose_dcate {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
+  (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
+  : DCatEquiv (compose_cate g f) a' c'
+  := Build_DCatEquiv (dcate_fun g' $o' f').
+
+Notation "g $oE' f" := (compose_dcate g f).
+
+(** Composing equivalences commutes with composing the underlying maps. *)
+Definition compose_dcate_fun {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
+  (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
+  : DGpdHom (compose_cate_fun g f)
+    (dcate_fun (g' $oE' f')) (dcate_fun g' $o' f')
+  := dcate_buildequiv_fun _.
+
+Definition compose_dcate_funinv {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
+  (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
+  : DGpdHom (compose_cate_funinv g f)
+    (dcate_fun g' $o' f') (dcate_fun (g' $oE' f')).
+Proof.
+  apply dgpd_rev.
+  apply dcate_buildequiv_fun.
+Defined.
+
+(** The underlying map of the identity equivalence is homotopic to the identity. *)
+Definition id_dcate_fun {A} {D : A -> Type} `{DHasEquivs A D} {a : A} (a' : D a)
+  : DGpdHom (id_cate_fun a) (dcate_fun (id_dcate a')) (DId a')
+  := dcate_buildequiv_fun _.
+
+(** Composition of equivalences is associative. *)
+Definition compose_dcate_assoc {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c d : A} {f : a $<~> b} {g : b $<~> c} {h : c $<~> d} {a'} {b'} {c'} {d'}
+  (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c') (h' : DCatEquiv h c' d')
+  : DGpdHom (compose_cate_assoc f g h) (dcate_fun ((h' $oE' g') $oE' f'))
+    (dcate_fun (h' $oE' (g' $oE' f'))).
+Proof.
+  refine (compose_dcate_fun _ f' $@' _ $@' dcat_assoc (dcate_fun f') g' h'
+          $@' _ $@' compose_dcate_funinv h' _).
+  - apply (compose_dcate_fun h' g' $@R' _).
+  - apply (_ $@L' compose_dcate_funinv g' f').
+Defined.
+
+Definition compose_dcate_idl {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b}  {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
+  : DGpdHom (compose_cate_idl f) (dcate_fun (id_dcate b' $oE' f'))
+    (dcate_fun f').
+Proof.
+  refine (compose_dcate_fun _ f' $@' _ $@' dcat_idl (dcate_fun f')).
+  apply (dcate_buildequiv_fun _ $@R' _).
+Defined.
+
+Definition compose_dcate_idr {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {f : a $<~> b} {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
+  : DGpdHom (compose_cate_idr f) (dcate_fun (f' $oE' id_dcate a'))
+    (dcate_fun f').
+Proof.
+  refine (compose_dcate_fun f' _ $@' _ $@' dcat_idr (dcate_fun f')).
+  apply (_ $@L' dcate_buildequiv_fun _).
+Defined.
+
+(** Some more convenient equalities for equivalences. The naming scheme is similar to [PathGroupoids.v].*)
+
+Definition dcompose_V_hh {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {f : b $<~> c} {g : a $-> b} {a' : D a} {b' : D b} {c' : D c}
+  (f' : DCatEquiv f b' c') (g' : DHom g a' b')
+  : DGpdHom (compose_V_hh f g) (dcate_fun f'^-1$' $o' (dcate_fun f' $o' g')) g'
+  := (dcat_assoc _ _ _)^$' $@' (dcate_issect f' $@R' g') $@' dcat_idl g'.
+
+Definition dcompose_h_Vh {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {f : c $<~> b} {g : a $-> b} {a' : D a} {b' : D b} {c' : D c}
+  (f' : DCatEquiv f c' b') (g' : DHom g a' b')
+  : DGpdHom (compose_h_Vh f g) (dcate_fun f' $o' (dcate_fun f'^-1$' $o' g')) g'
+  := (dcat_assoc _ _ _)^$' $@' (dcate_isretr f' $@R' g') $@' dcat_idl g'.
+
+Definition dcompose_hh_V {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {f : b $-> c} {g : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
+  (f' : DHom f b' c') (g' : DCatEquiv g a' b')
+  : DGpdHom (compose_hh_V f g) ((f' $o' g') $o' g'^-1$') f'
+  := dcat_assoc _ _ _ $@' (f' $@L' dcate_isretr g') $@' dcat_idr f'.
+
+Definition dcompose_hV_h {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {f : b $-> c} {g : b $<~> a} {a' : D a} {b' : D b} {c' : D c}
+  (f' : DHom f b' c') (g' : DCatEquiv g b' a')
+  : DGpdHom (compose_hV_h f g) ((f' $o' g'^-1$') $o' g') f'
+  := dcat_assoc _ _ _ $@' (f' $@L' dcate_issect g') $@' dcat_idr f'.
+
+(** Equivalences are both monomorphisms and epimorphisms (but not the converse). *)
+
+Definition dcate_monic_equiv {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {a' : D a} {b' : D b} (e' : DCatEquiv e a' b')
+  : DMonic (mon:=cate_monic_equiv e) (dcate_fun e').
+Proof.
+  intros c f g p c' f' g' p'.
+  refine ((dcompose_V_hh e' _)^$' $@' _ $@' dcompose_V_hh e' _).
+  1: exact is0dgpd_dhom.
+  exact (_ $@L' p').
+Defined.
+
+Definition dcate_epic_equiv {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {a' : D a} {b' : D b} (e' : DCatEquiv e a' b')
+  : DEpic (epi:=cate_epic_equiv e) (dcate_fun e').
+Proof.
+  intros c f g p c' f' g' p'.
+  refine ((dcompose_hh_V _ e')^$' $@' _ $@' dcompose_hh_V _ e').
+  1: exact is0dgpd_dhom.
+  exact (p' $@R' _).
+Defined.
+
+(** Some lemmas for moving equivalences around.  Naming based on EquivGroupoids.v. *)
+
+Definition dcate_moveR_eM {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {e : b $<~> a} {f : b $<~> c} {g : a $<~> c}
+  {p : cate_fun g $== f $o e^-1$} {a' : D a} {b' : D b} {c' : D c}
+  (e' : DCatEquiv e b' a') (f' : DCatEquiv f b' c') (g' : DCatEquiv g a' c')
+  (p' : DGpdHom p (dcate_fun g') (dcate_fun f' $o' e'^-1$'))
+  : DGpdHom (cate_moveR_eM e f g p) (dcate_fun g' $o' e') (dcate_fun f').
+Proof.
+  apply (dcate_epic_equiv e'^-1$').
+  exact (dcompose_hh_V _ _ $@' p').
+Defined.
+
+Definition dcate_moveR_Ve {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {e : b $<~> a} {f : b $<~> c} {g : c $<~> a}
+  {p : cate_fun e $== g $o f} {a' : D a} {b' : D b} {c' : D c}
+  (e' : DCatEquiv e b' a') (f' : DCatEquiv f b' c') (g' : DCatEquiv g c' a')
+  (p' : DGpdHom p (dcate_fun e') (dcate_fun g' $o' f'))
+  : DGpdHom (cate_moveR_Ve e f g p) (dcate_fun g'^-1$' $o' e') (dcate_fun f').
+Proof.
+  apply (dcate_monic_equiv g').
+  exact (dcompose_h_Vh _ _ $@' p').
+Defined.
+
+Definition dcate_moveL_V1 {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {f : b $-> a} {p : e $o f $== Id b}
+  {a' : D a} {b' : D b} {e' : DCatEquiv e a' b'}
+  (f' : DHom f b' a') (p' : DGpdHom p (dcate_fun e' $o' f') (DId b'))
+  : DGpdHom (cate_moveL_V1 f p) f' (dcate_fun e'^-1$').
+Proof.
+  apply (dcate_monic_equiv e').
+  nrapply (p' $@' (dcate_isretr e')^$').
+  exact is0dgpd_dhom.
+Defined.
+
+Definition dcate_moveL_1V {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {f : b $-> a} {p : f $o e $== Id a}
+  {a' : D a} {b' : D b} {e' : DCatEquiv e a' b'}
+  (f' : DHom f b' a') (p' : DGpdHom p (f' $o' e') (DId a'))
+  : DGpdHom (cate_moveL_1V f p) f' (dcate_fun e'^-1$').
+Proof.
+  apply (dcate_epic_equiv e').
+  nrapply (p' $@' (dcate_issect e')^$').
+  exact is0dgpd_dhom.
+Defined.
+
+Definition dcate_moveR_V1 {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {f : b $-> a} {p : Id b $== e $o f}
+  {a' : D a} {b' : D b} {e' : DCatEquiv e a' b'}
+  (f' : DHom f b' a') (p' : DGpdHom p (DId b') (dcate_fun e' $o' f'))
+  : DGpdHom (cate_moveR_V1 f p) (dcate_fun e'^-1$') f'.
+Proof.
+  apply (dcate_monic_equiv e').
+  exact (dcate_isretr e' $@' p').
+Defined.
+
+Definition dcate_moveR_1V {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {f : b $-> a} {p : Id a $== f $o e}
+  {a' : D a} {b' : D b} {e' : DCatEquiv e a' b'}
+  (f' : DHom f b' a') (p' : DGpdHom p (DId a') (f' $o' e'))
+  : DGpdHom (cate_moveR_1V f p) (dcate_fun e'^-1$') f'.
+Proof.
+  apply (dcate_epic_equiv e').
+  exact (dcate_issect e' $@' p').
+Defined.
+
+(** Lemmas about the underlying map of an equivalence. *)
+
+Definition dcate_inv2 {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e f : a $<~> b} {p : cate_fun e $== cate_fun f}
+  {a' : D a} {b' : D b} {e' : DCatEquiv e a' b'} {f' : DCatEquiv f a' b'}
+  (p' : DGpdHom p (dcate_fun e') (dcate_fun f'))
+  : DGpdHom (cate_inv2 p) (dcate_fun e'^-1$') (dcate_fun f'^-1$').
+Proof.
+  apply dcate_moveL_V1.
+  rapply ((p'^$' $@R' _) $@' dcate_isretr _).
+  exact is0dgpd_dhom.
+Defined.
+
+Definition dcate_inv_compose {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b c : A} {e : a $<~> b} {f : b $<~> c} {a' : D a} {b' : D b} {c' : D c}
+  (e' : DCatEquiv e a' b') (f' : DCatEquiv f b' c')
+  : DGpdHom (cate_inv_compose e f)
+    (dcate_fun (f' $oE' e')^-1$') (dcate_fun (e'^-1$' $oE' f'^-1$')).
+Proof.
+  refine (_ $@' (compose_dcate_fun e'^-1$' f'^-1$')^$').
+  - snrapply dcate_inv_adjointify.
+  - exact is0dgpd_dhom.
+Defined.
+
+Definition dcate_inv_V {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} {e : a $<~> b} {a' : D a} {b' : D b}
+  (e' : DCatEquiv e a' b')
+  : DGpdHom (cate_inv_V e) (dcate_fun (e'^-1$')^-1$') (dcate_fun e').
+Proof.
+  apply dcate_moveR_V1.
+  apply dgpd_rev.
+  apply dcate_issect.
+Defined.
+
+(** Any sufficiently coherent displayed functor preserves displayed equivalences. *)
+Global Instance diemap {A B : Type}
+  {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  {a b : A} {f : a $<~> b} {a' : DA a} {b' : DA b} (f' : DCatEquiv f a' b')
+  : DCatIsEquiv (fe:=iemap F f) (dfmap F F' (dcate_fun f')).
+Proof.
+  refine (dcatie_adjointify
+           (dfmap F F' (dcate_fun f')) (dfmap F F' (dcate_fun f'^-1$')) _ _).
+  - refine ((dfmap_comp F F' (dcate_fun f'^-1$') f')^$' $@' _ $@' _).
+    + exact (dfmap2 F F' (dcate_isretr _)).
+    + exact (dfmap_id F F' _).
+  - refine ((dfmap_comp F F' (dcate_fun f') f'^-1$')^$' $@' _ $@' _).
+    + exact (dfmap2 F F' (dcate_issect _)).
+    + exact (dfmap_id F F' _).
+Defined.
+
+Definition demap {A B : Type}
+  {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  {a b : A} {f : a $<~> b} {a' : DA a} {b' : DA b} (f' : DCatEquiv f a' b')
+  : DCatEquiv (emap F f) (F' a a') (F' b b')
+  := Build_DCatEquiv (dfmap F F' (dcate_fun f')).
+
+Definition demap_id {A B : Type}
+  {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  {a : A} {a' : DA a}
+  : DGpdHom (emap_id F)
+    (dcate_fun (demap F F' (id_dcate a'))) (dcate_fun (id_dcate (F' a a'))).
+Proof.
+  refine (dcate_buildequiv_fun _ $@' _).
+  refine (dfmap2 F F' (id_dcate_fun a') $@' _ $@' _).
+  - rapply dfmap_id.
+  - apply dgpd_rev.
+    exact (id_dcate_fun (F' a a')).
+Defined.
+
+Definition demap_compose {A B : Type}
+  {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  {a b c : A} {f : a $<~> b} {g : b $<~> c} {a' : DA a} {b' : DA b} {c' : DA c}
+  (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c')
+  : DGpdHom (emap_compose F f g) (dcate_fun (demap F F' (g' $oE' f')))
+    (dfmap F F' (dcate_fun g') $o' dfmap F F' (dcate_fun f')).
+Proof.
+  refine (dcate_buildequiv_fun _ $@' _).
+  refine (dfmap2 F F' (compose_dcate_fun _ _) $@' _).
+  rapply dfmap_comp.
+Defined.
+
+(** A variant. *)
+Definition demap_compose' {A B : Type}
+  {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  {a b c : A} {f : a $<~> b} {g : b $<~> c} {a' : DA a} {b' : DA b} {c' : DA c}
+  (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c')
+  : DGpdHom (emap_compose' F f g) (dcate_fun (demap F F' (g' $oE' f')))
+    (dcate_fun ((demap F F' g') $oE' (demap F F' f'))).
+Proof.
+  refine (demap_compose F F' f' g' $@' _).
+  apply dgpd_rev.
+  refine (compose_dcate_fun _ _ $@' _).
+  exact (dcate_buildequiv_fun _ $@@' dcate_buildequiv_fun _).
+Defined.
+
+Definition demap_inv {A B : Type}
+  {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  {a b : A} {e : a $<~> b} {a' : DA a} {b' : DA b} (e' : DCatEquiv e a' b')
+  : DGpdHom (emap_inv F e)
+    (dcate_fun (demap F F' e')^-1$') (dcate_fun (demap F F' e'^-1$')).
+Proof.
+  refine (dcate_inv_adjointify _ _ _ _ $@' _).
+  apply dgpd_rev.
+  exact (dcate_buildequiv_fun _).
+Defined.
+
+(** When we have equivalences, we can define what it means for a displayed category to be univalent. *)
+Definition dcat_equiv_path {A} {D : A -> Type} `{DHasEquivs A D}
+  {a b : A} (p : a = b) (a' : D a) (b' : D b)
+  : transport D p a' = b' -> DCatEquiv (cat_equiv_path a b p) a' b'.
+Proof.
+  intro p'. destruct p, p'. reflexivity.
+Defined.
+
+Class IsUnivalent1DCat {A} (D : A -> Type) `{DHasEquivs A D} :=
+{
+  isequiv_dcat_equiv_path : forall {a b : A} (p : a = b) a' b',
+    IsEquiv (dcat_equiv_path p a' b')
+}.
+Global Existing Instance isequiv_dcat_equiv_path.
+
+Definition dcat_path_equiv {A} {D : A -> Type} `{IsUnivalent1DCat A D}
+  {a b : A} (p : a = b) (a' : D a) (b' : D b)
+  : DCatEquiv (cat_equiv_path a b p) a' b' -> transport D p a' = b'
+  := (dcat_equiv_path p a' b')^-1.

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -6,7 +6,7 @@ Require Import WildCat.Equiv.
 
 (** Equivalences in displayed wild categories *)
 Class DHasEquivs {A : Type} `{HasEquivs A}
-  (D : A -> Type) `{!IsDGraph D, !Is2DGraph D, !Is01DCat D, !Is1DCat D} :=
+  (D : A -> Type) `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D, !IsD1Cat D} :=
 {
   DCatEquiv : forall {a b}, (a $<~> b) -> D a -> D b -> Type;
   DCatIsEquiv : forall {a b} {f : a $-> b} {fe : CatIsEquiv f} {a'} {b'},
@@ -99,7 +99,7 @@ Definition dcate_inverse_sect {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   refine ((dcat_idr _)^$' $@' _).
   refine ((_ $@L' p'^$') $@' _).
-  1: exact is0dgpd_dhom.
+  1: exact isd0gpd_hom.
   refine (dcat_assoc_opp _ _ _ $@' _).
   refine (dcate_issect f' $@R' _ $@' _).
   apply dcat_idl.
@@ -114,7 +114,7 @@ Definition dcate_inverse_retr {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   refine ((dcat_idl _)^$' $@' _).
   refine ((p'^$' $@R' _) $@' _).
-  1: exact is0dgpd_dhom.
+  1: exact isd0gpd_hom.
   refine (dcat_assoc _ _ _ $@' _).
   refine (_ $@L' dcate_isretr f' $@' _).
   apply dcat_idr.
@@ -160,17 +160,17 @@ Global Instance dcatie_id {A} {D : A -> Type} `{DHasEquivs A D}
   : DCatIsEquiv (DId a')
   := dcatie_adjointify (DId a') (DId a') (dcat_idl (DId a')) (dcat_idl (DId a')).
 
-Definition id_dcate {A} {D : A -> Type} `{DHasEquivs A D}
+Definition did_cate {A} {D : A -> Type} `{DHasEquivs A D}
   {a : A} (a' : D a)
   : DCatEquiv (id_cate a) a' a'
   := Build_DCatEquiv (DId a').
 
 Global Instance reflexive_dcate {A} {D : A -> Type} `{DHasEquivs A D} {a : A}
   : Reflexive (DCatEquiv (id_cate a))
-  := id_dcate.
+  := did_cate.
 
 (** Equivalences can be composed. *)
-Global Instance compose_dcatie {A} {D : A -> Type} `{DHasEquivs A D}
+Global Instance dcompose_catie {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
   (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
   : DCatIsEquiv (dcate_fun g' $o' f').
@@ -189,23 +189,23 @@ Proof.
     apply dcate_issect.
 Defined.
 
-Definition compose_dcate {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcompose_cate {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
   (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
   : DCatEquiv (compose_cate g f) a' c'
   := Build_DCatEquiv (dcate_fun g' $o' f').
 
-Notation "g $oE' f" := (compose_dcate g f).
+Notation "g $oE' f" := (dcompose_cate g f).
 
 (** Composing equivalences commutes with composing the underlying maps. *)
-Definition compose_dcate_fun {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcompose_cate_fun {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
   (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
   : DGpdHom (compose_cate_fun g f)
     (dcate_fun (g' $oE' f')) (dcate_fun g' $o' f')
   := dcate_buildequiv_fun _.
 
-Definition compose_dcate_funinv {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcompose_cate_funinv {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {g : b $<~> c} {f : a $<~> b} {a' : D a} {b' : D b} {c' : D c}
   (g' : DCatEquiv g b' c') (f' : DCatEquiv f a' b')
   : DGpdHom (compose_cate_funinv g f)
@@ -216,38 +216,38 @@ Proof.
 Defined.
 
 (** The underlying map of the identity equivalence is homotopic to the identity. *)
-Definition id_dcate_fun {A} {D : A -> Type} `{DHasEquivs A D} {a : A} (a' : D a)
-  : DGpdHom (id_cate_fun a) (dcate_fun (id_dcate a')) (DId a')
+Definition did_cate_fun {A} {D : A -> Type} `{DHasEquivs A D} {a : A} (a' : D a)
+  : DGpdHom (id_cate_fun a) (dcate_fun (did_cate a')) (DId a')
   := dcate_buildequiv_fun _.
 
 (** Composition of equivalences is associative. *)
-Definition compose_dcate_assoc {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcompose_cate_assoc {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c d : A} {f : a $<~> b} {g : b $<~> c} {h : c $<~> d} {a'} {b'} {c'} {d'}
   (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c') (h' : DCatEquiv h c' d')
   : DGpdHom (compose_cate_assoc f g h) (dcate_fun ((h' $oE' g') $oE' f'))
     (dcate_fun (h' $oE' (g' $oE' f'))).
 Proof.
-  refine (compose_dcate_fun _ f' $@' _ $@' dcat_assoc (dcate_fun f') g' h'
-          $@' _ $@' compose_dcate_funinv h' _).
-  - apply (compose_dcate_fun h' g' $@R' _).
-  - apply (_ $@L' compose_dcate_funinv g' f').
+  refine (dcompose_cate_fun _ f' $@' _ $@' dcat_assoc (dcate_fun f') g' h'
+          $@' _ $@' dcompose_cate_funinv h' _).
+  - apply (dcompose_cate_fun h' g' $@R' _).
+  - apply (_ $@L' dcompose_cate_funinv g' f').
 Defined.
 
-Definition compose_dcate_idl {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcompose_cate_idl {A} {D : A -> Type} `{DHasEquivs A D}
   {a b : A} {f : a $<~> b}  {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
-  : DGpdHom (compose_cate_idl f) (dcate_fun (id_dcate b' $oE' f'))
+  : DGpdHom (compose_cate_idl f) (dcate_fun (did_cate b' $oE' f'))
     (dcate_fun f').
 Proof.
-  refine (compose_dcate_fun _ f' $@' _ $@' dcat_idl (dcate_fun f')).
+  refine (dcompose_cate_fun _ f' $@' _ $@' dcat_idl (dcate_fun f')).
   apply (dcate_buildequiv_fun _ $@R' _).
 Defined.
 
-Definition compose_dcate_idr {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcompose_cate_idr {A} {D : A -> Type} `{DHasEquivs A D}
   {a b : A} {f : a $<~> b} {a' : D a} {b' : D b} (f' : DCatEquiv f a' b')
-  : DGpdHom (compose_cate_idr f) (dcate_fun (f' $oE' id_dcate a'))
+  : DGpdHom (compose_cate_idr f) (dcate_fun (f' $oE' did_cate a'))
     (dcate_fun f').
 Proof.
-  refine (compose_dcate_fun f' _ $@' _ $@' dcat_idr (dcate_fun f')).
+  refine (dcompose_cate_fun f' _ $@' _ $@' dcat_idr (dcate_fun f')).
   apply (_ $@L' dcate_buildequiv_fun _).
 Defined.
 
@@ -285,7 +285,7 @@ Definition dcate_monic_equiv {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   intros c f g p c' f' g' p'.
   refine ((dcompose_V_hh e' _)^$' $@' _ $@' dcompose_V_hh e' _).
-  1: exact is0dgpd_dhom.
+  1: exact isd0gpd_hom.
   exact (_ $@L' p').
 Defined.
 
@@ -295,7 +295,7 @@ Definition dcate_epic_equiv {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   intros c f g p c' f' g' p'.
   refine ((dcompose_hh_V _ e')^$' $@' _ $@' dcompose_hh_V _ e').
-  1: exact is0dgpd_dhom.
+  1: exact isd0gpd_hom.
   exact (p' $@R' _).
 Defined.
 
@@ -331,7 +331,7 @@ Definition dcate_moveL_V1 {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   apply (dcate_monic_equiv e').
   nrapply (p' $@' (dcate_isretr e')^$').
-  exact is0dgpd_dhom.
+  exact isd0gpd_hom.
 Defined.
 
 Definition dcate_moveL_1V {A} {D : A -> Type} `{DHasEquivs A D}
@@ -342,7 +342,7 @@ Definition dcate_moveL_1V {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   apply (dcate_epic_equiv e').
   nrapply (p' $@' (dcate_issect e')^$').
-  exact is0dgpd_dhom.
+  exact isd0gpd_hom.
 Defined.
 
 Definition dcate_moveR_V1 {A} {D : A -> Type} `{DHasEquivs A D}
@@ -375,7 +375,7 @@ Definition dcate_inv2 {A} {D : A -> Type} `{DHasEquivs A D}
 Proof.
   apply dcate_moveL_V1.
   rapply ((p'^$' $@R' _) $@' dcate_isretr _).
-  exact is0dgpd_dhom.
+  exact isd0gpd_hom.
 Defined.
 
 Definition dcate_inv_compose {A} {D : A -> Type} `{DHasEquivs A D}
@@ -384,9 +384,9 @@ Definition dcate_inv_compose {A} {D : A -> Type} `{DHasEquivs A D}
   : DGpdHom (cate_inv_compose e f)
     (dcate_fun (f' $oE' e')^-1$') (dcate_fun (e'^-1$' $oE' f'^-1$')).
 Proof.
-  refine (_ $@' (compose_dcate_fun e'^-1$' f'^-1$')^$').
+  refine (_ $@' (dcompose_cate_fun e'^-1$' f'^-1$')^$').
   - snrapply dcate_inv_adjointify.
-  - exact is0dgpd_dhom.
+  - exact isd0gpd_hom.
 Defined.
 
 Definition dcate_inv_V {A} {D : A -> Type} `{DHasEquivs A D}
@@ -403,7 +403,7 @@ Defined.
 Global Instance diemap {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
   {a b : A} {f : a $<~> b} {a' : DA a} {b' : DA b} (f' : DCatEquiv f a' b')
   : DCatIsEquiv (fe:=iemap F f) (dfmap F F' (dcate_fun f')).
 Proof.
@@ -420,7 +420,7 @@ Defined.
 Definition demap {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
   {a b : A} {f : a $<~> b} {a' : DA a} {b' : DA b} (f' : DCatEquiv f a' b')
   : DCatEquiv (emap F f) (F' a a') (F' b b')
   := Build_DCatEquiv (dfmap F F' (dcate_fun f')).
@@ -428,29 +428,29 @@ Definition demap {A B : Type}
 Definition demap_id {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
   {a : A} {a' : DA a}
   : DGpdHom (emap_id F)
-    (dcate_fun (demap F F' (id_dcate a'))) (dcate_fun (id_dcate (F' a a'))).
+    (dcate_fun (demap F F' (did_cate a'))) (dcate_fun (did_cate (F' a a'))).
 Proof.
   refine (dcate_buildequiv_fun _ $@' _).
-  refine (dfmap2 F F' (id_dcate_fun a') $@' _ $@' _).
+  refine (dfmap2 F F' (did_cate_fun a') $@' _ $@' _).
   - rapply dfmap_id.
   - apply dgpd_rev.
-    exact (id_dcate_fun (F' a a')).
+    exact (did_cate_fun (F' a a')).
 Defined.
 
 Definition demap_compose {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
   {a b c : A} {f : a $<~> b} {g : b $<~> c} {a' : DA a} {b' : DA b} {c' : DA c}
   (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c')
   : DGpdHom (emap_compose F f g) (dcate_fun (demap F F' (g' $oE' f')))
     (dfmap F F' (dcate_fun g') $o' dfmap F F' (dcate_fun f')).
 Proof.
   refine (dcate_buildequiv_fun _ $@' _).
-  refine (dfmap2 F F' (compose_dcate_fun _ _) $@' _).
+  refine (dfmap2 F F' (dcompose_cate_fun _ _) $@' _).
   rapply dfmap_comp.
 Defined.
 
@@ -458,7 +458,7 @@ Defined.
 Definition demap_compose' {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
   {a b c : A} {f : a $<~> b} {g : b $<~> c} {a' : DA a} {b' : DA b} {c' : DA c}
   (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c')
   : DGpdHom (emap_compose' F f g) (dcate_fun (demap F F' (g' $oE' f')))
@@ -466,14 +466,14 @@ Definition demap_compose' {A B : Type}
 Proof.
   refine (demap_compose F F' f' g' $@' _).
   apply dgpd_rev.
-  refine (compose_dcate_fun _ _ $@' _).
+  refine (dcompose_cate_fun _ _ $@' _).
   exact (dcate_buildequiv_fun _ $@@' dcate_buildequiv_fun _).
 Defined.
 
 Definition demap_inv {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!Is0DFunctor F F', !Is1DFunctor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
   {a b : A} {e : a $<~> b} {a' : DA a} {b' : DA b} (e' : DCatEquiv e a' b')
   : DGpdHom (emap_inv F e)
     (dcate_fun (demap F F' e')^-1$') (dcate_fun (demap F F' e'^-1$')).
@@ -491,14 +491,14 @@ Proof.
   intro p'. destruct p, p'. reflexivity.
 Defined.
 
-Class IsUnivalent1DCat {A} (D : A -> Type) `{DHasEquivs A D} :=
+Class IsDUnivalent1Cat {A} (D : A -> Type) `{DHasEquivs A D} :=
 {
   isequiv_dcat_equiv_path : forall {a b : A} (p : a = b) a' b',
     IsEquiv (dcat_equiv_path p a' b')
 }.
 Global Existing Instance isequiv_dcat_equiv_path.
 
-Definition dcat_path_equiv {A} {D : A -> Type} `{IsUnivalent1DCat A D}
+Definition dcat_path_equiv {A} {D : A -> Type} `{IsDUnivalent1Cat A D}
   {a b : A} (p : a = b) (a' : D a) (b' : D b)
   : DCatEquiv (cat_equiv_path a b p) a' b' -> transport D p a' = b'
   := (dcat_equiv_path p a' b')^-1.


### PR DESCRIPTION
Changes to WildCat/Displayed.v include:
- One fix -- `dcat_assoc_opp` and `dcat_assoc_opp_strong` both took the type family `D` as an unnecessary argument.
- Monomorphisms and epimorphisms.
- Changes to arguments. All functor methods now expect both the underlying functor and the displayed functor.
- An unrelated proof that was missing (`is1catstrong_sigma`).

The additions in WildCat/DisplayedEquiv.v closely follow [WildCat/Equiv.v](https://github.com/HoTT/Coq-HoTT/blob/3002e0d82dca445ef3072e12c11f8a36936aa3d8/theories/WildCat/Equiv.v) up through univalence.

There is still more work to do to make this useful (namely proving that univalence of the base category and univalence of the displayed category implies univalence of the total category). I'm happy to wait and PR all at once, but it seems simpler to first review everything that follows existing proofs.
