### PR TITLE
cleanup and document Group.v

### DIFF
--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -274,7 +274,7 @@ Defined.
 Definition grp_iso_id {G : Group} : GroupIsomorphism G G
   := Build_GroupIsomorphism _ _ grp_homo_id _.
 
-(** Group isomorphisms can be composed by composing the underlying group homomorphism. This is equivalence because equivalences are also preserved under composition. *)
+(** Group isomorphisms can be composed by composing the underlying group homomorphism. *)
 Definition grp_iso_compose {G H K : Group}
   (g : GroupIsomorphism H K) (f : GroupIsomorphism G H)
   : GroupIsomorphism G K

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -28,7 +28,7 @@ Declare Scope group_scope.
 
 (** * Groups *)
 
-(** A group is an abstraction of several common situations in mathematics. For example, when considering the symmetries of an object you may notice that there are ways in which certain symmetries can be "combined". There are also other symmetries can be "reversed", as to undo the original symmetry and yield a symmetry that does "nothing". Such situations arise in geometry, algebra and importantly for us homotopy theory. *)
+(** A group is an abstraction of several common situations in mathematics. For example, consider the symmetries of an object.  Two symmetries can be combined; there is a symmetry that does nothing; and any symmetry can be reversed. Such situations arise in geometry, algebra and, importantly for us, homotopy theory. *)
 
 Local Open Scope pointed_scope.
 Local Open Scope mc_mult_scope.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -290,17 +290,17 @@ Proof.
   - exact _.
 Defined.
 
-(** Group isomorphisms are a reflexive relation. *)
+(** Group isomorphism is a reflexive relation. *)
 Global Instance reflexive_groupisomorphism
   : Reflexive GroupIsomorphism
   := fun G => grp_iso_id.
 
-(** Group isomorphisms are a symmetric relation. *)
+(** Group isomorphism is a symmetric relation. *)
 Global Instance symmetric_groupisomorphism
   : Symmetric GroupIsomorphism
   := fun G H => grp_iso_inverse.
 
-(** Group isomorphisms are a transitive relation. *)
+(** Group isomorphism is a transitive relation. *)
 Global Instance transitive_groupisomorphism
   : Transitive GroupIsomorphism
   := fun G H K f g => grp_iso_compose g f.
@@ -374,7 +374,7 @@ Proof.
   apply grp_inv_r.
 Defined.
 
-(** The operation inverting group elements is an equivalence. Note that since the order of the operation will change after inversion that this isn't a group homomorphism. *)
+(** The operation inverting group elements is an equivalence. Note that, since the order of the operation will change after inversion, this isn't a group homomorphism. *)
 Global Instance isequiv_group_inverse {G : Group}
   : IsEquiv ((-) : G -> G).
 Proof.
@@ -489,7 +489,7 @@ Defined.
 
 (** ** The category of Groups *)
 
-(** ** Groups together with homomorphisms form a 1-category whose equivalences are the group isomorphsisms. *)
+(** ** Groups together with homomorphisms form a 1-category whose equivalences are the group isomorphisms. *)
 
 Global Instance isgraph_group : IsGraph Group
   := Build_IsGraph Group GroupHomomorphism.
@@ -544,7 +544,7 @@ Proof.
   intros []; reflexivity. 
 Defined.
 
-(** Group isomorphisms become equivalences in the category of gorups. *)
+(** Group isomorphisms become equivalences in the category of groups. *)
 Global Instance hasequivs_group
   : HasEquivs Group.
 Proof.
@@ -652,7 +652,7 @@ Definition grp_homo_const {G H : Group} : GroupHomomorphism G H
 
 (** ** The direct product of groups *)
 
-(** The cartesian product of the underlying sets of two groups has a natural group structure we can give it. We call this the direct product of groups. *)
+(** The cartesian product of the underlying sets of two groups has a natural group structure. We call this the direct product of groups. *)
 Definition grp_prod : Group -> Group -> Group.
 Proof.
   intros G H.
@@ -710,7 +710,7 @@ Proof.
   exact (snd ((equiv_path_prod _ _)^-1 q)).
 Defined.
 
-(** Given two pairs of isomorphic groups we can conclude that their pairwise direct products ought to be isomorphic. *)
+(** Given two pairs of isomorphic groups, their pairwise direct products are isomorphic. *)
 Definition grp_iso_prod {A B C D : Group}
   : A ≅ B -> C ≅ D -> (grp_prod A C) ≅ (grp_prod B D).
 Proof.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -280,7 +280,7 @@ Definition grp_iso_compose {G H K : Group}
   : GroupIsomorphism G K
   := Build_GroupIsomorphism _ _ (grp_homo_compose g f) _.
 
-(** Group isomorphisms can be inverted unlike regular group homomorphisms. The inverse map of the underlying equivalence also preserves the group operation and unit. *)
+(** Group isomorphisms can be inverted. The inverse map of the underlying equivalence also preserves the group operation and unit. *)
 Definition grp_iso_inverse {G H : Group}
   : GroupIsomorphism G H -> GroupIsomorphism H G.
 Proof.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -227,7 +227,7 @@ Record GroupIsomorphism (G H : Group) := Build_GroupIsomorphism {
   isequiv_group_iso :: IsEquiv grp_iso_homo;
 }.
 
-(** We can build an isomorphism from an operation preserving equivalence. *)
+(** We can build an isomorphism from an operation-preserving equivalence. *)
 Definition Build_GroupIsomorphism' {G H : Group}
   (f : G <~> H) (h : IsSemiGroupPreserving f)
   : GroupIsomorphism G H.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -124,13 +124,9 @@ Defined.
 
 (** A group homomorphism consists of a map between groups and a proof that the map preserves the group operation. *)
 Record GroupHomomorphism (G H : Group) := Build_GroupHomomorphism' {
-  grp_homo_map : group_type G -> group_type H;
-  grp_homo_ishomo :> IsMonoidPreserving grp_homo_map;
+  grp_homo_map :> group_type G -> group_type H;
+  grp_homo_ishomo :: IsMonoidPreserving grp_homo_map;
 }.
-
-(** We coerce a homomorphism to its underlying map. *)
-Coercion grp_homo_map : GroupHomomorphism >-> Funclass.
-Global Existing Instance grp_homo_ishomo.
 
 (** Group homomorphisms are pointed maps. *)
 Definition pmap_GroupHomomorphism {G H : Group} (f : GroupHomomorphism G H) : G ->* H


### PR DESCRIPTION
I've gone ahead and fixed the documentation in Group.v:
- The header styles have been fixed to be the correct ones.
- Spelling mistakes have been corrected, although I still may have missed or introduced a few.
- I've added some descriptions of the ideas that go into group theory, although nothing too deep just some introductory comments.
- I've reordered and tweaked a few things in the file.

I've been running a live server in vscode and viewing the html file built by dune in watch mode. This has been helpful in quickly updated the document and seeing how it looks.