### PR TITLE
Zero-groupoid universal property for coequalizers

### DIFF
--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -55,6 +55,7 @@ Proof.
 Defined.
 
 (** ** Universal property *)
+(** See Colimits/CoeqUnivProp.v for a similar universal property without [Funext]. *)
 
 Definition Coeq_unrec {B A} (f g : B -> A) {P}
   (h : Coeq f g -> P)

--- a/theories/Colimits/CoeqUnivProp.v
+++ b/theories/Colimits/CoeqUnivProp.v
@@ -12,57 +12,26 @@ Require Import WildCat.Forall.
 Require Import WildCat.Paths.
 Require Import WildCat.ZeroGroupoid.
 
-(** Using wild 0-groupoids, the universal property can be proven without funext.  A simple equivalence of 0-groupoids between [Coeq f g -> P] and [{ h : A -> P & h o f == h o g }] would not carry all the higher-dimensional information, but if we generalize it to dependent functions, then it does suffice. *)
+(** Using wild 0-groupoids, the universal property can be proven without funext. A simple equivalence of 0-groupoids between [Coeq f g -> P] and [{ h : A -> P & h o f == h o g }] would not carry all the higher-dimensional information, but if we generalize it to dependent functions, then it does suffice. *)
 Section UnivProp.
   Context {B A : Type} (f g : B -> A) (P : Coeq f g -> Type).
 
-  (** The domain of the equivalence is the fully-applied type of [Coeq_ind]: sections of [P] over [Coeq f g] *)
-  Definition Coeq_ind_type := forall z : Coeq f g, P z.
-
-  Local Instance isgraph_Coeq_ind_type : IsGraph Coeq_ind_type.
-  Proof.
-    apply isgraph_forall; intros; apply isgraph_paths.
-  Defined.
-
-  Local Instance is01cat_Coeq_ind_type: Is01Cat Coeq_ind_type.
-  Proof.
-    apply is01cat_forall; intros; apply is01cat_paths.
-  Defined.
-
-  Local Instance is0gpd_Coeq_ind_type: Is0Gpd Coeq_ind_type.
-  Proof.
-    apply is0gpd_forall; intros; apply is0gpd_paths.
-  Defined.
-
-  Definition Coeq_ind_map := forall a : A, P (coeq a).
-
-  Local Instance isgraph_Coeq_ind_map : IsGraph Coeq_ind_map.
-  Proof.
-    apply isgraph_forall. intros; apply isgraph_paths.
-  Defined.
-
-  Local Instance is01cat_Coeq_ind_map : Is01Cat Coeq_ind_map.
-  Proof.
-    apply is01cat_forall; intros; apply is01cat_paths.
-  Defined.
-
-  Local Instance is0gpd_Coeq_ind_map : Is0Gpd Coeq_ind_map.
-  Proof.
-    apply is0gpd_forall; intros; apply is0gpd_paths.
-  Defined.
+  Local Existing Instances isgraph_forall is01cat_forall is0gpd_forall | 1.
+  Local Existing Instances isgraph_total is01cat_total is0gpd_total | 1.
+  Local Existing Instances isgraph_paths is01cat_paths is0gpd_paths | 2.
 
   (** The codomain of the equivalence is a sigma-groupoid of this family. *)
-  Definition Coeq_ind_data' (h : Coeq_ind_map)
+  Definition Coeq_ind_data (h : forall a : A, P (coeq a))
     := forall b : B, DPath P (cglue b) (h (f b)) (h (g b)).
 
-  (** We consider [Coeq_ind_data'] to be a displayed 0-groupoid over [Coeq_ind_map], where objects over [h : forall a : A, P (coeq a)] are homotopies [h o f == h o g] and morphisms over [p : h == k] are witnesses that p commutes with the homotopies over [h] and [k]. *)
-  Local Instance isdgraph_Coeq_ind_data' : IsDGraph Coeq_ind_data'.
+  (** We consider [Coeq_ind_data] to be a displayed 0-groupoid, where objects over [h : forall a : A, P (coeq a)] are homotopies [h o f == h o g] and morphisms over [p : h == k] are witnesses that p commutes with the homotopies over [h] and [k]. *)
+  Local Instance isdgraph_Coeq_ind_data : IsDGraph Coeq_ind_data.
   Proof.
     intros h k p r s.
     exact (forall b, ap (transport P (cglue b)) (p (f b)) @ s b = r b @ p (g b)).
   Defined.
 
-  Local Instance isd01cat_Coeq_ind_data' : IsD01Cat Coeq_ind_data'.
+  Local Instance isd01cat_Coeq_ind_data : IsD01Cat Coeq_ind_data.
   Proof.
     nrapply Build_IsD01Cat.
     - intros h h' b; exact (concat_1p_p1 _).
@@ -74,7 +43,7 @@ Section UnivProp.
       nrapply concat_pp_p.
   Defined.
 
-  Local Instance isd0gpd_Coeq_ind_data' : IsD0Gpd Coeq_ind_data'.
+  Local Instance isd0gpd_Coeq_ind_data : IsD0Gpd Coeq_ind_data.
   Proof.
     intros h k p r s p' b.
     lhs nrapply (whiskerR (ap_V _ _)).
@@ -86,25 +55,8 @@ Section UnivProp.
     nrapply concat_1p.
   Defined.
 
-  (** The codomain of the equivalence, consisting of input data for [Coeq_ind]. *)
-  Definition Coeq_ind_data := sig Coeq_ind_data'.
-
-  Local Instance isgraph_Coeq_ind_data : IsGraph Coeq_ind_data.
-  Proof.
-    rapply isgraph_total.
-  Defined.
-
-  Local Instance is01cat_Coeq_ind_data : Is01Cat Coeq_ind_data.
-  Proof.
-    rapply is01cat_total.
-  Defined.
-
-  Local Instance is0gpd_Coeq_ind_data : Is0Gpd Coeq_ind_data.
-  Proof.
-    rapply is0gpd_total.
-  Defined.
-
-  Definition Coeq_ind_inv : Coeq_ind_type -> Coeq_ind_data.
+  (** Here is the functor. The domain is the fully-applied type of [Coeq_ind]: sections of [P] over [Coeq f g]. The codomain consists of input data for [Coeq_ind]. *)
+  Definition Coeq_ind_inv : (forall z : Coeq f g, P z) -> sig Coeq_ind_data.
   Proof.
     intros h.
     exists (h o coeq).
@@ -145,7 +97,8 @@ Section UnivProp.
   Defined.
 
   Definition equiv_0gpd_Coeq_ind
-    : Build_ZeroGpd Coeq_ind_type _ _ _ $<~> Build_ZeroGpd Coeq_ind_data _ _ _.
+    : Build_ZeroGpd (forall z : Coeq f g, P z) _ _ _
+      $<~> Build_ZeroGpd (sig Coeq_ind_data) _ _ _.
   Proof.
     snrapply Build_CatEquiv.
     1: rapply Build_Morphism_0Gpd.

--- a/theories/Colimits/CoeqUnivProp.v
+++ b/theories/Colimits/CoeqUnivProp.v
@@ -16,6 +16,7 @@ Require Import WildCat.ZeroGroupoid.
 Section UnivProp.
   Context {B A : Type} (f g : B -> A) (P : Coeq f g -> Type).
 
+  (** This allows Coq to infer 0-groupoid structures of the form [@isgraph_forall _ P (fun a => isgraph_paths (P a))] whenever the (co)domain is of the form [forall z, P z]. *)
   Local Existing Instances isgraph_forall is01cat_forall is0gpd_forall | 1.
   Local Existing Instances isgraph_total is01cat_total is0gpd_total | 1.
   Local Existing Instances isgraph_paths is01cat_paths is0gpd_paths | 2.
@@ -24,7 +25,7 @@ Section UnivProp.
   Definition Coeq_ind_data (h : forall a : A, P (coeq a))
     := forall b : B, DPath P (cglue b) (h (f b)) (h (g b)).
 
-  (** We consider [Coeq_ind_data] to be a displayed 0-groupoid, where objects over [h : forall a : A, P (coeq a)] are homotopies [h o f == h o g] and morphisms over [p : h == k] are witnesses that p commutes with the homotopies over [h] and [k]. *)
+  (** We consider [Coeq_ind_data] to be a displayed 0-groupoid, where objects over [h : forall a : A, P (coeq a)] are dependent paths as defined above and morphisms over [p : h == k] are witnesses that p commutes with the homotopies over [h] and [k]. *)
   Local Instance isdgraph_Coeq_ind_data : IsDGraph Coeq_ind_data.
   Proof.
     intros h k p r s.
@@ -55,7 +56,7 @@ Section UnivProp.
     nrapply concat_1p.
   Defined.
 
-  (** Here is the functor. The domain is the fully-applied type of [Coeq_ind]: sections of [P] over [Coeq f g]. The codomain consists of input data for [Coeq_ind]. *)
+  (** Here is the functor. The domain is the fully-applied type of [Coeq_ind]: sections of [P] over [Coeq f g]. The codomain consists of input data for [Coeq_ind] given a 0-groupoid structure via [is0gpd_total]. *)
   Definition Coeq_ind_inv : (forall z : Coeq f g, P z) -> sig Coeq_ind_data.
   Proof.
     intros h.

--- a/theories/Colimits/CoeqUnivProp.v
+++ b/theories/Colimits/CoeqUnivProp.v
@@ -16,7 +16,7 @@ Require Import WildCat.ZeroGroupoid.
 Section UnivProp.
   Context {B A : Type} (f g : B -> A) (P : Coeq f g -> Type).
 
-  (** This allows Coq to infer 0-groupoid structures of the form [@isgraph_forall _ P (fun a => isgraph_paths (P a))] whenever the (co)domain is of the form [forall z, P z]. *)
+  (** This allows Coq to infer 0-groupoid structures of the form [@isgraph_forall C P (fun c => isgraph_paths (P c))] on any type of the form [forall c, P c]. *)
   Local Existing Instances isgraph_forall is01cat_forall is0gpd_forall | 1.
   Local Existing Instances isgraph_total is01cat_total is0gpd_total | 1.
   Local Existing Instances isgraph_paths is01cat_paths is0gpd_paths | 2.
@@ -65,6 +65,7 @@ Section UnivProp.
     exact (apD h (cglue b)).
   Defined.
 
+  (** Use [Set Printing Implicit] to see the 0-groupoid structures described above. *)
   Local Instance is0functor_Coeq_ind_inv : Is0Functor Coeq_ind_inv.
   Proof.
     nrapply Build_Is0Functor.

--- a/theories/Colimits/CoeqUnivProp.v
+++ b/theories/Colimits/CoeqUnivProp.v
@@ -1,0 +1,155 @@
+Require Import Basics.Overture.
+Require Import Basics.Tactics.
+Require Import Basics.PathGroupoids.
+Require Import Types.Paths.
+Require Import Colimits.Coeq.
+Require Import Cubical.DPath.
+Require Import WildCat.Core.
+Require Import WildCat.Displayed.
+Require Import WildCat.Equiv.
+Require Import WildCat.EquivGpd.
+Require Import WildCat.Forall.
+Require Import WildCat.Paths.
+Require Import WildCat.ZeroGroupoid.
+
+(** Using wild 0-groupoids, the universal property can be proven without funext.  A simple equivalence of 0-groupoids between [Coeq f g -> P] and [{ h : A -> P & h o f == h o g }] would not carry all the higher-dimensional information, but if we generalize it to dependent functions, then it does suffice. *)
+Section UnivProp.
+  Context {B A : Type} (f g : B -> A) (P : Coeq f g -> Type).
+
+  (** The domain of the equivalence is the fully-applied type of [Coeq_ind]: sections of [P] over [Coeq f g] *)
+  Definition Coeq_ind_type := forall z : Coeq f g, P z.
+
+  Local Instance isgraph_Coeq_ind_type : IsGraph Coeq_ind_type.
+  Proof.
+    apply isgraph_forall; intros; apply isgraph_paths.
+  Defined.
+
+  Local Instance is01cat_Coeq_ind_type: Is01Cat Coeq_ind_type.
+  Proof.
+    apply is01cat_forall; intros; apply is01cat_paths.
+  Defined.
+
+  Local Instance is0gpd_Coeq_ind_type: Is0Gpd Coeq_ind_type.
+  Proof.
+    apply is0gpd_forall; intros; apply is0gpd_paths.
+  Defined.
+
+  Definition Coeq_ind_map := forall a : A, P (coeq a).
+
+  Local Instance isgraph_Coeq_ind_map : IsGraph Coeq_ind_map.
+  Proof.
+    apply isgraph_forall. intros; apply isgraph_paths.
+  Defined.
+
+  Local Instance is01cat_Coeq_ind_map : Is01Cat Coeq_ind_map.
+  Proof.
+    apply is01cat_forall; intros; apply is01cat_paths.
+  Defined.
+
+  Local Instance is0gpd_Coeq_ind_map : Is0Gpd Coeq_ind_map.
+  Proof.
+    apply is0gpd_forall; intros; apply is0gpd_paths.
+  Defined.
+
+  (** The codomain of the equivalence is a sigma-groupoid of this family. *)
+  Definition Coeq_ind_data' (h : Coeq_ind_map)
+    := forall b : B, DPath P (cglue b) (h (f b)) (h (g b)).
+
+  (** We consider [Coeq_ind_data'] to be a displayed 0-groupoid over [Coeq_ind_map], where objects over [h : forall a : A, P (coeq a)] are homotopies [h o f == h o g] and morphisms over [p : h == k] are witnesses that p commutes with the homotopies over [h] and [k]. *)
+  Local Instance isdgraph_Coeq_ind_data' : IsDGraph Coeq_ind_data'.
+  Proof.
+    intros h k p r s.
+    exact (forall b, ap (transport P (cglue b)) (p (f b)) @ s b = r b @ p (g b)).
+  Defined.
+
+  Local Instance isd01cat_Coeq_ind_data' : IsD01Cat Coeq_ind_data'.
+  Proof.
+    nrapply Build_IsD01Cat.
+    - intros h h' b; exact (concat_1p_p1 _).
+    - intros h k j p q h' k' j' p' q' b.
+      lhs nrapply ap_pp_p.
+      lhs nrapply (whiskerL _ (p' b)).
+      lhs nrapply concat_p_pp.
+      lhs nrapply (whiskerR (q' b)).
+      nrapply concat_pp_p.
+  Defined.
+
+  Local Instance isd0gpd_Coeq_ind_data' : IsD0Gpd Coeq_ind_data'.
+  Proof.
+    intros h k p r s p' b.
+    lhs nrapply (whiskerR (ap_V _ _)).
+    nrapply moveL_pV.
+    lhs nrapply concat_pp_p.
+    lhs nrapply (whiskerL _ (p' b)^).
+    lhs nrapply concat_p_pp.
+    lhs nrapply (whiskerR (concat_Vp _)).
+    nrapply concat_1p.
+  Defined.
+
+  (** The codomain of the equivalence, consisting of input data for [Coeq_ind]. *)
+  Definition Coeq_ind_data := sig Coeq_ind_data'.
+
+  Local Instance isgraph_Coeq_ind_data : IsGraph Coeq_ind_data.
+  Proof.
+    rapply isgraph_total.
+  Defined.
+
+  Local Instance is01cat_Coeq_ind_data : Is01Cat Coeq_ind_data.
+  Proof.
+    rapply is01cat_total.
+  Defined.
+
+  Local Instance is0gpd_Coeq_ind_data : Is0Gpd Coeq_ind_data.
+  Proof.
+    rapply is0gpd_total.
+  Defined.
+
+  Definition Coeq_ind_inv : Coeq_ind_type -> Coeq_ind_data.
+  Proof.
+    intros h.
+    exists (h o coeq).
+    intros b.
+    exact (apD h (cglue b)).
+  Defined.
+
+  Local Instance is0functor_Coeq_ind_inv : Is0Functor Coeq_ind_inv.
+  Proof.
+    nrapply Build_Is0Functor.
+    intros h k p.
+    exists (p o coeq).
+    intros b.
+    nrapply moveL_pM.
+    exact ((apD_homotopic p (cglue b))^).
+  Defined.
+
+  Local Instance issurjinj_Coeq_ind_inv : IsSurjInj Coeq_ind_inv.
+  Proof.
+    nrapply Build_IsSurjInj.
+    - intros [h r].
+      exists (Coeq_ind P h r).
+      exists (fun a => idpath).
+      intros b.
+      nrefine (concat_1p _ @ _ @ (concat_p1 _)^).
+      symmetry.
+      nrapply Coeq_ind_beta_cglue.
+    - intros h k [p p'].
+      snrapply Coeq_ind.
+      1: exact p.
+      intros b; specialize (p' b).
+      lhs nrapply transport_paths_FlFr_D.
+      lhs nrapply concat_pp_p.
+      lhs nrapply (whiskerL _ p').
+      lhs nrapply concat_p_pp.
+      lhs nrapply (whiskerR (concat_Vp _)).
+      nrapply concat_1p.
+  Defined.
+
+  Definition equiv_0gpd_Coeq_ind
+    : Build_ZeroGpd Coeq_ind_type _ _ _ $<~> Build_ZeroGpd Coeq_ind_data _ _ _.
+  Proof.
+    snrapply Build_CatEquiv.
+    1: rapply Build_Morphism_0Gpd.
+    rapply isequiv_0gpd_issurjinj.
+  Defined.
+
+End UnivProp.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -166,7 +166,7 @@ Definition DEpic {A} {D : A -> Type} `{IsD1Cat A D} {a b : A}
       (g' : DHom g b' c') (h' : DHom h b' c'),
       DGpdHom p (g' $o' f') (h' $o' f') -> DGpdHom (epi c g h p) g' h'.
 
-Global Instance isgraph_sigma {A : Type} (D : A -> Type) `{IsDGraph A D}
+Global Instance isgraph_total {A : Type} (D : A -> Type) `{IsDGraph A D}
   : IsGraph (sig D).
 Proof.
   srapply Build_IsGraph.
@@ -174,7 +174,7 @@ Proof.
   exact {f : a $-> b & DHom f a' b'}.
 Defined.
 
-Global Instance is01cat_sigma {A : Type} (D : A -> Type) `{IsD01Cat A D}
+Global Instance is01cat_total {A : Type} (D : A -> Type) `{IsD01Cat A D}
   : Is01Cat (sig D).
 Proof.
   srapply Build_Is01Cat.
@@ -184,7 +184,7 @@ Proof.
     exact (g $o f; g' $o' f').
 Defined.
 
-Global Instance is0gpd_sigma {A : Type} (D : A -> Type) `{IsD0Gpd A D}
+Global Instance is0gpd_total {A : Type} (D : A -> Type) `{IsD0Gpd A D}
   : Is0Gpd (sig D).
 Proof.
   srapply Build_Is0Gpd.
@@ -192,7 +192,7 @@ Proof.
   exact (f^$; dgpd_rev f').
 Defined.
 
-Global Instance is0functor_pr1 {A : Type} (D : A -> Type) `{IsDGraph A D}
+Global Instance is0functor_total_pr1 {A : Type} (D : A -> Type) `{IsDGraph A D}
   : Is0Functor (pr1 : sig D -> A).
 Proof.
   srapply Build_Is0Functor.
@@ -200,7 +200,7 @@ Proof.
   exact f.
 Defined.
 
-Global Instance is2graph_sigma {A : Type} (D : A -> Type) `{IsD2Graph A D}
+Global Instance is2graph_total {A : Type} (D : A -> Type) `{IsD2Graph A D}
   : Is2Graph (sig D).
 Proof.
   intros [a a'] [b b'].
@@ -209,7 +209,7 @@ Proof.
   exact ({p : f $-> g & DHom p f' g'}).
 Defined.
 
-Global Instance is0functor_sigma {A : Type} (DA : A -> Type) `{IsD01Cat A DA}
+Global Instance is0functor_total {A : Type} (DA : A -> Type) `{IsD01Cat A DA}
   {B : Type} (DB : B -> Type) `{IsD01Cat B DB} (F : A -> B) `{!Is0Functor F}
   (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F'}
   : Is0Functor (functor_sigma F F').
@@ -220,7 +220,7 @@ Proof.
   exact (fmap F f; dfmap F F' f').
 Defined.
 
-Global Instance is1cat_sigma {A : Type} (D : A -> Type) `{IsD1Cat A D}
+Global Instance is1cat_total {A : Type} (D : A -> Type) `{IsD1Cat A D}
   : Is1Cat (sig D).
 Proof.
   srapply Build_Is1Cat.
@@ -313,7 +313,7 @@ Proof.
     exact (DHom_path (cat_idr_strong f) (dcat_idr_strong f')).
 Defined.
 
-Global Instance is1catstrong_sigma {A : Type}
+Global Instance is1catstrong_total {A : Type}
   (D : A -> Type) `{IsD1Cat_Strong A D}
   : Is1Cat_Strong (sig D).
 Proof.
@@ -350,7 +350,7 @@ Arguments dfmap_id {A B DA _ _ _ _ _ _ _ _ DB _ _ _ _ _ _ _ _}
 Arguments dfmap_comp {A B DA _ _ _ _ _ _ _ _ DB _ _ _ _ _ _ _ _}
   F {_ _} F' {_ _ a b c f g a' b' c'} f' g'.
 
-Global Instance is1functor_sigma {A B : Type} (DA : A -> Type) (DB : B -> Type)
+Global Instance is1functor_total {A B : Type} (DA : A -> Type) (DB : B -> Type)
   (F : A -> B) (F' : forall (a : A), DA a -> DB (F a)) `{IsD1Functor A B DA DB F F'}
   : Is1Functor (functor_sigma F F').
 Proof.

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -136,7 +136,7 @@ Proof.
 Defined.
 
 (** If the base category has equivalences and the displayed category has displayed equivalences, then the total category has equivalences. *)
-Global Instance hasequivs_sigma {A} (D : A -> Type) `{DHasEquivs A D}
+Global Instance hasequivs_total {A} (D : A -> Type) `{DHasEquivs A D}
   : HasEquivs (sig D).
 Proof.
   snrapply Build_HasEquivs.
@@ -540,13 +540,13 @@ Definition dcat_path_equiv {A} {D : A -> Type} `{IsDUnivalent1Cat A D}
   := (dcat_equiv_path p a' b')^-1.
 
 (** If [IsUnivalent1Cat A] and [IsDUnivalent1Cat D], then this is an equivalence by [isequiv_functor_sigma]. *)
-Definition dcat_equiv_path_sigma {A} {D : A -> Type} `{DHasEquivs A D}
+Definition dcat_equiv_path_total {A} {D : A -> Type} `{DHasEquivs A D}
   {a b : A} (a' : D a) (b' : D b)
   : {p : a = b & p # a' = b'} -> {e : a $<~> b & DCatEquiv e a' b'}
   := functor_sigma (cat_equiv_path a b) (fun p => dcat_equiv_path p a' b').
 
 (** If the base category and the displayed category are both univalent, then the total category is univalent. *)
-Global Instance isunivalent1cat_sigma {A} `{IsUnivalent1Cat A} (D : A -> Type)
+Global Instance isunivalent1cat_total {A} `{IsUnivalent1Cat A} (D : A -> Type)
   `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D, !IsD1Cat D, !DHasEquivs D}
   `{!IsDUnivalent1Cat D}
   : IsUnivalent1Cat (sig D).
@@ -554,6 +554,6 @@ Proof.
   snrapply Build_IsUnivalent1Cat.
   intros aa' bb'.
   apply (isequiv_homotopic
-          (dcat_equiv_path_sigma _ _ o (path_sigma_uncurried D aa' bb')^-1)).
+          (dcat_equiv_path_total _ _ o (path_sigma_uncurried D aa' bb')^-1)).
   intros []; reflexivity.
 Defined.


### PR DESCRIPTION
Addresses step (3) from #1259. A few notes:

- The graph structure that I put on things "worked", but is there a more correct alternative?
- The naming of the file is a bit awkward. Assuming that we want to add naturality of this universal property w.r.t. `functor_coeq` (step (4) from 1259), my thought was that the combination of the two would make Colimits/Coeq.v untenably long, so I decided to separate this.
- I'm still making sense of the comment [here](https://github.com/gio256/Coq-HoTT/blob/82aece3a1983231dea398550e09031ce3974ec57/theories/Homotopy/Suspension.v#L284), but it seems to imply that we might need a small disclaimer on this, at least until step (4) is added.