### PR TITLE
Matrix Rings

### DIFF
--- a/test/Algebra/Rings/Matrix.v
+++ b/test/Algebra/Rings/Matrix.v
@@ -1,7 +1,7 @@
 From HoTT Require Import Basics.
 From HoTT Require Import Algebra.Rings.Matrix.
 From HoTT Require Import Spaces.Nat.Core Spaces.List.Core.
-From HoTT Require Import Algebra.Rings.Z Spaces.Int.Core Algebra.Rings.CRing.
+From HoTT Require Import Algebra.Rings.Z Spaces.BinInt.Core Algebra.Rings.CRing.
 From HoTT Require Import Classes.interfaces.canonical_names.
 
 Local Open Scope mc_scope.
@@ -38,7 +38,7 @@ Definition test2_B := Build_Matrix' nat 4 4
 
 Definition test2 : entries test2_A = entries test2_B := idpath.
 
-Local Open Scope int_scope.
+Local Open Scope binint_scope.
 
 (** Matrices with ring entries can be multiplied *)
 

--- a/test/Algebra/Rings/Matrix.v
+++ b/test/Algebra/Rings/Matrix.v
@@ -1,0 +1,126 @@
+From HoTT Require Import Basics.
+From HoTT Require Import Algebra.Rings.Matrix.
+From HoTT Require Import Spaces.Nat.Core Spaces.List.Core.
+From HoTT Require Import Algebra.Rings.Z Spaces.Int.Core Algebra.Rings.CRing.
+From HoTT Require Import Classes.interfaces.canonical_names.
+
+Local Open Scope mc_scope.
+Local Open Scope nat_scope.
+Local Open Scope list_scope.
+
+(** Matrices can be built with lists of lists. *)
+Definition test1 := Build_Matrix' nat 5 7
+   [ [  1 ,  2 ,  3 ,  4 ,  5 ,  6 ,  7 ]
+   , [  8 ,  9 , 10 , 11 , 12 , 13 , 14 ]
+   , [ 15 , 16 , 17 , 18 , 19 , 20 , 21 ]
+   , [ 22 , 23 , 24 , 25 , 26 , 27 , 28 ]
+   , [ 29 , 30 , 31 , 32 , 33 , 34 , 35 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+(** Malformed matrices are not accepted. *)
+Fail Definition test2 := Build_Matrix' nat 2 2
+   [ [ 1 , 2 ]
+   , [ 3 , 4 , 5] ]
+   ltac:(decide)
+   ltac:(decide).
+
+(** Matrices can also be built with functions. *)
+Definition test2_A := Build_Matrix nat 4 4 (fun i j _ _ => i * j).
+
+Definition test2_B := Build_Matrix' nat 4 4
+   [ [  0 ,  0 ,  0 ,  0 ]
+   , [  0 ,  1 ,  2 ,  3 ]
+   , [  0 ,  2 ,  4 ,  6 ]
+   , [  0 ,  3 ,  6 ,  9 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+Definition test2 : entries test2_A = entries test2_B := idpath.
+
+Local Open Scope int_scope.
+
+(** Matrices with ring entries can be multiplied *)
+
+(** This is the first matrix. *)
+Definition test3_A := Build_Matrix' cring_Z 3 2
+   [ [ 1 ,  3 ]
+   , [ 2 , -1 ]
+   , [ 1 ,  1 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+(** This is the second matrix. *)
+Definition test3_B := Build_Matrix' cring_Z 2 4
+   [ [  4 , 1 , 0 , -2 ]
+   , [ -1 , 1 , 5 ,  1 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+(** This is the expected result of the multiplication. *)
+Definition test3_AB := Build_Matrix' cring_Z 3 4
+   [ [  1 , 4 , 15 ,  1 ]
+   , [  9 , 1 , -5 , -5 ]
+   , [  3 , 2 ,  5 , -1 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+(** The entries should be the same, although the well-formedness proofs may differ definitionally. *)
+Definition test3 : entries (matrix_mult test3_A test3_B) = entries test3_AB := idpath.
+
+(** Here we check the minors of a matrix are computed correctly. *)
+
+Definition test4 := Build_Matrix' cring_Z 3 3
+   [ [  1 ,  3 ,  5 ]
+   , [  2 ,  4 ,  6 ]
+   , [  7 ,  8 ,  9 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+Definition test4_minor_0_1 := Build_Matrix' cring_Z 2 2
+   [ [  2 ,  6 ]
+   , [  7 ,  9 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+Definition test4_minor_0_1_eq
+   : entries (matrix_minor 0 1 test4) = entries test4_minor_0_1
+   := idpath.
+
+Definition test4_minor_1_1 := Build_Matrix' cring_Z 2 2
+   [ [  1 ,  5 ]
+   , [  7 ,  9 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+Definition test4_minor_1_1_eq
+   : entries (matrix_minor 1 1 test4) = entries test4_minor_1_1
+   := idpath.
+
+(** Now we check the determinant of a matrix is computed correctly. *)
+
+Definition test5_a := Build_Matrix' cring_Z 3 3
+   [ [  1 ,  3 ,  5 ]
+   , [  2 ,  4 ,  6 ]
+   , [  7 ,  8 ,  9 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+Definition test5_a_det_eq : det test5_a = 0 := idpath.
+
+Definition test5_b := Build_Matrix' cring_Z 3 3
+   [ [  2 ,  1 ,  3 ]
+   , [  1 , -2 ,  3 ]
+   , [  0 ,  2 ,  1 ] ]
+   ltac:(decide)
+   ltac:(decide).
+
+Definition test5_b_det_eq : det test5_b = -11 := idpath.
+
+Definition test5_c := Build_Matrix' cring_Z 2 2
+   [ [ 1 , 2 ]
+   , [ 3 , 4 ] ]
+   ltac:(decide)
+   ltac:(decide).
+      
+Definition test5_c_det_eq : det test5_c = -2 := idpath.

--- a/test/Algebra/Rings/Matrix.v
+++ b/test/Algebra/Rings/Matrix.v
@@ -97,30 +97,3 @@ Definition test4_minor_1_1_eq
    : entries (matrix_minor 1 1 test4) = entries test4_minor_1_1
    := idpath.
 
-(** Now we check the determinant of a matrix is computed correctly. *)
-
-Definition test5_a := Build_Matrix' cring_Z 3 3
-   [ [  1 ,  3 ,  5 ]
-   , [  2 ,  4 ,  6 ]
-   , [  7 ,  8 ,  9 ] ]
-   ltac:(decide)
-   ltac:(decide).
-
-Definition test5_a_det_eq : det test5_a = 0 := idpath.
-
-Definition test5_b := Build_Matrix' cring_Z 3 3
-   [ [  2 ,  1 ,  3 ]
-   , [  1 , -2 ,  3 ]
-   , [  0 ,  2 ,  1 ] ]
-   ltac:(decide)
-   ltac:(decide).
-
-Definition test5_b_det_eq : det test5_b = -11 := idpath.
-
-Definition test5_c := Build_Matrix' cring_Z 2 2
-   [ [ 1 , 2 ]
-   , [ 3 , 4 ] ]
-   ltac:(decide)
-   ltac:(decide).
-      
-Definition test5_c_det_eq : det test5_c = -2 := idpath.

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -116,7 +116,7 @@ Global Instance isleftmodule_abgroup_matrix (R : Ring) (m n : nat)
   : IsLeftModule R (abgroup_matrix R m n)
   := _.
 
-Definition matrix_scale {R : Ring} {m n : nat} (r : R) (M : Matrix R m n)
+Definition matrix_lact {R : Ring} {m n : nat} (r : R) (M : Matrix R m n)
   : Matrix R m n
   := lact r M.  
 
@@ -129,18 +129,6 @@ Proof.
   snrapply Build_Matrix.
   intros i j Hi Hj.
   exact (ab_sum n (fun k Hk => entry M i k * entry N k j)).
-Defined.
-
-(** TODO move *)
-Definition diagonal_matrix {R : Ring@{i}} {n : nat} (v : list R) (p : length v = n)
-  : Matrix R n n.
-Proof.
-  snrapply Build_Matrix.
-  intros i j H1 H2.
-  destruct (dec (i = j)).
-  - destruct p.
-    exact (nth' v i H1).
-  - exact 0.
 Defined.
 
 (** The identity matrix is the matrix with ones on the diagonal and zeros elsewhere. It acts as the multiplicative identity for matrix multiplication. We define it here using the [kronecker_delta] function which will make proving properties about it conceptually easier later. *)
@@ -265,8 +253,8 @@ Defined.
 
 (** Transpose commutes with scalar multiplication. *)
 Definition matrix_transpose_scale {R : Ring} {m n} (r : R) (M : Matrix R m n)
-  : matrix_transpose (matrix_scale r M)
-    = matrix_scale r (matrix_transpose M).
+  : matrix_transpose (matrix_lact r M)
+    = matrix_lact r (matrix_transpose M).
 Proof.
   apply path_matrix.
   intros i j Hi Hj.
@@ -286,6 +274,20 @@ Proof.
   intros k Hk.
   rewrite 2 entry_Build_Matrix.
   apply rng_mult_comm.
+Defined.
+
+(** ** Diagonal matrices *)
+
+(** A diagonal matrix is a matrix with zeros everywhere except on the diagonal. *)
+Definition diagonal_matrix {R : Ring@{i}} {n : nat} (v : list R) (p : length v = n)
+  : Matrix R n n.
+Proof.
+  snrapply Build_Matrix.
+  intros i j H1 H2.
+  destruct (dec (i = j)).
+  - destruct p.
+    exact (nth' v i H1).
+  - exact 0.
 Defined.
 
 (** ** Trace *)
@@ -386,7 +388,7 @@ Defined.
 
 Definition matrix_minor_scale {R : Ring@{i}} {n : nat} (i j : nat)
   (Hi : (i < n.+1)%nat) (Hj : (j < n.+1)%nat) (r : R) (M : Matrix R n.+1 n.+1)
-  : matrix_minor i j (matrix_scale r M) = matrix_scale r (matrix_minor i j M).
+  : matrix_minor i j (matrix_lact r M) = matrix_lact r (matrix_minor i j M).
 Proof.
   apply path_matrix.
   intros k l Hk Hl.

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -32,6 +32,24 @@ Proof.
   exact (M_fun i j Hi Hj).
 Defined.
 
+(** The length conditions here are decidable so can be inferred in proofs. *)
+Definition Build_Matrix' (R : Type) (m n : nat)
+  (l : list (list R))
+  (wf_row : length l = m)
+  (wf_col : for_all (fun row => length row = n) l)
+  : Matrix R m n.
+Proof.
+  snrefine (_; _).
+  - snrapply list_sigma.
+    + exact l.
+    + exact wf_col.
+  - by lhs nrapply length_list_sigma.
+Defined.
+
+Definition entries {R : Type} {m n} (M : Matrix R m n)
+  : list (list R)
+  := list_map pr1 (pr1 M).
+
 (** The entry at row [i] and column [j] of a matrix [M]. *)
 Definition entry {R : Type} {m n} (M : Matrix R m n) (i j : nat)
   {H1 : (i < m)%nat} {H2 : (j < n)%nat}

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -1,0 +1,553 @@
+Require Import Basics.Overture Basics.Trunc Basics.Tactics Basics.Decidable.
+Require Import Types.Sigma.
+Require Import Spaces.List.Core Spaces.List.Theory Spaces.List.Paths.
+Require Import Algebra.Rings.Ring Algebra.Rings.Module Algebra.Rings.CRing.
+Require Import abstract_algebra.
+
+Set Universe Minimization ToSet.
+
+Local Open Scope mc_scope.
+
+(** * Matrices *)
+
+(** ** Definition *)
+
+(** A matrix is a list of lists of elements of a ring that is well-formed. A matrix is well-formed if all the rows and columns have the specified length. *)
+Record Matrix (R : Type@{i}) (m n : nat) : Type@{i} := Build_Matrix' {
+  entries :> list (list R);
+  mx_wf_rows : length entries = m;
+  mx_wf_cols : for_all (fun row => length row = n) entries;
+}.
+
+Arguments entries {R m n} M : rename.
+Arguments mx_wf_rows {R m n} M : rename. 
+Arguments mx_wf_cols {R m n} M : rename.
+
+Definition issig_Matrix (R : Type) (m n : nat) : _ <~> Matrix R m n := ltac:(issig).
+
+Global Instance istrunc_matrix (R : Type) k `{IsTrunc k.+2 R} m n
+  : IsTrunc k.+2 (Matrix R m n).
+Proof.
+  nrapply istrunc_equiv_istrunc.
+  1: apply issig_Matrix.
+  exact _.
+Defined.
+
+(** Building a matrix from a function that takes row and column indices. *)
+Definition Build_Matrix (R : Type) (m n : nat)
+  (M_fun : forall (i : nat) (j : nat), (i < m)%nat -> (j < n)%nat -> R)
+  : Matrix R m n.
+Proof.
+  exists (map (fun '(i; H1)
+    => map (fun '(j; H2)
+      => M_fun i j H1 H2) (seq' n)) (seq' m)).
+  - lhs nrapply length_map.
+    apply length_seq'.
+  - snrapply for_all_map'.
+    apply for_all_inlist.
+    intros [k ?] H.
+    lhs nrapply length_map.
+    apply length_seq'.
+Defined.
+
+(** The entry at row [i] and column [j] of a matrix [M]. *)
+Definition entry {R : Type} {m n} (M : Matrix R m n) (i j : nat)
+  {H1 : (i < m)%nat} {H2 : (j < n)%nat}
+  : R.
+Proof.
+  snrefine (nth' (nth' M i _) j _).
+  1: exact ((mx_wf_rows M)^ # H1).
+  nrefine (_^ # H2).
+  apply (inlist_for_all M (mx_wf_cols M)).
+  apply inlist_nth'.
+Defined.
+
+(** Mapping a function on all the entries of a matrix. *)
+Definition matrix_map {R S : Type} {m n} (f : R -> S)
+  : Matrix R m n -> Matrix S m n
+  := fun M => Build_Matrix S m n (fun i j _ _ => f (entry M i j)).
+
+Definition matrix_map2 {R S T : Type} {m n} (f : R -> S -> T)
+  : Matrix R m n -> Matrix S m n -> Matrix T m n
+  := fun M N => Build_Matrix T m n
+    (fun i j _ _ => f (entry M i j) (entry N i j)).
+
+(** The [(i, j)]-entry of [Build_Matrix R m n M_fun] is [M_fun i j]. *)
+Definition entry_Build_Matrix {R : Type} {m n}
+  (M_fun : forall i j, (i < m)%nat -> (j < n)%nat -> R)
+  (i j : nat) (H1 : (i < m)%nat) (H2 : (j < n)%nat)
+  : entry (Build_Matrix R m n M_fun) i j = M_fun i j _ _.
+Proof.
+  snrefine (ap011D (fun l => nth' l _) _ _ @ _).
+  2: rapply nth'_map.
+  - nrefine (_^ # H1).
+    nrapply length_seq'.
+  - nrefine (_^ # H2).
+    lhs nrapply length_map.
+    nrapply length_seq'.
+  - apply path_ishprop.
+  - snrefine (nth'_map _ _ _ _ _ @ _).
+    { nrefine (_^ # H2).
+      nrapply length_seq'. }
+    snrefine (ap011D (fun x y => M_fun x _ y _) _ _ @ _).
+    + exact i.
+    + nrapply nth'_seq'.
+    + assumption.
+    + apply path_ishprop.
+    + snrefine (ap011D (fun x y => M_fun _ x _ y) _ _).
+      * nrapply nth'_seq'.
+      * apply path_ishprop.
+Defined.
+
+(** Two matrices are equal if all their entries are equal. *)
+Definition path_matrix {R : Type} {m n} (M N : Matrix R m n)
+  (H : forall i j (Hi : (i < m)%nat) (Hj : (j < n)%nat), entry M i j = entry N i j)
+  : M = N.
+Proof.
+  nrefine ((equiv_ap' (issig_Matrix _ _ _)^-1%equiv _ _)^-1%equiv _).
+  rapply path_sigma_hprop; cbn.
+  snrapply path_list_nth'.
+  1: exact (mx_wf_rows M @ (mx_wf_rows N)^).
+  intros i Hi.
+  snrapply path_list_nth'.
+  { lhs nrapply (inlist_for_all _ (mx_wf_cols M)).
+    1: nrapply inlist_nth'.
+    symmetry; nrapply (inlist_for_all _ (mx_wf_cols N)).
+    nrapply inlist_nth'. }
+  intros j Hj.
+  snrefine (ap011D (fun l => nth' l _) _ _ @ H i j _ _
+    @ (ap011D (fun l => nth' l _) _ _)^).
+  2,6: apply path_ishprop.
+  1,4: snrapply ap011D.
+  1,3: reflexivity.
+  1,2: apply path_ishprop.
+  - exact (mx_wf_rows M # Hi).
+  - nrefine (_ # Hj).
+    apply (inlist_for_all M (mx_wf_cols M)).
+    apply inlist_nth'.
+Defined.
+
+(** ** Addition *)
+
+(** Here we define the abelian group of (n x m)-matrices over a ring. This is not particularly interesting, just the entry-wise abelian group structure. We later show that this abelian group is a left R-module so we assume [R] is a ring throughout. Strictly speaking [R] does not have to be a ring for just the abelian group structure, but the extra generality doesn't seem useful. *)
+
+Section MatrixAddition.
+
+  Context (R : Ring) (m n : nat).
+
+  (** The addition of two matrices is the matrix with the sum of the corresponding entries. *)
+  Definition matrix_plus : Plus (Matrix R m n) := matrix_map2 (+).
+
+  (** The zero matrix is the matrix with all entries equal to zero. *)
+  Definition zero_matrix : Zero (Matrix R m n)
+    := Build_Matrix R m n (fun _ _ _ _ => 0).
+
+  (** The negation of a matrix is the matrix with the negation of the entries. *)
+  Definition neg_matrix : Negate (Matrix R m n) := matrix_map (-).
+
+  (** Matrix addition is associative. *)
+  Definition associative_matrix_plus : Associative matrix_plus.
+  Proof.
+    intros M N P; apply path_matrix; intros i j Hi Hj.
+    rewrite 4 entry_Build_Matrix.
+    apply associativity.
+  Defined.
+
+  (** Matrix addition is commutative. *)
+  Definition commutative_matrix_plus : Commutative matrix_plus.
+  Proof.
+    intros M N; apply path_matrix; intros i j Hi Hj.
+    rewrite 2 entry_Build_Matrix.
+    apply commutativity.
+  Defined.
+
+  (** The zero matrix is a left identity for matrix addition. *)
+  Definition left_identity_matrix_plus : LeftIdentity matrix_plus zero_matrix.
+  Proof.
+    intros M; apply path_matrix; intros i j Hi Hj.
+    rewrite 2 entry_Build_Matrix.
+    apply left_identity.
+  Defined.
+
+  (** The zero matrix is a right identity for matrix addition. *)
+  Definition right_identity_matrix_plus : RightIdentity matrix_plus zero_matrix.
+  Proof.
+    intros M; apply path_matrix; intros i j Hi Hj.
+    rewrite 2 entry_Build_Matrix.
+    apply right_identity.
+  Defined.
+
+  (** Matrix negation is a left inverse for matrix addition. *)
+  Definition left_inverse_matrix_plus
+    : LeftInverse matrix_plus neg_matrix zero_matrix.
+  Proof.
+    intros M; apply path_matrix; intros i j Hi Hj.
+    rewrite 3 entry_Build_Matrix.
+    rapply left_inverse.
+  Defined.
+
+  (** Matrix negation is a right inverse for matrix addition. *)
+  Definition right_inverse_matrix_plus
+    : RightInverse matrix_plus neg_matrix zero_matrix.
+  Proof.
+    intros M; apply path_matrix; intros i j Hi Hj.
+    rewrite 3 entry_Build_Matrix.
+    rapply right_inverse.
+  Defined.
+
+  (** Matrix addition forms an abelian group. *)
+  Definition abgroup_matrix : AbGroup.
+  Proof.
+    snrapply Build_AbGroup.
+    1: snrapply Build_Group.
+    5: repeat split.
+    - exact (Matrix R m n).
+    - exact matrix_plus.
+    - exact zero_matrix.
+    - exact neg_matrix.
+    - exact _.
+    - exact associative_matrix_plus.
+    - exact left_identity_matrix_plus.
+    - exact right_identity_matrix_plus.
+    - exact left_inverse_matrix_plus.
+    - exact right_inverse_matrix_plus.
+    - exact commutative_matrix_plus.
+  Defined.
+
+  (** The (left) scalar multiplication of a matrix is the matrix with each entry multiplied by the scalar. *)
+  Definition matrix_scale (r : R) : Matrix R m n -> Matrix R m n
+    := matrix_map (r *.).
+
+  (** Scalar multiplication distributes over matrix addition on the left. *)
+  Definition left_heterodistribute_matrix_scale_plus
+    : LeftHeteroDistribute matrix_scale matrix_plus matrix_plus.
+  Proof.
+    intros r M N; apply path_matrix; intros i j Hi Hj.
+    rewrite 5 entry_Build_Matrix.
+    apply distribute_l.
+  Defined.
+
+  (** Scalar multiplication distributes over addition of scalars on the right. *)
+  Definition right_heterodistribute_matrix_scale_plus
+    : RightHeteroDistribute matrix_scale (+) matrix_plus.
+  Proof.
+    intros r s M; apply path_matrix; intros i j Hi Hj.
+    rewrite 4 entry_Build_Matrix.
+    apply distribute_r.
+  Defined.
+
+  (** Scalar multiplication is associative. *)
+  Definition heteroassociative_matrix_scale_plus
+    : HeteroAssociative matrix_scale matrix_scale matrix_scale (.*.).
+  Proof.
+    intros r s N; apply path_matrix; intros i j Hi Hj.
+    rewrite 3 entry_Build_Matrix.
+    apply associativity.
+  Defined.
+
+  (** [1 : R] acts as an identity for scalar multiplication. *)
+  Definition left_identity_matrix_scale : LeftIdentity matrix_scale 1.
+  Proof.
+    intros M; apply path_matrix; intros i j Hi Hj.
+    lhs nrapply entry_Build_Matrix.
+    apply left_identity.
+  Defined.
+
+  (** The abelian group of matrices is a left module over the ring of coefficients. The ring acts on the matrices by scalar multplication. *)
+  Global Instance isleftmodule_abgroup_matrix : IsLeftModule R abgroup_matrix.
+  Proof.
+    snrapply Build_IsLeftModule.
+    - exact matrix_scale.
+    - exact left_heterodistribute_matrix_scale_plus.
+    - exact right_heterodistribute_matrix_scale_plus.
+    - exact heteroassociative_matrix_scale_plus.
+    - exact left_identity_matrix_scale.
+  Defined.
+
+End MatrixAddition.
+
+Arguments matrix_plus {R m n} M N.
+Arguments matrix_scale {R m n} r M.
+
+(** ** Multiplication *)
+
+(** Matrix multiplication is defined such that the entry at row [i] and column [j] of the resulting matrix is the sum of the products of the corresponding entries from the [i]th row of the first matrix and the [j]th column of the second matrix. Matrices correspond to module homomorphisms between free modules of finite rank (think vector spaces), and matrix multiplication represents the composition of these homomorphisms. **)
+Definition matrix_mult {R : Ring@{i}} {m n k : nat} (M : Matrix R m n) (N : Matrix R n k)
+  : Matrix R m k.
+Proof.
+  snrapply Build_Matrix.
+  intros i j Hi Hj.
+  exact (rng_sum n (fun k Hk => entry M i k * entry N k j)).
+Defined.
+
+(** TODO move *)
+Definition diagonal_matrix {R : Ring@{i}} {n : nat} (v : list R) (p : length v = n)
+  : Matrix R n n.
+Proof.
+  snrapply Build_Matrix.
+  intros i j H1 H2.
+  destruct (dec (i = j)).
+  - destruct p.
+    exact (nth' v i H1).
+  - exact 0.
+Defined.
+
+(** The identity matrix is the matrix with ones on the diagonal and zeros elsewhere. It acts as the multiplicative identity for matrix multiplication. We define it here using the [kronecker_delta] function which will make proving properties about it conceptually easier later. *)
+Definition identity_matrix (R : Ring@{i}) (n : nat) : Matrix R n n
+  := Build_Matrix R n n (fun i j _ _ => kronecker_delta i j).
+
+(** This is the most general statement of associativity for matrix multiplication. *)
+Definition associative_matrix_mult (R : Ring@{i}) (m n p q : nat)
+  : HeteroAssociative
+      (@matrix_mult R m n q) (@matrix_mult R n p q)
+      (@matrix_mult R m p q) (@matrix_mult R m n p).
+Proof.
+  intros M N P; nrapply path_matrix; intros i j Hi Hj.
+  rewrite 2 entry_Build_Matrix.
+  lhs nrapply path_rng_sum.
+  { intros k Hk.
+    rewrite entry_Build_Matrix.
+    apply rng_sum_dist_l. }
+  lhs nrapply rng_sum_sum.
+  rhs nrapply path_rng_sum.
+  2: intros k Hk; by rewrite entry_Build_Matrix.
+  nrapply path_rng_sum.
+  intros k Hk.
+  rhs nrapply rng_sum_dist_r.
+  nrapply path_rng_sum.
+  intros l Hl.
+  apply associativity.
+Defined.
+
+(** Matrix multiplication distributes over addition of matrices on the left. *)
+Definition left_distribute_matrix_mult (R : Ring@{i}) (m n p : nat)
+  : LeftHeteroDistribute (@matrix_mult R m n p) matrix_plus matrix_plus.
+Proof.
+  intros M N P; apply path_matrix; intros i j Hi Hj.
+  rewrite 4 entry_Build_Matrix.
+  rewrite <- rng_sum_plus.
+  nrapply path_rng_sum.
+  intros k Hk.
+  rewrite entry_Build_Matrix.
+  apply rng_dist_l.
+Defined.
+
+(** Matrix multiplication distributes over addition of matrices on the right. *)
+Definition right_distribute_matrix_mult (R : Ring@{i}) (m n p : nat)
+  : RightHeteroDistribute (@matrix_mult R m n p) matrix_plus matrix_plus.
+Proof.
+  intros M N P; apply path_matrix; intros i j Hi Hj.
+  rewrite 4 entry_Build_Matrix.
+  rewrite <- rng_sum_plus.
+  nrapply path_rng_sum.
+  intros k Hk.
+  rewrite entry_Build_Matrix.
+  apply rng_dist_r.
+Defined.
+
+(** The identity matrix acts as a left identity for matrix multiplication. *)
+Definition left_identity_matrix_mult (R : Ring@{i}) (m n: nat)
+  : LeftIdentity (@matrix_mult R m m n) (identity_matrix R m).
+Proof.
+  intros M; apply path_matrix; intros i j Hi Hj.
+  rewrite entry_Build_Matrix.
+  lhs nrapply path_rng_sum.
+  1: intros k Hk; by rewrite entry_Build_Matrix.
+  nrapply rng_sum_kronecker_delta_l.
+Defined.
+
+(** The identity matrix acts as a right identity for matrix multiplication. *)
+Definition right_identity_matrix_mult (R : Ring@{i}) (m n : nat)
+  : RightIdentity (@matrix_mult R m n n) (identity_matrix R n).
+Proof.
+  intros M; apply path_matrix; intros i j Hi Hj.
+  rewrite entry_Build_Matrix.
+  lhs nrapply path_rng_sum.
+  1: intros k Hk; by rewrite entry_Build_Matrix.
+  nrapply rng_sum_kronecker_delta_r'.
+Defined.
+
+(** TODO: define this as an R-algebra *)
+(** Matrices over a ring form a (generally) non-commutative ring. *)
+Definition matrix_ring (R : Ring@{i}) (n : nat) : Ring.
+Proof.
+  snrapply Build_Ring.
+  6: repeat split.
+  - exact (abgroup_matrix R n n).
+  - exact matrix_mult.
+  - exact (identity_matrix R n).
+  - exact (left_distribute_matrix_mult R n n n).
+  - exact (right_distribute_matrix_mult R n n n).
+  - exact _.
+  - exact (associative_matrix_mult R n n n n).
+  - exact (left_identity_matrix_mult R n n).
+  - exact (right_identity_matrix_mult R n n).
+Defined.
+
+(** ** Transpose *)
+
+(** The transpose of a matrix is the matrix with the rows and columns swapped. *)
+Definition matrix_transpose {R : Type} {m n} : Matrix R m n -> Matrix R n m
+  := fun M => Build_Matrix R n m (fun i j H1 H2 => entry M j i).
+
+(** Tranposing a matrix is involutive. *)
+Definition matrix_transpose_transpose {R : Type} {m n} (M : Matrix R m n)
+  : matrix_transpose (matrix_transpose M) = M.
+Proof.
+  apply path_matrix.
+  intros i j Hi Hj.
+  lhs nrapply entry_Build_Matrix.
+  nrapply entry_Build_Matrix.
+Defined.
+
+(** Transpose distributes over addition. *)
+Definition matrix_transpose_plus {R : Ring} {m n} (M N : Matrix R m n)
+  : matrix_transpose (matrix_plus M N)
+    = matrix_plus (matrix_transpose M) (matrix_transpose N).
+Proof.
+  apply path_matrix.
+  intros i j Hi Hj.
+  by rewrite 5 entry_Build_Matrix.
+Defined.
+
+(** Transpose commutes with scalar multiplication. *)
+Definition matrix_transpose_scale {R : Ring} {m n} (r : R) (M : Matrix R m n)
+  : matrix_transpose (matrix_scale r M)
+    = matrix_scale r (matrix_transpose M).
+Proof.
+  apply path_matrix.
+  intros i j Hi Hj.
+  by rewrite 4 entry_Build_Matrix.
+Defined.
+
+(** Transpose distributes over multiplication (in a commutative ring). *)
+Definition matrix_transpose_mult {R : CRing} {m n p}
+  (M : Matrix R m n) (N : Matrix R n p)
+  : matrix_transpose (matrix_mult M N)
+    = matrix_mult (matrix_transpose N) (matrix_transpose M).
+Proof.
+  apply path_matrix.
+  intros i j Hi Hj.
+  rewrite 3 entry_Build_Matrix.
+  apply path_rng_sum.
+  intros k Hk.
+  rewrite 2 entry_Build_Matrix.
+  apply rng_mult_comm.
+Defined.
+
+(** ** Trace *)
+
+(** The trace of a square matrix is the sum of the diagonal entries. *)
+Definition matrix_trace {R : Ring} {n} (M : Matrix R n n) : R
+  := rng_sum n (fun i Hi => entry M i i).
+
+(** The trace of a matrix multiplication is the same as the trace of the reverse multiplication. *)
+Definition matrix_trace_mult {R : CRing} {n} (M N : Matrix R n n)
+  : matrix_trace (matrix_mult M N) = matrix_trace (matrix_mult N M).
+Proof.
+  lhs nrapply path_rng_sum.
+  { intros i Hi.
+    lhs nrapply entry_Build_Matrix.
+    nrapply path_rng_sum.
+    { intros j Hj.
+      apply rng_mult_comm. } }
+  lhs nrapply rng_sum_sum. 
+  apply path_rng_sum.
+  intros i Hi.
+  rhs nrapply entry_Build_Matrix.
+  reflexivity.
+Defined.
+
+(** The trace of the transpose of a matrix is the same as the trace of the matrix. *)
+Definition trace_transpose {R : Ring} {n} (M : Matrix R n n)
+  : matrix_trace (matrix_transpose M) = matrix_trace M.
+Proof.
+  apply path_rng_sum.
+  intros i Hi.
+  nrapply entry_Build_Matrix.
+Defined.
+
+(** ** Matrix minors *)
+
+Definition skip (n : nat) : nat -> nat
+  := fun i => if dec (i < n)%nat then i else i.+1%nat.
+
+Global Instance isinjective_skip n : IsInjective (skip n).
+Proof.
+  hnf.
+  intros x y p.
+  unfold skip in p.
+  destruct (dec (x < n)%nat) as [H|H], (dec (y < n)%nat) as [H'|H'].
+  - exact p.
+  - destruct p^.
+    contradiction (H' (leq_trans _ H)).
+  - destruct p.
+    contradiction (H (leq_trans _ H')).
+  - by apply path_nat_S.
+Defined.
+
+Local Instance lt_n1_skip k i n (H : (i < n.+1)%nat) (H' : (k < n)%nat)
+  : (skip i k < n.+1)%nat.
+Proof.
+  unfold skip.
+  destruct (dec (k < i))%nat as [H''|H''].
+  - exact (transitive_lt _ _ _ H'' H) .
+  - apply leq_S_n'.
+    exact H'.
+Defined.
+
+Definition matrix_minor {R : Ring@{i}} {n : nat} (i j : nat)
+  {Hi : (i < n.+1)%nat} {Hj : (j < n.+1)%nat} (M : Matrix R n.+1 n.+1)
+  : Matrix R n n
+  := Build_Matrix R n n (fun k l _ _ => entry M (skip i k) (skip j l)).
+
+(** A minor of the zero matrix is again the zero matrix. *)
+Definition matrix_minor_zero {R : Ring@{i}} {n : nat} (i j : nat)
+  (Hi : (i < n.+1)%nat) (Hj : (j < n.+1)%nat)
+  : matrix_minor i j (zero_matrix R n.+1 n.+1) = zero_matrix R n n.
+Proof.
+  apply path_matrix.
+  intros k l Hk Hl.
+  lhs nrapply entry_Build_Matrix.
+  rhs nrapply entry_Build_Matrix.
+  nrapply entry_Build_Matrix.
+Defined.
+
+Definition matrix_minor_identity {R : Ring@{i}} {n : nat}
+  (i : nat) (Hi : (i < n.+1)%nat)
+  : matrix_minor i i (identity_matrix R n.+1) = identity_matrix R n.
+Proof.
+  apply path_matrix.
+  intros j k Hj Hk.
+  rewrite 3 entry_Build_Matrix.
+  rapply kronecker_delta_map_inj.
+Defined.
+
+Definition matrix_minor_plus {R : Ring@{i}} {n : nat} (i j : nat)
+  (Hi : (i < n.+1)%nat) (Hj : (j < n.+1)%nat) (M N : Matrix R n.+1 n.+1)
+  : matrix_minor i j (matrix_plus M N)
+    = matrix_plus (matrix_minor i j M) (matrix_minor i j N).
+Proof.
+  apply path_matrix.
+  intros k l Hk Hl.
+  by rewrite 5 entry_Build_Matrix.
+Defined.
+
+Definition matrix_minor_scale {R : Ring@{i}} {n : nat} (i j : nat)
+  (Hi : (i < n.+1)%nat) (Hj : (j < n.+1)%nat) (r : R) (M : Matrix R n.+1 n.+1)
+  : matrix_minor i j (matrix_scale r M) = matrix_scale r (matrix_minor i j M).
+Proof.
+  apply path_matrix.
+  intros k l Hk Hl.
+  by rewrite 4 entry_Build_Matrix.
+Defined.
+
+Definition matrix_minor_transpose {R : Ring@{i}} {n : nat} (i j : nat)
+  (Hi : (i < n.+1)%nat) (Hj : (j < n.+1)%nat) (M : Matrix R n.+1 n.+1)
+  : matrix_minor j i (matrix_transpose M)
+    = matrix_transpose (matrix_minor i j M).
+Proof.
+  apply path_matrix.
+  intros k l Hk Hl.
+  by rewrite 4 entry_Build_Matrix.
+Defined.

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -46,7 +46,7 @@ Proof.
     apply length_seq'.
   - snrapply for_all_list_map'.
     apply for_all_inlist.
-    intros [k ?] H.
+    intros k H.
     lhs nrapply length_list_map.
     apply length_seq'.
 Defined.
@@ -128,11 +128,11 @@ Proof.
     apply inlist_nth'.
 Defined.
 
-(** ** Addition *)
+(** ** Addition and module structure *)
 
 (** Here we define the abelian group of (n x m)-matrices over a ring. This is not particularly interesting, just the entry-wise abelian group structure. We later show that this abelian group is a left R-module so we assume [R] is a ring throughout. Strictly speaking [R] does not have to be a ring for just the abelian group structure, but the extra generality doesn't seem useful. *)
 
-Section MatrixAddition.
+Section MatrixModule.
 
   Context (R : Ring) (m n : nat).
 
@@ -265,7 +265,7 @@ Section MatrixAddition.
     - exact left_identity_matrix_scale.
   Defined.
 
-End MatrixAddition.
+End MatrixModule.
 
 Arguments matrix_plus {R m n} M N.
 Arguments matrix_scale {R m n} r M.

--- a/theories/Algebra/Rings/Module.v
+++ b/theories/Algebra/Rings/Module.v
@@ -85,6 +85,12 @@ Section ModuleFacts.
 
 End ModuleFacts.
 
+(** Every ring [R] is a left [R]-module over itself. *)
+Global Instance isleftmodule_ring (R : Ring) : IsLeftModule R R.
+Proof.
+  rapply Build_IsLeftModule.
+Defined.
+
 (** ** Left Submodules *)
 
 (** A subgroup of a left R-module is a left submodule if it is closed under the action of R. *)

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -16,9 +16,7 @@ Local Open Scope mc_scope.
 Definition Vector (A : Type) (n : nat)
  := { l : list A & length l = n }.
 
-Global Instance istrunc_vector (A : Type) (n : nat) k `{IsTrunc k.+2 A}
-  : IsTrunc k.+2 (Vector A n)
-  := _. 
+(** *** Constructors *)
 
 Definition Build_Vector (A : Type) (n : nat)
   (f : forall (i : nat), (i < n)%nat -> A)
@@ -29,16 +27,12 @@ Proof.
   apply length_seq'.
 Defined.
 
+(** *** Projections *)
+
 Definition entry {A : Type} {n} (v : Vector A n) i {Hi : (i < n)%nat} : A
   := nth' (pr1 v) i ((pr2 v)^ # Hi).
 
-Definition vector_map {A B : Type} {n} (f : A -> B)
-  : Vector A n -> Vector B n
-  := fun v => Build_Vector B n (fun i _ => f (entry v i)).
-
-Definition vector_map2 {A B C : Type} {n} (f : A -> B -> C)
-  : Vector A n -> Vector B n -> Vector C n
-  := fun v1 v2 => Build_Vector C n (fun i _ => f (entry v1 i) (entry v2 i)).
+(** *** Basic properties *) 
 
 Definition entry_Build_Vector {A : Type} {n}
   (f : forall (i : nat), (i < n)%nat -> A) i {Hi : (i < n)%nat}
@@ -51,6 +45,10 @@ Proof.
   rapply path_ishprop. 
 Defined.
 
+Global Instance istrunc_vector (A : Type) (n : nat) k `{IsTrunc k.+2 A}
+  : IsTrunc k.+2 (Vector A n)
+  := _. 
+
 Definition path_vector (A : Type) {n : nat} (v1 v2 : Vector A n)
   (H : forall i (H : (i < n)%nat), entry v1 i = entry v2 i)
   : v1 = v2.
@@ -62,6 +60,18 @@ Proof.
   snrefine (_ @ H i (pr2 v1 # Hi) @ _).
   1, 2: apply nth'_nth'.
 Defined.
+
+(** ** Operations *)
+
+Definition vector_map {A B : Type} {n} (f : A -> B)
+  : Vector A n -> Vector B n
+  := fun v => Build_Vector B n (fun i _ => f (entry v i)).
+
+Definition vector_map2 {A B C : Type} {n} (f : A -> B -> C)
+  : Vector A n -> Vector B n -> Vector C n
+  := fun v1 v2 => Build_Vector C n (fun i _ => f (entry v1 i) (entry v2 i)).
+
+(** ** Abelian group structure *)
 
 Section VectorAddition.
 
@@ -139,6 +149,8 @@ Section VectorAddition.
 End VectorAddition.
 
 Arguments vector_plus {A n} v1 v2.
+
+(** ** Module structure *)
 
 Section VectorScale.
   (** A vector of elements of an R-module is itself an R-module. A special case is when the R-module is the ring R itself. *)

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -156,34 +156,34 @@ Section VectorScale.
   (** A vector of elements of an R-module is itself an R-module. A special case is when the R-module is the ring R itself. *)
   Context (M : AbGroup) (n : nat) {R : Ring} `{IsLeftModule R M}.
 
-  Definition vector_scale (r : R) : Vector M n -> Vector M n
+  Definition vector_lact (r : R) : Vector M n -> Vector M n
     := vector_map (lact r).
   
-  Definition left_heterodistribute_vector_scale_plus
-    : LeftHeteroDistribute vector_scale vector_plus vector_plus.
+  Definition left_heterodistribute_vector_lact_plus
+    : LeftHeteroDistribute vector_lact vector_plus vector_plus.
   Proof.
     intros r v1 v2; apply path_vector; intros i Hi.
     rewrite 5 entry_Build_Vector.
     apply distribute_l.
   Defined.
 
-  Definition right_heterodistribute_vector_scale_plus
-    : RightHeteroDistribute vector_scale (+) vector_plus.
+  Definition right_heterodistribute_vector_lact_plus
+    : RightHeteroDistribute vector_lact (+) vector_plus.
   Proof.
     intros r1 r2 v; apply path_vector; intros i Hi.
     rewrite 4 entry_Build_Vector.
     apply distribute_r.
   Defined.
 
-  Definition heteroassociative_vector_scale_plus
-    : HeteroAssociative vector_scale vector_scale vector_scale (.*.).
+  Definition heteroassociative_vector_lact_plus
+    : HeteroAssociative vector_lact vector_lact vector_lact (.*.).
   Proof.
     intros r s v; apply path_vector; intros i Hi.
     rewrite 3 entry_Build_Vector.
     apply associativity.
   Defined.
 
-  Definition left_identity_vector_scale : LeftIdentity vector_scale 1.
+  Definition left_identity_vector_lact : LeftIdentity vector_lact 1.
   Proof.
     intros v; apply path_vector; intros i Hi.
     rewrite entry_Build_Vector.
@@ -194,13 +194,13 @@ Section VectorScale.
     : IsLeftModule R (abgroup_vector M n).
   Proof.
     snrapply Build_IsLeftModule.
-    - exact vector_scale.
-    - exact left_heterodistribute_vector_scale_plus.
-    - exact right_heterodistribute_vector_scale_plus.
-    - exact heteroassociative_vector_scale_plus.
-    - exact left_identity_vector_scale.
+    - exact vector_lact.
+    - exact left_heterodistribute_vector_lact_plus.
+    - exact right_heterodistribute_vector_lact_plus.
+    - exact heteroassociative_vector_lact_plus.
+    - exact left_identity_vector_lact.
   Defined.
 
 End VectorScale.
 
-Arguments vector_scale {M n R _} r v.
+Arguments vector_lact {M n R _} r v.

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -9,7 +9,7 @@ Local Open Scope mc_scope.
 
 (** * Vectors *)
 
-(** A vector is simply a list with a specified length. This datastructure has many uses, but here we will foxus on lists of ring elements, giving us free modules of a given rank. *)
+(** A vector is simply a list with a specified length. This data structure has many uses, but here we will focus on lists of left module elements. *)
 
 (** ** Definition *)
 

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -59,9 +59,8 @@ Proof.
   snrapply path_list_nth'.
   1: exact (pr2 v1 @ (pr2 v2)^).
   intros i Hi.
-  snrefine (ap011D (fun l => nth' l _) 1 _ @ H i (pr2 v1 # Hi)
-    @ (ap011D (fun l => nth' l _) 1 _)^).
-  1,2: apply path_ishprop.
+  snrefine (_ @ H i (pr2 v1 # Hi) @ _).
+  1, 2: apply nth'_nth'.
 Defined.
 
 Section VectorAddition.

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -1,0 +1,195 @@
+Require Import Basics.Overture Basics.Trunc Basics.Tactics Basics.PathGroupoids.
+Require Import Types.Sigma.
+Require Import Algebra.AbGroups.AbelianGroup Algebra.Rings.Ring Algebra.Rings.Module.
+Require Import Spaces.Nat.Core.
+Require Import Spaces.List.Core Spaces.List.Theory Spaces.List.Paths.
+Require Import abstract_algebra.
+
+Local Open Scope mc_scope.
+
+(** * Vectors *)
+
+(** A vector is simply a list with a specified length. This datastructure has many uses, but here we will foxus on lists of ring elements, giving us free modules of a given rank. *)
+
+(** ** Definition *)
+
+Definition Vector (A : Type) (n : nat)
+ := { l : list A & length l = n }.
+
+Global Instance istrunc_vector (A : Type) (n : nat) k `{IsTrunc k.+2 A}
+  : IsTrunc k.+2 (Vector A n)
+  := _. 
+
+Definition Build_Vector (A : Type) (n : nat)
+  (f : forall (i : nat), (i < n)%nat -> A)
+  : Vector A n. 
+Proof.
+  exists (list_map (fun '(i; Hi) => f i Hi) (seq' n)).
+  lhs nrapply length_list_map.
+  apply length_seq'.
+Defined.
+
+Definition entry {A : Type} {n} (v : Vector A n) i {Hi : (i < n)%nat} : A
+  := nth' (pr1 v) i ((pr2 v)^ # Hi).
+
+Definition vector_map {A B : Type} {n} (f : A -> B)
+  : Vector A n -> Vector B n
+  := fun v => Build_Vector B n (fun i _ => f (entry v i)).
+
+Definition vector_map2 {A B C : Type} {n} (f : A -> B -> C)
+  : Vector A n -> Vector B n -> Vector C n
+  := fun v1 v2 => Build_Vector C n (fun i _ => f (entry v1 i) (entry v2 i)).
+
+Definition entry_Build_Vector {A : Type} {n}
+  (f : forall (i : nat), (i < n)%nat -> A) i {Hi : (i < n)%nat}
+  : entry (Build_Vector A n f) i = f i Hi.
+Proof.
+  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
+  1: nrapply length_seq'.
+  snrapply ap011D.
+  1: nrapply nth'_seq'.
+  rapply path_ishprop. 
+Defined.
+
+Definition path_vector (A : Type) {n : nat} (v1 v2 : Vector A n)
+  (H : forall i (H : (i < n)%nat), entry v1 i = entry v2 i)
+  : v1 = v2.
+Proof.
+  rapply path_sigma_hprop.
+  snrapply path_list_nth'.
+  1: exact (pr2 v1 @ (pr2 v2)^).
+  intros i Hi.
+  snrefine (ap011D (fun l => nth' l _) 1 _ @ H i (pr2 v1 # Hi)
+    @ (ap011D (fun l => nth' l _) 1 _)^).
+  1,2: apply path_ishprop.
+Defined.
+
+Section VectorAddition.
+
+  Context (A : AbGroup) (n : nat).
+
+  Definition vector_plus : Plus (Vector A n) := vector_map2 (+).
+
+  Definition vector_zero : Zero (Vector A n)
+    := Build_Vector A n (fun _ _ => 0).
+
+  Definition vector_neg : Negate (Vector A n) := vector_map (-).
+
+  Definition associative_vector_plus : Associative vector_plus.
+  Proof.
+    intros v1 v2 v3; apply path_vector; intros i Hi.
+    rewrite 4 entry_Build_Vector.
+    apply associativity.
+  Defined.
+  
+  Definition commutative_vector_plus : Commutative vector_plus.
+  Proof.
+    intros v1 v2; apply path_vector; intros i Hi.
+    rewrite 2 entry_Build_Vector.
+    apply commutativity.
+  Defined.
+
+  Definition left_identity_vector_plus : LeftIdentity vector_plus vector_zero.
+  Proof.
+    intros v; apply path_vector; intros i Hi.
+    rewrite 2 entry_Build_Vector.
+    apply left_identity.
+  Defined.
+
+  Definition right_identity_vector_plus : RightIdentity vector_plus vector_zero.
+  Proof.
+    intros v; apply path_vector; intros i Hi.
+    rewrite 2 entry_Build_Vector.
+    apply right_identity.
+  Defined.
+
+  Definition left_inverse_vector_plus
+    : LeftInverse vector_plus vector_neg vector_zero.
+  Proof.
+    intros v; apply path_vector; intros i Hi.
+    rewrite 3 entry_Build_Vector.
+    apply left_inverse.
+  Defined.
+
+  Definition right_inverse_vector_plus
+    : RightInverse vector_plus vector_neg vector_zero.
+  Proof.
+    intros v; apply path_vector; intros i Hi.
+    rewrite 3 entry_Build_Vector.
+    apply right_inverse.
+  Defined.
+
+  Definition abgroup_vector : AbGroup.
+  Proof.
+    snrapply Build_AbGroup.
+    1: snrapply Build_Group.
+    5: repeat split.
+    - exact (Vector A n).
+    - exact vector_plus.
+    - exact vector_zero.
+    - exact vector_neg.
+    - exact _.
+    - exact associative_vector_plus.
+    - exact left_identity_vector_plus.
+    - exact right_identity_vector_plus.
+    - exact left_inverse_vector_plus.
+    - exact right_inverse_vector_plus.
+    - exact commutative_vector_plus.
+  Defined.
+
+End VectorAddition.
+
+Arguments vector_plus {A n} v1 v2.
+
+Section VectorScale.
+  (** A vector of elements of an R-module is itself an R-module. A special case is when the R-module is the ring R itself. *)
+  Context (M : AbGroup) (n : nat) {R : Ring} `{IsLeftModule R M}.
+
+  Definition vector_scale (r : R) : Vector M n -> Vector M n
+    := vector_map (lact r).
+  
+  Definition left_heterodistribute_vector_scale_plus
+    : LeftHeteroDistribute vector_scale vector_plus vector_plus.
+  Proof.
+    intros r v1 v2; apply path_vector; intros i Hi.
+    rewrite 5 entry_Build_Vector.
+    apply distribute_l.
+  Defined.
+
+  Definition right_heterodistribute_vector_scale_plus
+    : RightHeteroDistribute vector_scale (+) vector_plus.
+  Proof.
+    intros r1 r2 v; apply path_vector; intros i Hi.
+    rewrite 4 entry_Build_Vector.
+    apply distribute_r.
+  Defined.
+
+  Definition heteroassociative_vector_scale_plus
+    : HeteroAssociative vector_scale vector_scale vector_scale (.*.).
+  Proof.
+    intros r s v; apply path_vector; intros i Hi.
+    rewrite 3 entry_Build_Vector.
+    apply associativity.
+  Defined.
+
+  Definition left_identity_vector_scale : LeftIdentity vector_scale 1.
+  Proof.
+    intros v; apply path_vector; intros i Hi.
+    rewrite entry_Build_Vector.
+    apply left_identity.
+  Defined.
+
+  Definition isleftmodule_isleftmodule_vector
+    : IsLeftModule R (abgroup_vector M n).
+  Proof.
+    snrapply Build_IsLeftModule.
+    - exact vector_scale.
+    - exact left_heterodistribute_vector_scale_plus.
+    - exact right_heterodistribute_vector_scale_plus.
+    - exact heteroassociative_vector_scale_plus.
+    - exact left_identity_vector_scale.
+  Defined.
+
+End VectorScale.
+
+Arguments vector_scale {M n R _} r v.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -361,6 +361,13 @@ Defined.
 Definition nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat) : A
   := pr1 (nth_lt l n H).
 
+(** The [nth'] element doesn't depend on the proof that [n < length l]. *)
+Definition nth'_nth' {A} (l : list A) (n : nat) (H H' : (n < length l)%nat)
+  : nth' l n H = nth' l n H'.
+Proof.
+  apply ap, path_ishprop.
+Defined.
+
 (** The [nth'] element of a list is in the list. *)
 Definition inlist_nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat)
   : InList (nth' l n H) l.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -1003,6 +1003,27 @@ Proof.
   exact (H, IHn).
 Defined.
 
+(** We can form a list of pairs of a sigma type given a list and a for_all predicate over it. *)
+Definition list_sigma {A} (P : A -> Type) (l : list A) (p : for_all P l)
+  : list {x : A & P x}.
+Proof.
+  induction l as [|x l IHl] in p |- *.
+  1: exact nil.
+  destruct p as [Hx Hl].
+  exact ((x; Hx) :: IHl Hl).
+Defined.
+
+(** The length of a list of sigma types is the same as the original list. *)
+Definition length_list_sigma {A} {P : A -> Type} {l} {p}
+  : length (list_sigma P l p) = length l.
+Proof.
+  induction l as [|x l IHl] in p |- *.
+  1: reflexivity.
+  destruct p as [Hx Hl].
+  cbn; f_ap.
+  apply IHl.
+Defined.
+
 (** If a predicate [P] is decidable then so is [for_all P]. *)
 Global Instance decidable_for_all {A : Type} (P : A -> Type)
   `{forall x, Decidable (P x)} (l : list A)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -976,7 +976,7 @@ Proof.
 Defined.
 
 (** [for_all] preserves the truncation predicate. *)
-Global Instance istrunc_for_all {A} {n} (P : A -> Type) (l : list A)
+Definition istrunc_for_all {A} {n} (P : A -> Type) (l : list A)
   : for_all (fun x => IsTrunc n (P x)) l -> IsTrunc n (for_all P l).
 Proof.
   induction l as [|x l IHl]; simpl.
@@ -984,6 +984,13 @@ Proof.
   - intros [Hx Hl].
     apply IHl in Hl.
     exact _.
+Defined.
+
+Global Instance istrunc_for_all' {A} {n} (P : A -> Type) (l : list A)
+  `{forall x, IsTrunc n (P x)}
+  : IsTrunc n (for_all P l).
+Proof.
+  by apply istrunc_for_all, for_all_inlist.
 Defined.
 
 (** If a predicate holds for an element, then it holds [for_all] the elements of the repeated list. *)


### PR DESCRIPTION
This PR is a draft until the following dependencies are merged:
- #1956 
- #1957 
- #1959 

In this PR we define matrices together with:
- The abelian group structure of matrices over a ring (could be an abelian group but no need for now).
- The ring structure of matrices given by matrix multiplication
- Transposed matrices and some basic properties
- Matrix minors and some basic properties
- Trace of a matrix and some basic properties

There is also a test file demonstrating how matrices can be built and used in practice. We also test some examples there too.

I have some more work on the determinant, however this requires some more work on finite types such as sums over an arbitrary finite type and permutations. We can define the determinant using the rule with minors however it is not easy to prove properties about it. My future attempt will be to define it as a sum of products with sign given by the permutation we sum over.