### PR TITLE
Use correct scheme kind for CarriersTermAlgebra_ind

### DIFF
--- a/theories/Algebra/Universal/TermAlgebra.v
+++ b/theories/Algebra/Universal/TermAlgebra.v
@@ -30,7 +30,7 @@ Inductive CarriersTermAlgebra {σ} (C : Carriers σ) : Carriers σ :=
       DomOperation (CarriersTermAlgebra C) (σ u) ->
       CarriersTermAlgebra C (sort_cod (σ u)).
 
-Scheme CarriersTermAlgebra_ind := Elimination for CarriersTermAlgebra Sort Type.
+Scheme CarriersTermAlgebra_ind := Induction for CarriersTermAlgebra Sort Type.
 Arguments CarriersTermAlgebra_ind {σ}.
 
 Definition CarriersTermAlgebra_rect {σ} := @CarriersTermAlgebra_ind σ.


### PR DESCRIPTION
Elimination is documented as nonrecursive although incorrectly behaves like Induction until coq/coq#19017