### PR TITLE
refactor: hasmorext_core

### DIFF
--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -959,10 +959,9 @@ Defined.
 Global Instance hasmorext_core_ptype `{Funext} : HasMorExt (core pType).
 Proof.
   rapply hasmorext_core.
-  intros a b f g.
-  snrapply isequiv_homotopic.
-  1: apply equiv_path_pequiv'. 
-  1: exact _.
+  intros A B f g.
+  snrapply isequiv_homotopic'.
+  1: exact (equiv_path_pequiv' f g)^-1%equiv.
   by intros [].
 Defined.
 

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -958,14 +958,12 @@ Defined.
 
 Global Instance hasmorext_core_ptype `{Funext} : HasMorExt (core pType).
 Proof.
-  snrapply Build_HasMorExt.
+  rapply hasmorext_core.
   intros a b f g.
-  unfold GpdHom_path.
-  cbn in f, g.
-  (* [GpdHom_path] and the inverse of [equiv_path_pequiv] are not definitionally equal, but they compute to definitionally equal things on [idpath]. *)
-  apply (isequiv_homotopic (equiv_path_pequiv f g)^-1%equiv).
-  intro p; induction p; cbn.
-  reflexivity.
+  snrapply isequiv_homotopic.
+  1: apply equiv_path_pequiv'. 
+  1: exact _.
+  by intros [].
 Defined.
 
 (** pType is a univalent 1-coherent 1-category *)

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.Utf8 Basics.Overture Basics.Tactics.
+Require Import Basics.Utf8 Basics.Overture Basics.Tactics Basics.Equivalences.
 Require Import WildCat.Core.
 
 (** We declare a scope for printing [CatEquiv] as [≅] *)
@@ -520,6 +520,18 @@ Proof.
     refine (cate_isretr _ $@ _).
     symmetry; apply id_cate_fun.
   - exact tt.
+Defined.
+
+Global Instance hasmorext_core {A : Type} `{HasEquivs A, !HasMorExt A}
+  `{forall x y (f g : uncore x $<~> uncore y), IsEquiv (ap (x := f) (y := g) cate_fun)} 
+  : HasMorExt (core A).
+Proof.
+  snrapply Build_HasMorExt.
+  intros X Y f g; cbn in *.
+  snrapply isequiv_homotopic.
+  - exact (GpdHom_path o (ap (x:=f) (y:=g) cate_fun)).
+  - rapply isequiv_compose.
+  - intro p; by induction p.
 Defined.
 
 (** * Initial objects and terminal objects are all respectively equivalent. *)

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -72,17 +72,7 @@ Proof.
   - intros g r s; refine (isequiv_adjointify f g r s).
 Defined.
 
-Global Instance hasmorext_core_type `{Funext}: HasMorExt (core Type).
-Proof.
-  snrapply Build_HasMorExt.
-  intros A B f g; cbn in *.
-  snrapply isequiv_homotopic.
-  - exact (GpdHom_path o (ap (x:=f) (y:=g) cate_fun)).
-  - nrapply isequiv_compose.
-    1: apply isequiv_ap_equiv_fun.
-    exact (isequiv_Htpy_path (uncore A) (uncore B) f g).
-  - intro p; by induction p.
-Defined.
+Global Instance hasmorext_core_type `{Funext} : HasMorExt (core Type) := _.
 
 Definition catie_isequiv {A B : Type} {f : A $-> B}
        `{IsEquiv A B f} : CatIsEquiv f.


### PR DESCRIPTION
It would be nice if we can work out a way to generalise paths of `CatEquiv`s with morphism extensionality, but I wasn't able to work one out.