### PR TITLE
Rename `Displayed.is**_sigma`

### DIFF
--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -166,7 +166,7 @@ Definition DEpic {A} {D : A -> Type} `{IsD1Cat A D} {a b : A}
       (g' : DHom g b' c') (h' : DHom h b' c'),
       DGpdHom p (g' $o' f') (h' $o' f') -> DGpdHom (epi c g h p) g' h'.
 
-Global Instance isgraph_sigma {A : Type} (D : A -> Type) `{IsDGraph A D}
+Global Instance isgraph_total {A : Type} (D : A -> Type) `{IsDGraph A D}
   : IsGraph (sig D).
 Proof.
   srapply Build_IsGraph.
@@ -174,7 +174,7 @@ Proof.
   exact {f : a $-> b & DHom f a' b'}.
 Defined.
 
-Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{IsD01Cat A D}
+Global Instance is01cat_total {A : Type} (D : A -> Type) `{IsD01Cat A D}
   : Is01Cat (sig D).
 Proof.
   srapply Build_Is01Cat.
@@ -184,7 +184,7 @@ Proof.
     exact (g $o f; g' $o' f').
 Defined.
 
-Global Instance is0gpd_sigma {A : Type} (D : A -> Type) `{IsD0Gpd A D}
+Global Instance is0gpd_total {A : Type} (D : A -> Type) `{IsD0Gpd A D}
   : Is0Gpd (sig D).
 Proof.
   srapply Build_Is0Gpd.
@@ -192,7 +192,7 @@ Proof.
   exact (f^$; dgpd_rev f').
 Defined.
 
-Global Instance is0functor_pr1 {A : Type} (D : A -> Type) `{IsDGraph A D}
+Global Instance is0functor_total_pr1 {A : Type} (D : A -> Type) `{IsDGraph A D}
   : Is0Functor (pr1 : sig D -> A).
 Proof.
   srapply Build_Is0Functor.
@@ -200,7 +200,7 @@ Proof.
   exact f.
 Defined.
 
-Global Instance is2graph_sigma {A : Type} (D : A -> Type) `{IsD2Graph A D}
+Global Instance is2graph_total {A : Type} (D : A -> Type) `{IsD2Graph A D}
   : Is2Graph (sig D).
 Proof.
   intros [a a'] [b b'].
@@ -209,7 +209,7 @@ Proof.
   exact ({p : f $-> g & DHom p f' g'}).
 Defined.
 
-Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{IsD01Cat A DA}
+Global Instance is0functor_total {A : Type} (DA : A -> Type) `{IsD01Cat A DA}
   {B : Type} (DB : B -> Type) `{IsD01Cat B DB} (F : A -> B) `{!Is0Functor F}
   (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F'}
   : Is0Functor (functor_sigma F F').
@@ -220,7 +220,7 @@ Proof.
   exact (fmap F f; dfmap F F' f').
 Defined.
 
-Global Instance is1cat_sigma {A : Type} (D : A -> Type) `{IsD1Cat A D}
+Global Instance is1cat_total {A : Type} (D : A -> Type) `{IsD1Cat A D}
   : Is1Cat (sig D).
 Proof.
   srapply Build_Is1Cat.
@@ -313,7 +313,7 @@ Proof.
     exact (DHom_path (cat_idr_strong f) (dcat_idr_strong f')).
 Defined.
 
-Global Instance is1catstrong_sigma {A : Type}
+Global Instance is1catstrong_total {A : Type}
   (D : A -> Type) `{IsD1Cat_Strong A D}
   : Is1Cat_Strong (sig D).
 Proof.
@@ -350,7 +350,7 @@ Arguments dfmap_id {A B DA _ _ _ _ _ _ _ _ DB _ _ _ _ _ _ _ _}
 Arguments dfmap_comp {A B DA _ _ _ _ _ _ _ _ DB _ _ _ _ _ _ _ _}
   F {_ _} F' {_ _ a b c f g a' b' c'} f' g'.
 
-Global Instance is1functor_sigma {A B : Type} (DA : A -> Type) (DB : B -> Type)
+Global Instance is1functor_total {A B : Type} (DA : A -> Type) (DB : B -> Type)
   (F : A -> B) (F' : forall (a : A), DA a -> DB (F a)) `{IsD1Functor A B DA DB F F'}
   : Is1Functor (functor_sigma F F').
 Proof.

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -136,7 +136,7 @@ Proof.
 Defined.
 
 (** If the base category has equivalences and the displayed category has displayed equivalences, then the total category has equivalences. *)
-Global Instance hasequivs_sigma {A} (D : A -> Type) `{DHasEquivs A D}
+Global Instance hasequivs_total {A} (D : A -> Type) `{DHasEquivs A D}
   : HasEquivs (sig D).
 Proof.
   snrapply Build_HasEquivs.
@@ -540,13 +540,13 @@ Definition dcat_path_equiv {A} {D : A -> Type} `{IsDUnivalent1Cat A D}
   := (dcat_equiv_path p a' b')^-1.
 
 (** If [IsUnivalent1Cat A] and [IsDUnivalent1Cat D], then this is an equivalence by [isequiv_functor_sigma]. *)
-Definition dcat_equiv_path_sigma {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcat_equiv_path_total {A} {D : A -> Type} `{DHasEquivs A D}
   {a b : A} (a' : D a) (b' : D b)
   : {p : a = b & p # a' = b'} -> {e : a $<~> b & DCatEquiv e a' b'}
   := functor_sigma (cat_equiv_path a b) (fun p => dcat_equiv_path p a' b').
 
 (** If the base category and the displayed category are both univalent, then the total category is univalent. *)
-Global Instance isunivalent1cat_sigma {A} `{IsUnivalent1Cat A} (D : A -> Type)
+Global Instance isunivalent1cat_total {A} `{IsUnivalent1Cat A} (D : A -> Type)
   `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D, !IsD1Cat D, !DHasEquivs D}
   `{!IsDUnivalent1Cat D}
   : IsUnivalent1Cat (sig D).
@@ -554,6 +554,6 @@ Proof.
   snrapply Build_IsUnivalent1Cat.
   intros aa' bb'.
   apply (isequiv_homotopic
-          (dcat_equiv_path_sigma _ _ o (path_sigma_uncurried D aa' bb')^-1)).
+          (dcat_equiv_path_total _ _ o (path_sigma_uncurried D aa' bb')^-1)).
   intros []; reflexivity.
 Defined.


### PR DESCRIPTION
Currently, the naming of `is**_sigma` in WildCat/Displayed.v and WildCat/DisplayedEquiv.v conflicts with that of WildCat/Sigma.v. This renames `is**_sigma` to `is**_total`.