### PR TITLE
ps/rr/redefine dpath as transport   cleanup proofs

### DIFF
--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -87,7 +87,6 @@ Section Abel.
     1: apply a.
     intros [[x y] z].
     refine (transport_compose _ _ _ _ @ _).
-    srapply dp_path_transport^-1%equiv.
     apply c.
   Defined.
 
@@ -96,9 +95,8 @@ Section Abel.
     `{forall x, IsHSet (P x)}(a : forall x, P (ab x))
     (c : forall x y z, DPath P (ab_comm x y z)
       (a (x * (y * z))) (a (x * (z * y))))
-    (x y z : G) : dp_apD (Abel_ind P a c) (ab_comm x y z) = c x y z.
+    (x y z : G) : apD (Abel_ind P a c) (ab_comm x y z) = c x y z.
   Proof.
-    apply dp_apD_path_transport.
     refine (apD_compose' tr _ _ @ ap _ _ @ concat_V_pp _ _).
     rapply Coeq_ind_beta_cglue.
   Defined.
@@ -117,8 +115,7 @@ Section Abel.
     (a : forall x, P (ab x)) : forall (x : Abel), P x.
   Proof.
     srapply (Abel_ind _ a).
-    intros; apply dp_path_transport.
-    apply path_ishprop.
+    intros; apply path_ishprop.
   Defined.
 
   (** And its recursion version. *)

--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -242,7 +242,6 @@ Section FreeProduct.
     snrapply Coeq_ind.
     1: exact e.
     intro a.
-    nrapply dp_path_transport^-1%equiv.
     destruct a as [ [ [ [a | a ] | a] | a ] | a ].
     + destruct a as [[[x h1] h2] y].
       apply dp_compose.
@@ -267,7 +266,7 @@ Section FreeProduct.
   Proof.
     srapply amal_type_ind.
     1: exact e.
-    all: intros; apply dp_path_transport, path_ishprop.
+    all: intros; apply path_ishprop.
   Defined.
 
   (** From which we can derive the non-dependent eliminator / recursion principle *)

--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -54,25 +54,6 @@ Proof.
   rapply GraphQuotient_rec_beta_gqglue.
 Defined.
 
-Definition Coeq_ind_dp {B A f g} (P : @Coeq B A f g -> Type)
-  (coeq' : forall a, P (coeq a))
-  (cglue' : forall b, DPath P (cglue b) (coeq' (f b)) (coeq' (g b)))
-  : forall w, P w.
-Proof.
-  srapply (Coeq_ind P coeq'); intros b.
-  apply dp_path_transport^-1, cglue'.
-Defined.
-
-Definition Coeq_ind_dp_beta_cglue {B A f g} (P : @Coeq B A f g -> Type)
-  (coeq' : forall a, P (coeq a))
-  (cglue' : forall b, DPath P (cglue b) (coeq' (f b)) (coeq' (g b)))
-  (b : B)
-  : dp_apD (Coeq_ind_dp P coeq' cglue') (cglue b) = cglue' b.
-Proof.
-  apply dp_apD_path_transport.
-  srapply Coeq_ind_beta_cglue.
-Defined.
-
 (** ** Universal property *)
 
 Definition Coeq_unrec {B A} (f g : B -> A) {P}

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -116,7 +116,6 @@ Section Flattening.
   Lemma equiv_dp_dgraphquotient (x y : A) (s : R x y) (a : F x) (b : F y)
     : DPath DGraphQuotient (gqglue s) a b <~> (e x y s a = b).
   Proof.
-    refine (_ oE dp_path_transport^-1).
     refine (equiv_concat_l _^ _).
     apply transport_DGraphQuotient.
   Defined.
@@ -132,21 +131,17 @@ Section Flattening.
     snrapply GraphQuotient_ind.
     1: exact Qgq.
     intros a b s.
-    apply equiv_dp_path_transport.
     apply dp_forall.
     intros x y.
     srapply (equiv_ind (equiv_dp_dgraphquotient a b s x y)^-1).
     intros q.
     destruct q.
-    apply equiv_dp_path_transport.
     refine (transport2 _ _ _ @ Qgqglue a b s x).
     refine (ap (path_sigma_uncurried DGraphQuotient _ _) _).
     snrapply path_sigma.
     1: reflexivity.
-    apply moveR_equiv_V.
-    simpl; f_ap.
-    lhs rapply concat_p1.
-    rapply inv_V.
+    lhs nrapply concat_p1.
+    apply inv_V.
   Defined.
 
   (** Rather than use [flatten_ind] to define [flatten_rec] we reprove this simple case. This means we can later reason about it and derive the computation rules easily. The full computation rule for [flatten_ind] takes some work to derive and is not actually needed. *)

--- a/theories/Colimits/MappingCylinder.v
+++ b/theories/Colimits/MappingCylinder.v
@@ -33,41 +33,24 @@ Section MappingCylinder.
             (cylb : forall b, P (cyr b))
             (cylg : forall a, DPath P (cyglue a) (cyla a) (cylb (f a))).
 
-    Definition Cyl_ind_dp : forall c, P c.
-    Proof.
-      srapply Pushout_ind.
-      - apply cyla.
-      - apply cylb.
-      - intros a; apply dp_path_transport^-1, cylg.
-    Defined.
+    Definition Cyl_ind : forall c, P c
+      := Pushout_ind _ cyla cylb cylg.
 
-    Definition Cyl_ind_dp_beta_cyglue (a : A)
-      : dp_apD Cyl_ind_dp (cyglue a) = cylg a.
-    Proof.
-      unfold Cyl_ind_dp.
-      refine ((dp_path_transport_apD _ _)^ @ _).
-      apply moveR_equiv_M.
-      rapply Pushout_ind_beta_pglue.
-    Defined.
+    Definition Cyl_ind_beta_cyglue (a : A)
+      : apD Cyl_ind (cyglue a) = cylg a
+      := Pushout_ind_beta_pglue _ _ _ _ _.
 
   End CylInd.
 
   Section CylRec.
     Context {P : Type} (cyla : A -> P) (cylb : B -> P) (cylg : cyla == cylb o f).
 
-    Definition Cyl_rec : Cyl f -> P.
-    Proof.
-      srapply Pushout_rec.
-      - apply cyla.
-      - apply cylb.
-      - apply cylg.
-    Defined.
+    Definition Cyl_rec : Cyl f -> P
+      := Pushout_rec _ cyla cylb cylg.
 
     Definition Cyl_rec_beta_cyglue (a : A)
-      : ap Cyl_rec (cyglue a) = cylg a.
-    Proof.
-      rapply Pushout_rec_beta_pglue.
-    Defined.
+      : ap Cyl_rec (cyglue a) = cylg a
+      := Pushout_rec_beta_pglue _ _ _ _ _.
 
   End CylRec.
 
@@ -82,7 +65,7 @@ Section MappingCylinder.
       + exact f.
       + exact idmap.
       + reflexivity.
-    - srapply Cyl_ind_dp.
+    - srapply Cyl_ind.
       + intros a; cbn.
         symmetry; apply cyglue.
       + intros b; reflexivity.

--- a/theories/Cubical/DPathSquare.v
+++ b/theories/Cubical/DPathSquare.v
@@ -71,7 +71,7 @@ Notation ds_dpath := equiv_ds_dpath.
 (* We have an apD for DPathSquares *)
 Definition ds_apD {A} {B : A -> Type} (f : forall a, B a) {a00 a10 a01 a11 : A}
   {px0 : a00 = a10} {px1 : a01 = a11} {p0x p1x} (s : PathSquare px0 px1 p0x p1x)
-  : DPathSquare B s (dp_apD f px0) (dp_apD f px1) (dp_apD f p0x) (dp_apD f p1x).
+  : DPathSquare B s (apD f px0) (apD f px1) (apD f p0x) (apD f p1x).
 Proof.
   by destruct s.
 Defined.
@@ -110,7 +110,7 @@ Notation ds_const' := equiv_ds_const'.
 (* dp_apD fits into a natural square *)
 Definition dp_apD_nat {A} {P : A -> Type} {f g : forall x, P x} {x y : A}
   (q : f == g) (p : x = y)
-  : DPathSquare P (sq_refl_h _) (dp_apD f p) (dp_apD g p) (q x) (q y).
+  : DPathSquare P (sq_refl_h _) (apD f p) (apD g p) (q x) (q y).
 Proof.
   destruct p.
   by apply sq_1G.
@@ -133,7 +133,7 @@ Notation ds_G1 := equiv_ds_G1.
 Definition equiv_ds_dp {A : Type} {B : A -> Type} (f g : forall a : A, B a)
   {x1 x2 : A} (p : x1 = x2) (q1 : f x1 = g x1) (q2 : f x2 = g x2)
   : DPath (fun x : A => f x = g x) p q1 q2
-    <~> DPathSquare B (sq_refl_h p) (dp_apD f p) (dp_apD g p) q1 q2.
+    <~> DPathSquare B (sq_refl_h p) (apD f p) (apD g p) q1 q2.
 Proof.
   destruct p.
   exact sq_1G.

--- a/theories/Cubical/PathCube.v
+++ b/theories/Cubical/PathCube.v
@@ -358,8 +358,8 @@ Definition equiv_dp_cu {A B : Type} {x1 x2 : A} {a00 a01 a10 a11 : A -> B}
   {f1 : PathSquare (px0 x1) (px1 x1) (p0x x1) (p1x x1)}
   {f2 : PathSquare (px0 x2) (px1 x2) (p0x x2) (p1x x2)}
   {p : x1 = x2}
-  : PathCube f1 f2 (sq_dp (dp_apD px0 p)) (sq_dp (dp_apD px1 p))
-     (sq_dp (dp_apD p0x p)) (sq_dp (dp_apD p1x p))
+  : PathCube f1 f2 (sq_dp (apD px0 p)) (sq_dp (apD px1 p))
+     (sq_dp (apD p0x p)) (sq_dp (apD p1x p))
   <~> DPath (fun x => PathSquare (px0 x) (px1 x) (p0x x) (p1x x)) p f1 f2.
 Proof.
   destruct p; symmetry; exact cu_G11.

--- a/theories/Cubical/PathSquare.v
+++ b/theories/Cubical/PathSquare.v
@@ -595,6 +595,9 @@ Notation sq_dp := equiv_sq_dp.
 Definition sq_ap011 {A B C} (f : A -> B -> C)
   {a a' : A} (p : a = a') {b b' : B} (q : b = b')
   : PathSquare (ap (fun x => f x b) p) (ap (fun x => f x b') p)
-    (ap (f a) q) (ap (f a') q)
-  := sq_dp (dp_apD (fun y => ap (fun x => f x y) _) _).
+    (ap (f a) q) (ap (f a') q).
+Proof.
+  apply sq_dp.
+  exact (apD (fun y => ap (fun x => f x y) p) q).
+Defined.
 

--- a/theories/Extensions.v
+++ b/theories/Extensions.v
@@ -440,9 +440,9 @@ Definition cyl_extension {A B} (f : A -> B) (C : Cyl f -> Type)
            (ext : ExtensionAlong cyl C g)
   : ExtensionAlong cyl C g.
 Proof.
-  srefine (Cyl_ind_dp C g (ext.1 o cyr) _ ; _); intros a.
+  srefine (Cyl_ind C g (ext.1 o cyr) _ ; _); intros a.
   + refine ((ext.2 a)^ @Dl _)%dpath.
-    apply dp_apD.
+    apply apD.
   + reflexivity. (** The point is that this equality is now definitional. *)
 Defined.
 
@@ -725,13 +725,12 @@ Proof.
         - rapply extendable_equiv.
         - exact (eh (fun x => cglue x # u (cyr x)) (v o cyr)). }
     intros x; subst C'.
-    refine (_ oE dp_path_transport).
     refine ((dp_compose (pr_cylcoeq p q) C _)^-1 oE _).
     symmetry; srapply equiv_ds_fill_lr.
     3:rapply ap_pr_cylcoeq_cglue.
     all:srapply (transport (fun r => DPath C r _ _)).
-    3:exact (dp_inverse (dp_compose _ C _ (dp_apD u (eissect pr_cyl x)))).
-    4:exact (dp_inverse (dp_compose _ C _ (dp_apD v (eissect pr_cyl x)))).
+    3:exact (dp_inverse (dp_compose _ C _ (apD u (eissect pr_cyl x) : DPath _ _ _ _))).
+    4:exact (dp_inverse (dp_compose _ C _ (apD v (eissect pr_cyl x) : DPath _ _ _ _))).
     1:change (fun y => pr_cylcoeq p q (coeq (functor_cyl p y)))
       with (fun y => coeq (f := f') (g := g') (pr_cyl (functor_cyl p y))).
     2:change (fun y => pr_cylcoeq p q (coeq (functor_cyl q y)))
@@ -740,11 +739,11 @@ Proof.
     all: exact (ap_compose (fun x => pr_cyl (functor_cyl _ x)) coeq _). }
   pose (eb1 := fun u v w => (fst (cyl_extendable _ _ _ (eb'' u v)) w).1).
   (** Now we construct an extension using Coeq-induction, and prove that it *is* an extension also using Coeq-induction. *)
-  srefine (_;_); srapply Coeq_ind_dp.
+  srefine (_;_); srapply Coeq_ind.
   + exact (ea1 (s' o coeq)).
   + apply eb1; intros b.
     rapply (dp_compose' _ _ (ap_cyl_cylcoeq_cglue p q b)).
-    exact (dp_apD s' (cglue b)).
+    exact (apD s' (cglue b)).
   + (** Since we're using cofibrations, this holds definitionally. *)
     intros a; reflexivity.
   + (** And this one is much simpler than it would be otherwise. *)
@@ -753,7 +752,7 @@ Proof.
     rapply ds_G1.
     refine (dp_apD_compose' _ _ (ap_cyl_cylcoeq_cglue p q b) _ @ _).
     apply moveR_equiv_V.
-    rapply (Coeq_ind_dp_beta_cglue C').
+    nrapply Coeq_ind_beta_cglue.
 Defined.
 
 (** Now we can easily iterate into higher extendability. *)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -102,7 +102,7 @@ Class CayleyDicksonImaginaroid (A : Type) := {
 Global Instance involutive_negate_susp {A} `(CayleyDicksonImaginaroid A)
   : Involutive (negate_susp A cdi_negate).
 Proof.
-  srapply Susp_ind_dp; try reflexivity.
+  srapply Susp_ind; try reflexivity.
   intro x.
   apply dp_paths_FFlr.
   rewrite concat_p1.
@@ -117,7 +117,7 @@ Defined.
 Global Instance involutive_conjugate_susp {A} `(CayleyDicksonImaginaroid A)
   : Involutive (conjugate_susp A cdi_negate).
 Proof.
-  srapply Susp_ind_dp; try reflexivity.
+  srapply Susp_ind; try reflexivity.
   intro x.
   apply dp_paths_FFlr.
   rewrite concat_p1.
@@ -134,7 +134,7 @@ Defined.
 Global Instance swapop_conjugate_susp {A} `(CayleyDicksonImaginaroid A)
   : SwapOp negate (conjugate_susp A cdi_negate).
 Proof.
-  srapply Susp_ind_dp; try reflexivity.
+  srapply Susp_ind; try reflexivity.
   intro x.
   apply dp_paths_FlFr.
   rewrite concat_p1.
@@ -272,11 +272,11 @@ Section ImaginaroidHSpace.
         apply jglue. }
     intros a b.
     revert y.
-    srapply Join_ind_dp.
+    srapply Join_ind.
     1: intro; apply jglue.
     1: intro; cbn; symmetry; apply jglue.
     intros c d.
-    srapply sq_dp^-1.
+    apply sq_dp^-1.
     refine (sq_ccGG _^ _^ _).
     1,2: apply Join_rec_beta_jglue.
     change (PathSquare (jglue (a * c) (c * b)) (jglue ((- d) * conj b) (conj a * d))^
@@ -294,7 +294,7 @@ Section ImaginaroidHSpace.
     clear a b c d.
     change (forall s : Susp A,
       Diamond (-mon_unit) s (mon_unit) s).
-    srapply Susp_ind_dp; hnf.
+    srapply Susp_ind; hnf.
     1: by apply diamond_v_sq.
     1: by apply diamond_h_sq.
     intro a.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -74,7 +74,7 @@ Module Export ClassifyingSpace.
       (bloop_pp' : forall x y,  DPathSquare P (sq_G1 (bloop_pp x y))
         (bloop' (x * y)) ((bloop' x) @Dp (bloop' y)) 1 1)
       (x : G)
-      : dp_apD (ClassifyingSpace_ind P bbase' bloop' bloop_pp') (bloop x) = bloop' x.
+      : apD (ClassifyingSpace_ind P bbase' bloop' bloop_pp') (bloop x) = bloop' x.
     Proof. Admitted.
 
   End ClassifyingSpace_ind.
@@ -123,8 +123,8 @@ Section Eliminators.
   Proof.
     refine (ClassifyingSpace_ind P bbase' bloop' _).
     intros.
-    apply ds_G1, dp_path_transport.
-    srapply path_ishprop.
+    apply ds_G1. 
+    apply path_ishprop.
   Defined.
 
   Definition ClassifyingSpace_rec_hset
@@ -377,8 +377,9 @@ Section HSpace_bg.
     snrapply ClassifyingSpace_ind_hprop.
     1: exact _.
     simpl.
-    apply sq_dp^-1, sq_1G.
-    refine (_ @ (ap_idmap _)^).
+    nrapply (transport_paths_FFlr' (g := idmap)).
+    apply equiv_p1_1q.
+    lhs nrapply ap_idmap.
     nrapply ClassifyingSpace_rec_beta_bloop.
   Defined.
 

--- a/theories/Homotopy/HSpaceS1.v
+++ b/theories/Homotopy/HSpaceS1.v
@@ -21,7 +21,6 @@ Section HSpace_S1.
     srapply Susp_ind; hnf.
     { apply moveL_transport_p.
       refine ((transport_pp _ _ _ _)^ @ _).
-      apply dp_path_transport^-1.
       apply p. }
     1: reflexivity.
     apply Empty_ind.
@@ -101,8 +100,7 @@ Section HSpace_S1.
     { apply (sq_flip_v (px0:=1) (px1:=1)).
       exact (ap_nat' (fun a => ap (fun b => sgop_s1 b z)
         (rightidentity_s1 a)) (merid North @ (merid South)^)). }
-    simpl.
-    srapply dp_ishprop.
+    apply path_ishprop.
   Defined.
 
   Global Instance commutative_sgop_s1

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -42,27 +42,6 @@ Section Join.
     : apD (Join_ind P P_A P_B P_g) (jglue a b) = P_g a b
     := Pushout_ind_beta_pglue _ _ _ _ _.
 
-  (** A version of [Join_ind] that uses dependant paths. *)
-  Definition Join_ind_dp {A B : Type} (P : Join A B -> Type)
-    (P_A : forall a, P (joinl a)) (P_B : forall b, P (joinr b))
-    (P_g : forall a b, DPath P (jglue a b) (P_A a) (P_B b))
-    : forall (x : Join A B), P x.
-  Proof.
-    refine (Join_ind P P_A P_B _).
-    intros a b.
-    apply dp_path_transport^-1.
-    exact (P_g a b).
-  Defined.
-
-  Definition Join_ind_dp_beta_jglue {A B : Type} (P : Join A B -> Type)
-    (P_A : forall a, P (joinl a)) (P_B : forall b, P (joinr b))
-    (P_g : forall a b, DPath P (jglue a b) (P_A a) (P_B b)) a b
-    : dp_apD (Join_ind_dp P P_A P_B P_g) (jglue a b) = P_g a b.
-  Proof.
-    apply dp_apD_path_transport.
-    snrapply Join_ind_beta_jglue.
-  Defined.
-
   (** A version of [Join_ind] specifically for proving that two functions defined on a [Join] are homotopic. *)
   Definition Join_ind_FlFr {A B P : Type} (f g : Join A B -> P)
     (Hl : forall a, f (joinl a) = g (joinl a))

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -81,7 +81,7 @@ Section Smash.
     + intros [a b].
       apply Psm.
     + apply (Bool_ind _ Pr Pl).
-    + srapply sum_ind; intro; apply dp_path_transport^-1.
+    + srapply sum_ind.
       - apply Pgl.
       - apply Pgr.
   Defined.
@@ -90,64 +90,63 @@ Section Smash.
     {Psm : forall a b, P (sm a b)} {Pl : P auxl} {Pr : P auxr}
     (Pgl : forall a, DPath P (gluel a) (Psm a pt) Pl)
     (Pgr : forall b, DPath P (gluer b) (Psm pt b) Pr) (a : X)
-    : dp_apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluel a) = Pgl a.
-  Proof.
-    apply dp_apD_path_transport.
-    refine (Pushout_ind_beta_pglue P _ _ _ (inl a) @ _).
-    unfold sum_ind.
-    by apply ap.
-  Qed.
+    : apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluel a) = Pgl a
+    := Pushout_ind_beta_pglue P _ _ _ (inl a).
 
   Definition Smash_ind_beta_gluer {P : Smash X Y -> Type}
     {Psm : forall a b, P (sm a b)} {Pl : P auxl} {Pr : P auxr}
     (Pgl : forall a, DPath P (gluel a) (Psm a pt) Pl)
     (Pgr : forall b, DPath P (gluer b) (Psm pt b) Pr) (b : Y)
-    : dp_apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluer b) = Pgr b.
-  Proof.
-    apply dp_apD_path_transport.
-    refine (Pushout_ind_beta_pglue P _ _ _ (inr b) @ _).
-    unfold sum_ind.
-    by apply ap.
-  Qed.
+    : apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluer b) = Pgr b
+    := Pushout_ind_beta_pglue P _ _ _ (inr b).
 
   Definition Smash_ind_beta_gluel' {P : Smash X Y -> Type}
     {Psm : forall a b, P (sm a b)} {Pl : P auxl} {Pr : P auxr}
     (Pgl : forall a, DPath P (gluel a) (Psm a pt) Pl)
     (Pgr : forall b, DPath P (gluer b) (Psm pt b) Pr) (a b : X)
-    : dp_apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluel' a b)
+    : apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluel' a b)
     = (Pgl a) @Dp ((Pgl b)^D).
   Proof.
-    unfold gluel'.
-    rewrite dp_apD_pp, dp_apD_V.
-    by rewrite 2 Smash_ind_beta_gluel.
-  Qed.
+    lhs nrapply dp_apD_pp.
+    apply ap011.
+    1: apply Smash_ind_beta_gluel.
+    lhs nrapply dp_apD_V.
+    apply ap.
+    apply Smash_ind_beta_gluel.
+  Defined.
 
   Definition Smash_ind_beta_gluer' {P : Smash X Y -> Type}
     {Psm : forall a b, P (sm a b)} {Pl : P auxl} {Pr : P auxr}
     (Pgl : forall a, DPath P (gluel a) (Psm a pt) Pl)
     (Pgr : forall b, DPath P (gluer b) (Psm pt b) Pr) (a b : Y)
-    : dp_apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluer' a b)
+    : apD (Smash_ind Psm Pl Pr Pgl Pgr) (gluer' a b)
     = (Pgr a) @Dp ((Pgr b)^D).
   Proof.
-    unfold gluer'.
-    rewrite dp_apD_pp, dp_apD_V.
-    by rewrite 2 Smash_ind_beta_gluer.
-  Qed.
+    lhs nrapply dp_apD_pp.
+    apply ap011.
+    1: apply Smash_ind_beta_gluer.
+    lhs nrapply dp_apD_V.
+    apply ap.
+    apply Smash_ind_beta_gluer.
+  Defined.
 
   Definition Smash_ind_beta_glue {P : Smash X Y -> Type}
     {Psm : forall a b, P (sm a b)} {Pl : P auxl} {Pr : P auxr}
     (Pgl : forall a, DPath P (gluel a) (Psm a pt) Pl)
     (Pgr : forall b, DPath P (gluer b) (Psm pt b) Pr) (a : X) (b : Y)
-    : dp_apD (Smash_ind Psm Pl Pr Pgl Pgr) (glue a b)
+    : apD (Smash_ind Psm Pl Pr Pgl Pgr) (glue a b)
     = ((Pgl a) @Dp ((Pgl pt)^D)) @Dp ((Pgr pt) @Dp ((Pgr b)^D)).
   Proof.
-    by rewrite dp_apD_pp, Smash_ind_beta_gluel', Smash_ind_beta_gluer'.
-  Qed.
+    lhs nrapply dp_apD_pp.
+    apply ap011.
+    - apply Smash_ind_beta_gluel'.
+    - apply Smash_ind_beta_gluer'.
+  Defined.
 
   Definition Smash_rec {P : Type} (Psm : X -> Y -> P) (Pl Pr : P)
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr)
-    : Smash X Y -> P := Smash_ind Psm Pl Pr
-      (fun x => dp_const (Pgl x)) (fun x => dp_const (Pgr x)).
+    : Smash X Y -> P
+    := Smash_ind Psm Pl Pr (fun x => dp_const (Pgl x)) (fun x => dp_const (Pgr x)).
 
   Local Open Scope path_scope.
 
@@ -155,59 +154,67 @@ Section Smash.
   Definition Smash_rec' {P : Type} {Psm : X -> Y -> P}
     (Pgl : forall a, Psm a pt = Psm pt pt) (Pgr : forall b, Psm pt b = Psm pt pt)
     (ql : Pgl pt = 1) (qr : Pgr pt = 1)
-    : Smash X Y -> P := Smash_rec Psm (Psm pt pt) (Psm pt pt) Pgl Pgr.
+    : Smash X Y -> P
+    := Smash_rec Psm (Psm pt pt) (Psm pt pt) Pgl Pgr.
 
   Definition Smash_rec_beta_gluel {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (a : X)
     : ap (Smash_rec Psm Pl Pr Pgl Pgr) (gluel a) = Pgl a.
   Proof.
-    refine (_ @ eissect dp_const (Pgl a)).
+    rhs_V nrapply (eissect dp_const).
     apply moveL_equiv_V.
-    unfold Smash_rec.
-    refine ((dp_apD_const (Smash_ind Psm Pl Pr (fun x : X => dp_const (Pgl x))
-      (fun x : Y => dp_const (Pgr x))) (gluel a))^ @ _).
-    rapply Smash_ind_beta_gluel.
-  Qed.
+    lhs_V nrapply dp_apD_const.
+    nrapply Smash_ind_beta_gluel.
+  Defined.
 
-  Definition smash_rec_beta_gluer {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
+  Definition Smash_rec_beta_gluer {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (b : Y)
     : ap (Smash_rec Psm Pl Pr Pgl Pgr) (gluer b) = Pgr b.
   Proof.
-    refine (_ @ eissect dp_const (Pgr b)).
+    rhs_V nrapply (eissect dp_const).
     apply moveL_equiv_V.
-    unfold Smash_rec.
-    refine ((dp_apD_const (Smash_ind Psm Pl Pr (fun x : X => dp_const (Pgl x))
-      (fun x : Y => dp_const (Pgr x))) (gluer b))^ @ _).
-    rapply Smash_ind_beta_gluer.
-  Qed.
+    lhs_V nrapply dp_apD_const.
+    nrapply Smash_ind_beta_gluer.
+  Defined.
 
   Definition Smash_rec_beta_gluel' {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (a b : X)
     : ap (Smash_rec Psm Pl Pr Pgl Pgr) (gluel' a b) = Pgl a @ (Pgl b)^.
   Proof.
-    rewrite ap_pp, ap_V.
-    by rewrite 2 Smash_rec_beta_gluel.
-  Qed.
+    lhs nrapply ap_pp.
+    f_ap.
+    1: apply Smash_rec_beta_gluel.
+    lhs nrapply ap_V.
+    apply inverse2.
+    apply Smash_rec_beta_gluel.
+  Defined. 
 
   Definition Smash_rec_beta_gluer' {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (a b : Y)
     : ap (Smash_rec Psm Pl Pr Pgl Pgr) (gluer' a b) = Pgr a @ (Pgr b)^.
   Proof.
-    rewrite ap_pp, ap_V.
-    by rewrite 2 smash_rec_beta_gluer.
-  Qed.
+    lhs nrapply ap_pp.
+    f_ap.
+    1: apply Smash_rec_beta_gluer.
+    lhs nrapply ap_V.
+    apply inverse2.
+    apply Smash_rec_beta_gluer.
+  Defined.
 
-  Definition smash_rec_beta_glue {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
+  Definition Smash_rec_beta_glue {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (a : X)
     (b : Y) : ap (Smash_rec Psm Pl Pr Pgl Pgr) (glue a b)
     = ((Pgl a) @ (Pgl pt)^) @ (Pgr pt @ (Pgr b)^).
   Proof.
-    by rewrite ap_pp, Smash_rec_beta_gluel', Smash_rec_beta_gluer'.
+    lhs nrapply ap_pp.
+    f_ap.
+    - apply Smash_rec_beta_gluel'.
+    - apply Smash_rec_beta_gluer'.
   Defined.
 
-  Arguments sm : simpl never.
-  Arguments auxl : simpl never.
-  Arguments gluel : simpl never.
-  Arguments gluer : simpl never.
-
 End Smash.
+
+Arguments sm : simpl never.
+Arguments auxl : simpl never.
+Arguments gluel : simpl never.
+Arguments gluer : simpl never.

--- a/theories/Spaces/Circle.v
+++ b/theories/Spaces/Circle.v
@@ -236,18 +236,6 @@ Proof.
   apply Circle_rec_beta_loop.
 Defined.
 
-(** An alternative induction principle for Circle that produces a DPath. *)
-Definition Circle_ind_dp (P : Circle -> Type) (b : P base)
-  (bl : DPath P loop b b) (x : Circle) : P x
-  := Circle_ind P b (dp_path_transport^-1 bl) x.
-
-Definition Circle_ind_dp_beta_loop (P : Circle -> Type) (b : P base)
-  (bl : DPath P loop b b) : dp_apD (Circle_ind_dp P b bl) loop = bl.
-Proof.
-  apply dp_apD_path_transport.
-  exact (Circle_ind_beta_loop _ _ _).
-Defined.
-
 (** The universal property of the circle (Lemma 6.2.9 in the Book).  We could deduce this from [isequiv_Coeq_rec], but it's nice to see a direct proof too. *)
 Definition Circle_rec_uncurried (P : Type)
   : {b : P & b = b} -> (Circle -> P)

--- a/theories/Spaces/Torus/Torus.v
+++ b/theories/Spaces/Torus/Torus.v
@@ -25,12 +25,12 @@ Module Export Torus.
   Axiom Torus_ind_beta_loop_a : forall (P : Torus -> Type) (pb : P tbase)
     (pla : DPath P loop_a pb pb) (plb : DPath P loop_b pb pb)
     (ps : DPathSquare P surf pla pla plb plb), DPathSquare P hr
-      (dp_apD (Torus_ind P pb pla plb ps) (loop_a)) pla 1%dpath 1%dpath.
+      (apD (Torus_ind P pb pla plb ps) (loop_a)) pla 1%dpath 1%dpath.
 
   Axiom Torus_ind_beta_loop_b : forall (P : Torus -> Type) (pb : P tbase)
     (pla : DPath P loop_a pb pb) (plb : DPath P loop_b pb pb)
     (ps : DPathSquare P surf pla pla plb plb), DPathSquare P hr
-      (dp_apD (Torus_ind P pb pla plb ps) (loop_b)) plb 1%dpath 1%dpath.
+      (apD (Torus_ind P pb pla plb ps) (loop_b)) plb 1%dpath 1%dpath.
 
   (** We write out the computation rule for surf even though we will not use it. Instead we currently have an unfinished recursion computation principle, but we don't currently know how to derive it from this *)
   Axiom Torus_ind_beta_surf : forall (P : Torus -> Type) (pb : P tbase)

--- a/theories/Spaces/Torus/TorusEquivCircles.v
+++ b/theories/Spaces/Torus/TorusEquivCircles.v
@@ -35,7 +35,7 @@ Proof.
     - exact tbase.      (* The basepoint is sent to the point of the torus *)
     - exact loop_b.     (* The second loop is sent to loop_b *)
   + apply path_forall.  (* We use function extensionality here to induct *)
-    snrapply Circle_ind_dp.  (* Circle induction as a DPath *)
+    snrapply Circle_ind.  (* Circle induction as a DPath *)
     - exact loop_a.     (* The first loop is sent to loop_a *)
     - srapply sq_dp^-1. (* This DPath is actually a square *)
       apply (pr1 c2t_square_and_cube). (* We apply the cap we found above *)
@@ -66,8 +66,8 @@ Proof.
   (* 3. Reducing ap10 on function extensionality *)
   nrefine (cu_concat_lr (cu_ds (dp_apD_nat (ap10_path_forall _ _ _) _)) _
     (sji0:=?[X3]) (sji1:=?X3) (sj0i:=?[Y3]) (sj1i:=?Y3) (pj11:=1)).
-  (* 4. Reducing Circle_ind_dp on loop *)
-  nrefine (cu_concat_lr (cu_G11 (ap _ (Circle_ind_dp_beta_loop _ _ _))) _
+  (* 4. Reducing Circle_ind on loop *)
+  nrefine (cu_concat_lr (cu_G11 (ap _ (Circle_ind_beta_loop _ _ _))) _
     (sji0:=?[X4]) (sji1:=?X4) (sj0i:=?[Y4]) (sj1i:=?Y4) (pj11:=1)).
   (* 5. collapsing equivalence *)
   nrefine (cu_concat_lr (cu_G11 (eisretr _ _)) _
@@ -144,17 +144,17 @@ Definition c2t2c `{Funext} : t2c o c2t == idmap.
 Proof.
   nrapply prod_ind.
   (* Start with double circle induction *)
-  snrefine (Circle_ind_dp _ (Circle_ind_dp _ 1 _) _).
+  snrefine (Circle_ind _ (Circle_ind _ 1 _) _).
   (* Change the second loop case into a square and shelve *)
   1: apply sq_dp^-1, sq_tr^-1; shelve.
   (* Take the forall out of the DPath *)
   apply dp_forall_domain.
   intro x; apply sq_dp^-1; revert x.
-  snrefine (Circle_ind_dp _ _ _).
+  snrefine (Circle_ind _ _ _).
   1: apply sq_tr^-1; shelve.
   apply dp_cu.
   nrefine (cu_ccGGcc _ _ _).
-  1,2: nrefine (ap sq_dp (Circle_ind_dp_beta_loop _ _ _)
+  1,2: nrefine (ap sq_dp (Circle_ind_beta_loop _ _ _)
     @ eisretr _ _)^.
   apply cu_rot_tb_fb.
   nrefine (cu_ccGGGG _ _ _ _ _).


### PR DESCRIPTION
- **Suspension: prove that Susp is a 1-functor**
- **Join: Join Bool <~> Susp**
- **simplify various proofs**
- **Spheres: simplify definition of psphere**
- **Join: add results about Empty and Spheres**
- **JoinSusp: include the (-1)-spheres in equiv_join_sphere**
- **Nat/Core: remove redundant iter (same as nat_iter)**
- **Nat/Core: make nat_iter a notation and clean up proofs**
- **Join/Core**
- **Group**
- **Sets/Powers: use nat_iter; clean up whole file and imports**
- **Change Join_power -> iterated_join and Join_power' -> join_power**
- **Fix coqdoc section titles**
- **STYLE.md: Add instructions on comments**
- **More coqdoc/comment fixes**
- **coqdoc: get rid of warnings about << and >>**
- **dune: pass same(?) coqdoc options as make does**
- **coqdoc: add --parse-comments**
- **Update dead link to coq/coq#3745 from 84247bb**
- **Spaces.No: Add "Universe i" to reduce universes variables**
- **Spaces.No: change InSort@{i} to InSort (cosmetic)**
- **Spaces.No.Core: move No_Empty_for_admitted earlier**
- **make sure No uses HIT idiom**
- **github1759: rebase**
- **github1759: add comment and a second test that shouldn't pass**
- **github1759.v:  add a third test**
- **Spaces.No.Core: Use the HIT idiom to make this safe**
- **Spaces.No.Core: get rid of destruct in No_ind_internal**
- **Spaces.No.Core: speed up the two slowest lines**
- **Declare universe variables in Context commands**
- **etc/emacs/run-etags: also index Notation**
- **Basics/Contractible: simplify logic**
- **Fix typo in comment**
- **Join/JoinSusp: add and use bool_pow for join power of Bool**
- **Basics/Contractible: a few more minor changes**
- **WildCat/TwoOneCat: make comment no longer a heading**
- **Functoriality of the triple join and reln to functor_join**
- **Make NatEquiv's easier to work with**
- **JoinAssoc: naturality of trijoin_twist and join_assoc**
- **Reorganize and add 1-functoriality of functor_trijoin**
- **wildcat: show Universe is a 2-cat**
- **Yoneda: add faithfulness of Yoneda embedding & missing dual 0gpd results**
- **Join/Core: prove naturality of unit laws (unitors) & minor cleanups**
- **Join: prove triangle and hexagon laws**
- **Don't Export all of Classes.interfaces.abstract_algebra**
- **canonical_names: use Module to allow just some notations to be exported**
- **Join: reverse naming of triangle_v/h and triangle_v/h'**
- **Join: define trijoin_id_sym and prove that it is natural**
- **HSpace/Core: Export a few more things from canonical_names**
- **No/Core: add todo saying to remove workaround when Coq 8.19 is required**
- **Basics/Equivalences: move equiv_ap earlier**
- **Basics/Equivalences: various clean-ups**
- **Update theories/Basics/Equivalences.v**
- **Colimit_Flattening: speed it up a lot**
- **Colimit_Flattening: reindent; no changes**
- **Colimit_Flattening: name variables in set and assert tactics**
- **ReflectiveSubuniverse: workaround no longer needed**
- **Modalities: add comments about another work around**
- **ReflectiveSubuniverse: give term instead of using Proof**
- **WildCat: reduce universe vars from unused Context vars**
- **Introduce and use a new simple_path_induction tactic**
- **Modalitities/Localization: clarify why workaround needed**
- **Basics/Tactics: remove simple_path_induction**
- **Join.Core: remove unneeded universe annotations**
- **tests/bugs/github1791: add tests for universe variables**
- **Typo Fix in Book.py**
- **Join/Core: allow joinl B a (= joinl (B:=B) a) and joinr A b (= joinr (A:=A) b)**
- **PathGroupoids: define ap02 using ap**
- **TwoSphere: fix whitespace and remove unused Generalizable Variables**
- **Overture: explain creation of internal_paths_rew; remove paths_rect_r**
- **Overture: move internal_paths_rew to near transport; fix whitespace**
- **test/bugs/github1794: check internal_paths_rew(_r) universe vars**
- **Tactics: rewrite_to_transport replaces internal_paths* with transport**
- **Overture: add TODO about registering transport for rewrite**
- **2-cat of pointed types (#1795)**
- **Add cancelR_equiv_mapinO; change cancelL to cancelR in various places**
- **Join/Core: add diamond lemmas for paths**
- **HSpace/Coherent: use pt instead of _**
- **EMSpace: use IsCoherent; mv K(G**
- **Tactics**
- **HSpace/*: lots of updates related to central types/bands paper**
- **Trunc: more about trunc_index arithmetic**
- **Connectedness: add isconnected_pred_add'**
- **Make pelim more robust**
- **EMSpace: they are 0-connected coherent H-spaces**
- **Basics/Trunc: get rid of stray universe variables**
- **Pointed/Core: slightly simplify pelim tactic**
- **Pointed/Core: get rid of stray universe variable in pHomotopy**
- **Adjust pmap_(pre/post)whisker in pHomotopy.v**
- **pHomotopy: remove redundant pmap_postwhisker/prewhisker**
- **pHomotopy: remove Funext in phomotopy_hcompose**
- **pFiber: minor clean-up to main definition**
- **Pointed/Core: remove stray univ var from phomotopy_refl/symm/trans**
- **ExactSequence: avoid some WildCat notation to improve univ vars**
- **pHomotopy: rm unneeded results; make ishprop_phomotopy_hset only use Funext**
- **Pointed/Core: rm unneeded equiv_path_pmap_1; update comments**
- **Pointed: merge pHomotopy into Core: lots of reordering of things**
- **Remove three Local Instances that are already Global Instances**
- **1-category of successor structures**
- **pi_n(S^n) = Z**
- **HomotopyGroup.v: improve pi_prod**
- **Miscellaneous clean-up**
- **HomotopyGroup.v: add pequiv_pi_connmap and pequiv_pi_Tr**
- **Pi1S1: remove unneeded Requires**
- **Rename Pi1S1.v to PinSn.v**
- **Remove a few "Require" commands that aren't needed**
- **CayleyDickson: some cleanups**
- **review comments**
- **Add pmap_from_psphere_iterated_loops**
- **Adjust to renaming of (p)equiv_pequiv_postcompose**
- **wildcat: binary products**
- **rename with cat_ and remove superfluous assumptions**
- **change to representable definition of binary products**
- **binary coproducts**
- **binary coproducts in Type**
- **binary coproducts for pType**
- **binary coproducts for category of groups**
- **address review comments**
- **leave comment about functoriality of products following from symmetry**
- **test: wildcat opposite being definitionally involuted**
- **remove old comment from dune file**
- **test: move Classes/test/ring_tac to tests folder**
- **use Quotient in ua library**
- **use Quotient in Ordinals.v**
- **symmetry and associativity of products**
- **slicker proof of associativity for products**
- **trim whitespace**
- **WIP: Make IsTrunc an inductive type**
- **Overture: add a Coercion istrunc_fun : IsTrunc >-> Funclass**
- **Convert more files to Inductive IsTrunc**
- **Simplify proof of ishprop_istrunc**
- **Minor changes in response to review**
- **Make library build with inductive IsTrunc**
- **Make compatible with Coq 8.17**
- **HoTTBookExercises: fix universe error in Book_4_6_iii**
- **Speed up Algebra/Universal/Algebra and Modalities/Fracture a bit**
- **Homotopy.Hopf: define the Hopf construction; show Prop 2.19 of BCFR**
- **Homotopy.Hopf: stronger Freudenthal for H-spaces**
- **Sets/Hartogs: remove two of the three admits**
- **Sets/Powers: make hset_power have same signature as before**
- **Sets/Ordinals: remove redundant Instance**
- **Sets/Hartogs: remove last admit.**
- **Overture: update comments**
- **Equivalences: make make_equiv work with Contr**
- **Move Contr_ind to Contractible**
- **Reduce universe variables and other clean-ups**
- **Free up universe in proofs of IsHSet**
- **Revert "Free up universe in proofs of IsHSet**
- **Empty.v: Local Set Universe Minimization ToSet**
- **Basics/Tactics: improve simple_induction**
- **Spaces.Nat: get rid of lots of universe variables; adjust Classes**
- **Apply review suggestions**
- **Truncations/Connectedness: Universe Min ToSet simplifies two results**
- **HomotopyGroup.v: fix typo**
- **add prod_0gpd_corec**
- **Sets/Hartogs: speed it up by a factor of 2**
- **Sets/Hartogs**
- **Sets/Hartogs: use 1-4: notation**
- **Remove some Global Instances**
- **Supply some implicit variables**
- **Truncatedness of pointed maps and pForall**
- **Various cleanups and minor additions**
- **BlakersMassey: slight speedup**
- **Pointed/Core: update comments about ppMap and ppForall**
- **Prove generalization of Licata-Finster theorem**
- **EMSpace: reverse some equivalences to be in the natural direction**
- **Basics/Trunc: add some leq lemmas (currently unused)**
- **ReflectiveSubuniverse: add a couple of things and simplify one proof**
- **Homotopy/Hopf: improvements based on review**
- **Colimit_Pushout: speed up slowest line in library**
- **TorusHomotopy: simpler proof of loops_torus**
- **Torus: explicitly record the fact that the loops commute**
- **TorusEquivCircles: remove Section**
- **TorusEquivCircles: change indentation**
- **TorusEquivCircles: use nrefine and nrapply when possible**
- **ReflectiveSubuniverse: cleaner fix for typeclass oddness**
- **Torus/*: update comments and naming**
- **all cube concatenations**
- **Pullback**
- **make coproduct definition more definitional**
- **add op graph involutive test**
- **symmetry and associativity for coproducts**
- **Update test/WildCat/Opposite.v**
- **Wedge of a family of pType**
- **address review comments for wedge**
- **simplify definition of indexed wedge**
- **ReflectiveSubuniverse: simplify extendable_to_O'**
- **Pointed: fix universe vars in istrunc_pforall**
- **Pointed: other minor updates**
- **Use snrefine instead of simple notypeclasses refine**
- **Add "n" (notypeclasses) to some (s)rapply and (s)refine tactics**
- **Remove `{Univalence} when it isn't needed**
- **Change `{Univalence} to `{Funext} when possible**
- **Remove `{Funext} when not needed**
- **ReflectiveSubuniverse: remove Univalence and Funext from a Context line**
- **Add .Core to many Require Import lines**
- **WhiteheadsPrinciple: import Groups.Group instead of Groups**
- **etc/coqcreplace.py: a script for trying search & replace on files**
- **etc/coqcstriprequires.py: minor updates**
- **Displayed.v: Displayed wild categories**
- **Add instances for displayed functor composition**
- **Notation and formatting (DHom**
- **Attempt to minimize typeclass constraints**
- **Make A:Type implicit in displayed cat typeclasses**
- **Add instances for products of displayed categories**
- **Displayed.v: simplify typeclass arguments**
- **Displayed.v: use notypeclasses for slight speedup**
- **Displayed.v: avoid destructing arguments when not needed**
- **Make families implicit in Is0DFunctor**
- **Formatting**
- **Displayed: minor indentation change**
- **Displayed: remove redundant typeclass assumptions**
- **WildCat.v: Export Displayed**
- **Pointed/Core: slightly speed up pelim tactic**
- **ReflectiveSubuniverse: simplify universe vars in conn_map_homotopic**
- **Pointed/Core: fix pelim so pEquiv.v builds**
- **WildCat/Induced: various minor simplifications**
- **WildCat/Induced: add and use intros_of_type tactic**
- **Create Utf8Minimal.v for Classes to use**
- **Colimits/Pushout**
- **ReflectiveSubuniverse: add inO_retract_inO: RSU closed under retracts**
- **Projective: use inO_retract_inO and reduce dependencies**
- **flattening for pushouts**
- **Hopf fibration total space is a join**
- **second coherence for flattening proof**
- **address review comments**
- **fixup hopf**
- **new better proof for PushoutFlattening avoiding coh result**
- **review comments for Hopf**
- **better proofs in Colimit_Pushout_Flattening**
- **add comments about the different kinds of pushout and their flattenings**
- **fix spelling**
- **reorder contents of Hopf.v**
- **add Hopf construction to HoTTBook.v**
- **Colimit_Pushout: clean up and speed up a bit**
- **Hopf: slight speed up**
- **wedge projections**
- **update alectryon**
- **pinch map of suspension**
- **address review comments**
- **fix typo**
- **diagonal map into binary product**
- **Makefile.coq.local: reduce long line warnings in alectryon build**
- **Makefile.coq.local: use --long-line-threshold=99999**
- **put hor \/ notation in module**
- **various improvements to wedge**
- **remove universe variables in wedge**
- **functoriality of binary coproducts**
- **add comment and name hypotheses**
- **characterize fiber of loop-susp counit**
- **add comment about path algebra**
- **add connectivity of loop_susp_counit**
- **move simpl**
- **improve connectivity result**
- **add transport_arrow_toconst'**
- **speed up proof slightly**
- **Flattening lemma for GraphQuotient**
- **add curried version of equiv_sigma_prod**
- **transport011: transport over 2 1-paths and lemmas about them**
- **review comments**
- **GraphQuotient: rephrase comments; tiny adjustments to proofs**
- **Apply suggestions from code review**
- **remove rewrite**
- **remove leftover rewrite**
- **Apply suggestions from code review**
- **functoriality of GraphQuotient**
- **whisker properly**
- **simplify proofs**
- **flattening lemma for Coeq**
- **flattening lemma for Pushout**
- **make hopf equivalence computable**
- **delete PushoutFlattening**
- **simplify hopf fibration total space proof**
- **Coeq: simplify the path algebra a bit**
- **Pushout: simplify flattening by using Coeq_rec instead of Pushout_ind**
- **Colimits/***
- **Notations: remove redundant Declare Scope commands**
- **Cubical: reduce dependencies**
- **WildCat/Opposite: simplify; remove eta-expansions**
- **GraphQuotient: add isequiv_functor_gq instance**
- **Coeq**
- **Colimit_Sigma: adjust comment**
- **Add equivalences for displayed wild categories**
- **Update naming convention for displayed categories**
- **WildCat/DisplayedEquiv.v: Show total cat univalent**
- **nix: update flake**
- **surpress argument-scope-delimiter warning**
- **test: move Groups.Presentation tests to test/**
- **[8.18] bump minimal version to Coq 8.18**
- **[8.18] surpress -uniform-inheritance warning**
- **[8.18] update opam and nix versions**
- **add universe constraints in GraphQuotient**
- **ordinals: small images with prop-resizing**
- **GraphQuotient: use a Section to simplify the main definition**
- **Quotient.v**
- **Improve make_equiv tactic and illustrate in Groups/Group.v**
- **Adjust/add usage of make_equiv in other places**
- **Spaces/Int and Pos: minor cleanups**
- **Spaces/Int/Spec: more things transparent with Defined**
- **Add instances isconnected_em' and is_minus_one_connected_pointed**
- **Pointed/Core: get rid of redundant universe variable**
- **Classes/theory/groups: make group_cancelL transparent and avoid rewrites**
- **Pointed/pTrunc: really fix typo in comment**
- **HIT/quotient: fix universe variables**
- **Generalize quotient_kernel_factor**
- **Make universe vars in quotient_kernel_factor work with Coq 8.18/8.19**
- **Ordinals.v: speed it up a bit**
- **Set/Ordinals: add a comment about universes**
- **Group is a pointed WildCat**
- **Pointedness of fmap loops in two contexts**
- **Pointed/Core: generalize pfmap_loops to any pointed functor**
- **AbelianGroup.v: condense proof of ispointedcat_abgroup**
- **WildCat/Core.v: fix is0functor_compose arguments**
- **redefine DPath as transport + cleanup proofs**
