### PR TITLE
Fix: is0functor_compose arguments

### DIFF
--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -329,7 +329,7 @@ End ConstantFunctor.
 
 Global Instance is0functor_compose {A B C : Type}
   `{IsGraph A, IsGraph B, IsGraph C}
-  (F : A -> B) (G : B -> C) `{!Is0Functor F, !Is0Functor G}
+  (F : A -> B) `{!Is0Functor F} (G : B -> C) `{!Is0Functor G}
   : Is0Functor (G o F).
 Proof.
   srapply Build_Is0Functor.


### PR DESCRIPTION
Tiny fix: `is0functor_compose` has an `Arguments ... : rename` command that previously made the wrong arguments implicit.

`Print is0functor_compose` before:
```coq
Arguments is0functor_compose {A B C}%type_scope
  {isgraph_A isgraph_B isgraph_C} F%function_scope
  {is0functor_F}%function_scope G {is0functor_G}
  (where some original arguments have been renamed)
```
after:
```coq
Arguments is0functor_compose {A B C}%type_scope
  {isgraph_A isgraph_B isgraph_C} F%function_scope 
  {is0functor_F} G%function_scope {is0functor_G}
  (where some original arguments have been renamed)
```