### PR TITLE
Clean-ups to Spaces/Int/ and Spaces/Pos/

### DIFF
--- a/theories/Spaces/Int/LoopExp.v
+++ b/theories/Spaces/Int/LoopExp.v
@@ -182,7 +182,7 @@ Proof.
   all: induction n as [|n IH]
     using pos_peano_ind; try reflexivity; cbn in *.
   all: unfold loopexp_pos; rewrite pos_peano_ind_beta_pos_succ.
-  all: unfold pos_iter; rewrite pos_peano_ind_beta_pos_succ.
+  all: unfold pos_iter; rewrite pos_peano_rec_beta_pos_succ.
   all: refine (transport_pp _ _ _ _ @ _); cbn; apply ap, IH.
 Defined.
 

--- a/theories/Spaces/Int/Spec.v
+++ b/theories/Spaces/Int/Spec.v
@@ -10,98 +10,92 @@ Local Open Scope int_scope.
 
 Lemma int_add_comm n m : n + m = m + n.
 Proof.
-  destruct n, m; cbn; trivial; by rewrite pos_add_comm.
-Qed.
+  destruct n, m; trivial. all: cbn.
+  all: apply ap, pos_add_comm.
+Defined.
 
 (** ** Zero is the additive identity. *)
 
-Lemma int_add_0_l n : 0 + n = n.
-Proof.
-  reflexivity.
-Qed.
+Definition int_add_0_l n : 0 + n = n
+  := 1.
 
 Lemma int_add_0_r n : n + 0 = n.
 Proof.
   by destruct n.
-Qed.
+Defined.
 
 (** ** Multiplication by zero is zero *)
 
-Lemma int_mul_0_l n : 0 * n = 0.
-Proof.
-  reflexivity.
-Qed.
+Definition int_mul_0_l n : 0 * n = 0
+  := 1.
 
 Lemma int_mul_0_r n : n * 0 = 0.
 Proof.
   by destruct n.
-Qed.
+Defined.
 
 (** ** One is the multiplicative identity *)
 
 Lemma int_mul_1_l n : 1 * n = n.
 Proof.
   by destruct n.
-Qed.
+Defined.
 
 Lemma int_mul_1_r n : n * 1 = n.
 Proof.
   destruct n; trivial; cbn; apply ap, pos_mul_1_r.
-Qed.
+Defined.
 
 (** ** Inverse laws *)
 
 Lemma int_pos_sub_diag n : int_pos_sub n n = 0.
 Proof.
-  induction n; trivial; cbn; by rewrite IHn.
-Qed.
+  induction n; trivial; cbn.
+  all: exact (ap int_double IHn).
+Defined.
 
 Lemma int_add_negation_l n : (-n) + n = 0.
 Proof.
   destruct n; trivial; cbn; apply int_pos_sub_diag.
-Qed.
+Defined.
 
 Lemma int_add_negation_r n : n + (-n) = 0.
 Proof.
   destruct n; trivial; cbn; apply int_pos_sub_diag.
-Qed.
+Defined.
 
 (** ** Permutation of neg and pos_succ *)
 Lemma int_neg_pos_succ p : neg (pos_succ p) = int_pred (neg p).
 Proof.
   by destruct p.
-Qed.
+Defined.
 
 (** ** Permutation of pos and pos_succ *)
 Lemma int_pos_pos_succ p : pos (pos_succ p) = int_succ (pos p).
 Proof.
   by destruct p.
-Qed.
+Defined.
 
 (** ** Negation of a doubled positive integer *)
-Lemma int_negation_double a
-  : - (int_double a) = int_double (- a).
+Lemma int_negation_double a : - (int_double a) = int_double (- a).
 Proof.
   by destruct a.
-Qed.
+Defined.
 
 (** Negation of the predecessor of a doubled positive integer. *)
-Lemma int_negation_pred_double a
-  : - (int_pred_double a) = int_succ_double (- a).
+Lemma int_negation_pred_double a : - (int_pred_double a) = int_succ_double (- a).
 Proof.
   by destruct a.
-Qed.
+Defined.
 
 (** Negation of the doubling of the sucessor of an positive. *)
-Lemma int_negation_succ_double a
-  : - (int_succ_double a) = int_pred_double (- a).
+Lemma int_negation_succ_double a : - (int_succ_double a) = int_pred_double (- a).
 Proof.
   by destruct a.
-Qed.
+Defined.
 
 (** Negation of subtraction of positive integers *)
-Lemma int_pos_sub_negation a b
-  : - (int_pos_sub a b) = int_pos_sub b a.
+Lemma int_pos_sub_negation a b : - (int_pos_sub a b) = int_pos_sub b a.
 Proof.
   revert a b.
   induction a as [|a ah|a ah];
@@ -111,7 +105,7 @@ Proof.
     ?int_negation_succ_double,
     ?int_negation_pred_double.
   all: apply ap, ah.
-Qed.
+Defined.
 
 (** ** int_succ is a retract of int_pred *)
 Definition int_succ_pred : int_succ o int_pred == idmap.
@@ -122,7 +116,7 @@ Proof.
   1: apply pos_pred_double_succ.
   rewrite pos_add_1_r.
   apply pos_succ_pred_double.
-Qed.
+Defined.
 
 (** ** int_pred is a retract of int_succ *)
 Definition int_pred_succ : int_pred o int_succ == idmap.
@@ -133,7 +127,7 @@ Proof.
   1: rewrite pos_add_1_r.
   1: apply pos_succ_pred_double.
   apply pos_pred_double_succ.
-Qed.
+Defined.
 
 (* ** The successor autoequivalence. *)
 Global Instance isequiv_int_succ : IsEquiv int_succ | 0
@@ -146,7 +140,7 @@ Definition equiv_int_succ : Int <~> Int
 Lemma int_negation_add_distr n m : - (n + m) = - n + - m.
 Proof.
  destruct n, m; simpl; trivial using int_pos_sub_negation.
-Qed.
+Defined.
 
 (** ** Negation is injective *)
 Lemma int_negation_inj n m : -n = -m -> n = m.
@@ -161,7 +155,7 @@ Proof.
   8: apply  neg_neq_zero in H.
   9: apply  neg_inj in H.
   all: by destruct H.
-Qed.
+Defined.
 
 (** ** Subtracting 1 from a sucessor gives the positive integer. *)
 Lemma int_pos_sub_succ_l a
@@ -169,7 +163,7 @@ Lemma int_pos_sub_succ_l a
 Proof.
   destruct a; trivial.
   cbn; apply ap, pos_pred_double_succ.
-Qed.
+Defined.
 
 (** ** Subtracting a sucessor from 1 gives minus the integer. *)
 Lemma int_pos_sub_succ_r a
@@ -177,7 +171,7 @@ Lemma int_pos_sub_succ_r a
 Proof.
   destruct a; trivial.
   cbn; apply ap, pos_pred_double_succ.
-Qed.
+Defined.
 
 (** ** Interaction of doubling functions and subtraction *)
 
@@ -199,7 +193,7 @@ Proof.
   + cbn.
     rewrite IHa.
     cbn; destruct (int_pos_sub a b); trivial.
-Qed.
+Defined.
 
 Lemma int_pred_double_int_pos_sub a b 
   : int_pred_double (int_pos_sub (pos_succ a) b)
@@ -219,7 +213,7 @@ Proof.
   + cbn.
     rewrite IHa.
     by destruct (int_pos_sub a b).
-Qed.
+Defined.
 
 (** ** Subtractions cancel sucessors. *)
 Lemma int_pos_sub_succ_succ a b
@@ -263,7 +257,7 @@ Proof.
   intros b bH.
   rewrite 2 int_pos_sub_succ_succ.
   apply bH.
-Qed.
+Defined.
 
 (** ** Negation of the predecessor is an involution. *)
 Lemma int_negation_pred_negation_red x
@@ -274,7 +268,7 @@ Proof.
   1: apply pos_pred_double_succ.
   rewrite pos_add_1_r.
   apply pos_succ_pred_double.
-Qed.
+Defined.
 
 (** ** Predecessor of a sum is the sum with a predecessor *)
 Lemma int_pred_add_r a b
@@ -310,7 +304,7 @@ Proof.
       cbn; rewrite pos_add_assoc.
       change (int_pred (int_succ (pos (a + b)%pos)) = pos a + pos b).
       apply int_pred_succ.
-Qed.
+Defined.
 
 (** ** Subtraction from a sum is the sum of a subtraction *)
 Lemma int_pos_sub_add (a b c : Pos)
@@ -326,7 +320,7 @@ Proof.
   rewrite ch.
   rewrite <- int_pred_pos_sub_r.
   apply int_pred_add_r.
-Qed.
+Defined.
 
 (** An auxillary lemma used to prove associativity. *)
 Lemma int_add_assoc_pos p n m : pos p + (n + m) = pos p + n + m.
@@ -343,7 +337,7 @@ Proof.
   - symmetry.
     apply int_pos_sub_add.
   - cbn; apply ap, pos_add_assoc.
-Qed.
+Defined.
 
 (** ** Associativity of addition *)
 Lemma int_add_assoc n m p : n + (m + p) = n + m + p.
@@ -354,37 +348,37 @@ Proof.
     apply int_add_assoc_pos.
   - trivial.
   - apply int_add_assoc_pos.
-Qed.
+Defined.
 
 (** ** Relationship between [int_succ], [int_pred] and addition. *)
 Lemma int_add_succ_l a b : int_succ a + b = int_succ (a + b).
 Proof.
   rewrite <- int_add_assoc, (int_add_comm 1 b).
   apply int_add_assoc.
-Qed.
+Defined.
 
 Lemma int_add_succ_r a b : a + int_succ b = int_succ (a + b).
 Proof.
   apply int_add_assoc.
-Qed.
+Defined.
 
 Lemma int_add_pred_l a b : int_pred a + b = int_pred (a + b).
 Proof.
   rewrite <- int_add_assoc, (int_add_comm (-1) b).
   apply int_add_assoc.
-Qed.
+Defined.
 
 Lemma int_add_pred_r a b : a + int_pred b = int_pred (a + b).
 Proof.
   apply int_add_assoc.
-Qed.
+Defined.
 
 (** ** Commutativity of multiplication *)
 Lemma int_mul_comm n m : n * m = m * n.
 Proof.
   destruct n, m; cbn; try reflexivity;
   apply ap; apply pos_mul_comm.
-Qed.
+Defined.
 
 (** Distributivity of multiplication over addition *)
 
@@ -411,7 +405,7 @@ Proof.
   rewrite <- IHp.
   set (int_pos_sub n m) as k.
   by destruct k.
-Qed.
+Defined.
 
 Lemma int_pos_sub_mul_neg n m p
   : int_pos_sub m n  * neg p = int_pos_sub (n * p)%pos (m * p)%pos.
@@ -439,7 +433,7 @@ Proof.
   rewrite <- (int_pos_sub_negation m).
   set (int_pos_sub m n) as k.
   by destruct k.
-Qed.
+Defined.
 
 Lemma int_mul_add_distr_r n m p : (n + m) * p = n * p + m * p.
 Proof.
@@ -448,14 +442,14 @@ Proof.
   try apply int_pos_sub_mul_neg;
   try apply int_pos_sub_mul_pos;
   apply int_mul_0_r.
-Qed.
+Defined.
 
 Lemma int_mul_add_distr_l n m p : n * (m + p) = n * m + n * p.
 Proof.
   rewrite 3 (int_mul_comm n); apply int_mul_add_distr_r.
-Qed.
+Defined.
 
 Lemma int_mul_assoc n m p : n * (m * p) = n * m * p.
 Proof.
   destruct n, m, p; cbn; trivial; f_ap; apply pos_mul_assoc.
-Qed.
+Defined.

--- a/theories/Spaces/Pos/Core.v
+++ b/theories/Spaces/Pos/Core.v
@@ -268,17 +268,24 @@ Infix "*" := pos_mul : positive_scope.
 Definition pos_iter {A : Type} (f : A -> A)
   : Pos -> A -> A.
 Proof.
-  apply (pos_peano_ind (fun _ => A -> A) f).
+  apply (pos_peano_rec (A -> A) f).
   intros n g.
   exact (f o g).
 Defined.
 
+(** ** Iteration of a two-variable function, with nesting reflecting the bits *)
+
+Definition pos_iter_op {A} (op : A -> A -> A)
+  := fix p_iter (p : Pos) (a : A) : A
+    := match p with
+        | 1 => a
+        | p~0 => p_iter p (op a a)
+        | p~1 => op a (p_iter p (op a a))
+       end.
+
 (** ** Power *)
 
 Definition pos_pow (x : Pos) := pos_iter (pos_mul x) 1.
-
-(* We cannot use this notation because it is reserved for path inverse. *)
-(* Infix "^" := pos_pow : positive_scope. *)
 
 (** ** Square *)
 
@@ -327,13 +334,9 @@ Fixpoint pos_size p :=
 
 (** ** From binary positive numbers to Peano natural numbers *)
 
-Definition pos_iter_op {A} (op : A -> A -> A)
-  := fix pos_iter (p : Pos) (a : A) : A
-    := match p with
-        | 1 => a
-        | p~0 => pos_iter p (op a a)
-        | p~1 => op a (pos_iter p (op a a))
-       end.
+(** Sends [n] to [n], missing [0]. *)
+Definition nat_of_pos (p : Pos) : nat
+  := pos_iter S p 0%nat.
 
 (** ** From Peano natural numbers to binary positive numbers *)
 

--- a/theories/Spaces/Pos/Spec.v
+++ b/theories/Spaces/Pos/Spec.v
@@ -189,7 +189,7 @@ Lemma pos_iter_succ_l {A} (f : A -> A) p a
   : pos_iter f (pos_succ p) a = f (pos_iter f p a).
 Proof.
   unfold pos_iter.
-  by rewrite pos_peano_ind_beta_pos_succ.
+  by rewrite pos_peano_rec_beta_pos_succ.
 Qed.
 
 Lemma pos_iter_succ_r {A} (f : A -> A) p a
@@ -201,7 +201,7 @@ Proof.
   hnf; intros p q f a.
   refine (_ @ _ @ _^).
   1,3: unfold pos_iter;
-    by rewrite pos_peano_ind_beta_pos_succ.
+    by rewrite pos_peano_rec_beta_pos_succ.
   apply ap.
   apply q.
 Qed.


### PR DESCRIPTION
The first commit changes `pos_peano_ind` to `pos_peano_rec`, moves `pos_iter_op` to a more sensible spot in the file, and fills in `nat_of_pos`, which had a comment describing it, but no implementation.

The second commit makes everything in Spaces/Int/Spec.v transparent, and cleans up a couple of things.  (I needed one result transparent for WIP, so I just made them all transparent.)