### PR TITLE
surpress argument-scope-delimiter warning

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -15,6 +15,9 @@ Create HintDb typeclass_instances discriminated.
 
 Local Set Polymorphic Inductive Cumulativity.
 
+(** Disable warning about argument scope delimiters. TODO: remove this once we bump the minimal Coq version to 8.19 and merge #1862. *)
+Global Set Warnings "-argument-scope-delimiter".
+
 (** ** Type classes *)
 
 (** This command prevents Coq from trying to guess the values of existential variables while doing typeclass resolution.  If you don't know what that means, ignore it. *)


### PR DESCRIPTION
This suppresses the `argument-scope-delimiter` warning which we cannot fix until Coq 8.19. A PR fixing it is ready in #1862. In the meantime we can safely ignore this warning.
