### PR TITLE
get rid of isgraph_arrow

### DIFF
--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -124,7 +124,7 @@ Defined.
 
 (* A group homomorphism consists of a map between groups and a proof that the map preserves the group operation. *)
 Record GroupHomomorphism (G H : Group) := Build_GroupHomomorphism' {
-  grp_homo_map : G -> H;
+  grp_homo_map : group_type G -> group_type H;
   grp_homo_ishomo :> IsMonoidPreserving grp_homo_map;
 }.
 
@@ -480,17 +480,20 @@ Global Instance isgraph_group : IsGraph Group
 Global Instance is01cat_group : Is01Cat Group :=
   Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose).
 
+(** Helper notation so that the wildcat instances can easily be inferred. *)
+Local Notation grp_homo_map' := (fun A B => @grp_homo_map A B : _ -> (group_type A $-> _)).
+
 Global Instance is2graph_group : Is2Graph Group
-  := fun A B => isgraph_induced (@grp_homo_map A B).
+  := fun A B => isgraph_induced (grp_homo_map' A B).
 
 Global Instance isgraph_grouphomomorphism {A B : Group} : IsGraph (A $-> B)
-  := isgraph_induced (@grp_homo_map A B).
+  := isgraph_induced (grp_homo_map' A B).
 
 Global Instance is01cat_grouphomomorphism {A B : Group} : Is01Cat (A $-> B)
-  := is01cat_induced (@grp_homo_map A B).
+  := is01cat_induced (grp_homo_map' A B).
 
 Global Instance is0gpd_grouphomomorphism {A B : Group}: Is0Gpd (A $-> B)
-  := is0gpd_induced (@grp_homo_map A B).
+  := is0gpd_induced (grp_homo_map' A B).
 
 Global Instance is0functor_postcomp_grouphomomorphism {A B C : Group} (h : B $-> C)
   : Is0Functor (@cat_postcomp Group _ _ A B C h).

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -481,7 +481,7 @@ Global Instance is01cat_group : Is01Cat Group :=
   Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose).
 
 (** Helper notation so that the wildcat instances can easily be inferred. *)
-Local Notation grp_homo_map' := (fun A B => @grp_homo_map A B : _ -> (group_type A $-> _)).
+Local Notation grp_homo_map' A B := (@grp_homo_map A B : _ -> (group_type A $-> _)).
 
 Global Instance is2graph_group : Is2Graph Group
   := fun A B => isgraph_induced (grp_homo_map' A B).

--- a/theories/Algebra/Rings/CRing.v
+++ b/theories/Algebra/Rings/CRing.v
@@ -238,7 +238,7 @@ Global Instance is01cat_cring : Is01Cat CRing
   := Build_Is01Cat _ _ rng_homo_id (@rng_homo_compose).
 
 Global Instance is2graph_cring : Is2Graph CRing
-  := fun A B => isgraph_induced (@rng_homo_map A B).
+  := fun A B => isgraph_induced (@rng_homo_map A B : _ -> (cring_type A $-> _)).
 
 Global Instance is01cat_cringhomomorphism {A B : CRing} : Is01Cat (A $-> B)
   := is01cat_induced (@rng_homo_map A B).

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -110,7 +110,7 @@ Arguments Build_JoinRecData {A B P}%type_scope (jl jr jg)%function_scope.
 
 (** We use the name [join_rec] for the version of [Join_rec] defined on this data. *)
 Definition join_rec {A B P : Type} (f : JoinRecData A B P)
-  : Join A B -> P
+  : Join A B $-> P
   := Join_rec (jl f) (jr f) (jg f).
 
 Definition join_rec_beta_jg {A B P : Type} (f : JoinRecData A B P) (a : A) (b : B)

--- a/theories/Homotopy/Join/TriJoin.v
+++ b/theories/Homotopy/Join/TriJoin.v
@@ -159,7 +159,7 @@ Arguments TriJoinRecData : clear implicits.
 Arguments Build_TriJoinRecData {A B C P}%type_scope (j1 j2 j3 j12 j13 j23 j123)%function_scope.
 
 Definition trijoin_rec {A B C P : Type} (f : TriJoinRecData A B C P)
-  : TriJoin A B C -> P.
+  : TriJoin A B C $-> P.
 Proof.
   snrapply Join_rec.
   - exact (j1 f).

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -17,10 +17,6 @@ Defined.
 Global Instance is2graph_type : Is2Graph Type
   := fun x y => Build_IsGraph _ (fun f g => f == g).
 
-(** Sometimes we need typeclasses to pick up that [A -> B] is a graph, but this cannot be done without first converting it to [A $-> B]. *)
-Global Instance isgraph_arrow {A B : Type} : IsGraph (A -> B)
-  := isgraph_hom A B.
-
 Global Instance is01cat_arrow {A B : Type} : Is01Cat (A $-> B).
 Proof.
   econstructor.
@@ -81,7 +77,7 @@ Proof.
   snrapply Build_HasMorExt.
   intros A B f g; cbn in *.
   snrapply isequiv_homotopic.
-  - exact (GpdHom_path o (ap (x:=f) (y:=g) equiv_fun)).
+  - exact (GpdHom_path o (ap (x:=f) (y:=g) cate_fun)).
   - nrapply isequiv_compose.
     1: apply isequiv_ap_equiv_fun.
     exact (isequiv_Htpy_path (uncore A) (uncore B) f g).


### PR DESCRIPTION
This instance is far too general and should be restricted to Universe.v where it is actually used. A few places in the library were picking this up. This can be fixed by changeing a -> to a $-> so that the correct instance is inferred.
