### PR TITLE
Improvements to make_equiv

### DIFF
--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -332,19 +332,7 @@ Proof.
       rewrite transport_const.
       funext x.
       exact (preserves_negate (f:=idmap) _). }
-  refine (_ oE (issig_GroupIsomorphism G H)^-1).
-  refine (_ oE (equiv_functor_sigma' (issig_GroupHomomorphism G H)
-    (fun f => 1%equiv))^-1).
-  refine (equiv_functor_sigma' (issig_equiv G H) (fun f => 1%equiv) oE _).
-  cbn.
-  refine (
-    equiv_adjointify
-      (fun f => (exist (IsMonoidPreserving o pr1)
-        (exist IsEquiv f.1.1 f.2) f.1.2))
-      (fun f => (exist (IsEquiv o pr1)
-        (exist IsMonoidPreserving f.1.1 f.2) f.1.2))
-       _ _).
-  all: intros [[]]; reflexivity.
+  make_equiv.
 Defined.
 
 (** A version with nicer universe variables. *)

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -574,10 +574,10 @@ Ltac ev_equiv :=
 
 (** The following tactic [make_equiv] builds an equivalence between two types built out of arbitrarily nested sigma and record types, not necessarily right-associated, as long as they have all the same underyling components.  This is more general than [issig] in that it doesn't just prove equivalences between a single record type and a single right-nested tower of sigma types, but less powerful in that it can't deduce the latter nested tower of sigmas automatically: you have to have both sides of the equivalence known. *)
 
-(* Perform [intros] repeatedly, recursively destructing all possibly-nested record types. We use a custom induction principle for [Contr], since [elim] produces two goals. *)
+(* Perform [intros] repeatedly, recursively destructing all possibly-nested record types. We use a custom induction principle for [Contr], since [elim] produces two goals. The [hnf] is important, for example to unfold [IsUnitPreserving] to an equality, which the [lazymatch] then ignores. *)
 Ltac decomposing_intros :=
   let x := fresh in
-  intros x; cbn in x;
+  intros x; hnf in x;
   try lazymatch type of x with
   | ?a = ?b => idtac           (** Don't destruct paths *)
   | forall y:?A, ?B => idtac   (** Don't apply functions *)

--- a/theories/Homotopy/HSpace/Coherent.v
+++ b/theories/Homotopy/HSpace/Coherent.v
@@ -21,13 +21,8 @@ Definition issig_iscohhspace (A : pType)
     & { hspace_left_identity : LeftIdentity hspace_op pt
     & { hspace_right_identity : RightIdentity hspace_op pt
     & hspace_left_identity pt = hspace_right_identity pt } } }
-      <~> IsCohHSpace A.
-Proof.
-  transitivity { H : IsHSpace A & IsCoherent A }.
-  2: issig.
-  unfold IsCoherent.
-  make_equiv.
-Defined.
+      <~> IsCohHSpace A
+  := ltac:(make_equiv).
 
 (** A type equivalent to a coherent H-space is a coherent H-space. *)
 Definition iscohhspace_equiv_cohhspace {X Y : pType} `{IsCohHSpace Y} (f : X <~>* Y)

--- a/theories/ObjectClassifier.v
+++ b/theories/ObjectClassifier.v
@@ -87,7 +87,7 @@ Proof.
   - refine (_ oE _).
     + do 5 (rapply equiv_functor_sigma_id; intro).
       apply equiv_path_sigma.
-    + make_equiv_contr_basedpaths.
+    + cbn; make_equiv_contr_basedpaths.
   - refine (_ oE _).
     2: { do 5 (rapply equiv_functor_sigma_id; intro).
          exact (equiv_path_inverse _ _ oE equiv_moveL_equiv_M _ _). }

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -20,12 +20,10 @@ Definition pfib {A B : pType} (f : A ->* B) : pfiber f ->* A
 Definition pfiber2_loops {A B : pType} (f : A ->* B)
   : pfiber (pfib f) <~>* loops B.
 Proof.
+  pointed_reduce_pmap f.
   snrapply Build_pEquiv'.
-  { transitivity (f (point A) = point B).
-    1: make_equiv_contr_basedpaths.
-    apply equiv_concat_l.
-    symmetry; apply point_eq. }
-  cbn; apply concat_Vp.
+  1: make_equiv_contr_basedpaths.
+  reflexivity.
 Defined.
 
 Definition pfiber_fmap_loops {A B : pType} (f : A ->* B)

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -91,10 +91,7 @@ Module Book_Loop_Susp_Adjunction.
     refine (_ oE (equiv_sigma_contr
                    (A := {p : B & A -> point B = p})
                    (fun pm => { q : point B = pm.1 & pm.2 (point A) = q }))^-1).
-    transitivity {bp : {b:B & point B = b} & {f : A -> point B = bp.1 & f (point A) = bp.2} }.
-    1:make_equiv.
-    refine (_ oE equiv_contr_sigma _); simpl.
-    refine (issig_pmap A (loops B)).
+    make_equiv_contr_basedpaths.
   Defined.
 
   (** Unfortunately, with this definition it seems to be quite hard to prove that the isomorphism is natural on pointed maps.  The following proof gets partway there, but ends with a pretty intractable goal.  It's also quite slow, so we don't want to compile it all the time. *)


### PR DESCRIPTION
The first commit changes `cbn` to `hnf` in the `make_equiv` tactic, so that the lazymatch can correctly detect path types.  If the path type was hidden in record or class, like `IsUnitPreserving`, then `make_equiv` would inadvertently destruct it with `elim`.  With the change, one proof in Group.v becomes much simpler.  `make_equiv` failed there before this change.

The second commit is independent and just gives some improvements coming from looking at places where `make_equiv` was used.  The `cbn` inserted in one spot speeds up the `make_equiv` there.