### PR TITLE
coproduct-product inclusion map

### DIFF
--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -255,7 +255,7 @@ Defined.
 
 (** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge should land. This makes it somewhat awkward to work with, however in practice we typically only care about decidable index sets. *)
 Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
-  : cat_coprod I X $-> pproduct X.
+  : FamilyWedge I X $-> pproduct X.
 Proof.
   exact (cat_coprod_prod_incl X).
 Defined.

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -217,19 +217,6 @@ Proof.
   - exact idpath.
 Defined.
 
-(** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge should land. This makes it somewhat awkward to work with, however in practice we typically only care about decidable index sets. *)
-Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
-  : FamilyWedge I X $-> pproduct X.
-Proof.
-  snrapply fwedge_rec.
-  intro i.
-  snrapply pproduct_corec.
-  intro a.
-  destruct (dec_paths i a).
-  - destruct p; exact pmap_idmap.
-  - exact pconst.
-Defined.
-
 Global Instance hasallcoproducts_ptype : HasAllCoproducts pType.
 Proof.
   intros I X.
@@ -263,6 +250,20 @@ Proof.
     + reflexivity.
 Defined.
 
+(** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge should land. This makes it somewhat awkward to work with, however in practice we typically only care about decidable index sets. *)
+Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
+  : cat_coprod I X $-> pproduct X.
+Proof.
+  unshelve epose (f := cat_coprod_prod_incl X).
+  1-5: exact _.
+  (** TODO: why can't these instances be picked up? *)
+  { rapply (has_coproducts (I:=I)).
+    rapply has_all_coproducts. }
+  { rapply (has_products (I:=I)).
+    rapply has_all_products. }
+  exact f.
+Defined.
+  
 (** ** The pinch map on the suspension *)
 
 (** Given a suspension, there is a natural map from the suspension to the wedge of the suspension with itself. This is known as the pinch map.

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -217,6 +217,9 @@ Proof.
   - exact idpath.
 Defined.
 
+(** The following instances have poor interaction with universe minimization to set so we disable it for a bit. *)
+Local Unset Universe Minimization ToSet.
+
 Global Instance hasallcoproducts_ptype : HasAllCoproducts pType.
 Proof.
   intros I X.
@@ -254,15 +257,10 @@ Defined.
 Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
   : cat_coprod I X $-> pproduct X.
 Proof.
-  unshelve epose (f := cat_coprod_prod_incl X).
-  1-5: exact _.
-  (** TODO: why can't these instances be picked up? *)
-  { rapply (has_coproducts (I:=I)).
-    rapply has_all_coproducts. }
-  { rapply (has_products (I:=I)).
-    rapply has_all_products. }
-  exact f.
+  exact (cat_coprod_prod_incl X).
 Defined.
+
+Local Set Universe Minimization ToSet.
   
 (** ** The pinch map on the suspension *)
 

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -217,10 +217,8 @@ Proof.
   - exact idpath.
 Defined.
 
-(** The following instances have poor interaction with universe minimization to set so we disable it for a bit. *)
-Local Unset Universe Minimization ToSet.
-
-Global Instance hasallcoproducts_ptype : HasAllCoproducts pType.
+(** We specify a universe variable here to prevent minimization to [Set]. *)
+Global Instance hasallcoproducts_ptype : HasAllCoproducts pType@{u}.
 Proof.
   intros I X.
   snrapply Build_Coproduct.
@@ -253,15 +251,11 @@ Proof.
     + reflexivity.
 Defined.
 
-(** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge should land. This makes it somewhat awkward to work with, however in practice we typically only care about decidable index sets. *)
+(** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge summand should land in. *)
 Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
-  : FamilyWedge I X $-> pproduct X.
-Proof.
-  exact (cat_coprod_prod_incl X).
-Defined.
+  : FamilyWedge I X $-> pproduct X
+  := cat_coprod_prod_incl X.
 
-Local Set Universe Minimization ToSet.
-  
 (** ** The pinch map on the suspension *)
 
 (** Given a suspension, there is a natural map from the suspension to the wedge of the suspension with itself. This is known as the pinch map.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -165,6 +165,15 @@ Proof.
     apply point_eq.
 Defined.
 
+Definition pproduct_proj {A : Type} {F : A -> pType} (a : A)
+  : pproduct F ->* F a.
+Proof.
+  snrapply Build_pMap.
+  - intros x.
+    exact (x a).
+  - reflexivity.
+Defined.
+
 (** The projections from a pointed product are pointed maps. *)
 Definition pfst {A B : pType} : A * B ->* A
   := Build_pMap (A * B) A fst idpath.
@@ -714,6 +723,34 @@ Proof.
       - exact (q a). }
     simpl.
     by pelim p q f g.
+Defined.
+
+(** pType has I-indexed product. *)
+Global Instance hasallproducts_ptype `{Funext} : HasAllProducts pType.
+Proof.
+  intros I x.
+  snrapply Build_Product.
+  - exact (pproduct x).
+  - exact pproduct_proj. 
+  - exact (pproduct_corec x).
+  - intros Z f i.
+    snrapply Build_pHomotopy.
+    1: reflexivity.
+    apply moveL_pV.
+    apply equiv_1p_q1.
+    exact (apD10_path_forall _ _ (fun a => point_eq (f a)) i)^.
+  - intros Z f g p.
+    snrapply Build_pHomotopy.
+    1: intros z; funext i; apply p.
+    cbn; apply moveR_equiv_V.
+    funext i.
+    rhs nrapply ap_pp.
+    lhs nrapply (dpoint_eq (p i)).
+    cbn; f_ap.
+    + apply concat_p1.
+    + rhs nrapply (ap_V _ (dpoint_eq g)).
+      apply inverse2.
+      apply concat_p1.
 Defined.
 
 (** Some higher homotopies *)

--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -1,8 +1,8 @@
-Require Import Basics.Overture Basics.Tactics.
+Require Import Basics.Overture Basics.Tactics Basics.Decidable.
 Require Import Types.Bool.
 Require Import WildCat.Core WildCat.Equiv WildCat.Forall WildCat.NatTrans
                WildCat.Opposite WildCat.Products WildCat.Universe
-               WildCat.Yoneda WildCat.ZeroGroupoid.
+               WildCat.Yoneda WildCat.ZeroGroupoid WildCat.PointedCat.
 
 (** * Categories with coproducts *)
 
@@ -284,3 +284,21 @@ Defined.
 (** In particular, [Type] has all binary coproducts. *)
 Global Instance hasbinarycoproducts_type : HasBinaryCoproducts Type
   := {}.
+
+(** ** Coproduct-product inclusions *)
+
+(** There is a canonical map from a coproduct to a product when the indexing set has decidable equality and the category is pointed. *)
+Definition cat_coprod_prod_incl {I : Type} `{DecidablePaths I} {A : Type}
+  `{Is1Cat A, !IsPointedCat A}
+  (x : I -> A) `{!Coproduct I x, !Product I x}
+  : cat_coprod I x $-> cat_prod I x. 
+Proof.
+  apply cat_coprod_rec.
+  intros i.
+  apply cat_prod_corec.
+  intros a.
+  destruct (dec_paths i a) as [p|].
+  - destruct p.
+    exact (Id _).
+  - apply zero_morphism. 
+Defined.


### PR DESCRIPTION
This generalises the wedge inclusion to other categories. I don't see anyway of removing the decidable paths requirement. In general I would assume this is equivalent to AC.