### PR TITLE
pointed truncation preserves products

### DIFF
--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -148,6 +148,15 @@ Proof.
     reflexivity.
 Defined.
 
+(** Pointed truncation preserves binary products. *)
+Definition pequiv_ptr_prod (n : trunc_index) (A B : pType)
+  : pTr n (A * B) <~>* pTr n A * pTr n B.
+Proof.
+  snrapply Build_pEquiv'.
+  1: nrapply equiv_Trunc_prod_cmp.
+  reflexivity.
+Defined.
+
 (** ** Truncatedness of [pForall] and [pMap] *)
 
 (** Buchholtz-van Doorn-Rijke, Theorem 4.2:  Let [j >= -1] and [n >= -2].  When [X] is [j]-connected and [Y] is a pointed family of [j+k+1]-truncated types, the type of pointed sections is [n]-truncated.  We formalize it with [j] replaced with a trunc index [m], and so there is a shift compared to the informal statement. This version also allows [n] to be one smaller than BvDR allow. *)


### PR DESCRIPTION
Simple corollary that pointed truncations preserve pointed products.