### PR TITLE
nix: add 8.18 dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,17 +7,20 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-      in
-      {
+        makeDevShell = coqVersion:
+          pkgs.mkShell {
+            buildInputs = with pkgs."coqPackages_${coqVersion}"; [
+              pkgs.dune_3
+              pkgs.ocaml
+              coq
+              coq-lsp
+            ];
+          };
+      in {
         packages.default = pkgs.coqPackages.mkCoqDerivation {
           pname = "hott";
           version = "8.18";
@@ -25,16 +28,9 @@
           useDune = true;
         };
 
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs.coqPackages_8_19; [
-            pkgs.dune_3
-            pkgs.ocaml
-            coq
-            coq-lsp
-          ];
-        };
+        devShells.default = makeDevShell "8_19";
+        devShells.coq_8_18 = makeDevShell "8_18";
 
         formatter = pkgs.nixpkgs-fmt;
-      }
-    );
+      });
 }


### PR DESCRIPTION
This makes it easy to check an older Coq version by doing `nix develop .#coq_8_18` since we use 8.19 by default in the Nix flake.