### PR TITLE
remove bg_scope

### DIFF
--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -12,9 +12,6 @@ Local Open Scope mc_scope.
 Local Open Scope trunc_scope.
 Local Open Scope mc_mult_scope.
 
-Declare Scope bg_scope.
-Local Open Scope bg_scope.
-
 (** * We define the Classifying space of a group to be the following HIT:
 
   HIT ClassifyingSpace (G : Group) : 1-Type

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -16,7 +16,6 @@ Require Import WildCat.
 
 Local Open Scope pointed_scope.
 Local Open Scope nat_scope.
-Local Open Scope bg_scope.
 Local Open Scope mc_mult_scope.
 
 (** The definition of the Eilenberg-Mac Lane spaces.  Note that while we allow [G] to be non-abelian for [n > 1], later results will need to assume that [G] is abelian. *)


### PR DESCRIPTION
This scope was introduced for the `B` notation, however it was later converted to an abbreviation IIRC making leaving it unused.