### PR TITLE
Pointed/Core and Classes/theory/groups

### DIFF
--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -40,13 +40,15 @@ Section group_props.
   Global Instance group_cancelL : forall z : G, LeftCancellation (.*.) z.
   Proof.
     intros z x y E.
-    rewrite <- (left_identity x).
-    rewrite <- (left_inverse (unit:=mon_unit) z).
-    rewrite <- simple_associativity.
-    rewrite E.
-    rewrite simple_associativity, (left_inverse z), left_identity.
-    reflexivity.
-  Qed.
+    rhs_V rapply left_identity.
+    rhs_V rapply (ap (.* y) (left_inverse z)).
+    rhs_V rapply simple_associativity.
+    rhs_V rapply (ap (-z *.) E).
+    symmetry.
+    lhs rapply simple_associativity.
+    lhs rapply (ap (.* x) (left_inverse z)).
+    apply left_identity.
+  Defined.
 
   Global Instance group_cancelR: forall z : G, RightCancellation (.*.) z.
   Proof.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -876,12 +876,12 @@ Proof.
 Defined.
 
 (** Univalence for pointed types *)
-Definition equiv_path_ptype `{Univalence} (A B : pType) : A <~>* B <~> A = B.
+Definition equiv_path_ptype `{Univalence} (A B : pType@{u}) : A <~>* B <~> A = B.
 Proof.
   refine (equiv_path_from_contr A (fun C => A <~>* C) pequiv_pmap_idmap _ B).
-  nrapply (contr_equiv' { X : Type & { f : A <~> X & {x : X & f pt = x} }}).
+  nrapply (contr_equiv' { X : Type@{u} & { f : A <~> X & {x : X & f pt = x} }}).
   1: make_equiv.
-  rapply (contr_equiv' { X : Type &  A <~> X }).
+  rapply (contr_equiv' { X : Type@{u} &  A <~> X }).
   nrapply equiv_functor_sigma_id; intro X; symmetry.
   rapply equiv_sigma_contr.
   (** If you replace the type in the second line with { Xf : {X : Type & A <~> X} & {x : Xf.1 & Xf.2 pt = x} }, then the third line completes the proof, but that results in an extra universe variable. *)


### PR DESCRIPTION
Two unrelated commits.

The first commit gets rid of a universe variable that is constrained to be equal to another one.  (I'm not sure why Coq doesn't automatically get rid of the redundant one.)

The second commit makes `group_cancelL` transparent, which is needed for WIP.  I didn't adjust the other results in this file.