### PR TITLE
functoriality of smash

### DIFF
--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -774,8 +774,49 @@ Definition transportD2 {A : Type} (B C : A -> Type) (D : forall a:A, B a -> C a 
 Definition ap011 {A B C} (f : A -> B -> C) {x x' y y'} (p : x = x') (q : y = y')
   : f x y = f x' y'.
 Proof.
-  destruct p, q.
-  reflexivity.
+  destruct p.
+  apply ap.
+  exact q.
+Defined.
+
+Definition ap011_V {A B C} (f : A -> B -> C) {x x' y y'} (p : x = x') (q : y = y')
+  : ap011 f p^ q^ = (ap011 f p q)^.
+Proof.
+  destruct p.
+  apply ap_V.
+Defined.
+
+Definition ap011_pp {A B C} (f : A -> B -> C) {x x' x'' y y' y''}
+  (p : x = x') (p' : x' = x'') (q : y = y') (q' : y' = y'')
+  : ap011 f (p @ p') (q @ q') = ap011 f p q @ ap011 f p' q'.
+Proof.
+  destruct p, p'.
+  apply ap_pp.
+Defined.
+
+Definition ap011_compose {A B C D} (f : A -> B -> C) (g : C -> D) {x x' y y'}
+  (p : x = x') (q : y = y')
+  : ap011 (fun x y => g (f x y)) p q = ap g (ap011 f p q).
+Proof.
+  destruct p; simpl.
+  apply ap_compose.
+Defined.
+
+Definition ap011_compose' {A B C D E} (f : A -> B -> C) (g : D -> A) (h : E -> B)
+  {x x' y y'}
+  (p : x = x') (q : y = y')
+  : ap011 (fun x y => f (g x) (h y)) p q = ap011 f (ap g p) (ap h q).
+Proof.
+  destruct p; simpl.
+  apply ap_compose.
+Defined.
+
+Definition ap011_is_ap {A B C} (f : A -> B -> C) {x x' : A} {y y' : B} (p : x = x') (q : y = y')
+  : ap011 f p q = ap (fun x => f x y) p @ ap (fun y => f x' y) q.
+Proof.
+  destruct p.
+  symmetry.
+  apply concat_1p.
 Defined.
 
 (** It would be nice to have a consistent way to name the different ways in which this can be dependent.  The following are a sort of half-hearted attempt. *)
@@ -1317,6 +1358,15 @@ Definition apD02_pp {A} (B : A -> Type) (f : forall x:A, B x) {x y : A}
   @ (whiskerR (transport2_p2p B r1 r2 (f x))^ (apD f p3)).
 Proof.
   destruct r1, r2. destruct p1. reflexivity.
+Defined.
+
+Definition ap022 {A B C} (f : A -> B -> C) {x x' y y'}
+  {p p' : x = x'} (r : p = p') {q q' : y = y'} (s : q = q')
+  : ap011 f p q = ap011 f p' q'.
+Proof.
+  destruct r, p.
+  apply ap02.
+  exact s.
 Defined.
 
 (** These lemmas need better names. *)

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -294,6 +294,9 @@ Definition functor_smash_homotopic {X Y A B : pType}
   (p : f $== h) (q : g $== k)
   : functor_smash f g $== functor_smash h k.
 Proof.
+  destruct f as [f f_eq], g as [g g_eq].
+  revert p q.
+  pointed_reduce.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
     - intros x y.
@@ -346,8 +349,8 @@ Proof.
       2: apply concat_Vp.
       symmetry.
       nrapply ap_sm_right. }
-  simpl.
-  by pelim p q f g h k.
+  lhs nrapply (ap022 _ (dpoint_eq p) (dpoint_eq q)).
+  rapply ap011_pp.
 Defined.
 
 Global Instance is0bifunctor_smash : IsBifunctor Smash.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -220,6 +220,8 @@ Arguments auxl : simpl never.
 Arguments gluel : simpl never.
 Arguments gluer : simpl never.
 
+(** ** Functoriality of the smash product *)
+
 Definition functor_smash {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
   : Smash A B $-> Smash X Y.
 Proof.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -220,7 +220,7 @@ Arguments auxl : simpl never.
 Arguments gluel : simpl never.
 Arguments gluer : simpl never.
 
-Definition Smash_functor {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
+Definition functor_smash {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
   : Smash A B $-> Smash X Y.
 Proof.
   srapply Build_pMap.
@@ -235,8 +235,8 @@ Proof.
   - exact (ap011 _ (point_eq f) (point_eq g)).
 Defined.
 
-Definition Smash_functor_idmap (X Y : pType)
-  : Smash_functor (@pmap_idmap X) (@pmap_idmap Y) $== pmap_idmap.
+Definition functor_smash_idmap (X Y : pType)
+  : functor_smash (@pmap_idmap X) (@pmap_idmap Y) $== pmap_idmap.
 Proof.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
@@ -256,9 +256,9 @@ Proof.
   reflexivity.
 Defined.
 
-Definition Smash_functor_compose {X Y A B C D : pType}
+Definition functor_smash_compose {X Y A B C D : pType}
   (f : X $-> A) (g : Y $-> B) (h : A $-> C) (k : B $-> D)
-  : Smash_functor (h $o f) (k $o g) $== Smash_functor h k $o Smash_functor f g.
+  : functor_smash (h $o f) (k $o g) $== functor_smash h k $o functor_smash f g.
 Proof.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
@@ -267,7 +267,7 @@ Proof.
       nrapply transport_paths_FlFr'.
       apply equiv_p1_1q.
       lhs nrapply Smash_rec_beta_gluel.
-      rhs nrapply (ap_compose (Smash_functor f g) _ (gluel x)).
+      rhs nrapply (ap_compose (functor_smash f g) _ (gluel x)).
       rhs nrapply ap.
       2: apply Smash_rec_beta_gluel.
       rhs nrapply ap_pp.
@@ -285,7 +285,7 @@ Proof.
       nrapply transport_paths_FlFr'.
       apply equiv_p1_1q.
       lhs nrapply Smash_rec_beta_gluer.
-      rhs nrapply (ap_compose (Smash_functor f g) _ (gluer y)).
+      rhs nrapply (ap_compose (functor_smash f g) _ (gluer y)).
       rhs nrapply ap.
       2: apply Smash_rec_beta_gluer.
       rhs nrapply ap_pp.
@@ -296,17 +296,17 @@ Proof.
       unfold point_eq, dpoint_eq.
       lhs nrapply (ap011_pp sm _ _ 1 1).
       apply whiskerR.
-      rhs_V nrapply (ap011_compose sm (Smash_functor h k) (dpoint_eq f) 1).
+      rhs_V nrapply (ap011_compose sm (functor_smash h k) (dpoint_eq f) 1).
       symmetry.
       nrapply (ap011_compose' sm h). }
   simpl; pelim f g.
   by simpl; pelim h k.
 Defined.
 
-Definition Smash_functor_homotopic {X Y A B : pType}
+Definition functor_smash_homotopic {X Y A B : pType}
   {f h : X $-> A} {g k : Y $-> B}
   (p : f $== h) (q : g $== k)
-  : Smash_functor f g $== Smash_functor h k.
+  : functor_smash f g $== functor_smash h k.
 Proof.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
@@ -370,11 +370,11 @@ Proof.
   - intros X.
     snrapply Build_Is0Functor.
     intros Y B g.
-    exact (Smash_functor (Id _) g).
+    exact (functor_smash (Id _) g).
   - intros Y.
     snrapply Build_Is0Functor.
     intros X A f.
-    exact (Smash_functor f (Id _)).
+    exact (functor_smash f (Id _)).
   - intros X A f Y B g.
     snrapply Build_pHomotopy.
     + snrapply Smash_ind.
@@ -382,8 +382,8 @@ Proof.
       * intros x.
         nrapply transport_paths_FlFr'.
         apply equiv_p1_1q.
-        lhs rapply (ap_compose (Smash_functor _ _) (Smash_functor _ _) (gluel x)).
-        rhs rapply (ap_compose (Smash_functor (Id _) g) (Smash_functor f (Id _)) (gluel x)).
+        lhs rapply (ap_compose (functor_smash f (Id _)) (functor_smash (Id _) g) (gluel x)).
+        rhs rapply (ap_compose (functor_smash (Id _) g) (functor_smash f (Id _)) (gluel x)).
         lhs nrapply ap.
         1: apply Smash_rec_beta_gluel.
         rhs nrapply ap.
@@ -396,12 +396,12 @@ Proof.
         2: apply Smash_rec_beta_gluel.
         f_ap.
         2: symmetry; apply concat_1p.
-        exact (ap_compose (sm x) (Smash_functor f (Id _)) (point_eq g)).
+        exact (ap_compose (sm x) (functor_smash f (Id _)) (point_eq g)).
       * intros y.
         nrapply transport_paths_FlFr'.
         apply equiv_p1_1q.
-        lhs rapply (ap_compose (Smash_functor _ _) (Smash_functor _ _) (gluer y)).
-        rhs rapply (ap_compose (Smash_functor (Id _) g) (Smash_functor f (Id _)) (gluer y)).
+        lhs rapply (ap_compose (functor_smash _ _) (functor_smash _ _) (gluer y)).
+        rhs rapply (ap_compose (functor_smash (Id _) g) (functor_smash f (Id _)) (gluer y)).
         lhs nrapply ap.
         1: apply Smash_rec_beta_gluer.
         rhs nrapply ap.
@@ -414,7 +414,7 @@ Proof.
         1: apply Smash_rec_beta_gluer.
         f_ap.
         2: apply concat_1p.
-        exact (ap_compose (fun x => sm x y)  (Smash_functor (Id _) g) (point_eq f))^.
+        exact (ap_compose (fun x => sm x y)  (functor_smash (Id _) g) (point_eq f))^.
     + apply moveL_pV.
       lhs nrapply concat_1p.
       simpl.
@@ -433,17 +433,17 @@ Proof.
   - intros X.
     snrapply Build_Is1Functor.
     + intros Y B f' g' q.
-      rapply (Smash_functor_homotopic (Id _) q).
+      rapply (functor_smash_homotopic (Id _) q).
     + intros Y; cbn.
-      rapply Smash_functor_idmap.
+      rapply functor_smash_idmap.
     + intros Y A C f g.
-      exact (Smash_functor_compose (Id _) f (Id _) g).
+      exact (functor_smash_compose (Id _) f (Id _) g).
   - intros Y.
     snrapply Build_Is1Functor.
     + intros X A f g q.
-      rapply (Smash_functor_homotopic q (Id _)).
+      rapply (functor_smash_homotopic q (Id _)).
     + intros X; cbn.
-      rapply Smash_functor_idmap.
+      rapply functor_smash_idmap.
     + intros X A C f g.
-      exact (Smash_functor_compose f (Id _) g (Id _)).
+      exact (functor_smash_compose f (Id _) g (Id _)).
 Defined.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -219,7 +219,7 @@ Arguments auxl : simpl never.
 Arguments gluel : simpl never.
 Arguments gluer : simpl never.
 
-(** ** Miscallaneous lemmas about Smash *)
+(** ** Miscellaneous lemmas about Smash *)
 
 (** A version of [Smash_ind] specifically for proving that two functions from a [Smash] are homotopic. *)
 Definition Smash_ind_FlFr {A B : pType} {P : Type} (f g : Smash A B -> P)
@@ -386,12 +386,12 @@ Proof.
       apply equiv_p1_1q.
       lhs nrapply ap.
       1: apply Smash_rec_beta_gluel.
-      apply Smash_rec_beta_gluer.
+      nrapply Smash_rec_beta_gluer.
     + intros x.
       apply equiv_p1_1q.
       lhs nrapply ap.
       1: apply Smash_rec_beta_gluer.
-      apply Smash_rec_beta_gluel.
+      nrapply Smash_rec_beta_gluel.
   - reflexivity.
 Defined.
 
@@ -425,7 +425,7 @@ Proof.
       nrapply Smash_rec_beta_gluel.
     + intros b.
       apply equiv_p1_1q.
-      rhs nrapply (ap_compose (pswap _ _) _ (gluer b)).
+      rhs nrapply (ap_compose (pswap _ _) (functor_smash _ _) (gluer b)).
       rhs nrapply ap.
       2: apply Smash_rec_beta_gluer.
       rhs nrapply Smash_rec_beta_gluel.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -299,7 +299,7 @@ Proof.
   pointed_reduce.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
-    - intros x y; simpl.
+    - intros x y.
       exact (ap011 _ (p x) (q y)).
     - reflexivity.
     - reflexivity.
@@ -325,8 +325,8 @@ Proof.
       nrapply (ap011_pp _ _ _ 1 1). }
   symmetry; simpl.
   lhs nrapply concat_p1.
-  apply ap022; apply concat_p1.
-Defined.
+  exact (ap022 _ (concat_p1 (p pt)) (concat_p1 (q pt))).
+Time Defined.
 
 Global Instance is0bifunctor_smash : Is0Bifunctor Smash.
 Proof.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -1,9 +1,9 @@
-Require Import Basics.
-Require Import Pointed.Core.
-Require Import Types.
+Require Import Basics.Overture Basics.PathGroupoids Basics.Tactics Basics.Equivalences.
+Require Import Types.Sum Types.Bool Types.Paths.
+Require Import WildCat.Core WildCat.Bifunctor.
 Require Import Colimits.Pushout.
 Require Import Cubical.DPath.
-Require Import WildCat.Core WildCat.Bifunctor.
+Require Import Pointed.Core.
 
 Local Open Scope pointed_scope.
 Local Open Scope dpath_scope.
@@ -294,7 +294,6 @@ Definition functor_smash_homotopic {X Y A B : pType}
   (p : f $== h) (q : g $== k)
   : functor_smash f g $== functor_smash h k.
 Proof.
-  pointed_reduce.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
     - intros x y.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -384,40 +384,38 @@ Defined.
 Definition pswap_natural {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
   : pswap X Y $o functor_smash f g $== functor_smash g f $o pswap A B.
 Proof.
+  pointed_reduce.
   snrapply Build_pHomotopy.
   - snrapply Smash_ind.
     1-3: reflexivity.
     + intros a.
       nrapply transport_paths_FlFr'.
       apply equiv_p1_1q.
-      rhs nrapply (ap_compose (pswap A B) _ (gluel a)).
+      rhs nrapply (ap_compose (pswap _ _) _ (gluel a)).
       rhs nrapply ap.
       2: apply Smash_rec_beta_gluel.
       rhs nrapply Smash_rec_beta_gluer.
-      lhs nrapply (ap_compose (functor_smash f g) (pswap X Y) (gluel a)).
+      lhs nrapply (ap_compose (functor_smash _ _) (pswap _ _) (gluel a)).
       lhs nrapply ap.
       1: apply Smash_rec_beta_gluel.
-      lhs nrapply (ap_pp (pswap X Y) (ap011 sm 1 (point_eq g)) (gluel (f a))).
-      lhs nrapply whiskerL.
-      1: apply Smash_rec_beta_gluel.
-      apply whiskerR.
-      symmetry.
-      exact (ap_compose _ _ _).
+      simpl.
+      lhs nrapply ap.
+      1: apply concat_1p.
+      rhs nrapply concat_1p.
+      nrapply Smash_rec_beta_gluel.
     + intros b.
       nrapply transport_paths_FlFr'.
       apply equiv_p1_1q.
-      rhs nrapply (ap_compose (pswap A B) _ (gluer b)).
+      rhs nrapply (ap_compose (pswap _ _) _ (gluer b)).
       rhs nrapply ap.
       2: apply Smash_rec_beta_gluer.
       rhs nrapply Smash_rec_beta_gluel.
-      lhs nrapply (ap_compose (functor_smash f g) (pswap X Y) (gluer b)).
+      lhs nrapply (ap_compose (functor_smash _ _) (pswap _ _) (gluer b)).
       lhs nrapply ap.
       1: apply Smash_rec_beta_gluer.
-      lhs nrapply (ap_pp (pswap X Y) (ap011 sm (point_eq f) 1) (gluer (g b))).
-      lhs nrapply whiskerL.
-      1: apply Smash_rec_beta_gluer.
-      apply whiskerR.
-      symmetry.
-      exact (ap011_compose _ _ (point_eq f) 1).
-  - by simpl; pelim f g.
+      lhs nrapply ap.
+      1: apply concat_1p.
+      rhs nrapply concat_1p.
+      nrapply Smash_rec_beta_gluer.
+  - reflexivity.
 Defined.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -16,8 +16,8 @@ Definition sum_to_prod (X Y : pType) : X + Y -> X * Y
 Definition sum_to_bool X Y : X + Y -> Bool
   := sum_ind _ (fun _ => false) (fun _ => true).
 
-Definition Smash (X Y : pType) : pType
-  := [Pushout (sum_to_prod X Y) (sum_to_bool X Y), pushl (point X, point Y)].
+Definition Smash@{u v w | u <= w, v <= w} (X : pType@{u}) (Y : pType@{v}) : pType@{w}
+  := [Pushout@{w w w w} (sum_to_prod@{w w w} X Y) (sum_to_bool@{u v w} X Y), pushl (point X, point Y)].
 
 Section Smash.
 

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -7,6 +7,7 @@ Require Import Pointed.Core.
 
 Local Open Scope pointed_scope.
 Local Open Scope dpath_scope.
+Local Open Scope path_scope.
 
 (* Definition of smash product *)
 
@@ -149,8 +150,6 @@ Section Smash.
     : Smash X Y -> P
     := Smash_ind Psm Pl Pr (fun x => dp_const (Pgl x)) (fun x => dp_const (Pgr x)).
 
-  Local Open Scope path_scope.
-
   (* Version of smash_rec that forces (Pgl pt) and (Pgr pt) to be idpath *)
   Definition Smash_rec' {P : Type} {Psm : X -> Y -> P}
     (Pgl : forall a, Psm a pt = Psm pt pt) (Pgr : forall b, Psm pt b = Psm pt pt)
@@ -233,8 +232,7 @@ Proof.
     + intro b; cbn beta.
       rhs_V nrapply (gluer (g b)).
       exact (ap011 _ (point_eq f) 1).
-  - simpl.
-    exact (ap011 _ (point_eq f) (point_eq g)).
+  - exact (ap011 _ (point_eq f) (point_eq g)).
 Defined.
 
 Definition functor_smash_idmap (X Y : pType)

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -188,7 +188,7 @@ Section Smash.
     lhs nrapply ap_V.
     apply inverse2.
     apply Smash_rec_beta_gluel.
-  Defined. 
+  Defined.
 
   Definition Smash_rec_beta_gluer' {P : Type} {Psm : X -> Y -> P} {Pl Pr : P}
     (Pgl : forall a, Psm a pt = Pl) (Pgr : forall b, Psm pt b = Pr) (a b : Y)
@@ -296,63 +296,36 @@ Definition functor_smash_homotopic {X Y A B : pType}
   (p : f $== h) (q : g $== k)
   : functor_smash f g $== functor_smash h k.
 Proof.
-  destruct f as [f f_eq], g as [g g_eq].
-  revert p q.
   pointed_reduce.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
-    - intros x y.
+    - intros x y; simpl.
       exact (ap011 _ (p x) (q y)).
     - reflexivity.
     - reflexivity.
     - intros x.
-      nrapply transport_paths_FlFr'.
+      nrapply transport_paths_FlFr'; simpl.
       lhs nrapply concat_p1.
       lhs nrapply Smash_rec_beta_gluel.
       rhs nrapply whiskerL.
       2: nrapply Smash_rec_beta_gluel.
-      rhs nrapply concat_p_pp.
-      apply moveL_pM.
-      lhs nrapply concat_pp_p.
-      rhs_V nrapply (ap011_pp sm).
-      rhs nrapply ap022.
-      2: apply moveR_pM, (dpoint_eq q).
-      2: apply concat_p1.
-      apply moveR_Mp.
-      rhs_V nrapply whiskerR.
-      2: apply ap011_V.
-      rhs_V nrapply ap011_pp.
-      rhs nrapply ap011.
-      2: apply concat_Vp.
-      2: apply concat_1p.
-      symmetry.
-      lhs nrapply ap011_is_ap.
-      lhs nrapply concat_p1.
-      nrapply ap_sm_left.
+      induction (p x); simpl.
+      rhs_V nrapply concat_pp_p.
+      apply whiskerR.
+      nrapply ap_pp.
     - intros y.
-      nrapply transport_paths_FlFr'.
+      nrapply transport_paths_FlFr'; simpl.
       lhs nrapply concat_p1.
       lhs nrapply Smash_rec_beta_gluer.
       rhs nrapply whiskerL.
       2: nrapply Smash_rec_beta_gluer.
-      rhs nrapply concat_p_pp.
-      apply moveL_pM.
-      lhs nrapply concat_pp_p.
-      rhs_V nrapply (ap011_pp sm).
-      rhs nrapply ap022.
-      3: apply moveR_pM, (dpoint_eq p).
-      2: apply concat_p1.
-      apply moveR_Mp.
-      rhs_V nrapply whiskerR.
-      2: apply ap011_V.
-      rhs_V nrapply ap011_pp.
-      rhs nrapply ap011.
-      2: apply concat_1p.
-      2: apply concat_Vp.
-      symmetry.
-      nrapply ap_sm_right. }
-  lhs nrapply (ap022 _ (dpoint_eq p) (dpoint_eq q)).
-  rapply ap011_pp.
+      induction (q y); simpl.
+      rhs_V nrapply concat_pp_p.
+      apply whiskerR.
+      nrapply (ap011_pp _ _ _ 1 1). }
+  symmetry; simpl.
+  lhs nrapply concat_p1.
+  apply ap022; apply concat_p1.
 Defined.
 
 Global Instance is0bifunctor_smash : IsBifunctor Smash.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -2,7 +2,8 @@ Require Import Basics.
 Require Import Pointed.Core.
 Require Import Types.
 Require Import Colimits.Pushout.
-Require Import Cubical.
+Require Import Cubical.DPath.
+Require Import WildCat.Core WildCat.Bifunctor.
 
 Local Open Scope pointed_scope.
 Local Open Scope dpath_scope.
@@ -218,3 +219,231 @@ Arguments sm : simpl never.
 Arguments auxl : simpl never.
 Arguments gluel : simpl never.
 Arguments gluer : simpl never.
+
+Definition Smash_functor {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
+  : Smash A B $-> Smash X Y.
+Proof.
+  srapply Build_pMap.
+  - snrapply (Smash_rec (fun a b => sm (f a) (g b)) auxl auxr).
+    + intro b.
+      rhs_V nrapply (gluel (f b)).
+      exact (ap011 _ 1 (point_eq g)).
+    + intro a.
+      simpl.
+      rhs_V nrapply (gluer (g a)).
+      exact (ap011 _ (point_eq f) 1).
+  - exact (ap011 _ (point_eq f) (point_eq g)).
+Defined.
+
+Definition Smash_functor_idmap (X Y : pType)
+  : Smash_functor (@pmap_idmap X) (@pmap_idmap Y) $== pmap_idmap.
+Proof.
+  snrapply Build_pHomotopy.
+  { snrapply Smash_ind.
+    1-3: reflexivity.
+    - intros x.
+      nrapply transport_paths_FlFr'.
+      apply equiv_p1_1q.
+      rhs nrapply ap_idmap.
+      lhs nrapply Smash_rec_beta_gluel.
+      apply concat_1p.
+    - intros y.
+      nrapply transport_paths_FlFr'.
+      apply equiv_p1_1q.
+      rhs nrapply ap_idmap.
+      lhs nrapply Smash_rec_beta_gluer.
+      apply concat_1p. }
+  reflexivity.
+Defined.
+
+Definition Smash_functor_compose {X Y A B C D : pType}
+  (f : X $-> A) (g : Y $-> B) (h : A $-> C) (k : B $-> D)
+  : Smash_functor (h $o f) (k $o g) $== Smash_functor h k $o Smash_functor f g.
+Proof.
+  snrapply Build_pHomotopy.
+  { snrapply Smash_ind.
+    1-3: reflexivity.
+    - intros x.
+      nrapply transport_paths_FlFr'.
+      apply equiv_p1_1q.
+      lhs nrapply Smash_rec_beta_gluel.
+      rhs nrapply (ap_compose (Smash_functor f g) _ (gluel x)).
+      rhs nrapply ap.
+      2: apply Smash_rec_beta_gluel.
+      rhs nrapply ap_pp.
+      rhs nrapply whiskerL.
+      2: apply Smash_rec_beta_gluel.
+      rhs nrapply concat_p_pp.
+      apply whiskerR.
+      rhs_V nrapply whiskerR.
+      2: nrapply (ap_compose (sm _) _ (point_eq g)).
+      lhs nrapply (ap011_pp sm 1 1).
+      apply whiskerR.
+      symmetry.
+      rapply ap_compose.
+    - intros y.
+      nrapply transport_paths_FlFr'.
+      apply equiv_p1_1q.
+      lhs nrapply Smash_rec_beta_gluer.
+      rhs nrapply (ap_compose (Smash_functor f g) _ (gluer y)).
+      rhs nrapply ap.
+      2: apply Smash_rec_beta_gluer.
+      rhs nrapply ap_pp.
+      rhs nrapply whiskerL.
+      2: apply Smash_rec_beta_gluer.
+      rhs nrapply concat_p_pp.
+      apply whiskerR.
+      unfold point_eq, dpoint_eq.
+      lhs nrapply (ap011_pp sm _ _ 1 1).
+      apply whiskerR.
+      rhs_V nrapply (ap011_compose sm (Smash_functor h k) (dpoint_eq f) 1).
+      symmetry.
+      nrapply (ap011_compose' sm h). }
+  simpl; pelim f g.
+  by simpl; pelim h k.
+Defined.
+
+Definition Smash_functor_homotopic {X Y A B : pType}
+  {f h : X $-> A} {g k : Y $-> B}
+  (p : f $== h) (q : g $== k)
+  : Smash_functor f g $== Smash_functor h k.
+Proof.
+  snrapply Build_pHomotopy.
+  { snrapply Smash_ind.
+    - intros x y.
+       exact (ap011 _ (p x) (q y)).
+    - reflexivity.
+    - reflexivity.
+    - intros x.
+      nrapply transport_paths_FlFr'.
+      lhs nrapply concat_p1.
+      lhs nrapply Smash_rec_beta_gluel.
+      rhs nrapply whiskerL.
+      2: nrapply Smash_rec_beta_gluel.
+      rhs nrapply concat_p_pp.
+      apply moveL_pM.
+      lhs nrapply concat_pp_p.
+      rhs_V nrapply (ap011_pp sm).
+      rhs nrapply ap022.
+      2: apply moveR_pM, (dpoint_eq q).
+      2: apply concat_p1.
+      apply moveR_Mp.
+      rhs_V nrapply whiskerR.
+      2: apply ap011_V.
+      rhs_V nrapply ap011_pp.
+      rhs nrapply ap011.
+      2: apply concat_Vp.
+      2: apply concat_1p.
+      symmetry.
+      lhs nrapply ap011_is_ap.
+      lhs nrapply concat_p1.
+      nrapply ap_sm_left.
+    - intros y.
+      nrapply transport_paths_FlFr'.
+      lhs nrapply concat_p1.
+      lhs nrapply Smash_rec_beta_gluer.
+      rhs nrapply whiskerL.
+      2: nrapply Smash_rec_beta_gluer.
+      rhs nrapply concat_p_pp.
+      apply moveL_pM.
+      lhs nrapply concat_pp_p.
+      rhs_V nrapply (ap011_pp sm).
+      rhs nrapply ap022.
+      3: apply moveR_pM, (dpoint_eq p).
+      2: apply concat_p1.
+      apply moveR_Mp.
+      rhs_V nrapply whiskerR.
+      2: apply ap011_V.
+      rhs_V nrapply ap011_pp.
+      rhs nrapply ap011.
+      2: apply concat_1p.
+      2: apply concat_Vp.
+      symmetry.
+      nrapply ap_sm_right. }
+  simpl.
+  by pelim p q f g h k.
+Defined.
+
+Global Instance is0bifunctor_smash : IsBifunctor Smash.
+Proof.
+  snrapply Build_IsBifunctor.
+  - intros X.
+    snrapply Build_Is0Functor.
+    intros Y B g.
+    exact (Smash_functor (Id _) g).
+  - intros Y.
+    snrapply Build_Is0Functor.
+    intros X A f.
+    exact (Smash_functor f (Id _)).
+  - intros X A f Y B g.
+    snrapply Build_pHomotopy.
+    + snrapply Smash_ind.
+      1-3: reflexivity.
+      * intros x.
+        nrapply transport_paths_FlFr'.
+        apply equiv_p1_1q.
+        lhs rapply (ap_compose (Smash_functor _ _) (Smash_functor _ _) (gluel x)).
+        rhs rapply (ap_compose (Smash_functor (Id _) g) (Smash_functor f (Id _)) (gluel x)).
+        lhs nrapply ap.
+        1: apply Smash_rec_beta_gluel.
+        rhs nrapply ap.
+        2: apply Smash_rec_beta_gluel.
+        lhs nrapply ap.
+        1: apply concat_1p.
+        lhs nrapply Smash_rec_beta_gluel.
+        rhs nrapply (ap_pp _ _ (gluel x)).
+        rhs nrapply whiskerL.
+        2: apply Smash_rec_beta_gluel.
+        f_ap.
+        2: symmetry; apply concat_1p.
+        exact (ap_compose (sm x) (Smash_functor f (Id _)) (point_eq g)).
+      * intros y.
+        nrapply transport_paths_FlFr'.
+        apply equiv_p1_1q.
+        lhs rapply (ap_compose (Smash_functor _ _) (Smash_functor _ _) (gluer y)).
+        rhs rapply (ap_compose (Smash_functor (Id _) g) (Smash_functor f (Id _)) (gluer y)).
+        lhs nrapply ap.
+        1: apply Smash_rec_beta_gluer.
+        rhs nrapply ap.
+        2: apply Smash_rec_beta_gluer.
+        rhs nrapply ap.
+        2: apply concat_1p.
+        rhs nrapply Smash_rec_beta_gluer.
+        lhs nrapply (ap_pp _ _ (gluer y)).
+        lhs nrapply whiskerL.
+        1: apply Smash_rec_beta_gluer.
+        f_ap.
+        2: apply concat_1p.
+        exact (ap_compose (fun x => sm x y)  (Smash_functor (Id _) g) (point_eq f))^.
+    + apply moveL_pV.
+      lhs nrapply concat_1p.
+      simpl.
+      cbn in f, g.
+      lhs nrapply whiskerR.
+      1: rapply (ap_compose (fun x => sm pt x) _ (point_eq g))^.
+      rhs nrapply whiskerR.
+      2: rapply (ap_compose (fun x => sm x pt) _ (point_eq f))^.
+      simpl.
+      by pelim f g.
+Defined.
+
+Global Instance is1bifunctor_smash : Is1Bifunctor Smash.
+Proof.
+  snrapply Build_Is1Bifunctor.
+  - intros X.
+    snrapply Build_Is1Functor.
+    + intros Y B f' g' q.
+      rapply (Smash_functor_homotopic (Id _) q).
+    + intros Y; cbn.
+      rapply Smash_functor_idmap.
+    + intros Y A C f g.
+      exact (Smash_functor_compose (Id _) f (Id _) g).
+  - intros Y.
+    snrapply Build_Is1Functor.
+    + intros X A f g q.
+      rapply (Smash_functor_homotopic q (Id _)).
+    + intros X; cbn.
+      rapply Smash_functor_idmap.
+    + intros X A C f g.
+      exact (Smash_functor_compose f (Id _) g (Id _)).
+Defined.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -225,14 +225,14 @@ Definition functor_smash {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
 Proof.
   srapply Build_pMap.
   - snrapply (Smash_rec (fun a b => sm (f a) (g b)) auxl auxr).
-    + intro b.
-      rhs_V nrapply (gluel (f b)).
+    + intro a; cbn beta.
+      rhs_V nrapply (gluel (f a)).
       exact (ap011 _ 1 (point_eq g)).
-    + intro a.
-      simpl.
-      rhs_V nrapply (gluer (g a)).
+    + intro b; cbn beta.
+      rhs_V nrapply (gluer (g b)).
       exact (ap011 _ (point_eq f) 1).
-  - exact (ap011 _ (point_eq f) (point_eq g)).
+  - simpl.
+    exact (ap011 _ (point_eq f) (point_eq g)).
 Defined.
 
 Definition functor_smash_idmap (X Y : pType)
@@ -260,47 +260,33 @@ Definition functor_smash_compose {X Y A B C D : pType}
   (f : X $-> A) (g : Y $-> B) (h : A $-> C) (k : B $-> D)
   : functor_smash (h $o f) (k $o g) $== functor_smash h k $o functor_smash f g.
 Proof.
+  pointed_reduce.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
     1-3: reflexivity.
-    - intros x.
+    - cbn beta.
+      intros x.
       nrapply transport_paths_FlFr'.
       apply equiv_p1_1q.
       lhs nrapply Smash_rec_beta_gluel.
-      rhs nrapply (ap_compose (functor_smash f g) _ (gluel x)).
-      rhs nrapply ap.
-      2: apply Smash_rec_beta_gluel.
-      rhs nrapply ap_pp.
-      rhs nrapply whiskerL.
-      2: apply Smash_rec_beta_gluel.
-      rhs nrapply concat_p_pp.
-      apply whiskerR.
-      rhs_V nrapply whiskerR.
-      2: nrapply (ap_compose (sm _) _ (point_eq g)).
-      lhs nrapply (ap011_pp sm 1 1).
-      apply whiskerR.
       symmetry.
-      rapply ap_compose.
-    - intros y.
+      lhs nrapply (ap_compose (functor_smash _ _) _ (gluel x)).
+      lhs nrapply ap.
+      2: nrapply Smash_rec_beta_gluel.
+      lhs nrapply Smash_rec_beta_gluel.
+      apply concat_1p.
+    - cbn beta.
+      intros y.
       nrapply transport_paths_FlFr'.
       apply equiv_p1_1q.
       lhs nrapply Smash_rec_beta_gluer.
-      rhs nrapply (ap_compose (functor_smash f g) _ (gluer y)).
-      rhs nrapply ap.
-      2: apply Smash_rec_beta_gluer.
-      rhs nrapply ap_pp.
-      rhs nrapply whiskerL.
-      2: apply Smash_rec_beta_gluer.
-      rhs nrapply concat_p_pp.
-      apply whiskerR.
-      unfold point_eq, dpoint_eq.
-      lhs nrapply (ap011_pp sm _ _ 1 1).
-      apply whiskerR.
-      rhs_V nrapply (ap011_compose sm (functor_smash h k) (dpoint_eq f) 1).
       symmetry.
-      nrapply (ap011_compose' sm h). }
-  simpl; pelim f g.
-  by simpl; pelim h k.
+      lhs nrapply (ap_compose (functor_smash _ _) _ (gluer y)).
+      lhs nrapply ap.
+      2: nrapply Smash_rec_beta_gluer.
+      lhs nrapply Smash_rec_beta_gluer.
+      apply concat_1p. }
+  reflexivity.
 Defined.
 
 Definition functor_smash_homotopic {X Y A B : pType}
@@ -308,10 +294,11 @@ Definition functor_smash_homotopic {X Y A B : pType}
   (p : f $== h) (q : g $== k)
   : functor_smash f g $== functor_smash h k.
 Proof.
+  pointed_reduce.
   snrapply Build_pHomotopy.
   { snrapply Smash_ind.
     - intros x y.
-       exact (ap011 _ (p x) (q y)).
+      exact (ap011 _ (p x) (q y)).
     - reflexivity.
     - reflexivity.
     - intros x.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -348,9 +348,7 @@ Proof.
       rhs_V nrapply concat_pp_p.
       apply whiskerR.
       nrapply (ap011_pp _ _ _ 1 1). }
-  symmetry; simpl.
-  lhs nrapply concat_p1.
-  exact (ap022 _ (concat_p1 (p pt)) (concat_p1 (q pt))).
+  exact (ap022 _ (concat_p1 (p pt))^ (concat_p1 (q pt))^ @ (concat_p1 _)^).
 Defined.
 
 Global Instance is0bifunctor_smash : Is0Bifunctor Smash.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.PathGroupoids Basics.Tactics Basics.Equivalences.
-Require Import Types.Sum Types.Bool Types.Paths.
-Require Import WildCat.Core WildCat.Bifunctor.
+Require Import Types.Sum Types.Bool Types.Paths Types.Forall.
+Require Import WildCat.Core WildCat.Bifunctor WildCat.Equiv.
 Require Import Colimits.Pushout.
 Require Import Cubical.DPath.
 Require Import Pointed.Core.
@@ -410,4 +410,78 @@ Proof.
       rapply functor_smash_idmap.
     + intros X A C f g.
       exact (functor_smash_compose f (Id _) g (Id _)).
+Defined.
+
+(** ** Symmetry of the smash product *)
+
+Definition pswap (X Y : pType) : Smash X Y $-> Smash Y X
+  := Build_pMap _ _ (Smash_rec (flip sm) auxr auxl gluer gluel) 1.
+
+Definition pswap_pswap {X Y : pType}
+  : pswap X Y $o pswap Y X $== pmap_idmap.
+Proof.
+  snrapply Build_pHomotopy.
+  - snrapply Smash_ind.
+    1-3: reflexivity.
+    + intros y.
+      rapply (transport_paths_FFlr' (f := pswap _ _)).
+      apply equiv_p1_1q.
+      lhs nrapply ap.
+      1: apply Smash_rec_beta_gluel.
+      apply Smash_rec_beta_gluer.
+    + intros x.
+      rapply (transport_paths_FFlr' (f := pswap _ _)).
+      apply equiv_p1_1q.
+      lhs nrapply ap.
+      1: apply Smash_rec_beta_gluer.
+      apply Smash_rec_beta_gluel.
+  - reflexivity.
+Defined.
+
+Definition pequiv_pswap {X Y : pType} : Smash X Y $<~> Smash Y X.
+Proof.
+  snrapply cate_adjointify.
+  1,2: exact (pswap _ _).
+  1,2: exact pswap_pswap.
+Defined.
+
+Definition pswap_natural {A B X Y : pType} (f : A $-> X) (g : B $-> Y)
+  : pswap X Y $o functor_smash f g $== functor_smash g f $o pswap A B.
+Proof.
+  snrapply Build_pHomotopy.
+  - snrapply Smash_ind.
+    1-3: reflexivity.
+    + intros a.
+      nrapply transport_paths_FlFr'.
+      apply equiv_p1_1q.
+      rhs nrapply (ap_compose (pswap A B) _ (gluel a)).
+      rhs nrapply ap.
+      2: apply Smash_rec_beta_gluel.
+      rhs nrapply Smash_rec_beta_gluer.
+      lhs nrapply (ap_compose (functor_smash f g) (pswap X Y) (gluel a)).
+      lhs nrapply ap.
+      1: apply Smash_rec_beta_gluel.
+      lhs nrapply (ap_pp (pswap X Y) (ap011 sm 1 (point_eq g)) (gluel (f a))).
+      lhs nrapply whiskerL.
+      1: apply Smash_rec_beta_gluel.
+      apply whiskerR.
+      symmetry.
+      exact (ap_compose _ _ _).
+    + intros b.
+      nrapply transport_paths_FlFr'.
+      apply equiv_p1_1q.
+      rhs nrapply (ap_compose (pswap A B) _ (gluer b)).
+      rhs nrapply ap.
+      2: apply Smash_rec_beta_gluer.
+      rhs nrapply Smash_rec_beta_gluel.
+      lhs nrapply (ap_compose (functor_smash f g) (pswap X Y) (gluer b)).
+      lhs nrapply ap.
+      1: apply Smash_rec_beta_gluer.
+      lhs nrapply (ap_pp (pswap X Y) (ap011 sm (point_eq f) 1) (gluer (g b))).
+      lhs nrapply whiskerL.
+      1: apply Smash_rec_beta_gluer.
+      apply whiskerR.
+      symmetry.
+      exact (ap011_compose _ _ (point_eq f) 1).
+  - by simpl; pelim f g.
 Defined.

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -328,88 +328,24 @@ Proof.
   apply ap022; apply concat_p1.
 Defined.
 
-Global Instance is0bifunctor_smash : IsBifunctor Smash.
+Global Instance is0bifunctor_smash : Is0Bifunctor Smash.
 Proof.
-  snrapply Build_IsBifunctor.
-  - intros X.
-    snrapply Build_Is0Functor.
-    intros Y B g.
-    exact (functor_smash (Id _) g).
-  - intros Y.
-    snrapply Build_Is0Functor.
-    intros X A f.
-    exact (functor_smash f (Id _)).
-  - intros X A f Y B g.
-    snrapply Build_pHomotopy.
-    + snrapply Smash_ind.
-      1-3: reflexivity.
-      * intros x.
-        nrapply transport_paths_FlFr'.
-        apply equiv_p1_1q.
-        lhs rapply (ap_compose (functor_smash f (Id _)) (functor_smash (Id _) g) (gluel x)).
-        rhs rapply (ap_compose (functor_smash (Id _) g) (functor_smash f (Id _)) (gluel x)).
-        lhs nrapply ap.
-        1: apply Smash_rec_beta_gluel.
-        rhs nrapply ap.
-        2: apply Smash_rec_beta_gluel.
-        lhs nrapply ap.
-        1: apply concat_1p.
-        lhs nrapply Smash_rec_beta_gluel.
-        rhs nrapply (ap_pp _ _ (gluel x)).
-        rhs nrapply whiskerL.
-        2: apply Smash_rec_beta_gluel.
-        f_ap.
-        2: symmetry; apply concat_1p.
-        exact (ap_compose (sm x) (functor_smash f (Id _)) (point_eq g)).
-      * intros y.
-        nrapply transport_paths_FlFr'.
-        apply equiv_p1_1q.
-        lhs rapply (ap_compose (functor_smash _ _) (functor_smash _ _) (gluer y)).
-        rhs rapply (ap_compose (functor_smash (Id _) g) (functor_smash f (Id _)) (gluer y)).
-        lhs nrapply ap.
-        1: apply Smash_rec_beta_gluer.
-        rhs nrapply ap.
-        2: apply Smash_rec_beta_gluer.
-        rhs nrapply ap.
-        2: apply concat_1p.
-        rhs nrapply Smash_rec_beta_gluer.
-        lhs nrapply (ap_pp _ _ (gluer y)).
-        lhs nrapply whiskerL.
-        1: apply Smash_rec_beta_gluer.
-        f_ap.
-        2: apply concat_1p.
-        exact (ap_compose (fun x => sm x y)  (functor_smash (Id _) g) (point_eq f))^.
-    + apply moveL_pV.
-      lhs nrapply concat_1p.
-      simpl.
-      cbn in f, g.
-      lhs nrapply whiskerR.
-      1: rapply (ap_compose (fun x => sm pt x) _ (point_eq g))^.
-      rhs nrapply whiskerR.
-      2: rapply (ap_compose (fun x => sm x pt) _ (point_eq f))^.
-      simpl.
-      by pelim f g.
+  rapply Build_Is0Bifunctor'.
+  nrapply Build_Is0Functor.
+  intros [X Y] [A B] [f g].
+  exact (functor_smash f g).
 Defined.
 
 Global Instance is1bifunctor_smash : Is1Bifunctor Smash.
 Proof.
-  snrapply Build_Is1Bifunctor.
-  - intros X.
-    snrapply Build_Is1Functor.
-    + intros Y B f' g' q.
-      rapply (functor_smash_homotopic (Id _) q).
-    + intros Y; cbn.
-      rapply functor_smash_idmap.
-    + intros Y A C f g.
-      exact (functor_smash_compose (Id _) f (Id _) g).
-  - intros Y.
-    snrapply Build_Is1Functor.
-    + intros X A f g q.
-      rapply (functor_smash_homotopic q (Id _)).
-    + intros X; cbn.
-      rapply functor_smash_idmap.
-    + intros X A C f g.
-      exact (functor_smash_compose f (Id _) g (Id _)).
+  snrapply Build_Is1Bifunctor'.
+  snrapply Build_Is1Functor.
+  - intros [X Y] [A B] [f g] [h i] [p q].
+    exact (functor_smash_homotopic p q).
+  - intros [X Y].
+    exact (functor_smash_idmap X Y).
+  - intros [X Y] [A B] [C D] [f g] [h i].
+    exact (functor_smash_compose f g h i).
 Defined.
 
 (** ** Symmetry of the smash product *)


### PR DESCRIPTION
Here is a new attempt at the functoriality of smash. I've done it directly without using the swapping infrastructure in the Hurewicz formalization. It was quite straightforward and allowed me to define some useful lemmas about `ap011`. (Actually from what I could tell, this wasn't proven to the full extent in the Hurewicz formalization anyway).

I'll wait till after #1886 which will mean some proofs will need to be shifted around.