### PR TITLE
Bool: add convenient variant of negb_ne

### DIFF
--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -92,6 +92,16 @@ Proof.
   - intros oops; case (oops idpath).
 Defined.
 
+(** This version of [negb_ne] is more convenient to [destruct] against. *)
+Definition negb_ne' {b1 b2 : Bool}
+  : (b1 <> b2) -> (negb b1 = b2).
+Proof.
+  intros oops.
+  symmetry.
+  apply negb_ne.
+  intros p; symmetry in p; contradiction.
+Defined.
+
 (** ** Products as [forall] over [Bool] *)
 
 Section BoolForall.

--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -99,7 +99,7 @@ Proof.
   intros oops.
   symmetry.
   apply negb_ne.
-  intros p; symmetry in p; contradiction.
+  exact (symmetric_neq oops).
 Defined.
 
 (** ** Products as [forall] over [Bool] *)


### PR DESCRIPTION
This is more useful in proof when you want to apply it to a hypothesis and then destruct.