### PR TITLE
redefine Bifunctor

### DIFF
--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -92,13 +92,13 @@ Defined.
 Global Instance is0bifunctor_ab_hom `{Funext}
   : Is0Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).
 Proof.
-  rapply Build_Is0Bifunctor.
+  rapply Build_Is0Bifunctor''.
 Defined.
 
 Global Instance is1bifunctor_ab_hom `{Funext}
   : Is1Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).
 Proof.
-  nrapply Build_Is1Bifunctor.
+  nrapply Build_Is1Bifunctor''.
   1,2: exact _.
   intros A A' f B B' g phi; cbn.
   by apply equiv_path_grouphomomorphism.

--- a/theories/Algebra/AbSES/BaerSum.v
+++ b/theories/Algebra/AbSES/BaerSum.v
@@ -54,13 +54,13 @@ Defined.
 Global Instance is0bifunctor_abses' `{Univalence}
   : Is0Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type).
 Proof.
-  rapply Build_Is0Bifunctor.
+  rapply Build_Is0Bifunctor''.
 Defined.
 
 Global Instance is1bifunctor_abses' `{Univalence}
   : Is1Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type).
 Proof.
-  snrapply Build_Is1Bifunctor.
+  snrapply Build_Is1Bifunctor''.
   1,2: exact _.
   intros ? ? g ? ? f E; cbn.
   exact (abses_pushout_pullback_reorder E f g).
@@ -232,13 +232,13 @@ Defined.
 Global Instance is0bifunctor_abses `{Univalence}
   : Is0Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType).
 Proof.
-  rapply Build_Is0Bifunctor.
+  rapply Build_Is0Bifunctor''.
 Defined.
 
 Global Instance is1bifunctor_abses `{Univalence}
   : Is1Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType).
 Proof.
-  snrapply Build_Is1Bifunctor.
+  snrapply Build_Is1Bifunctor''.
   1,2: exact _.
   intros ? ? f ? ? g.
   rapply hspace_phomotopy_from_homotopy.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -129,12 +129,8 @@ Global Instance is1bifunctor_abext `{Univalence}
 Proof.
   snrapply Build_Is1Bifunctor''.
   1,2: exact _.
-  intros A B f C D g.
-  intros x.
-  strip_truncations; cbn.
-  pose proof (bifunctor_coh (Ext : AbGroup^op -> AbGroup -> pType) f g (tr x)) as X.
-  cbn in X.
-  exact X.
+  intros A B.
+  exact (bifunctor_coh (Ext : AbGroup^op -> AbGroup -> pType)).
 Defined.
 
 (** We can push out a fixed extension while letting the map vary, and this defines a group homomorphism. *)
@@ -143,10 +139,10 @@ Definition abses_pushout_ext `{Univalence}
   : GroupHomomorphism (ab_hom A G) (ab_ext B G).
 Proof.
   snrapply Build_GroupHomomorphism.
-  1: exact (fun f => fmap (Ext' (_ : AbGroup^op)) f (tr E)).
+  1: exact (fun f => fmap01 (A:=AbGroup^op) Ext' _ f (tr E)).
   intros f g; cbn.
   nrapply (ap tr).
-  exact (baer_sum_distributive_pushouts (E:=E) f g).
+  exact (baer_sum_distributive_pushouts f g).
 Defined.
 
 (** ** Extensions ending in a projective are trivial *)

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -63,9 +63,9 @@ Defined.
 
 (** ** The bifunctor [ab_ext] *)
 
-Definition ab_ext `{Univalence} (B : AbGroup@{u}^op) (A : AbGroup@{u}) : AbGroup.
+Definition ab_ext@{u v|u < v} `{Univalence} (B : AbGroup@{u}^op) (A : AbGroup@{u}) : AbGroup@{v}.
 Proof.
-  snrapply (Build_AbGroup (grp_ext B A)).
+  snrapply (Build_AbGroup (grp_ext@{u v} B A)).
   intros E F.
   strip_truncations; cbn.
   apply ap.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -121,13 +121,13 @@ Defined.
 Global Instance is0bifunctor_abext `{Univalence}
   : Is0Bifunctor (A:=AbGroup^op) ab_ext.
 Proof.
-  rapply Build_Is0Bifunctor.
+  rapply Build_Is0Bifunctor''.
 Defined.
 
 Global Instance is1bifunctor_abext `{Univalence}
   : Is1Bifunctor (A:=AbGroup^op) ab_ext.
 Proof.
-  snrapply Build_Is1Bifunctor'.
+  snrapply Build_Is1Bifunctor''.
   1,2: exact _.
   intros A B f C D g.
   intros x.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -63,7 +63,7 @@ Defined.
 
 (** ** The bifunctor [ab_ext] *)
 
-Definition ab_ext `{Univalence} (B A : AbGroup@{u}) : AbGroup.
+Definition ab_ext `{Univalence} (B : AbGroup@{u}^op) (A : AbGroup@{u}) : AbGroup.
 Proof.
   snrapply (Build_AbGroup (grp_ext B A)).
   intros E F.
@@ -127,10 +127,14 @@ Defined.
 Global Instance is1bifunctor_abext `{Univalence}
   : Is1Bifunctor (A:=AbGroup^op) ab_ext.
 Proof.
-  snrapply Build_Is1Bifunctor.
+  snrapply Build_Is1Bifunctor'.
   1,2: exact _.
-  intros A B.
-  exact (bifunctor_isbifunctor (Ext : AbGroup^op -> AbGroup -> pType)).
+  intros A B f C D g.
+  intros x.
+  strip_truncations; cbn.
+  pose proof (bifunctor_coh (Ext : AbGroup^op -> AbGroup -> pType) f g (tr x)) as X.
+  cbn in X.
+  exact X.
 Defined.
 
 (** We can push out a fixed extension while letting the map vary, and this defines a group homomorphism. *)
@@ -139,10 +143,10 @@ Definition abses_pushout_ext `{Univalence}
   : GroupHomomorphism (ab_hom A G) (ab_ext B G).
 Proof.
   snrapply Build_GroupHomomorphism.
-  1: exact (fun f => fmap01 (A:=AbGroup^op) Ext' _ f (tr E)).
+  1: exact (fun f => fmap (Ext' (_ : AbGroup^op)) f (tr E)).
   intros f g; cbn.
   nrapply (ap tr).
-  exact (baer_sum_distributive_pushouts f g).
+  exact (baer_sum_distributive_pushouts (E:=E) f g).
 Defined.
 
 (** ** Extensions ending in a projective are trivial *)

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -98,7 +98,8 @@ Proof.
       destruct g as [g k].
     exists g.
     apply path_sigma_hprop; cbn.
-    exact k^.
+    elim k^. 
+    by apply equiv_path_grouphomomorphism.
 Defined.
 
 (** *** Exactness of [ab_hom A G -> Ext1 B G -> Ext1 E G]. *)

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -98,7 +98,7 @@ Proof.
       destruct g as [g k].
     exists g.
     apply path_sigma_hprop; cbn.
-    exact k^. 
+    exact k^.
 Defined.
 
 (** *** Exactness of [ab_hom A G -> Ext1 B G -> Ext1 E G]. *)

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -98,8 +98,7 @@ Proof.
       destruct g as [g k].
     exists g.
     apply path_sigma_hprop; cbn.
-    elim k^. 
-    by apply equiv_path_grouphomomorphism.
+    exact k^. 
 Defined.
 
 (** *** Exactness of [ab_hom A G -> Ext1 B G -> Ext1 E G]. *)

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -562,7 +562,6 @@ Section FunctorJoin.
 
   Global Instance is0bifunctor_join : Is0Bifunctor Join.
   Proof.
-    rapply Build_Is0Functor.
     apply Build_Is0Functor.
     intros A B [f g].
     exact (functor_join f g).

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -572,7 +572,7 @@ Section FunctorJoin.
   Global Instance is1bifunctor_join : Is1Bifunctor Join.
   Proof.
     snrapply Build_Is1Bifunctor'.
-    snrapply Build_Is1Functor.
+    nrapply Build_Is1Functor.
     - intros A B f g [p q].
       exact (functor2_join p q).
     - intros A; exact functor_join_idmap.

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -562,6 +562,8 @@ Section FunctorJoin.
 
   Global Instance is0bifunctor_join : Is0Bifunctor Join.
   Proof.
+    snrapply Build_Is0Bifunctor'.
+    1,2: exact _.
     apply Build_Is0Functor.
     intros A B [f g].
     exact (functor_join f g).
@@ -569,6 +571,7 @@ Section FunctorJoin.
 
   Global Instance is1bifunctor_join : Is1Bifunctor Join.
   Proof.
+    snrapply Build_Is1Bifunctor'.
     snrapply Build_Is1Functor.
     - intros A B f g [p q].
       exact (functor2_join p q).

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -562,7 +562,7 @@ Section FunctorJoin.
 
   Global Instance is0bifunctor_join : Is0Bifunctor Join.
   Proof.
-    rapply Build_Is0Bifunctor'.
+    rapply Build_Is0Functor.
     apply Build_Is0Functor.
     intros A B [f g].
     exact (functor_join f g).
@@ -570,8 +570,7 @@ Section FunctorJoin.
 
   Global Instance is1bifunctor_join : Is1Bifunctor Join.
   Proof.
-    snrapply Build_Is1Bifunctor'.
-    nrapply Build_Is1Functor.
+    snrapply Build_Is1Functor.
     - intros A B f g [p q].
       exact (functor2_join p q).
     - intros A; exact functor_join_idmap.

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -266,20 +266,7 @@ Proof.
   - intros A B C.
     apply join_assoc.
   - intros [[A B] C] [[A' B'] C'] [[f g] h]; cbn.
-    (* This is awkward because Monoidal.v works with a tensor that is separately a functor in each variable. *)
-    intro x.
-    rhs_V nrapply functor_join_compose.
-    rhs_V nrapply functor2_join.
-    2: reflexivity.
-    2: nrapply functor_join_compose.
-    cbn.
-    rhs_V nrapply join_assoc_nat; cbn.
-    apply ap.
-    lhs_V nrapply functor_join_compose.
-    lhs_V nrapply functor_join_compose.
-    apply functor2_join.
-    1: reflexivity.
-    symmetry; nrapply functor_join_compose.
+    apply join_assoc_nat.
 Defined.
 
 (** ** The Triangle Law *)

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -353,6 +353,8 @@ Defined.
 
 Global Instance is0bifunctor_smash : Is0Bifunctor Smash.
 Proof.
+  snrapply Build_Is0Bifunctor'.
+  1,2: exact _.
   nrapply Build_Is0Functor.
   intros [X Y] [A B] [f g].
   exact (functor_smash f g).
@@ -360,6 +362,7 @@ Defined.
 
 Global Instance is1bifunctor_smash : Is1Bifunctor Smash.
 Proof.
+  snrapply Build_Is1Bifunctor'.
   snrapply Build_Is1Functor.
   - intros [X Y] [A B] [f g] [h i] [p q].
     exact (functor_smash_homotopic p q).

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -353,7 +353,6 @@ Defined.
 
 Global Instance is0bifunctor_smash : Is0Bifunctor Smash.
 Proof.
-  rapply Build_Is0Bifunctor'.
   nrapply Build_Is0Functor.
   intros [X Y] [A B] [f g].
   exact (functor_smash f g).
@@ -361,7 +360,6 @@ Defined.
 
 Global Instance is1bifunctor_smash : Is1Bifunctor Smash.
 Proof.
-  snrapply Build_Is1Bifunctor'.
   snrapply Build_Is1Functor.
   - intros [X Y] [A B] [f g] [h i] [p q].
     exact (functor_smash_homotopic p q).

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -49,43 +49,6 @@ Proof.
   exact (fmap (flip F b') f $o fmap (F a) g).
 Defined.
 
-(* Global Instance is0functor01_bifunctor {A B C : Type}
-  `{Is01Cat A, IsGraph B, IsGraph C} (F : A -> B -> C) `{!Is0Bifunctor F}
-  : forall a, Is0Functor (F a).
-Proof.
-  intros a.
-  snrapply Build_Is0Functor.
-  intros b b' g.
-  change (uncurry F (a, b) $-> uncurry F (a, b')).
-  refine (fmap (uncurry F) (_, _)).
-  - exact (Id a).
-  - exact g.
-Defined. *)
-
-(* Global Instance is0functor10_bifunctor {A B C : Type}
-  `{IsGraph A, Is01Cat B, IsGraph C} (F : A -> B -> C) `{!Is0Bifunctor F}
-  : forall b, Is0Functor (flip F b).
-Proof.
-  intros b.
-  snrapply Build_Is0Functor.
-  intros a a' f.
-  change (uncurry F (a, b) $-> uncurry F (a', b)).
-  refine (fmap (uncurry F) (_, _)).
-  - exact f.
-  - exact (Id b).
-Defined. *)
-
-(* Definition Build_Is0Bifunctor {A B C : Type}
-  `{IsGraph A, IsGraph B, Is01Cat C} (F : A -> B -> C)
-  `{!forall a, Is0Functor (F a), !forall b, Is0Functor (flip F b)}
-  : Is0Bifunctor F.
-Proof.
-  snrapply Build_Is0Functor.
-  intros [a b] [a' b'] [f g].
-  change (F a b $-> F a' b').
-  exact (fmap (flip F b') f $o fmap (F a) g).
-Defined. *)
-
 (** *** 1-functorial action *)
 
 (** [fmap] in the first argument. *)
@@ -198,47 +161,9 @@ Proof.
     reflexivity.
 Defined.
 
-(** Here is an alternative constructor that uses [fmap01] and [fmap10] instead. *)
-(* Definition Build_Is1Bifunctor' {A B C : Type}
-  `{Is1Cat A, Is1Cat B, Is1Cat C} (F : A -> B -> C)
-  `{!forall a, Is0Functor (F a), !forall b, Is0Functor (flip F b)}
-  `{!forall a, Is1Functor (F a), !forall b, Is1Functor (flip F b)}
-  (Is0Bifunctor_F := Build_Is0Bifunctor F)
-  (bifunctor_coh : forall a0 a1 (f : a0 $-> a1) b0 b1 (g : b0 $-> b1),
-    fmap01 F a1 g $o fmap10 F f b0 $== fmap10 F f b1 $o fmap01 F a0 g)
-  : Is1Bifunctor F.
-Proof.
-  snrapply Build_Is1Bifunctor.
-  1,2: exact _.
-  intros a0 a1 f b0 b1 g.
-  refine ((_ $@@ _)^$ $@ bifunctor_coh a0 a1 f b0 b1 g $@ (_ $@@ _)).
-  1,4: exact ((_ $@L fmap_id (F _) _) $@ cat_idr _).
-  1,2: exact (( fmap_id (flip F _) _ $@R _) $@ cat_idl _).
-Defined. *)
-
 (** ** Bifunctor lemmas *)
 
 (** *** Coherence *)
-
-(* Definition fmap11_is_fmap01_fmap10 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
-  (F : A -> B -> C) `{!Is0Bifunctor F, !Is1Bifunctor F}
-  {a0 a1 : A} (f : a0 $-> a1) {b0 b1 : B} (g : b0 $-> b1)
-  : fmap11 F f g $== fmap01 F a1 g $o fmap10 F f b0.
-Proof.
-  refine (fmap2 (uncurry F) _^$ $@ fmap_comp (uncurry F)
-    (a := (a0, b0)) (b := (a1, b0)) (c := (a1, b1)) (f, Id b0) (Id a1, g)).
-  exact (cat_idl _, cat_idr _).
-Defined. *)
-
-(* Definition fmap11_is_fmap10_fmap01 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
-  (F : A -> B -> C) `{!Is0Bifunctor F, !Is1Bifunctor F}
-  {a0 a1 : A} (f : a0 $-> a1) {b0 b1 : B} (g : b0 $-> b1)
-  : fmap11 F f g $== fmap10 F f b1 $o fmap01 F a0 g.
-Proof.
-  refine (fmap2 (uncurry F) _^$ $@ fmap_comp (uncurry F)
-    (a := (a0, b0)) (b := (a0, b1)) (c := (a1, b1)) (Id a0, g) (f, Id b1)).
-  exact (cat_idr _, cat_idl _).
-Defined. *)
 
 Definition bifunctor_coh {A B C : Type}
   (F : A -> B -> C) `{Is1Bifunctor A B C F}

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -14,7 +14,7 @@ Class Is0Bifunctor {A B C : Type}
   is0functor10_bifunctor :: forall b, Is0Functor (flip F b);
 }.
 
-(** We provide two alternate constructors, allow the user to provide just the first field or the last two fields. *)
+(** We provide two alternate constructors, allowing the user to provide just the first field or the last two fields. *)
 Definition Build_Is0Bifunctor' {A B C : Type}
   `{Is01Cat A, Is01Cat B, IsGraph C} (F : A -> B -> C)
   `{!Is0Functor (uncurry F)}

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -105,7 +105,7 @@ Proof.
     + intros b.
       exact (fmap_id (uncurry F) _).
     + intros b b' b'' f g.
-      srefine (fmap2 (uncurry F) _ $@ _). 
+      srefine (fmap2 (uncurry F) _ $@ _).
       * exact (Id a $o Id a, g $o f).
       * exact ((cat_idl _)^$, Id _).
       * exact (fmap_comp (uncurry F) (a := (a, b)) (b := (a, b')) (c := (a, b''))
@@ -148,7 +148,7 @@ Proof.
       exact (fmap2 (F a) p' $@@ fmap2 (flip F b') p).
     + intros [a b].
       exact ((fmap_id (F a) b $@@ fmap_id (flip F b) _) $@ cat_idr _).
-    + intros [a b] [a' b'] [a'' b''] [f g] [f' g']; unfold fst, snd in * |- . 
+    + intros [a b] [a' b'] [a'' b''] [f g] [f' g']; unfold fst, snd in * |- .
       refine ((fmap_comp (F a) g g' $@@ fmap_comp (flip F b'') f f') $@ _).
       nrefine (cat_assoc_opp _ _ _ $@ (_ $@R _) $@ cat_assoc _ _ _).
       refine (cat_assoc _ _ _ $@ (_ $@L _^$) $@ cat_assoc_opp _ _ _).

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -58,7 +58,7 @@ Definition fmap11 {A B C : Type} `{IsGraph A, IsGraph B, IsGraph C}
   (F : A -> B -> C) `{!Is0Bifunctor F} {a0 a1 : A} (f : a0 $-> a1)
   {b0 b1 : B} (g : b0 $-> b1)
   : F a0 b0 $-> F a1 b1
-  := fmap (uncurry F) (a := (a0, b0)) (b := (a1, b1)) (f, g).
+  := fmap_pair (uncurry F) f g.
 
 (** As with [Is0Bifunctor], we store redundant information.  In addition, we store the proofs that they are consistent with each other. *)
 Class Is1Bifunctor {A B C : Type}
@@ -92,13 +92,11 @@ Proof.
   - exact (is1functor_functor_uncurried01 (uncurry F)).
   - exact (is1functor_functor_uncurried10 (uncurry F)).
   - intros a0 a1 f b0 b1 g.
-    refine (fmap2 (uncurry F) _^$ $@ fmap_comp (uncurry F)
-      (a := (a0, b0)) (b := (a1, b0)) (c := (a1, b1)) (f, Id b0) (Id a1, g)).
-    exact (cat_idl _, cat_idr _).
+    refine (_^$ $@ fmap_pair_comp (uncurry F) f (Id b0) (Id a1) g).
+    exact (fmap2_pair (uncurry F) (cat_idl _) (cat_idr _)).
   - intros a0 a1 f b0 b1 g.
-    refine (fmap2 (uncurry F) _^$ $@ fmap_comp (uncurry F)
-      (a := (a0, b0)) (b := (a0, b1)) (c := (a1, b1)) (Id a0, g) (f, Id b1)).
-    exact (cat_idr _, cat_idl _).
+    refine (_^$ $@ fmap_pair_comp (uncurry F) (Id a0) g f (Id b1)).
+    exact (fmap2_pair (uncurry F) (cat_idr _) (cat_idl _)).
 Defined.
 
 Definition Build_Is1Bifunctor'' {A B C : Type}
@@ -149,11 +147,8 @@ Definition fmap02 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
 Definition fmap12 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
   (F : A -> B -> C) `{!Is0Bifunctor F, !Is1Bifunctor F}
   {a0 a1 : A} (f : a0 $-> a1) {b0 b1 : B} {g g' : b0 $-> b1} (q : g $== g')
-  : fmap11 F f g $== fmap11 F f g'.
-Proof.
-  refine (fmap2 (uncurry F) _).
-  exact (Id _, q).
-Defined.
+  : fmap11 F f g $== fmap11 F f g'
+  := fmap2_pair (uncurry F) (Id _) q.
 
 Definition fmap20 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
   (F : A -> B -> C) `{!Is0Bifunctor F, !Is1Bifunctor F}
@@ -164,21 +159,15 @@ Definition fmap20 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
 Definition fmap21 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
   (F : A -> B -> C) `{!Is0Bifunctor F, !Is1Bifunctor F}
   {a0 a1 : A} {f f' : a0 $-> a1} (p : f $== f') {b0 b1 : B} (g : b0 $-> b1)
-  : fmap11 F f g $== fmap11 F f' g.
-Proof.
-  refine (fmap2 (uncurry F) _).
-  exact (p, Id _).
-Defined.
+  : fmap11 F f g $== fmap11 F f' g
+  := fmap2_pair (uncurry F) p (Id _).
 
 Definition fmap22 {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
   (F : A -> B -> C) `{!Is0Bifunctor F, !Is1Bifunctor F}
   {a0 a1 : A} {f f' : a0 $-> a1} (p : f $== f')
   {b0 b1 : B} {g g' : b0 $-> b1} (q : g $== g')
-  : fmap11 F f g $== fmap11 F f' g'.
-Proof.
-  refine (fmap2 (uncurry F) _).
-  exact (p, q).
-Defined.
+  : fmap11 F f g $== fmap11 F f' g'
+  := fmap2_pair (uncurry F) p q.
 
 (** *** Identity preservation *)
 
@@ -230,8 +219,7 @@ Definition fmap11_comp {A B C : Type} `{Is1Cat A, Is1Cat B, Is1Cat C}
   {a0 a1 a2 : A} (g : a1 $-> a2) (f : a0 $-> a1)
   {b0 b1 b2 : B} (k : b1 $-> b2) (h : b0 $-> b1)
   : fmap11 F (g $o f) (k $o h) $== fmap11 F g k $o fmap11 F f h
-  := fmap_comp (uncurry F)
-    (a := (a0, b0)) (b := (a1, b1)) (c := (a2, b2)) (_, _) (_, _).
+  := fmap_pair_comp (uncurry F) _ _ _ _.
 
 (** *** Equivalence preservation *)
 

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -165,23 +165,30 @@ Section Associator.
     : associator x' y z $o fmap10 F f (F y z)
       $== fmap10 F (fmap10 F f y) z $o associator x y z.
   Proof.
-    refine ((_ $@L _^$) $@ associator_nat f (Id _) (Id _)).
-    exact (fmap12 _ _ (fmap11_id _ _ _)).
+    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
+    2: rapply (associator_nat f (Id _) (Id _)).
+    - exact (fmap12 _ _ (fmap11_id _ _ _) $@ fmap10_is_fmap11 _ _ _).
+    - exact (fmap21 _ (fmap10_is_fmap11 _ _ _) _ $@ fmap10_is_fmap11 _ _ _).
   Defined.
 
   Local Definition associator_nat_m (x : A) {y y' : A} (g : y $-> y') (z : A)
     : associator x y' z $o fmap01 F x (fmap10 F g z)
       $== fmap10 F (fmap01 F x g) z $o associator x y z.
   Proof.
-    exact (associator_nat (Id _) g (Id _)).
+    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
+    2: nrapply (associator_nat (Id _) g (Id _)).
+    - exact (fmap12 _ _ (fmap10_is_fmap11 _ _ _) $@ fmap01_is_fmap11 _ _ _).
+    - exact (fmap21 _ (fmap01_is_fmap11 _ _ _) _ $@ fmap10_is_fmap11 _ _ _).
   Defined.
 
   Local Definition associator_nat_r (x y : A) {z z' : A} (h : z $-> z')
     : associator x y z' $o fmap01 F x (fmap01 F y h)
       $== fmap01 F (F x y) h $o associator x y z.
   Proof.
-    nrefine (associator_nat (Id _) (Id _) h $@ (_ $@R _)).
-    exact (fmap21 _ (fmap11_id _ _ _) _ ).
+    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
+    2: nrapply (associator_nat (Id _) (Id _) h).
+    - exact (fmap12 _ _ (fmap01_is_fmap11 _ _ _) $@ fmap01_is_fmap11 _ _ _).
+    - exact (fmap21 _ (fmap11_id _ _ _) _ $@ fmap01_is_fmap11 F _ _).
   Defined.
 
 End Associator.
@@ -357,6 +364,7 @@ Section SymmetricBraid.
   Local Definition braid_nat_l {a b c} (f : a $-> b)
     : braid b c $o fmap10 F f c $== fmap01 F c f $o braid a c.
   Proof.
+    refine ((_ $@L (fmap10_is_fmap11 _ _ _)^$) $@ _ $@ (fmap01_is_fmap11 _ _ _ $@R _)).
     exact (is1natural_braiding_uncurried (a, c) (b, c) (f, Id _)).
   Defined.
 
@@ -364,6 +372,7 @@ Section SymmetricBraid.
   Local Definition braid_nat_r {a b c} (g : b $-> c)
     : braid a c $o fmap01 F a g $== fmap10 F g a $o braid a b.
   Proof.
+    refine ((_ $@L (fmap01_is_fmap11 _ _ _)^$) $@ _ $@ (fmap10_is_fmap11 _ _ _ $@R _)).
     exact (is1natural_braiding_uncurried (a, b) (a, c) (Id _ , g)).
   Defined.
 
@@ -449,23 +458,33 @@ Section TwistConstruction.
     : twist a' b c $o fmap10 cat_tensor f (cat_tensor b c)
       $== fmap01 cat_tensor b (fmap10 cat_tensor f c) $o twist a b c.
   Proof.
-    refine ((_ $@L _^$) $@ twist_nat a a' b b c c f (Id _) (Id _)).
-    exact (fmap12 _ _ (fmap11_id _ _ _)).
+    refine ((_ $@L _^$) $@ twist_nat a a' b b c c f (Id _) (Id _) $@ (_ $@R _)).
+    - refine (fmap12 _ _ _ $@ fmap10_is_fmap11 _ _ _).
+      rapply fmap11_id.
+    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
+      rapply fmap10_is_fmap11.
   Defined.
 
   Local Definition twist_nat_m a {b b'} (g : b $-> b') c
     : twist a b' c $o fmap01 cat_tensor a (fmap10 cat_tensor g c)
       $== fmap10 cat_tensor g (cat_tensor a c) $o twist a b c.
   Proof.
-    nrefine (twist_nat a a b b' c c (Id _) g (Id _) $@ (_ $@R _)).
-    exact (fmap12 _ _ (fmap11_id _ _ _)).
+    refine ((_ $@L _^$) $@ twist_nat a a b b' c c (Id _) g (Id _) $@ (_ $@R _)).
+    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
+      rapply fmap10_is_fmap11.
+    - refine (fmap12 _ _ _ $@ fmap10_is_fmap11 _ _ _).
+      rapply fmap11_id.
   Defined.
 
   Local Definition twist_nat_r a b {c c'} (h : c $-> c')
     : twist a b c' $o fmap01 cat_tensor a (fmap01 cat_tensor b h)
       $== fmap01 cat_tensor b (fmap01 cat_tensor a h) $o twist a b c.
   Proof.
-    exact (twist_nat a a b b c c' (Id _) (Id _) h).
+    refine ((_ $@L _^$) $@ twist_nat a a b b c c' (Id _) (Id _) h $@ (_ $@R _)).
+    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
+      rapply fmap01_is_fmap11.
+    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
+      rapply fmap01_is_fmap11.
   Defined.
 
   (** *** Movement lemmas *)
@@ -606,6 +625,9 @@ Section TwistConstruction.
       (** The second square is just the naturality of twist. *)
       nrapply vconcat.
       2: apply twist_nat.
+      nrapply hconcatL.
+      2: nrapply hconcatR.
+      1,3: symmetry; rapply fmap01_is_fmap11.
       (** Leaving us with a square with a functor application. *)
       rapply fmap11_square.
       1: rapply vrefl.
@@ -628,7 +650,7 @@ Section TwistConstruction.
         change (?w $o ?x $== ?y $o ?z) with (Square z w x y).
         nrapply vconcat.
         2: rapply (isnat right_unitor f).
-        rapply braid_nat.
+        rapply braid_nat_r.
     - intros a.
       rapply compose_catie'.
       rapply catie_braid.

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -157,9 +157,8 @@ Section Associator.
     : associator x' y' z' $o fmap11 F f (fmap11 F g h)
       $== fmap11 F (fmap11 F f g) h $o associator x y z.
   Proof.
-    nrefine (_ $@ is1natural_associator_uncurried (x, y, z) (x', y', z') (f, g, h)).
-    refine (_ $@L ((_ $@R _) $@ cat_assoc _ _ _ $@ (_ $@L _^$))).
-    1,2: rapply fmap_comp. 
+    destruct assoc as [asso nat].
+    exact (nat (x, y, z) (x', y', z') (f, g, h)).
   Defined.
 
   Local Definition associator_nat_l {x x' : A} (f : x $-> x') (y z : A)
@@ -359,28 +358,20 @@ Section SymmetricBraid.
   Local Definition braid_nat {a b c d} (f : a $-> c) (g : b $-> d)
     : braid c d $o fmap11 F f g $== fmap11 F g f $o braid a b.
   Proof.
-    refine (is1natural_braiding_uncurried (a, b) (c, d) (f, g) $@ _).
-    refine (_ $@R _).
-    rapply fmap11_coh.
+    exact (is1natural_braiding_uncurried (a, b) (c, d) (f, g)).
   Defined.
 
   Local Definition braid_nat_l {a b c} (f : a $-> b)
     : braid b c $o fmap10 F f c $== fmap01 F c f $o braid a c.
   Proof.
-    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
-    - rapply fmap10_is_fmap11.
-    - exact (is1natural_braiding_uncurried (a, c) (b, c) (f, Id _)).
-    - exact ((fmap11_coh _ _ _)^$ $@ fmap01_is_fmap11 _ c f).
+    exact (is1natural_braiding_uncurried (a, c) (b, c) (f, Id _)).
   Defined.
 
   (** This is just the inverse of above. *)
   Local Definition braid_nat_r {a b c} (g : b $-> c)
     : braid a c $o fmap01 F a g $== fmap10 F g a $o braid a b.
   Proof.
-    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
-    - rapply fmap01_is_fmap11.
-    - exact (is1natural_braiding_uncurried (a, b) (a, c) (Id _ , g)).
-    - exact ((fmap11_coh _ _ _)^$ $@ fmap10_is_fmap11 _ g a).
+    exact (is1natural_braiding_uncurried (a, b) (a, c) (Id _ , g)).
   Defined.
 
 End SymmetricBraid.
@@ -632,15 +623,9 @@ Section TwistConstruction.
       (** The second square is just the naturality of twist. *)
       nrapply vconcat.
       2: apply twist_nat.
-      (** We rewrite one of the edges to make sure a functor application is grouped together. *)
-      nrapply vconcatL.
-      { refine ((cat_assoc _ _ _)^$ $@ (_^$ $@R _)).
-        rapply fmap_comp. }
-      (** This allows us to compose with bifunctor coherence on one side. *)
-      nrapply hconcat.
-      1: rapply fmap11_coh.
       (** Leaving us with a square with a functor application. *)
-      rapply fmap_square.
+      rapply fmap11_square.
+      1: rapply vrefl.
       (** We are finally left with the naturality of braid. *)
       apply braid_nat.
   Defined.

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -165,30 +165,23 @@ Section Associator.
     : associator x' y z $o fmap10 F f (F y z)
       $== fmap10 F (fmap10 F f y) z $o associator x y z.
   Proof.
-    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
-    2: rapply (associator_nat f (Id _) (Id _)).
-    - exact (fmap12 _ _ (fmap11_id _ _ _) $@ fmap10_is_fmap11 _ _ _).
-    - exact (fmap21 _ (fmap10_is_fmap11 _ _ _) _ $@ fmap10_is_fmap11 _ _ _).
+    refine ((_ $@L _^$) $@ associator_nat f (Id _) (Id _)).
+    exact (fmap12 _ _ (fmap11_id _ _ _)).
   Defined.
 
   Local Definition associator_nat_m (x : A) {y y' : A} (g : y $-> y') (z : A)
     : associator x y' z $o fmap01 F x (fmap10 F g z)
       $== fmap10 F (fmap01 F x g) z $o associator x y z.
   Proof.
-    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
-    2: nrapply (associator_nat (Id _) g (Id _)).
-    - exact (fmap12 _ _ (fmap10_is_fmap11 _ _ _) $@ fmap01_is_fmap11 _ _ _).
-    - exact (fmap21 _ (fmap01_is_fmap11 _ _ _) _ $@ fmap10_is_fmap11 _ _ _).
+    exact (associator_nat (Id _) g (Id _)).
   Defined.
 
   Local Definition associator_nat_r (x y : A) {z z' : A} (h : z $-> z')
     : associator x y z' $o fmap01 F x (fmap01 F y h)
       $== fmap01 F (F x y) h $o associator x y z.
   Proof.
-    refine ((_ $@L _^$) $@ _ $@ (_ $@R _)).
-    2: nrapply (associator_nat (Id _) (Id _) h).
-    - exact (fmap12 _ _ (fmap01_is_fmap11 _ _ _) $@ fmap01_is_fmap11 _ _ _).
-    - exact (fmap21 _ (fmap11_id _ _ _) _ $@ fmap01_is_fmap11 F _ _).
+    nrefine (associator_nat (Id _) (Id _) h $@ (_ $@R _)).
+    exact (fmap21 _ (fmap11_id _ _ _) _ ).
   Defined.
 
 End Associator.
@@ -456,33 +449,23 @@ Section TwistConstruction.
     : twist a' b c $o fmap10 cat_tensor f (cat_tensor b c)
       $== fmap01 cat_tensor b (fmap10 cat_tensor f c) $o twist a b c.
   Proof.
-    refine ((_ $@L _^$) $@ twist_nat a a' b b c c f (Id _) (Id _) $@ (_ $@R _)).
-    - refine (fmap12 _ _ _ $@ fmap10_is_fmap11 _ _ _).
-      rapply fmap11_id.
-    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
-      rapply fmap10_is_fmap11.
+    refine ((_ $@L _^$) $@ twist_nat a a' b b c c f (Id _) (Id _)).
+    exact (fmap12 _ _ (fmap11_id _ _ _)).
   Defined.
 
   Local Definition twist_nat_m a {b b'} (g : b $-> b') c
     : twist a b' c $o fmap01 cat_tensor a (fmap10 cat_tensor g c)
       $== fmap10 cat_tensor g (cat_tensor a c) $o twist a b c.
   Proof.
-    refine ((_ $@L _^$) $@ twist_nat a a b b' c c (Id _) g (Id _) $@ (_ $@R _)).
-    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
-      rapply fmap10_is_fmap11.
-    - refine (fmap12 _ _ _ $@ fmap10_is_fmap11 _ _ _).
-      rapply fmap11_id.
+    nrefine (twist_nat a a b b' c c (Id _) g (Id _) $@ (_ $@R _)).
+    exact (fmap12 _ _ (fmap11_id _ _ _)).
   Defined.
 
   Local Definition twist_nat_r a b {c c'} (h : c $-> c')
     : twist a b c' $o fmap01 cat_tensor a (fmap01 cat_tensor b h)
       $== fmap01 cat_tensor b (fmap01 cat_tensor a h) $o twist a b c.
   Proof.
-    refine ((_ $@L _^$) $@ twist_nat a a b b c c' (Id _) (Id _) h $@ (_ $@R _)).
-    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
-      rapply fmap01_is_fmap11.
-    - refine (fmap12 _ _ _ $@ fmap01_is_fmap11 _ _ _).
-      rapply fmap01_is_fmap11.
+    exact (twist_nat a a b b c c' (Id _) (Id _) h).
   Defined.
 
   (** *** Movement lemmas *)
@@ -645,10 +628,6 @@ Section TwistConstruction.
         change (?w $o ?x $== ?y $o ?z) with (Square z w x y).
         nrapply vconcat.
         2: rapply (isnat right_unitor f).
-        nrapply vconcatL.
-        1: symmetry; rapply fmap01_is_fmap11.
-        nrapply vconcatR.
-        2: symmetry; rapply fmap10_is_fmap11.
         rapply braid_nat.
     - intros a.
       rapply compose_catie'.

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -227,3 +227,27 @@ Definition fmap11_uncurry {A B C : Type} `{IsGraph A, IsGraph B, IsGraph C}
   {a0 a1 : A} (f : a0 $-> a1) {b0 b1 : B} (g : b0 $-> b1)
   : F a0 b0 $-> F a1 b1
   := @fmap _ _ _ _ (uncurry F) H2 (a0, b0) (a1, b1) (f, g).
+
+Definition fmap_pair {A B C : Type}  
+  `{IsGraph A, IsGraph B, IsGraph C}  
+  (F : A * B -> C) `{!Is0Functor F}  
+  {a0 a1 : A} (f : a0 $-> a1) {b0 b1 : B} (g : b0 $-> b1)  
+  : F (a0, b0) $-> F (a1, b1)  
+  := fmap (a:=(a0,b0)) (b:=(a1,b1)) F (f,g).  
+
+Definition fmap_pair_comp {A B C : Type}  
+  `{Is1Cat A, Is1Cat B, Is1Cat C}  
+  (F : A * B -> C) `{!Is0Functor F, !Is1Functor F}  
+  {a0 a1 a2 : A} {b0 b1 b2 : B}
+  (f : a0 $-> a1) (h : b0 $-> b1) (g : a1 $-> a2) (i : b1 $-> b2)  
+  : fmap_pair F (g $o f) (i $o h)
+    $== fmap_pair F g i $o fmap_pair F f h
+  := fmap_comp (a:=(a0,b0)) (b:=(a1,b1)) (c:=(a2,b2)) F (f,h) (g,i).
+
+Definition fmap2_pair {A B C : Type}
+  `{Is1Cat A, Is1Cat B, Is1Cat C}
+  (F : A * B -> C) `{!Is0Functor F, !Is1Functor F}
+  {a0 a1 : A} {f f' : a0 $-> a1} (p : f $== f')
+  {b0 b1 : B} {g g' : b0 $-> b1} (q : g $== g')
+  : fmap_pair F f g $== fmap_pair F f' g'
+  := fmap2 F (a:=(a0,b0)) (b:=(a1,b1)) (f:=(f,g)) (g:=(f',g')) (p,q).

--- a/theories/WildCat/Prod.v
+++ b/theories/WildCat/Prod.v
@@ -233,7 +233,7 @@ Definition fmap_pair {A B C : Type}
   (F : A * B -> C) `{!Is0Functor F}  
   {a0 a1 : A} (f : a0 $-> a1) {b0 b1 : B} (g : b0 $-> b1)  
   : F (a0, b0) $-> F (a1, b1)  
-  := fmap (a:=(a0,b0)) (b:=(a1,b1)) F (f,g).  
+  := fmap (a := (a0, b0)) (b := (a1, b1)) F (f, g).  
 
 Definition fmap_pair_comp {A B C : Type}  
   `{Is1Cat A, Is1Cat B, Is1Cat C}  
@@ -242,7 +242,7 @@ Definition fmap_pair_comp {A B C : Type}
   (f : a0 $-> a1) (h : b0 $-> b1) (g : a1 $-> a2) (i : b1 $-> b2)  
   : fmap_pair F (g $o f) (i $o h)
     $== fmap_pair F g i $o fmap_pair F f h
-  := fmap_comp (a:=(a0,b0)) (b:=(a1,b1)) (c:=(a2,b2)) F (f,h) (g,i).
+  := fmap_comp (a := (a0, b0)) (b := (a1, b1)) (c := (a2, b2)) F (f, h) (g, i).
 
 Definition fmap2_pair {A B C : Type}
   `{Is1Cat A, Is1Cat B, Is1Cat C}
@@ -250,4 +250,4 @@ Definition fmap2_pair {A B C : Type}
   {a0 a1 : A} {f f' : a0 $-> a1} (p : f $== f')
   {b0 b1 : B} {g g' : b0 $-> b1} (q : g $== g')
   : fmap_pair F f g $== fmap_pair F f' g'
-  := fmap2 F (a:=(a0,b0)) (b:=(a1,b1)) (f:=(f,g)) (g:=(f',g')) (p,q).
+  := fmap2 F (a := (a0, b0)) (b := (a1, b1)) (f := (f, g)) (g := (f' ,g')) (p, q).

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -440,44 +440,21 @@ Defined.
 Local Instance is0bifunctor_boolrec {A : Type} `{Is1Cat A}
   : Is0Bifunctor (Bool_rec A).
 Proof.
-  snrapply Build_Is0Bifunctor.
-  - intros x.
-    nrapply Build_Is0Functor.
-    intros a b f [|].
-    + reflexivity.
-    + exact f.
-  - intros y.
-    nrapply Build_Is0Functor.
-    intros a b f [|].
-    + exact f.
-    + reflexivity.
+  snrapply Build_Is0Functor.
+  intros [a b] [a' b'] [f g] [ | ].
+  - exact f.
+  - exact g.
 Defined.
 
 Local Instance is1bifunctor_boolrec {A : Type} `{Is1Cat A}
   : Is1Bifunctor (Bool_rec A).
 Proof.
-  nrapply Build_Is1Bifunctor.
-  - intros x.
-    nrapply Build_Is1Functor.
-    + intros a b f g p [|].
-      1: reflexivity.
-      exact p.
-    + intros a [|]; reflexivity.
-    + intros a b c f g [|].
-      1: exact (cat_idl _)^$.
-      reflexivity.
-  - intros y.
-    nrapply Build_Is1Functor.
-    + intros a b f g p [|].
-      1: exact p.
-      reflexivity.
-    + intros a [|]; reflexivity.
-    + intros a b c f g [|].
-      1: reflexivity.
-      exact (cat_idl _)^$.
-  - intros a a' f b b' g [|].
-    + exact (cat_idl _ $@ (cat_idr _)^$).
-    + exact (cat_idr _ $@ (cat_idl _)^$).
+  snrapply Build_Is1Functor.
+  - intros [a b] [a' b'] [f g] [f' g'] [p q] [ | ].
+    + exact p.
+    + exact q.
+  - intros [a b] [ | ]; reflexivity.
+  - intros [a b] [a' b'] [a'' b''] [f f'] [g g'] [ | ]; reflexivity.
 Defined.
 
 (** As a special case of the product functor, restriction along [Bool_rec A] yields bifunctoriality of [cat_binprod]. *)
@@ -502,28 +479,28 @@ Global Instance is0functor_cat_binprod_l {A : Type} `{HasBinaryProducts A}
   (y : A)
   : Is0Functor (fun x => cat_binprod x y).
 Proof.
-  exact (bifunctor_is0functor10 y).
+  exact (is0functor10_bifunctor _ y).
 Defined.
 
 Global Instance is1functor_cat_binprod_l {A : Type} `{HasBinaryProducts A}
   (y : A)
   : Is1Functor (fun x => cat_binprod x y).
 Proof.
-  exact (bifunctor_is1functor10 y).
+  exact (is1functor10_bifunctor _ y).
 Defined.
 
 Global Instance is0functor_cat_binprod_r {A : Type} `{HasBinaryProducts A}
   (x : A)
   : Is0Functor (fun y => cat_binprod x y).
 Proof.
-  exact (bifunctor_is0functor01 x).
+  exact (is0functor01_bifunctor _ x).
 Defined.
 
 Global Instance is1functor_cat_binprod_r {A : Type} `{HasBinaryProducts A}
   (x : A)
   : Is1Functor (fun y => cat_binprod x y).
 Proof.
-  exact (bifunctor_is1functor01 x).
+  exact (is1functor01_bifunctor _ x).
 Defined.
 
 (** [cat_binprod_corec] is also functorial in each morphsism. *)
@@ -558,12 +535,8 @@ Definition cat_pr1_fmap10_binprod {A : Type} `{HasBinaryProducts A}
 
 Definition cat_pr1_fmap11_binprod {A : Type} `{HasBinaryProducts A}
   {w x y z : A} (f : w $-> y) (g : x $-> z)
-  : cat_pr1 $o fmap11 (fun x y => cat_binprod x y) f g $== f $o cat_pr1.
-Proof.
-  refine ((cat_assoc _ _ _)^$ $@ (_ $@R _) $@ cat_assoc _ _ _ $@ _).
-  1: nrapply cat_binprod_beta_pr1.
-  exact (cat_idl _ $@ cat_binprod_beta_pr1 _ _).
-Defined.
+  : cat_pr1 $o fmap11 (fun x y => cat_binprod x y) f g $== f $o cat_pr1
+  := cat_binprod_beta_pr1 _ _.
 
 Definition cat_pr2_fmap01_binprod {A : Type} `{HasBinaryProducts A}
   (a : A) {x y : A} (g : x $-> y)
@@ -577,12 +550,8 @@ Definition cat_pr2_fmap10_binprod {A : Type} `{HasBinaryProducts A}
 
 Definition cat_pr2_fmap11_binprod {A : Type} `{HasBinaryProducts A}
   {w x y z : A} (f : w $-> y) (g : x $-> z)
-  : cat_pr2 $o fmap11 (fun x y => cat_binprod x y) f g $== g $o cat_pr2.
-Proof.
-  refine ((cat_assoc _ _ _)^$ $@ (_ $@R _) $@ cat_assoc _ _ _ $@ (_ $@L _)).
-  1: nrapply cat_binprod_beta_pr2.
-  nrapply cat_pr2_fmap10_binprod.
-Defined.
+  : cat_pr2 $o fmap11 (fun x y => cat_binprod x y) f g $== g $o cat_pr2
+  := cat_binprod_beta_pr2 _ _.
 
 (** *** Symmetry of binary products *)
 
@@ -644,8 +613,7 @@ Section Symmetry.
     - snrapply Build_Braiding.
       + exact cat_binprod_swap.
       + intros [a b] [c d] [f g]; cbn in f, g.
-        nrefine (cat_binprod_swap_nat f g $@ (_ $@R _)).
-        rapply fmap11_coh.
+        exact(cat_binprod_swap_nat f g).
     - exact cat_binprod_swap_cat_binprod_swap.
   Defined.
 
@@ -732,12 +700,11 @@ Section Associativity.
       2: nrapply cat_pr2_fmap11_binprod.
       refine (_ $@ (_ $@L _^$) $@ (cat_assoc _ _ _)^$).
       2: nrapply cat_binprod_beta_pr2.
-      nrefine (_ $@ cat_assoc_opp _ _ _).
-      nrefine (_ $@ (_ $@L _)).
-      2: rapply fmap11_coh.
-      nrefine (cat_assoc_opp _ _ _ $@ (_ $@R _) $@ cat_assoc _ _ _).
-      refine ((fmap01_comp _ _ _ _)^$ $@ fmap02 _ _ _ $@ fmap01_comp _ _ _ _).
-      nrapply cat_pr2_fmap11_binprod.
+      refine (_^$ $@ _ $@ _).
+      1,3: rapply fmap11_comp.
+      rapply fmap22.
+      1: exact (cat_idl _ $@ (cat_idr _)^$).
+      nrapply cat_binprod_beta_pr2.
   Defined.
 
   Local Existing Instance symmetricbraiding_binprod.

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -440,6 +440,8 @@ Defined.
 Local Instance is0bifunctor_boolrec {A : Type} `{Is1Cat A}
   : Is0Bifunctor (Bool_rec A).
 Proof.
+  snrapply Build_Is0Bifunctor'.
+  1,2: exact _.
   snrapply Build_Is0Functor.
   intros [a b] [a' b'] [f g] [ | ].
   - exact f.
@@ -449,6 +451,7 @@ Defined.
 Local Instance is1bifunctor_boolrec {A : Type} `{Is1Cat A}
   : Is1Bifunctor (Bool_rec A).
 Proof.
+  snrapply Build_Is1Bifunctor'.
   snrapply Build_Is1Functor.
   - intros [a b] [a' b'] [f g] [f' g'] [p q] [ | ].
     + exact p.
@@ -479,28 +482,28 @@ Global Instance is0functor_cat_binprod_l {A : Type} `{HasBinaryProducts A}
   (y : A)
   : Is0Functor (fun x => cat_binprod x y).
 Proof.
-  exact (is0functor10_bifunctor _ y).
+  exact (is0functor10_bifunctor y).
 Defined.
 
 Global Instance is1functor_cat_binprod_l {A : Type} `{HasBinaryProducts A}
   (y : A)
   : Is1Functor (fun x => cat_binprod x y).
 Proof.
-  exact (is1functor10_bifunctor _ y).
+  exact (is1functor10_bifunctor y).
 Defined.
 
 Global Instance is0functor_cat_binprod_r {A : Type} `{HasBinaryProducts A}
   (x : A)
   : Is0Functor (fun y => cat_binprod x y).
 Proof.
-  exact (is0functor01_bifunctor _ x).
+  exact (is0functor01_bifunctor x).
 Defined.
 
 Global Instance is1functor_cat_binprod_r {A : Type} `{HasBinaryProducts A}
   (x : A)
   : Is1Functor (fun y => cat_binprod x y).
 Proof.
-  exact (is1functor01_bifunctor _ x).
+  exact (is1functor01_bifunctor x).
 Defined.
 
 (** [cat_binprod_corec] is also functorial in each morphsism. *)

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -44,13 +44,20 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_hom {A} `{Is01Cat A}
-  : Is0Bifunctor (A:=A^op) (B:=A) (C:=Type) (@Hom A _)
-  := is0functor_hom.
+  : Is0Bifunctor (A:=A^op) (B:=A) (C:=Type) (@Hom A _).
+Proof.
+  nrapply Build_Is0Bifunctor'.
+  1-2: exact _.
+  exact is0functor_hom.
+Defined.
 
 (** While it is possible to prove the bifunctor coherence condition from [Is1Cat_Strong], 1-functoriality requires morphism extensionality.*)
 Global Instance is1bifunctor_hom {A} `{Is1Cat A} `{HasMorExt A}
-  : Is1Bifunctor (A:=A^op) (B:=A) (C:=Type) (@Hom A _)
-  := is1functor_hom.
+  : Is1Bifunctor (A:=A^op) (B:=A) (C:=Type) (@Hom A _).
+Proof.
+  nrapply Build_Is1Bifunctor'.
+  exact is1functor_hom.
+Defined.
 
 Definition fun01_hom {A} `{Is01Cat A}
   : Fun01 (A^op * A) Type
@@ -255,12 +262,19 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_hom_0gpd {A : Type} `{Is1Cat A}
-  : Is0Bifunctor (A:=A^op) (B:=A) (C:=ZeroGpd) (opyon_0gpd (A:=A))
-  := is0functor_hom_0gpd.
+  : Is0Bifunctor (A:=A^op) (B:=A) (C:=ZeroGpd) (opyon_0gpd (A:=A)).
+Proof.
+  snrapply Build_Is0Bifunctor'.
+  1,2: exact _.
+  exact is0functor_hom_0gpd.
+Defined.
 
 Global Instance is1bifunctor_hom_0gpd {A : Type} `{Is1Cat A}
-  : Is1Bifunctor (A:=A^op) (B:=A) (C:=ZeroGpd) (opyon_0gpd (A:=A))
-  := is1functor_hom_0gpd.
+  : Is1Bifunctor (A:=A^op) (B:=A) (C:=ZeroGpd) (opyon_0gpd (A:=A)).
+Proof.
+  snrapply Build_Is1Bifunctor'.
+  exact is1functor_hom_0gpd.
+Defined.
 
 Global Instance is0functor_opyon_0gpd {A : Type} `{Is1Cat A} (a : A)
   : Is0Functor (opyon_0gpd a).

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -45,12 +45,12 @@ Defined.
 
 Global Instance is0bifunctor_hom {A} `{Is01Cat A}
   : Is0Bifunctor (A:=A^op) (B:=A) (C:=Type) (@Hom A _)
-  := is0bifunctor_functor_uncurried _.
+  := is0functor_hom.
 
 (** While it is possible to prove the bifunctor coherence condition from [Is1Cat_Strong], 1-functoriality requires morphism extensionality.*)
 Global Instance is1bifunctor_hom {A} `{Is1Cat A} `{HasMorExt A}
   : Is1Bifunctor (A:=A^op) (B:=A) (C:=Type) (@Hom A _)
-  := is1bifunctor_functor_uncurried _.
+  := is1functor_hom.
 
 Definition fun01_hom {A} `{Is01Cat A}
   : Fun01 (A^op * A) Type
@@ -256,11 +256,11 @@ Defined.
 
 Global Instance is0bifunctor_hom_0gpd {A : Type} `{Is1Cat A}
   : Is0Bifunctor (A:=A^op) (B:=A) (C:=ZeroGpd) (opyon_0gpd (A:=A))
-  := is0bifunctor_functor_uncurried _.
+  := is0functor_hom_0gpd.
 
 Global Instance is1bifunctor_hom_0gpd {A : Type} `{Is1Cat A}
   : Is1Bifunctor (A:=A^op) (B:=A) (C:=ZeroGpd) (opyon_0gpd (A:=A))
-  := is1bifunctor_functor_uncurried _.
+  := is1functor_hom_0gpd.
 
 Global Instance is0functor_opyon_0gpd {A : Type} `{Is1Cat A} (a : A)
   : Is0Functor (opyon_0gpd a).


### PR DESCRIPTION
In this PR, we redefine `Is0Bifunctor` and `Is1Bifunctor` as discussed in #1933.

This has simplified things in lots of places however I got stuck with a universe issue in AbExt. @jdchristensen would you be able to take a look at that?

The reason I am doing this PR now is that I need some definitionally involutive opposite behaviour for bifunctors in #1929 and this isn't possible with the bifunctor coherence defintion.