### PR TITLE
chore: cleanup 8.11 compat

### DIFF
--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -364,8 +364,7 @@ Section AssumeStuff.
   Proof.
     intros [n nrec].
     pose (Q := fun m:Graph => forall (mrec : in_N m), P (m;mrec)).
-    (* The try clause below is only needed for Coq <= 8.11 *)
-    refine (resize_nrec n nrec Q _ _ _ nrec);clear n nrec; try (intros A; apply trunc_forall).
+    refine (resize_nrec n nrec Q _ _ _ nrec); clear n nrec.
     - intros zrec.
       refine (transport P _ P0).
       apply ap.

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -521,10 +521,10 @@ Definition detachable_finite_subset {X} `{Finite X}
 : forall x, Decidable (P x).
 Proof.
   intros x.
-  refine (decidable_equiv _ (hfiber_fibration x P)^-1 _).
-  (* The try clause below is only needed for Coq <= 8.11 *)
-  refine (detachable_image_finite pr1 x); try assumption.
-  - apply (mapinO_pr1 (Tr (-1))).  (** Why doesn't Coq find this? *)
+  nrefine (decidable_equiv' _ (hfiber_fibration x P)^-1%equiv _).
+  nrefine (detachable_image_finite pr1 x).
+  1,2: exact _.
+  apply (mapinO_pr1 (Tr (-1))).  (** Why doesn't Coq find this? *)
 Defined.
 
 (** ** Quotients *)


### PR DESCRIPTION
We had some `try` statements left over from a change in 8.11 about typeclass resolution and `refine`. Since we are well past that version we can remove these.

I also sped up the proof in Finite.v slightly.