### PR TITLE
(2,1)-cat structure for paths

### DIFF
--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -92,7 +92,7 @@ Proof.
     by destruct h, s, r, q.
   - intros a b p q h; cbn.
     apply moveL_Mp.
-    (* TODO: the naturliaty condition in path groupoids is not in the most natural form. *)
+    (* TODO: the naturality condition in PathGroupoids.v is not in the most natural form. *)
     lhs nrapply concat_p_pp.
     exact (whiskerR_p1 h).
   - intros a b p q h. simpl. hnf.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -1,5 +1,5 @@
-Require Import Basics.Overture.
-Require Import WildCat.Core.
+Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids.
+Require Import WildCat.Core WildCat.TwoOneCat.
 
 (** * Path groupoids as wild categories *)
 
@@ -21,4 +21,87 @@ Local Instance is0gpd_paths (A : Type) : Is0Gpd A.
 Proof.
   constructor.
   intros x y p; exact (p^).
+Defined.
+
+Local Instance is2graph_paths (A : Type) : Is2Graph A := fun _ _ => _.
+Local Instance is3graph_paths (A : Type) : Is3Graph A := fun _ _ => _.
+
+Local Instance is1cat_paths {A : Type} : Is1Cat A.
+Proof.
+  snrapply Build_Is1Cat.
+  - exact _.
+  - exact _.
+  - intros x y z p.
+    snrapply Build_Is0Functor.
+    intros q r h.
+    exact (whiskerR h p).
+  - intros x y z p.
+    snrapply Build_Is0Functor.
+    intros q r h.
+    exact (whiskerL p h).
+  - intros w x y z p q r.
+    exact (concat_p_pp p q r). 
+  - intros x y p.
+    exact (concat_p1 p).
+  - intros x y p.
+    exact (concat_1p p).
+Defined.
+
+Local Instance is1gpd_paths {A : Type} : Is1Gpd A.
+Proof.
+  snrapply Build_Is1Gpd.
+  - intros x y p.
+    exact (concat_pV p).
+  - intros x y p.
+    exact (concat_Vp p).
+Defined.
+
+Local Instance is21cat_paths {A : Type} : Is21Cat A.
+Proof.
+  snrapply Build_Is21Cat.
+  - exact _.
+  - exact _.
+  - intros x y z p.
+    snrapply Build_Is1Functor.
+    + intros a b q r h.
+      (* TODO: missing from path groupoids? *)
+      by destruct h.
+    + reflexivity.
+    + intros a b c q r.
+      exact (whiskerR_pp p q r).
+  - intros x y z p.
+    snrapply Build_Is1Functor.
+    + intros a b q r h.
+      (* TODO: missing from path groupoids *)
+      by destruct h.
+    + reflexivity.
+    + intros a b c q r.
+      exact (whiskerL_pp p q r).
+  - intros a b c q r s t h g.
+    simpl. cbn.
+    symmetry.
+    exact (concat_whisker q r s t h g).
+  - intros a b c d q r s t h.
+    (* TODO: missing from path groupoids *)
+    by destruct h, s, r, q.
+  - intros a b c d q r s t h.
+    (* TODO: missing from path groupoids *)
+    by destruct h, s, r, q.
+  - intros a b c d q r s t h.
+    (* TODO: missing from path groupoids *)
+    by destruct h, s, r, q.
+  - intros a b p q h; cbn.
+    apply moveL_Mp.
+    (* TODO: the naturliaty condition in path groupoids is not in the most natural form. *)
+    lhs nrapply concat_p_pp.
+    exact (whiskerR_p1 h).
+  - intros a b p q h. simpl. hnf.
+    apply moveL_Mp.
+    lhs rapply concat_p_pp.
+    exact (whiskerL_1p h).
+  - intros a b c d e p q r s.
+    lhs nrapply concat_p_pp.
+    exact (pentagon p q r s).
+  - intros a b c p q.
+    exact (triangulator p q).
 Defined.


### PR DESCRIPTION
We show that types are themselves (2,1)-categories in the obvious way. This can be useful when building higher morphisms for various structures. It also serves as a guiding principle for what is missing in PathGroupoids. I've added some TODO's so we can eventually add such lemmas in.