### PR TITLE
rename cat_coprod_prod_incl -> cat_coprod_prod

### DIFF
--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -254,7 +254,7 @@ Defined.
 (** Wedge inclusions into the product can be defined if the indexing type has decidable paths. This is because we need to choose which factor a given wedge summand should land in. *)
 Definition fwedge_incl `{Funext} (I : Type) `(DecidablePaths I) (X : I -> pType)
   : FamilyWedge I X $-> pproduct X
-  := cat_coprod_prod_incl X.
+  := cat_coprod_prod X.
 
 (** ** The pinch map on the suspension *)
 

--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -286,10 +286,10 @@ Defined.
 Global Instance hasbinarycoproducts_type : HasBinaryCoproducts Type
   := {}.
 
-(** ** Coproduct-product inclusions *)
+(** ** Canonical coproduct-product map *)
 
 (** There is a canonical map from a coproduct to a product when the indexing set has decidable equality and the category is pointed. *)
-Definition cat_coprod_prod_incl {I : Type} `{DecidablePaths I} {A : Type}
+Definition cat_coprod_prod {I : Type} `{DecidablePaths I} {A : Type}
   `{Is1Cat A, !IsPointedCat A}
   (x : I -> A) `{!Coproduct I x, !Product I x}
   : cat_coprod I x $-> cat_prod I x. 


### PR DESCRIPTION
As discussed in #1929, this is generally not an inclusion, take for example `Group`.