### PR TITLE
better definition of monoidal 1-category

### DIFF
--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -98,7 +98,8 @@ Defined.
 Global Instance is1bifunctor_ab_hom `{Funext}
   : Is1Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).
 Proof.
-  rapply Build_Is1Bifunctor.
+  nrapply Build_Is1Bifunctor.
+  1,2: exact _.
   intros A A' f B B' g phi; cbn.
   by apply equiv_path_grouphomomorphism.
 Defined.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -13,11 +13,11 @@ Definition Ext (B A : AbGroup@{u}) := pTr 0 (AbSES B A).
 
 Global Instance is0bifunctor_ext `{Univalence}
   : Is0Bifunctor (Ext : AbGroup^op -> AbGroup -> pType)
-  := is0bifunctor_compose _ _ (bf:=is0bifunctor_abses).
+  := is0bifunctor_postcompose _ _ (bf:=is0bifunctor_abses).
 
 Global Instance is1bifunctor_ext `{Univalence}
   : Is1Bifunctor (Ext : AbGroup^op -> AbGroup -> pType)
-  := is1bifunctor_compose _ _ (bf:=is1bifunctor_abses).
+  := is1bifunctor_postcompose _ _ (bf:=is1bifunctor_abses).
 
 (** An extension [E : AbSES B A] is trivial in [Ext B A] if and only if [E] merely splits. *)
 Proposition iff_ab_ext_trivial_split `{Univalence} {B A : AbGroup} (E : AbSES B A)
@@ -34,11 +34,11 @@ Definition Ext' (B A : AbGroup@{u}) := Tr 0 (AbSES' B A).
 
 Global Instance is0bifunctor_ext' `{Univalence}
   : Is0Bifunctor (Ext' : AbGroup^op -> AbGroup -> Type)
-  := is0bifunctor_compose _ _ (bf:=is0bifunctor_abses').
+  := is0bifunctor_postcompose _ _ (bf:=is0bifunctor_abses').
 
 Global Instance is1bifunctor_ext' `{Univalence}
   : Is1Bifunctor (Ext' : AbGroup^op -> AbGroup -> Type)
-  := is1bifunctor_compose _ _ (bf:=is1bifunctor_abses').
+  := is1bifunctor_postcompose _ _ (bf:=is1bifunctor_abses').
 
 (** [Ext B A] is an abelian group for any [A B : AbGroup]. The proof of commutativity is a bit faster if we separate out the proof that [Ext B A] is a group. *)
 Definition grp_ext `{Univalence} (B A : AbGroup@{u}) : Group.

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -831,7 +831,7 @@ Section JoinEmpty.
   Definition equiv_join_empty_left A : Join Empty A <~> A
     := equiv_join_empty_right _ oE equiv_join_sym _ _.
 
-  Global Instance join_right_unitor : RightUnitor Type Join Empty.
+  Global Instance join_right_unitor : RightUnitor Join Empty.
   Proof.
     snrapply Build_NatEquiv.
     - apply equiv_join_empty_right.
@@ -844,7 +844,7 @@ Section JoinEmpty.
       + intros a [].
   Defined.
 
-  Global Instance join_left_unitor : LeftUnitor Type Join Empty.
+  Global Instance join_left_unitor : LeftUnitor Join Empty.
   Proof.
     snrapply Build_NatEquiv.
     - apply equiv_join_empty_left.

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -260,10 +260,12 @@ Proof.
   apply trijoin_id_sym_nat.
 Defined.
 
-Global Instance join_associator : Associator Type Join.
+Global Instance join_associator : Associator Join.
 Proof.
-  unshelve econstructor; unfold right_assoc, left_assoc, uncurry; cbn.
-  - intros [[A B] C]; cbn.
+  snrapply Build_Associator_uncurried; simpl.
+  apply natequiv_inverse.
+  snrapply Build_NatEquiv.
+  - intros [[A B] C].
     apply join_assoc.
   - intros [[A B] C] [[A' B'] C'] [[f g] h]; cbn.
     (* This is awkward because Monoidal.v works with a tensor that is separately a functor in each variable. *)
@@ -275,6 +277,7 @@ Proof.
     cbn.
     rhs_V nrapply join_assoc_nat; cbn.
     apply ap.
+    lhs_V nrapply functor_join_compose.
     lhs_V nrapply functor_join_compose.
     apply functor2_join.
     1: reflexivity.
@@ -310,9 +313,14 @@ Proof.
     apply join_sym_beta_jglue.
 Defined.
 
-Definition join_trianglelaw A B : TriangleLaw Type Join Empty A B.
+Definition join_trianglelaw : TriangleIdentity Join Empty.
 Proof.
-  unfold TriangleLaw; intro x; cbn.
+  intros A B.
+  (** TODO: This should be a lemma *)
+  nrefine (_ $@ cat_idr _).
+  nrefine (_ $@ (_ $@L cate_issect _)).
+  nrefine ((_ $@R _) $@ cat_assoc _ _ _).
+  intros x. 
   lhs nrapply (functor_join_compose idmap _ idmap _).
   lhs_V nrapply join_trianglelaw'.
   unfold join_assoc; cbn.

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -262,10 +262,8 @@ Defined.
 
 Global Instance join_associator : Associator Join.
 Proof.
-  snrapply Build_Associator_uncurried; simpl.
-  apply natequiv_inverse.
-  snrapply Build_NatEquiv.
-  - intros [[A B] C].
+  snrapply Build_Associator; simpl.
+  - intros A B C.
     apply join_assoc.
   - intros [[A B] C] [[A' B'] C'] [[f g] h]; cbn.
     (* This is awkward because Monoidal.v works with a tensor that is separately a functor in each variable. *)
@@ -315,12 +313,7 @@ Defined.
 
 Definition join_trianglelaw : TriangleIdentity Join Empty.
 Proof.
-  intros A B.
-  (** TODO: This should be a lemma *)
-  nrefine (_ $@ cat_idr _).
-  nrefine (_ $@ (_ $@L cate_issect _)).
-  nrefine ((_ $@R _) $@ cat_assoc _ _ _).
-  intros x. 
+  intros A B x; cbn. 
   lhs nrapply (functor_join_compose idmap _ idmap _).
   lhs_V nrapply join_trianglelaw'.
   unfold join_assoc; cbn.

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import Types.Forall.
-Require Import WildCat.Core WildCat.Prod WildCat.Equiv.
+Require Import WildCat.Core WildCat.Prod WildCat.Equiv WildCat.NatTrans WildCat.Square.
 
 (** * Bifunctors between WildCats *)
 
@@ -235,4 +235,24 @@ Proof.
   change (Is0Functor (uncurry (fun x y => G x (F y b)))).
   apply is0functor_uncurry_bifunctor.
   apply (is0bifunctor_precompose' (flip F b) G).
+Defined.
+
+(** ** Natural transformations between bifunctors *)
+
+(** We can show that an uncurried natural transformation between uncurried bifunctors by composing the naturality square in each variable. *)
+Global Instance is1natural_uncurry {A B C : Type}
+  `{IsGraph A, IsGraph B, Is1Cat C}
+  (F : A -> B -> C)
+  `{!Is0Bifunctor F}
+  (G : A -> B -> C)
+  `{!Is0Bifunctor G}
+  (alpha : uncurry F $=> uncurry G)
+  (nat_l : forall b, Is1Natural (flip F b) (flip G b) (fun x : A => alpha (x, b)))
+  (nat_r : forall a, Is1Natural (F a) (G a) (fun y : B => alpha (a, y)))
+  : Is1Natural (uncurry F) (uncurry G) alpha.
+Proof.
+  intros [a b] [a' b'] [f f']; cbn in *.
+  change (?w $o ?x $== ?y $o ?z) with (Square z w x y).
+  unfold fmap11.
+  exact (hconcat (nat_l _ _ _ f) (nat_r _ _ _ f')).
 Defined.

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -141,7 +141,7 @@ Defined.
 Global Instance is0bifunctor_postcompose {A B C D : Type}
   `{IsGraph A, IsGraph B, IsGraph C, IsGraph D}
   (F : A -> B -> C) {bf : Is0Bifunctor F}
-  (G : C -> D) `{!Is0Functor G, !Is0Functor G}
+  (G : C -> D) `{!Is0Functor G}
   : Is0Bifunctor (fun a b => G (F a b)).
 Proof.
   rapply Build_Is0Bifunctor.
@@ -213,22 +213,26 @@ Proof.
     apply (bifunctor_isbifunctor F).
 Defined.
 
-Global Instance is0functor_uncurry_uncurry_left {A B} (F : A -> B -> A)
-  `{Is01Cat A, Is01Cat B, !Is0Bifunctor F}
-  : Is0Functor (uncurry (uncurry (fun x y z => F (F x y) z))).
+Global Instance is0functor_uncurry_uncurry_left {A B C D E}
+  (F : A -> B -> C) (G : C -> D -> E)
+  `{Is01Cat A, Is01Cat B, Is01Cat C, Is01Cat D, Is01Cat E,
+    !Is0Bifunctor F, !Is0Bifunctor G}
+  : Is0Functor (uncurry (uncurry (fun x y z => G (F x y) z))).
 Proof.
   rapply is0functor_uncurry_bifunctor.
 Defined.
 
-Global Instance is0functor_uncurry_uncurry_right {A B} (F : A -> B -> B)
-  `{Is01Cat A, Is01Cat B, !Is0Bifunctor F}
-  : Is0Functor (uncurry (uncurry (fun x y z => F x (F y z)))).
+Global Instance is0functor_uncurry_uncurry_right {A B C D E}
+  (F : A -> B -> D) (G : C -> D -> E)
+  `{Is01Cat A, Is01Cat B, Is01Cat C, Is01Cat D, Is01Cat E,
+    !Is0Bifunctor F, !Is0Bifunctor G}
+  : Is0Functor (uncurry (uncurry (fun x y z => G x (F y z)))).
 Proof.
   apply is0functor_uncurry_bifunctor.
   nrapply Build_Is0Bifunctor.
   1: exact _.
   intros b.
-  change (Is0Functor (uncurry (fun x y => F x (F y b)))).
+  change (Is0Functor (uncurry (fun x y => G x (F y b)))).
   apply is0functor_uncurry_bifunctor.
-  apply (is0bifunctor_precompose' (flip F b) F).
+  apply (is0bifunctor_precompose' (flip F b) G).
 Defined.

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -4,58 +4,143 @@ Require Import WildCat.Core WildCat.Bifunctor WildCat.Prod WildCat.Equiv WildCat
 
 (** * Monoidal 1-categories *)
 
-(** ** Definition *)
+(** ** Typeclasses for common diagrams *)
 
-(** A monoidal 1-category is a 1-category with equivalences and the following data: *)
-Class IsMonoidal {A : Type} `{HasEquivs A} := {
-  (** A bifunctor [cat_tensor] called the tensor product. *)
-  cat_tensor : A -> A -> A;
-  is0bifunctor_cat_tensor :: Is0Bifunctor cat_tensor;
-  is1bifunctor_cat_tensor :: Is1Bifunctor cat_tensor;
+(** TODO: These should eventually be moved to a separate file in WildCat and used in other places. They can be thought of as a wildcat generalization of the classes in canonical_names.v *)
 
-  (** An object [cat_tensor_unit] called the tensor unit. *)
-  cat_tensor_unit : A;
- 
-  (** An isomorphism [associator] witnessing associativity of [cat_tensor]. *)
-  associator a b c : cat_tensor (cat_tensor a b) c $<~> cat_tensor a (cat_tensor b c);
+(** *** Associators *)
 
+(** A natural equivalence witnessing the associativity of a bifunctor. *)
+Class Associator {A : Type} `{HasEquivs A}
+  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F} := {   
+  (** An isomorphism [associator] witnessing associativity of [F]. *)
+  associator a b c : F (F a b) c $<~> F a (F b c);
+  
   (** The [associator] is a natural isomorphism. Naturality is stated here in each variable separely. *)
   is1natural_associator_l {b c : A}
     :: Is1Natural
-        (flip cat_tensor c o flip cat_tensor b)
-        (flip cat_tensor (cat_tensor b c))
+        (flip F c o flip F b)
+        (flip F (F b c))
         (fun a => associator a b c);
 
   is1natural_associator_m {a c : A}
     :: Is1Natural
-        (flip cat_tensor c o cat_tensor a)
-        (cat_tensor a o flip cat_tensor c)
+        (flip F c o F a)
+        (F a o flip F c)
         (fun b => associator a b c);
 
   is1natural_associator_r {a b : A}
     :: Is1Natural
-        (cat_tensor (cat_tensor a b))
-        (cat_tensor a o cat_tensor b)
+        (F (F a b))
+        (F a o F b)
         (fun c => associator a b c);
-
-  (** A natural isomorphism [left_unitor] witnessing the left unit law. *)
-  left_unitor
-    : NatEquiv (cat_tensor cat_tensor_unit) idmap;
-
-  (** A natural isomorphism [right_unitor] witnessing the right unit law. *)
-  right_unitor
-    : NatEquiv (flip cat_tensor cat_tensor_unit) idmap;
-
-  (** The triangle identity. *)
-  triangle_identity a b
-    : fmap (cat_tensor a) (left_unitor b) $o (associator a cat_tensor_unit b)
-      $== fmap (flip cat_tensor b) (right_unitor a);
-     
-  (** The pentagon identity. *)
-  pentagon_identity a b c d
-    : associator a b (cat_tensor c d) $o associator (cat_tensor a b) c d
-      $== fmap (cat_tensor a) (associator b c d) $o associator a (cat_tensor b c) d
-        $o fmap (flip cat_tensor d) (associator a b c);
 }.
+Coercion associator : Associator >-> Funclass.
+Arguments associator {A _ _ _ _ _ F _ _ _} a b c.
 
-Arguments IsMonoidal A {_ _ _ _ _}.
+(** Alternatively, we can build an associator that is natural in an uncurried form. *)
+Definition Build_Associator_uncurried {A : Type} `{HasEquivs A}
+  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F}
+  (associator'
+    : NatEquiv
+      (fun '(a, b, c) => F (F a b) c)
+      (fun '(a, b, c) => F a (F b c)))
+  : Associator F.
+Proof.
+  simpl in associator'.
+  snrapply Build_Associator.
+  - intros a b c.
+    exact (associator' (a, b, c)).
+  (** Using the curried naturality, we need only subsitute the identity for each pair of variables. However this requires rewriting some functor actions on the identity map which is what most of the work here accomplishes. *)
+  - intros b c a a' f.
+    pose proof (isnat associator'
+      (a := (a, b, c)) (a' := (a', b, c)) (f, Id b, Id c)) as h.
+    cbn in h; unfold uncurry, fmap11 in h; cbn in h; unfold fmap11 in h; cbn in h.
+    refine ((_ $@L _^$) $@ h $@ _); clear h.
+    + refine ((_ $@@ (fmap_id _ _)) $@ cat_idl _).
+      exact (fmap2 _ (fmap_id _ _ $@R _  $@ cat_idl _)).
+    + refine ((_ $@@ (fmap_id (F a' o F b) _)) $@ cat_idl _ $@R _).
+      refine (_ $@R _ $@ cat_idl _).
+      exact (fmap_id (F a' o flip F c) b).
+  - intros a c b b' f.
+    pose proof (isnat associator'
+      (a := (a, b, c)) (a' := (a, b', c)) (Id a, f, Id c)) as h.
+    cbn in h; unfold uncurry, fmap11 in h; cbn in h; unfold fmap11 in h; cbn in h.
+    refine ((_ $@L _^$) $@ h $@ _); clear h.
+    + refine ((_ $@@ fmap_id _ _) $@ cat_idl _).
+      refine (fmap2 _ ((_ $@L fmap_id _ _) $@ cat_idr _)).
+    + refine ((_ $@@ (fmap2 _ (fmap_id _ _) $@ fmap_id _ _)) $@ cat_idl _ $@R _).
+      refine (_ $@L _ $@ cat_idr _).
+      exact (fmap_id _ _).
+  - intros a b c c' f.
+    pose proof (isnat associator'
+      (a := (a, b, c)) (a' := (a, b, c')) (Id a, Id b, f)) as h.
+    cbn in h; unfold uncurry, fmap11 in h; cbn in h; unfold fmap11 in h; cbn in h.
+    refine ((_ $@L _^$) $@ h $@ _); clear h.
+    + refine ((_ $@L (_ $@ cat_idr _)) $@ cat_idr _).
+      refine (fmap_comp _ _ _ $@ _).
+      exact (fmap_id (flip F c o flip F b) a $@@ fmap_id (flip F c o F a) b).
+    + exact (((_ $@L ((fmap_id (flip F (F b c)) _ $@@ fmap_id (F a o flip F c) _)
+        $@ cat_idr _)) $@ cat_idr _) $@R _).
+Defined.
+
+(** *** Unitors *)
+
+Class LeftUnitor {A : Type} `{HasEquivs A}
+  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F} (unit : A)
+  (** A natural isomorphism [left_unitor] witnessing the left unit law of [F]. *)
+  := left_unitor : NatEquiv (F unit) idmap.
+Coercion left_unitor : LeftUnitor >-> NatEquiv.
+Arguments left_unitor {A _ _ _ _ _ F _ _ unit _}.
+
+Class RightUnitor {A : Type} `{HasEquivs A}
+  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F} (unit : A)
+  (** A natural isomorphism [right_unitor] witnessing the right unit law of [F]. *)
+  := right_unitor : NatEquiv (flip F unit) idmap.
+Coercion right_unitor : RightUnitor >-> NatEquiv.
+Arguments right_unitor {A _ _ _ _ _ F _ _ unit _}.
+
+(** *** Triangle and Pentagon identities *)
+
+Class TriangleIdentity {A : Type} `{HasEquivs A}
+  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F, !Associator F}
+  (unit : A) `{!LeftUnitor F unit, !RightUnitor F unit}
+  (** The triangle identity for an associator and unitors. *)
+  := triangle_identity a b
+    : fmap01 F a (left_unitor b) $o (associator (F := F) a unit b)
+    $== fmap10 F (right_unitor a) b.
+Coercion triangle_identity : TriangleIdentity >-> Funclass.
+Arguments triangle_identity {A _ _ _ _ _} F {_ _ _} unit {_}.
+
+Class PentagonIdentity {A : Type} `{HasEquivs A}
+  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F, !Associator F}
+  (unit : A) `{!LeftUnitor F unit, !RightUnitor F unit}
+  (** The pentagon identity for an associator and unitors. *)
+  := pentagon_identity a b c d
+    : associator a b (F c d) $o associator (F a b) c d
+      $== fmap01 F a (associator b c d) $o associator a (F b c) d
+        $o fmap10 F (associator a b c) d.
+Coercion pentagon_identity : PentagonIdentity >-> Funclass.
+Arguments pentagon_identity {A _ _ _ _ _} F {_ _ _} unit {_}.
+
+(** ** Definition *)
+
+(** A monoidal 1-category is a 1-category with equivalences and the following data: *)
+Class IsMonoidal (A : Type) `{HasEquivs A} := {
+  (** A bifunctor [cat_tensor] called the tensor product. *)
+  cat_tensor : A -> A -> A;
+  is0bifunctor_cat_tensor :: Is0Bifunctor cat_tensor;
+  is1bifunctor_cat_tensor :: Is1Bifunctor cat_tensor;
+  (** A natural isomorphism [associator] witnessing the associativity of the tensor product. *)
+  cat_tensor_associator :: Associator cat_tensor;
+  (** An object [cat_tensor_unit] called the tensor unit. *)
+  cat_tensor_unit : A;
+  (** A natural isomorphism [left_unitor] witnessing the left unit law. *)
+  cat_tensor_left_unitor :: LeftUnitor cat_tensor cat_tensor_unit;
+  (** A natural isomorphism [right_unitor] witnessing the right unit law. *)
+  cat_tensor_right_unitor :: RightUnitor cat_tensor cat_tensor_unit;
+  (** The triangle identity. *)
+  cat_tensor_triangle_identity :: TriangleIdentity cat_tensor cat_tensor_unit;
+  (** The pentagon identity. *)
+  cat_tensor_pentagon_identity :: PentagonIdentity cat_tensor cat_tensor_unit;
+}.

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -14,75 +14,17 @@ Require Import WildCat.Core WildCat.Bifunctor WildCat.Prod WildCat.Equiv WildCat
 Class Associator {A : Type} `{HasEquivs A}
   (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F} := {   
   (** An isomorphism [associator] witnessing associativity of [F]. *)
-  associator a b c : F (F a b) c $<~> F a (F b c);
+  associator a b c : F a (F b c) $<~> F (F a b) c;
   
-  (** The [associator] is a natural isomorphism. Naturality is stated here in each variable separely. *)
-  is1natural_associator_l {b c : A}
+  (** The [associator] is a natural isomorphism. *)
+  is1natural_associator_uncurried
     :: Is1Natural
-        (flip F c o flip F b)
-        (flip F (F b c))
-        (fun a => associator a b c);
-
-  is1natural_associator_m {a c : A}
-    :: Is1Natural
-        (flip F c o F a)
-        (F a o flip F c)
-        (fun b => associator a b c);
-
-  is1natural_associator_r {a b : A}
-    :: Is1Natural
-        (F (F a b))
-        (F a o F b)
-        (fun c => associator a b c);
+        (fun '(a, b, c) => F a (F b c))
+        (fun '(a, b, c) => F (F a b) c)
+        (fun '(a, b, c) => associator a b c);
 }.
 Coercion associator : Associator >-> Funclass.
 Arguments associator {A _ _ _ _ _ F _ _ _} a b c.
-
-(** Alternatively, we can build an associator that is natural in an uncurried form. *)
-Definition Build_Associator_uncurried {A : Type} `{HasEquivs A}
-  (F : A -> A -> A) `{!Is0Bifunctor F, !Is1Bifunctor F}
-  (associator'
-    : NatEquiv
-      (fun '(a, b, c) => F (F a b) c)
-      (fun '(a, b, c) => F a (F b c)))
-  : Associator F.
-Proof.
-  simpl in associator'.
-  snrapply Build_Associator.
-  - intros a b c.
-    exact (associator' (a, b, c)).
-  (** Using the curried naturality, we need only subsitute the identity for each pair of variables. However this requires rewriting some functor actions on the identity map which is what most of the work here accomplishes. *)
-  - intros b c a a' f.
-    pose proof (isnat associator'
-      (a := (a, b, c)) (a' := (a', b, c)) (f, Id b, Id c)) as h.
-    cbn in h; unfold uncurry, fmap11 in h; cbn in h; unfold fmap11 in h; cbn in h.
-    refine ((_ $@L _^$) $@ h $@ _); clear h.
-    + refine ((_ $@@ (fmap_id _ _)) $@ cat_idl _).
-      exact (fmap2 _ (fmap_id _ _ $@R _  $@ cat_idl _)).
-    + refine ((_ $@@ (fmap_id (F a' o F b) _)) $@ cat_idl _ $@R _).
-      refine (_ $@R _ $@ cat_idl _).
-      exact (fmap_id (F a' o flip F c) b).
-  - intros a c b b' f.
-    pose proof (isnat associator'
-      (a := (a, b, c)) (a' := (a, b', c)) (Id a, f, Id c)) as h.
-    cbn in h; unfold uncurry, fmap11 in h; cbn in h; unfold fmap11 in h; cbn in h.
-    refine ((_ $@L _^$) $@ h $@ _); clear h.
-    + refine ((_ $@@ fmap_id _ _) $@ cat_idl _).
-      refine (fmap2 _ ((_ $@L fmap_id _ _) $@ cat_idr _)).
-    + refine ((_ $@@ (fmap2 _ (fmap_id _ _) $@ fmap_id _ _)) $@ cat_idl _ $@R _).
-      refine (_ $@L _ $@ cat_idr _).
-      exact (fmap_id _ _).
-  - intros a b c c' f.
-    pose proof (isnat associator'
-      (a := (a, b, c)) (a' := (a, b, c')) (Id a, Id b, f)) as h.
-    cbn in h; unfold uncurry, fmap11 in h; cbn in h; unfold fmap11 in h; cbn in h.
-    refine ((_ $@L _^$) $@ h $@ _); clear h.
-    + refine ((_ $@L (_ $@ cat_idr _)) $@ cat_idr _).
-      refine (fmap_comp _ _ _ $@ _).
-      exact (fmap_id (flip F c o flip F b) a $@@ fmap_id (flip F c o F a) b).
-    + exact (((_ $@L ((fmap_id (flip F (F b c)) _ $@@ fmap_id (F a o flip F c) _)
-        $@ cat_idr _)) $@ cat_idr _) $@R _).
-Defined.
 
 (** *** Unitors *)
 
@@ -107,8 +49,8 @@ Class TriangleIdentity {A : Type} `{HasEquivs A}
   (unit : A) `{!LeftUnitor F unit, !RightUnitor F unit}
   (** The triangle identity for an associator and unitors. *)
   := triangle_identity a b
-    : fmap01 F a (left_unitor b) $o (associator (F := F) a unit b)
-    $== fmap10 F (right_unitor a) b.
+    : fmap01 F a (left_unitor b)
+    $== fmap10 F (right_unitor a) b $o (associator (F := F) a unit b).
 Coercion triangle_identity : TriangleIdentity >-> Funclass.
 Arguments triangle_identity {A _ _ _ _ _} F {_ _ _} unit {_}.
 
@@ -117,24 +59,27 @@ Class PentagonIdentity {A : Type} `{HasEquivs A}
   (unit : A) `{!LeftUnitor F unit, !RightUnitor F unit}
   (** The pentagon identity for an associator and unitors. *)
   := pentagon_identity a b c d
-    : associator a b (F c d) $o associator (F a b) c d
-      $== fmap01 F a (associator b c d) $o associator a (F b c) d
-        $o fmap10 F (associator a b c) d.
+    : associator (F a b) c d $o associator a b (F c d)
+      $== fmap10 F (associator a b c) d $o associator a (F b c) d
+        $o fmap01 F a (associator b c d).
 Coercion pentagon_identity : PentagonIdentity >-> Funclass.
 Arguments pentagon_identity {A _ _ _ _ _} F {_ _ _} unit {_}.
 
 (** ** Definition *)
 
-(** A monoidal 1-category is a 1-category with equivalences and the following data: *)
-Class IsMonoidal (A : Type) `{HasEquivs A} := {
-  (** A bifunctor [cat_tensor] called the tensor product. *)
-  cat_tensor : A -> A -> A;
+(** A monoidal 1-category is a 1-category with equivalences together with the following: *)
+Class IsMonoidal (A : Type) `{HasEquivs A}
+  (** It has a binary operation [cat_tensor] called the tensor product. *)
+  (cat_tensor : A -> A -> A)
+  (** It has a unit object [cat_tensor_unit] called the tensor unit. *)
+  (cat_tensor_unit : A)
+  (** These all satisfy the following properties: *)
+  := {
+  (** A [cat_tensor] is a 1-bifunctor. *)
   is0bifunctor_cat_tensor :: Is0Bifunctor cat_tensor;
   is1bifunctor_cat_tensor :: Is1Bifunctor cat_tensor;
   (** A natural isomorphism [associator] witnessing the associativity of the tensor product. *)
   cat_tensor_associator :: Associator cat_tensor;
-  (** An object [cat_tensor_unit] called the tensor unit. *)
-  cat_tensor_unit : A;
   (** A natural isomorphism [left_unitor] witnessing the left unit law. *)
   cat_tensor_left_unitor :: LeftUnitor cat_tensor cat_tensor_unit;
   (** A natural isomorphism [right_unitor] witnessing the right unit law. *)

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -474,7 +474,7 @@ Global Instance isbifunctor_cat_binprod {A : Type} `{HasBinaryProducts A}
   : Is0Bifunctor (fun x y => cat_binprod x y).
 Proof.
   pose (p:=@has_products _ _ _ _ _ _ hasproductsbool_hasbinaryproducts).
-  exact (is0bifunctor_compose
+  exact (is0bifunctor_postcompose
           (Bool_rec A) (fun x => cat_prod Bool x (product:=p x))).
 Defined.
 
@@ -482,7 +482,7 @@ Global Instance is1bifunctor_cat_binprod {A : Type} `{HasBinaryProducts A}
   : Is1Bifunctor (fun x y => cat_binprod x y).
 Proof.
   pose (p:=@has_products _ _ _ _ _ _ hasproductsbool_hasbinaryproducts).
-  exact (is1bifunctor_compose
+  exact (is1bifunctor_postcompose
           (Bool_rec A) (fun x => cat_prod Bool x (product:=p x))).
 Defined.
 


### PR DESCRIPTION
We refactor the definition of a monoidal 1-category to be more inline with the rest of the wildcat library. This should also make it easier to actually use in the library. A simple example would be binary products in a pointed category.