### PR TITLE
HIT/quotient: fix universe variables, and uses in Classes

### DIFF
--- a/theories/Classes/implementations/field_of_fractions.v
+++ b/theories/Classes/implementations/field_of_fractions.v
@@ -301,7 +301,7 @@ Definition F_rec2@{i j} {T:Type@{i} } {sT : IsHSet T}
   (dequiv : forall x1 x2, equiv x1 x2 -> forall y1 y2, equiv y1 y2 ->
     dclass x1 y1 = dclass x2 y2),
   F -> F -> T
-  := @quotient_rec2@{UR UR j i} _ _ _ _ _ (Build_HSet _).
+  := @quotient_rec2@{UR UR UR j i} _ _ _ _ _ (Build_HSet _).
 
 Definition F_rec2_compute {T sT} dclass dequiv x y
   : @F_rec2 T sT dclass dequiv (' x) (' y) = dclass x y
@@ -400,7 +400,7 @@ Defined.
 
 Lemma classes_eq_related@{} : forall q r, ' q = ' r -> equiv q r.
 Proof.
-apply classes_eq_related@{UR UR Ularge Uhuge};apply _.
+apply classes_eq_related@{UR UR Ularge UR Ularge};apply _.
 Qed.
 
 Lemma class_neq@{} : forall q r, ~ (equiv q r) -> ' q <> ' r.

--- a/theories/Classes/implementations/natpair_integers.v
+++ b/theories/Classes/implementations/natpair_integers.v
@@ -312,7 +312,7 @@ Definition Z_path {x y} : PairT.equiv x y -> Z_of_pair x = Z_of_pair y
   := related_classes_eq _.
 
 Definition related_path {x y} : Z_of_pair x = Z_of_pair y -> PairT.equiv x y
-  := classes_eq_related@{UN UN Ularge Uhuge} _ _ _.
+  := classes_eq_related@{UN UN Ularge UN Ularge} _ _ _.
 
 Definition Z_rect@{i} (P : Z -> Type@{i}) {sP : forall x, IsHSet (P x)}
   (dclass : forall x : PairT.T N, P (' x))
@@ -368,7 +368,7 @@ Definition Z_rec2@{i j} {T:Type@{i} } {sT : IsHSet T}
   (dequiv : forall x1 x2, PairT.equiv x1 x2 -> forall y1 y2, PairT.equiv y1 y2 ->
     dclass x1 y1 = dclass x2 y2),
   Z -> Z -> T
-  := @quotient_rec2@{UN UN j i} _ _ _ _ _ (Build_HSet _).
+  := @quotient_rec2@{UN UN UN j i} _ _ _ _ _ (Build_HSet _).
 
 Definition Z_rec2_compute {T sT} dclass dequiv x y
   : @Z_rec2 T sT dclass dequiv (' x) (' y) = dclass x y

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -7,7 +7,7 @@ Require Import Truncations.Core.
 
 Local Open Scope path_scope.
 
-(** * Quotient of a type by an hprop-valued relation
+(** * The set-quotient of a type by an hprop-valued relation
 
 We aim to model:
 <<

--- a/theories/HIT/quotient.v
+++ b/theories/HIT/quotient.v
@@ -5,7 +5,7 @@ Require Import Truncations.Core.
 
 Local Open Scope path_scope.
 
-(** * Quotient of a Type by an hprop-valued relation
+(** * The set-quotient of a type by an hprop-valued relation
 
 We aim to model:
 <<
@@ -16,23 +16,23 @@ Inductive quotient : Type :=
 >>
 *)
 
-(** This development should be further connected with the sections in the book; see below.*)
+(** TODO:  This development should be further connected with the sections in the book; see below.  And it should be merged with Colimits.Quotient. Currently this file is only used in Classes/implementations/natpair_integers.v and Classes/implementations/field_of_fractions.v, so it shouldn't be too hard to switch to Colimits.Quotient. *)
 
 Module Export Quotient.
 
   Section Domain.
 
-    Context {A : Type} (R : Relation A) {sR: is_mere_relation _ R}.
+    Universes i j u.
+    Constraint i <= u, j <= u.
+
+    Context {A : Type@{i}} (R : Relation@{i j} A) {sR: is_mere_relation _ R}.
 
     (** We choose to let the definition of quotient depend on the proof that [R] is a set-relations.  Alternatively, we could have defined it for all relations and only develop the theory for set-relations.  The former seems more natural.
 
 We do not require [R] to be an equivalence relation, but implicitly consider its transitive-reflexive closure. *)
 
-
-    (** Note: If we wanted to be really accurate, we'd need to put [@quotient A R sr] in the max [U_{sup(i, j)}] of the universes of [A : U_i] and [R : A -> A -> U_j].  But this requires some hacky code, at the moment, and the only thing we gain is avoiding making use of an implicit hpropositional resizing "axiom". *)
-
     (** This definition has a parameter [sR] that shadows the ambient one in the Context in order to ensure that it actually ends up depending on everything in the Context when the section is closed, since its definition doesn't actually refer to any of them.  *)
-    Private Inductive quotient {sR: is_mere_relation _ R} : Type :=
+    Private Inductive quotient {sR: is_mere_relation _ R} : Type@{u} :=
     | class_of : A -> quotient.
 
     (** The path constructors. *)


### PR DESCRIPTION
Just like for Colimits.GraphQuotient, enforce that the quotient in HIT.quotient lands in a universe at least as big as the universe the relation takes values in.