### PR TITLE
bump to dune 3.13

### DIFF
--- a/contrib/dune
+++ b/contrib/dune
@@ -1,6 +1,4 @@
 (coq.theory
  (name HoTT.Contrib)
  (package coq-hott)
- (flags -noinit -indices-matter -color on)
- (coqdoc_flags :standard --interpolate --utf8 --no-externals --parse-comments)
  (theories HoTT))

--- a/coq-hott.opam
+++ b/coq-hott.opam
@@ -16,7 +16,7 @@ license: "BSD-2-Clause"
 homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 depends: [
-  "dune" {>= "3.8"}
+  "dune" {>= "3.13"}
   "coq" {>= "8.18.0"}
   "odoc" {with-doc}
 ]

--- a/dune
+++ b/dune
@@ -63,6 +63,28 @@
  (action
   (run etc/emacs/run-etags.sh %{vfile})))
 
+; Common flags for Coq
+
+(env
+ (dev
+  (coq
+   (coqdoc_flags
+    :standard
+    --interpolate
+    --utf8
+    --no-externals
+    --parse-comments)
+   (flags -noinit -indices-matter -color on)))
+ (_
+  (coq
+   (coqdoc_flags
+    :standard
+    --interpolate
+    --utf8
+    --no-externals
+    --parse-comments)
+   (flags -noinit -indices-matter))))
+
 ; Bench
 
 ; The following rule allows you to bench the running time of a file using

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.8)
+(lang dune 3.13)
 
 (using coq 0.8)
 

--- a/test/dune
+++ b/test/dune
@@ -1,8 +1,6 @@
 (coq.theory
  (name HoTT.Tests)
- (theories HoTT)
- (flags -noinit -indices-matter -color on)
- (coqdoc_flags :standard --interpolate --utf8 --no-externals --parse-comments))
+ (theories HoTT))
 
 (include_subdirs qualified)
 

--- a/theories/dune
+++ b/theories/dune
@@ -6,7 +6,4 @@
 
 (coq.theory
  (name HoTT)
- (package coq-hott)
- (modules :standard)
- (flags -noinit -indices-matter -color on)
- (coqdoc_flags :standard --interpolate --utf8 --no-externals --parse-comments))
+ (package coq-hott))


### PR DESCRIPTION
We have some better support for sharing flags in Dune 3.13 allowing us to reduce the size of the coq.theory stanzas.