### PR TITLE
Use Opposite.v in Equiv.v to remove duplication

### DIFF
--- a/test/WildCat/Opposite.v
+++ b/test/WildCat/Opposite.v
@@ -15,8 +15,6 @@ Definition core3 A `{HasEquivs A} : is01cat_op (A:=core A) = is01cat_core (A:=A^
 Definition core4 A `{HasEquivs A} : is2graph_op (A:=core A) = is2graph_core (A:=A^op) := 1.
 
 (** This also passes, but we comment it out as it is slow.  When uncommented, to save time, we end with [Admitted.] instead of [Defined.] *)
-(*
-Definition core5 A `{HasEquivs A} : is1cat_op (A:=core A) = is1cat_core (A:=A^op).
-  Time reflexivity. (* ~6s *)
-Admitted.
-*)
+
+Time Definition core5 A `{HasEquivs A} : is1cat_op (A:=core A) = is1cat_core (A:=A^op) := 1.
+(* Was 12s, now 0.25s. *)

--- a/test/WildCat/Opposite.v
+++ b/test/WildCat/Opposite.v
@@ -14,8 +14,6 @@ Definition core2 A `{HasEquivs A} : isgraph_op (A:=core A) = isgraph_core (A:=A^
 Definition core3 A `{HasEquivs A} : is01cat_op (A:=core A) = is01cat_core (A:=A^op) := 1.
 Definition core4 A `{HasEquivs A} : is2graph_op (A:=core A) = is2graph_core (A:=A^op) := 1.
 
-(** This also passes, but we comment it out as it is slow.  When uncommented, to save time, we end with [Admitted.] instead of [Defined.] *)
-
+(** The Opaque line reduces the time from 0.3s to 0.07s. *)
 Opaque compose_catie_isretr.
-Time Definition core5 A `{HasEquivs A} : is1cat_op (A:=core A) = is1cat_core (A:=A^op) := 1.
-(* 0.07s (or 0.3s without the Opaque line). *)
+Definition core5 A `{HasEquivs A} : is1cat_op (A:=core A) = is1cat_core (A:=A^op) := 1.

--- a/test/WildCat/Opposite.v
+++ b/test/WildCat/Opposite.v
@@ -16,5 +16,6 @@ Definition core4 A `{HasEquivs A} : is2graph_op (A:=core A) = is2graph_core (A:=
 
 (** This also passes, but we comment it out as it is slow.  When uncommented, to save time, we end with [Admitted.] instead of [Defined.] *)
 
+Opaque compose_catie_isretr.
 Time Definition core5 A `{HasEquivs A} : is1cat_op (A:=core A) = is1cat_core (A:=A^op) := 1.
-(* Was 12s, now 0.25s. *)
+(* 0.07s (or 0.3s without the Opaque line). *)

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -487,7 +487,7 @@ Definition demap_compose {A B : Type}
 Proof.
   refine (dcate_buildequiv_fun _ $@' _).
   refine (dfmap2 F F' (dcompose_cate_fun _ _) $@' _).
-  rapply dfmap_comp.
+  nrapply dfmap_comp; exact IsD1Functor0.
 Defined.
 
 (** A variant. *)

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -284,7 +284,7 @@ Definition dcompose_cate_idr {A} {D : A -> Type} `{DHasEquivs A D}
     (dcate_fun f').
 Proof.
   refine (dcompose_cate_fun f' _ $@' _ $@' dcat_idr (dcate_fun f')).
-  apply (_ $@L' dcate_buildequiv_fun _).
+  rapply (_ $@L' dcate_buildequiv_fun _).
 Defined.
 
 (** Some more convenient equalities for equivalences. The naming scheme is similar to [PathGroupoids.v].*)
@@ -293,13 +293,13 @@ Definition dcompose_V_hh {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {f : b $<~> c} {g : a $-> b} {a' : D a} {b' : D b} {c' : D c}
   (f' : DCatEquiv f b' c') (g' : DHom g a' b')
   : DGpdHom (compose_V_hh f g) (dcate_fun f'^-1$' $o' (dcate_fun f' $o' g')) g'
-  := (dcat_assoc _ _ _)^$' $@' (dcate_issect f' $@R' g') $@' dcat_idl g'.
+  := (dcat_assoc_opp _ _ _) $@' (dcate_issect f' $@R' g') $@' dcat_idl g'.
 
 Definition dcompose_h_Vh {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {f : c $<~> b} {g : a $-> b} {a' : D a} {b' : D b} {c' : D c}
   (f' : DCatEquiv f c' b') (g' : DHom g a' b')
   : DGpdHom (compose_h_Vh f g) (dcate_fun f' $o' (dcate_fun f'^-1$' $o' g')) g'
-  := (dcat_assoc _ _ _)^$' $@' (dcate_isretr f' $@R' g') $@' dcat_idl g'.
+  := (dcat_assoc_opp _ _ _) $@' (dcate_isretr f' $@R' g') $@' dcat_idl g'.
 
 Definition dcompose_hh_V {A} {D : A -> Type} `{DHasEquivs A D}
   {a b c : A} {f : b $-> c} {g : a $<~> b} {a' : D a} {b' : D b} {c' : D c}

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -479,7 +479,7 @@ Defined.
 Definition demap_compose {A B : Type}
   {DA : A -> Type} `{DHasEquivs A DA} {DB : B -> Type} `{DHasEquivs B DB}
   (F : A -> B) `{!Is0Functor F, !Is1Functor F}
-  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', !IsD1Functor F F'}
+  (F' : forall (a : A), DA a -> DB (F a)) `{!IsD0Functor F F', isd1f : !IsD1Functor F F'}
   {a b c : A} {f : a $<~> b} {g : b $<~> c} {a' : DA a} {b' : DA b} {c' : DA c}
   (f' : DCatEquiv f a' b') (g' : DCatEquiv g b' c')
   : DGpdHom (emap_compose F f g) (dcate_fun (demap F F' (g' $oE' f')))
@@ -487,7 +487,7 @@ Definition demap_compose {A B : Type}
 Proof.
   refine (dcate_buildequiv_fun _ $@' _).
   refine (dfmap2 F F' (dcompose_cate_fun _ _) $@' _).
-  nrapply dfmap_comp; exact IsD1Functor0.
+  nrapply dfmap_comp; exact isd1f.
 Defined.
 
 (** A variant. *)

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -2,6 +2,7 @@
 
 Require Import Basics.Utf8 Basics.Overture Basics.Tactics Basics.Equivalences.
 Require Import WildCat.Core.
+Require Import WildCat.Opposite.
 
 (** We declare a scope for printing [CatEquiv] as [≅] *)
 Declare Scope wc_iso_scope.
@@ -84,6 +85,30 @@ Proof.
 Defined.
 
 Notation "f ^-1$" := (cate_inv f).
+
+(** * Opposite categories preserve having equivalences. *)
+Global Instance hasequivs_op {A} `{HasEquivs A} : HasEquivs A^op.
+Proof.
+  snrapply Build_HasEquivs; intros a b; unfold op in a, b; cbn.
+  - exact (b $<~> a).
+  - apply CatIsEquiv.
+  - apply cate_fun'.
+  - apply cate_isequiv'.
+  - apply cate_buildequiv'.
+  - rapply cate_buildequiv_fun'.
+  - apply cate_inv'.
+  - rapply cate_isretr'.
+  - rapply cate_issect'.
+  - intros f g s t.
+    exact (catie_adjointify f g t s).
+Defined.
+
+Global Instance isequiv_op {A : Type} `{HasEquivs A}
+       {a b : A} (f : a $-> b) {ief : CatIsEquiv f}
+  : @CatIsEquiv A^op _ _ _ _ _ b a f.
+Proof.
+  assumption.
+Defined.
 
 Definition cate_issect {A} `{HasEquivs A} {a b} (f : a $<~> b)
   : f^-1$ $o f $== Id a.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -363,20 +363,14 @@ Defined.
 Definition cate_moveL_Ve {A} `{HasEquivs A} {a b c : A}
   (e : b $<~> c) (f : a $-> b) (g : a $-> c)
   (p : e $o f $== g)
-  : f $== e^-1$ $o g.
-Proof.
-  apply (cate_monic_equiv e).
-  exact (p $@ (compose_h_Vh _ _)^$).
-Defined.
+  : f $== e^-1$ $o g
+  := cate_moveL_eV (A:=A^op) (a:=c) (b:=b) (c:=a) e f g p.
 
 Definition cate_moveR_Ve {A} `{HasEquivs A} {a b c : A}
   (e : b $<~> c) (f : a $-> c) (g : a $-> b)
   (p : f $== e $o g)
-  : e^-1$ $o f $== g.
-Proof.
-  apply (cate_monic_equiv e).
-  exact (compose_h_Vh _ _ $@ p).
-Defined.
+  : e^-1$ $o f $== g
+  := cate_moveR_eV (A:=A^op) (a:=b) (b:=c) (c:=a) e f g p.
 
 Definition cate_moveL_V1 {A} `{HasEquivs A} {a b : A} {e : a $<~> b} (f : b $-> a)
   (p : e $o f $== Id _)
@@ -388,11 +382,8 @@ Defined.
 
 Definition cate_moveL_1V {A} `{HasEquivs A} {a b : A} {e : a $<~> b} (f : b $-> a)
   (p : f $o e $== Id _)
-  : f $== cate_fun e^-1$.
-Proof.
-  apply (cate_epic_equiv e).
-  exact (p $@ (cate_issect e)^$).
-Defined.
+  : f $== cate_fun e^-1$
+  := cate_moveL_V1 (A:=A^op) (a:=b) (b:=a) f p.
 
 Definition cate_moveR_V1 {A} `{HasEquivs A} {a b : A} {e : a $<~> b} (f : b $-> a)
   (p : Id _ $== e $o f)
@@ -404,11 +395,8 @@ Defined.
 
 Definition cate_moveR_1V {A} `{HasEquivs A} {a b : A} {e : a $<~> b} (f : b $-> a)
   (p : Id _ $== f $o e)
-  : cate_fun e^-1$ $== f.
-Proof.
-  apply (cate_epic_equiv e).
-  exact (cate_issect e $@ p).
-Defined.
+  : cate_fun e^-1$ $== f
+  := cate_moveR_V1 (A:=A^op) (a:=b) (b:=a) f p.
 
 (** Lemmas about the underlying map of an equivalence. *)
 
@@ -644,14 +632,9 @@ Proof.
   1: exact (((inx _).2 _)^$ $@ (inx _).2 _).
 Defined.
 
-Lemma cate_isterminal A `{HasEquivs A} (x y : A)
-  : IsTerminal x -> IsTerminal y -> x $<~> y.
-Proof.
-  intros tex tey.
-  srapply (cate_adjointify (tey x).1 (tex y).1).
-  1: exact (((tey _).2 _)^$ $@ (tey _).2 _).
-  1: exact (((tex _).2 _)^$ $@ (tex _).2 _).
-Defined.
+Definition cate_isterminal A `{HasEquivs A} (x y : A)
+  : IsTerminal x -> IsTerminal y -> y $<~> x
+  := cate_isinitial A^op x y.
 
 Lemma isinitial_cate A `{HasEquivs A} (x y : A)
   : x $<~> y -> IsInitial x -> IsInitial y.
@@ -664,16 +647,9 @@ Proof.
   exact ((inx z).2 _).
 Defined.
 
-Lemma isterminal_cate A `{HasEquivs A} (x y : A)
-  : x $<~> y -> IsTerminal x -> IsTerminal y.
-Proof.
-  intros f tex z.
-  exists (f $o (tex z).1).
-  intros g.
-  refine (_ $@ compose_h_Vh f _).
-  refine (_ $@L _).
-  exact ((tex z).2 _).
-Defined.
+Definition isterminal_cate A `{HasEquivs A} (x y : A)
+  : y $<~> x -> IsTerminal x -> IsTerminal y
+  := isinitial_cate A^op x y.
 
 (** * There is a default notion of equivalence for a 1-category, namely bi-invertibility. *)
 

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -252,7 +252,8 @@ Definition compose_cate_assoc_opp {A} `{HasEquivs A}
   : cate_fun (h $oE (g $oE f)) $== cate_fun ((h $oE g) $oE f).
 Proof.
   Opaque compose_catie_isretr.
-  exact (compose_cate_assoc (A:=A^op) (a:=d) (b:=c) (c:=b) (d:=a) h g f).
+  (* We use [exact_no_check] just to save a small amount of time. *)
+  exact_no_check (compose_cate_assoc (A:=A^op) (a:=d) (b:=c) (c:=b) (d:=a) h g f).
 Defined.
 Transparent compose_catie_isretr.
 

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -105,11 +105,8 @@ Defined.
 
 Global Instance isequiv_op {A : Type} `{HasEquivs A}
        {a b : A} (f : a $-> b) {ief : CatIsEquiv f}
-  : @CatIsEquiv A^op _ _ _ _ _ b a f.
-Proof.
-  assumption.
-Defined.
-
+  : @CatIsEquiv A^op _ _ _ _ _ b a f
+  := ief.
 Definition cate_issect {A} `{HasEquivs A} {a b} (f : a $<~> b)
   : f^-1$ $o f $== Id a.
 Proof.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -107,6 +107,7 @@ Global Instance isequiv_op {A : Type} `{HasEquivs A}
        {a b : A} (f : a $-> b) {ief : CatIsEquiv f}
   : @CatIsEquiv A^op _ _ _ _ _ b a f
   := ief.
+
 Definition cate_issect {A} `{HasEquivs A} {a b} (f : a $<~> b)
   : f^-1$ $o f $== Id a.
 Proof.
@@ -339,8 +340,6 @@ Definition cate_moveR_Me {A} `{HasEquivs A} {a b c : A}
   (p : f $== e^-1$ $o g)
   : e $o f $== g
   := cate_moveR_eM (A:=A^op) (a:=c) (b:=b) (c:=a) e f g p.
-
-(* TODO: lots more results are duals. *)
 
 Definition cate_moveL_eV {A} `{HasEquivs A} {a b c : A}
   (e : a $<~> b) (f : b $-> c) (g : a $-> c)

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -178,22 +178,31 @@ Proof.
     apply cate_issect.
 Defined.
 
-(** Equivalences can be composed. *)
+(** Equivalences can be composed.  In order to make use of duality, we factor out parts of the proof as two lemmas. *)
+
+Definition compose_catie_isretr {A} `{HasEquivs A} {a b c : A}
+  (g : b $<~> c) (f : a $<~> b)
+  : g $o f $o (f^-1$ $o g^-1$) $== Id c.
+Proof.
+  refine (cat_assoc _ _ _ $@ _).
+  refine ((_ $@L cat_assoc_opp _ _ _) $@ _).
+  refine ((_ $@L (cate_isretr _ $@R _)) $@ _).
+  refine ((_ $@L cat_idl _) $@ _).
+  apply cate_isretr.
+Defined.
+
+Definition compose_catie_issect {A} `{HasEquivs A} {a b c : A}
+  (g : b $<~> c) (f : a $<~> b)
+  : (f^-1$ $o g^-1$ $o (g $o f) $== Id a)
+  := compose_catie_isretr (A:=A^op) (a:=c) (b:=b) (c:=a) f g.
+
 Global Instance compose_catie {A} `{HasEquivs A} {a b c : A}
   (g : b $<~> c) (f : a $<~> b)
   : CatIsEquiv (g $o f).
 Proof.
   refine (catie_adjointify _ (f^-1$ $o g^-1$) _ _).
-  - refine (cat_assoc _ _ _ $@ _).
-    refine ((_ $@L cat_assoc_opp _ _ _) $@ _).
-    refine ((_ $@L (cate_isretr _ $@R _)) $@ _).
-    refine ((_ $@L cat_idl _) $@ _).
-    apply cate_isretr.
-  - refine (cat_assoc_opp _ _ _ $@ _).
-    refine ((cat_assoc _ _ _ $@R _) $@ _).
-    refine (((_ $@L cate_issect _) $@R _) $@ _).
-    refine ((cat_idr _ $@R _) $@ _).
-    apply cate_issect.
+  - apply compose_catie_isretr.
+  - apply compose_catie_issect.
 Defined.
 
 Global Instance compose_catie' {A} `{HasEquivs A} {a b c : A}
@@ -238,29 +247,14 @@ Proof.
   - refine (_ $@L compose_cate_funinv g f).
 Defined.
 
-Time Definition compose_cate_assoc_opp {A} `{HasEquivs A}
+Definition compose_cate_assoc_opp {A} `{HasEquivs A}
            {a b c d : A} (f : a $<~> b) (g : b $<~> c) (h : c $<~> d)
-  : cate_fun (h $oE (g $oE f)) $== cate_fun ((h $oE g) $oE f)
-:= @compose_cate_assoc (op A) (@isgraph_op A IsGraph0)
-  (@is2graph_op A IsGraph0 Is2Graph0)
-  (@is01cat_op A IsGraph0 Is01Cat0)
-  (@is1cat_op A IsGraph0 Is2Graph0 Is01Cat0 H)
-  (@hasequivs_op A IsGraph0 Is2Graph0 Is01Cat0 H H0) d c b a h g f.
-(* Why so slow?  ~3s *)
-(* But it fixes the slow test, which goes from 12s (including the Defined) to 0.2s. *)
-
-(* This also works and takes the same amount of time, ~3s:
-  := compose_cate_assoc (A:=A^op) (a:=d) (b:=c) (c:=b) (d:=a) h g f.
-*)
-
-(* This is the old proof, which is fast:
+  : cate_fun (h $oE (g $oE f)) $== cate_fun ((h $oE g) $oE f).
 Proof.
-  refine (compose_cate_fun h _ $@ _ $@ cat_assoc_opp f g h $@ _ $@
-                           compose_cate_funinv _ f).
-  - refine (_ $@L compose_cate_fun g f).
-  - refine (compose_cate_funinv h g $@R _).
+  Opaque compose_catie_isretr.
+  exact (compose_cate_assoc (A:=A^op) (a:=d) (b:=c) (c:=b) (d:=a) h g f).
 Defined.
-*)
+Transparent compose_catie_isretr.
 
 Definition compose_cate_idl {A} `{HasEquivs A}
            {a b : A} (f : a $<~> b)

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -2,6 +2,7 @@
 
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
+Require Import WildCat.Opposite.
 Require Import WildCat.Equiv.
 Require Import WildCat.Induced.
 Require Import WildCat.NatTrans.
@@ -113,6 +114,14 @@ Proof.
   - intros; apply cate_isretr.
   - intros [gamma ?] r s a; cbn in *.
     refine (catie_adjointify (alpha a) (gamma a) (r a) (s a)).
+Defined.
+
+(** Bundled opposite functors *)
+Definition fun01_op (A B : Type) `{IsGraph A} `{IsGraph B}
+  : Fun01 A B -> Fun01 A^op B^op.
+Proof.
+  intros F.
+  rapply (Build_Fun01 A^op B^op F).
 Defined.
 
 (** ** Categories of 1-coherent 1-functors *)

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -2,6 +2,7 @@ Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.Equiv.
 Require Import WildCat.Square.
+Require Import WildCat.Opposite.
 
 (** ** Natural transformations *)
 
@@ -163,6 +164,31 @@ Proof.
   exact ((p b $@R _) $@ isnat gamma f $@ (_ $@L (p a)^$)).
 Defined.
 
+(** Opposite natural transformations *)
+
+Definition transformation_op {A} {B} `{Is01Cat B}
+           (F : A -> B) (G : A -> B) (alpha : F $=> G)
+  : @Transformation A^op (fun _ => B^op) _
+                     (G : A^op -> B^op) (F : A^op -> B^op).
+Proof.
+  unfold op in *.
+  cbn in *.
+  intro a.
+  apply (alpha a).
+Defined.
+
+Global Instance is1nat_op A B `{Is01Cat A} `{Is1Cat B}
+       (F : A -> B) `{!Is0Functor F}
+       (G : A -> B) `{!Is0Functor G}
+       (alpha : F $=> G) `{!Is1Natural F G alpha}
+  : Is1Natural (G : A^op -> B^op) (F : A^op -> B^op) (transformation_op F G alpha).
+Proof.
+  unfold op.
+  unfold transformation_op.
+  intros a b f.
+  srapply isnat_tr.
+Defined.
+
 (** Natural equivalences *)
 
 Record NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
@@ -262,6 +288,16 @@ Proof.
   intros X Y f.
   refine (cat_prewhisker (id_cate_fun _) _ $@ cat_idl _ $@ _^$).
   refine (cat_postwhisker _ (id_cate_fun _) $@ cat_idr _).
+Defined.
+
+Lemma natequiv_op {A B : Type} `{Is01Cat A} `{HasEquivs B}
+  (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
+  : NatEquiv F G -> NatEquiv (G : A^op -> B^op) F.
+Proof.
+  intros [a n].
+  snrapply Build_NatEquiv.
+  1: exact a.
+  rapply is1nat_op.
 Defined.
 
 (** *** Pointed natural transformations *)

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -2,9 +2,6 @@
 
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
-Require Import WildCat.Equiv.
-Require Import WildCat.NatTrans.
-Require Import WildCat.FunctorCat.
 
 (** ** Opposite categories *)
 
@@ -122,78 +119,11 @@ Global Instance is1functor_op' A B (F : A^op -> B^op)
   : Is1Functor (F : A -> B)
   := is1functor_op A^op B^op F.
 
-(** Bundled opposite functors *)
-Definition fun01_op (A B : Type) `{IsGraph A} `{IsGraph B}
-  : Fun01 A B -> Fun01 A^op B^op.
-Proof.
-  intros F.
-  rapply (Build_Fun01 A^op B^op F).
-Defined.
-
-(** Opposite natural transformations *)
-
-Definition transformation_op {A} {B} `{Is01Cat B}
-           (F : A -> B) (G : A -> B) (alpha : F $=> G)
-  : @Transformation A^op (fun _ => B^op) _
-                     (G : A^op -> B^op) (F : A^op -> B^op).
-Proof.
-  unfold op in *.
-  cbn in *.
-  intro a.
-  apply (alpha a).
-Defined.
-
-Global Instance is1nat_op A B `{Is01Cat A} `{Is1Cat B}
-       (F : A -> B) `{!Is0Functor F}
-       (G : A -> B) `{!Is0Functor G}
-       (alpha : F $=> G) `{!Is1Natural F G alpha}
-  : Is1Natural (G : A^op -> B^op) (F : A^op -> B^op) (transformation_op F G alpha).
-Proof.
-  unfold op.
-  unfold transformation_op.
-  intros a b f.
-  srapply isnat_tr.
-Defined.
-
-(** Opposite categories preserve having equivalences. *)
-Global Instance hasequivs_op {A} `{HasEquivs A} : HasEquivs A^op.
-Proof.
-  snrapply Build_HasEquivs; intros a b; unfold op in a, b; cbn.
-  - exact (b $<~> a).
-  - apply CatIsEquiv.
-  - apply cate_fun'.
-  - apply cate_isequiv'.
-  - apply cate_buildequiv'.
-  - rapply cate_buildequiv_fun'.
-  - apply cate_inv'.
-  - rapply cate_isretr'.
-  - rapply cate_issect'.
-  - intros f g s t.
-    exact (catie_adjointify f g t s).
-Defined.
-
-Global Instance isequiv_op {A : Type} `{HasEquivs A}
-       {a b : A} (f : a $-> b) {ief : CatIsEquiv f}
-  : @CatIsEquiv A^op _ _ _ _ _ b a f.
-Proof.
-  assumption.
-Defined.
-
 Global Instance hasmorext_op {A : Type} `{H0 : HasMorExt A}
   : HasMorExt A^op.
 Proof.
   snrapply Build_HasMorExt.
   intros a b f g.
   refine (@isequiv_Htpy_path _ _ _ _ _ H0 b a f g).
-Defined.
-
-Lemma natequiv_op {A B : Type} `{Is01Cat A} `{HasEquivs B}
-  (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
-  : NatEquiv F G -> NatEquiv (G : A^op -> B^op) F.
-Proof.
-  intros [a n].
-  snrapply Build_NatEquiv.
-  1: exact a.
-  rapply is1nat_op.
 Defined.
 

--- a/theories/WildCat/PointedCat.v
+++ b/theories/WildCat/PointedCat.v
@@ -81,7 +81,6 @@ Proof.
     rapply cate_isinitial.
   + intros x tex.
     rapply isterminal_cate.
-    symmetry.
     refine (p $oE _).
     rapply (emap F _).
     rapply cate_isterminal.


### PR DESCRIPTION
Fixes #1936 

Currently, Opposite.v requires several other files, such as Equiv.v, and includes results such as `hasequivs_op`.  The first commit reverses such dependencies, so, for example, `hasequivs_op` is now in Equiv.v, and Equiv.v requires Opposite.v.  The same happens for FunctorCat.v and NatTrans.v, so Opposite.v now only depends on Core.v.

This means that opposite categories can be used to remove duplicate code in Equiv.v.  There are many dual results, and the second commit just gives some examples of how we can use opposites to remove proof duplication.

A great side effect of this is that it solves the slowdown in #1936 with test/WildCat/Opposite.v, with the test now taking 0.25s.  However, using opposites to prove `compose_cate_assoc_opp` was important for this, and for some reason it takes 3s for this proof.  (If you split it into a tactic and a Defined line, each takes around 1.5s.)  That's much better than the 12s for the test (including the Defined), but is still terrible.  But it at least gives us what might be a simpler problem:  figure out how to get Coq to accept this quickly.  Can anyone help with this?

(Strangely, if you revert this to the old proof, but leave the other dual proofs I gave, the test takes 35s!)

I also give other examples of places that opposites can be used in Equiv.v, but there are more that could be done if we proceed with this.  And there are probably more places in other files as well.  So I think this has benefits separate from the test speed.