### PR TITLE
cleanup NatTrans.v

### DIFF
--- a/contrib/SetoidRewrite.v
+++ b/contrib/SetoidRewrite.v
@@ -172,8 +172,7 @@ Proof.
        _ _ (cat_equiv_natequiv tau x))) in eq_Gf_Gg.
   cbn in eq_Gf_Gg.
   unfold cat_precomp in eq_Gf_Gg.
-  rewrite <- is1natural_natequiv in eq_Gf_Gg.
-  rewrite <- is1natural_natequiv in eq_Gf_Gg.
+  rewrite <- 2 (isnat tau) in eq_Gf_Gg.
   apply faithful_F.
   assert (X : RetractionOf (tau y)). {
     unshelve eapply Build_RetractionOf.

--- a/theories/Homotopy/Bouquet.v
+++ b/theories/Homotopy/Bouquet.v
@@ -36,7 +36,7 @@ Section AssumeUnivalence.
     1: refine (natequiv_prewhisker (natequiv_pointify_r S) ptype_group).
     (** Post-compose with [pequiv_loops_bg_g] *)
     nrefine (natequiv_compose _ _).
-1: rapply (natequiv_postwhisker _ (natequiv_inverse natequiv_g_loops_bg)).
+    1: rapply (natequiv_postwhisker _ (natequiv_inverse natequiv_g_loops_bg)).
     (** Loop-susp adjoint *)
     nrefine (natequiv_compose _ _).
     1: refine (natequiv_prewhisker

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -432,6 +432,7 @@ Definition natequiv_g_loops_bg `{Univalence}
 Proof.
   snrapply Build_NatEquiv.
   1: intros G; rapply pequiv_g_loops_bg.
+  snrapply Build_Is1Natural'.
   intros X Y f.
   symmetry.
   apply pbloop_natural.
@@ -533,6 +534,7 @@ Defined.
 Global Instance is1natural_grp_homo_pmap_bg_r {U : Univalence} (G : Group)
   : Is1Natural (opyon G) (opyon (B G) o B) (equiv_grp_homo_pmap_bg G).
 Proof.
+  snrapply Build_Is1Natural'.
   intros K H f h.
   apply path_hom.
   rapply (fmap_comp B h f).

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -627,7 +627,8 @@ Section JoinSym.
       1, 2: apply joinrecdata_sym.
       1, 2: apply joinrecdata_sym_inv.
     (* Naturality: *)
-    - intros P Q g f; simpl.
+    - snrapply Build_Is1Natural'.
+      intros P Q g f; simpl.
       bundle_joinrecpath.
       intros b a; simpl.
       symmetry; apply ap_V.
@@ -836,7 +837,8 @@ Section JoinEmpty.
   Proof.
     snrapply Build_NatEquiv.
     - apply equiv_join_empty_right.
-    - intros A B f.
+    - snrapply Build_Is1Natural'.
+      intros A B f.
       cbn -[equiv_join_empty_right].
       snrapply Join_ind_FlFr.
       + intro a.
@@ -849,7 +851,8 @@ Section JoinEmpty.
   Proof.
     snrapply Build_NatEquiv.
     - apply equiv_join_empty_left.
-    - intros A B f x.
+    - snrapply Build_Is1Natural'.
+      intros A B f x.
       cbn -[equiv_join_empty_right].
       rhs_V rapply (isnat_natequiv join_right_unitor).
       cbn -[equiv_join_empty_right].

--- a/theories/Homotopy/Join/JoinAssoc.v
+++ b/theories/Homotopy/Join/JoinAssoc.v
@@ -60,7 +60,8 @@ Proof.
     1, 2: apply trijoinrecdata_twist.
     1, 2: apply trijoinrecdata_twist_inv.
   (* Naturality: *)
-  - intros P Q g f; simpl.
+  - snrapply Build_Is1Natural'.
+    intros P Q g f; simpl.
     bundle_trijoinrecpath.
     all: intros; cbn.
     + symmetry; apply ap_V.
@@ -264,7 +265,8 @@ Global Instance join_associator : Associator Join.
 Proof.
   snrapply Build_Associator; simpl.
   - exact join_assoc.
-  - intros [[A B] C] [[A' B'] C'] [[f g] h]; cbn.
+  - snrapply Build_Is1Natural'.
+    intros [[A B] C] [[A' B'] C'] [[f g] h]; cbn.
     apply join_assoc_nat.
 Defined.
 

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -660,23 +660,33 @@ Proof.
     + intros x.
       exact (concat_Ap q _)^.
     + by pelim p f g q h k.
-  - intros A B C D f g r1 r2 s1.
+  - intros A B C D f g.
+    snrapply Build_Is1Natural'.
+    intros r1 r2 s1.
     srapply Build_pHomotopy.
     1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
     by pelim f g s1 r1 r2.
-  - intros A B C D f g r1 r2 s1.
+  - intros A B C D f g.
+    snrapply Build_Is1Natural'.
+    intros r1 r2 s1.
     srapply Build_pHomotopy.
     1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
     by pelim f s1 r1 r2 g.
-  - intros A B C D f g r1 r2 s1.
+  - intros A B C D f g.
+    snrapply Build_Is1Natural'.
+    intros r1 r2 s1.
     srapply Build_pHomotopy.
     1: cbn; exact (fun _ => concat_p1 _ @ ap_compose _ _ _ @ (concat_1p _)^).
     by pelim s1 r1 r2 f g.
-  - intros A B r1 r2 s1.
+  - intros A B.
+    snrapply Build_Is1Natural'.
+    intros r1 r2 s1.
     srapply Build_pHomotopy.
     1: exact (fun _ => concat_p1 _ @ ap_idmap _ @ (concat_1p _)^).
     by pelim s1 r1 r2.
-  - intros A B r1 r2 s1.
+  - intros A B.
+    snrapply Build_Is1Natural'.
+    intros r1 r2 s1.
     srapply Build_pHomotopy.
     1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
     simpl; by pelim s1 r1 r2.
@@ -1059,6 +1069,7 @@ Lemma natequiv_pointify_r `{Funext} (A : Type)
 Proof.
   snrapply Build_NatEquiv.
   1: rapply equiv_pointify_map.
+  snrapply Build_Is1Natural'.
   cbv; reflexivity.
 Defined.
 

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -428,6 +428,7 @@ Defined.
 (** [loops_inv] is a natural transformation. *)
 Global Instance is1natural_loops_inv : Is1Natural loops loops loops_inv.
 Proof.
+  snrapply Build_Is1Natural'.
   intros A B f.
   srapply Build_pHomotopy.
   + intros p. refine (inv_Vp _ _ @ whiskerR _ (point_eq f) @ concat_pp_p _ _ _).

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -292,6 +292,7 @@ Global Instance is1natural_loop_susp_adjoint_r `{Funext} (A : pType)
   : Is1Natural (opyon (psusp A)) (opyon A o loops)
       (loop_susp_adjoint A).
 Proof.
+  snrapply Build_Is1Natural'.
   intros B B' g f.
   refine ( _ @ cat_assoc_strong _ _ _).
   refine (ap (fun x => x o* loop_susp_unit A) _).

--- a/theories/WildCat/Adjoint.v
+++ b/theories/WildCat/Adjoint.v
@@ -112,6 +112,7 @@ Section AdjunctionData.
   Proof.
     snrapply Build_NatEquiv.
     1: intros [x y]; exact (equiv_adjunction adj x y).
+    snrapply Build_Is1Natural'.
     intros [a b] [a' b'] [f g] K.
     refine (_ @ ap (fun x : a $-> G b' => x $o f)
       (is1natural_equiv_adjunction_r adj a b b' g K)).
@@ -124,7 +125,7 @@ Section AdjunctionData.
     snrapply Build_NatTrans.
     { hnf. intros x.
       exact (equiv_adjunction adj x (F x) (Id _)). }
-    hnf.
+    snrapply Build_Is1Natural'.
     intros x x' f.
     apply GpdHom_path.
     refine (_^ @ _ @ _).
@@ -142,7 +143,7 @@ Section AdjunctionData.
     snrapply Build_NatTrans.
     { hnf. intros y.
       exact ((equiv_adjunction adj (G y) y)^-1 (Id _)). }
-    hnf.
+    snrapply Build_Is1Natural'.
     intros y y' f.
     apply GpdHom_path.
     refine (_^ @ _ @ _).
@@ -334,7 +335,8 @@ Proof.
   - snrapply Build_NatTrans.
     + intros K.
       exact (nattrans_prewhisker (adjunction_unit adj) K).
-    + intros K K' θ j.
+    + snrapply Build_Is1Natural'.
+      intros K K' θ j.
       apply GpdHom_path.
       refine (_ @ is1natural_natequiv (natequiv_inverse
         (natequiv_adjunction_r adj _)) _ _ _ _).
@@ -346,7 +348,8 @@ Proof.
   - snrapply Build_NatTrans.
     + intros K.
       exact (nattrans_prewhisker (adjunction_counit adj) K).
-    + intros K K' θ j.
+    + snrapply Build_Is1Natural'.
+      intros K K' θ j.
       apply GpdHom_path.
       refine (_ @ is1natural_natequiv
         (natequiv_adjunction_r adj _) _ _ _ _).

--- a/theories/WildCat/Bifunctor.v
+++ b/theories/WildCat/Bifunctor.v
@@ -388,6 +388,7 @@ Global Instance is1natural_uncurry {A B C : Type}
   (nat_r : forall a, Is1Natural (F a) (G a) (fun y : B => alpha (a, y)))
   : Is1Natural (uncurry F) (uncurry G) alpha.
 Proof.
+  snrapply Build_Is1Natural'.
   intros [a b] [a' b'] [f f']; cbn in *.
   change (?w $o ?x $== ?y $o ?z) with (Square z w x y).
   nrapply vconcatL.
@@ -408,7 +409,8 @@ Proof.
   intros [alpha nat].
   snrapply Build_NatTrans.
   - exact (alpha o equiv_prod_symm _ _).
-  - intros [b a] [b' a'] [g f].
+  - snrapply Build_Is1Natural'.
+    intros [b a] [b' a'] [g f].
     exact (nat (a, b) (a', b') (f, g)).
 Defined.
 

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -37,9 +37,9 @@ Global Instance is01cat_fun01 (A B : Type) `{IsGraph A} `{Is1Cat B} : Is01Cat (F
 Proof.
   srapply Build_Is01Cat.
   - intros [F ?]; cbn.
-    exists (id_transformation F); exact _.
-  - intros [F ?] [G ?] [K ?] [gamma ?] [alpha ?]; cbn in *.
-    exists (trans_comp gamma alpha); exact _.
+    exact (nattrans_id F).
+  - intros F G K gamma alpha; cbn in *.
+    exact (nattrans_comp gamma alpha).
 Defined.
 
 Global Instance is2graph_fun01 (A B : Type) `{IsGraph A, Is1Cat B}
@@ -87,29 +87,14 @@ Global Instance hasequivs_fun01 (A B : Type) `{Is01Cat A} `{HasEquivs B}
   : HasEquivs (Fun01 A B).
 Proof.
   srapply Build_HasEquivs.
-  1:{ intros [F ?] [G ?]. exact (NatEquiv F G). }
-  1:{ intros [F ?] [G ?] [alpha ?]; cbn in *.
-      exact (forall a, CatIsEquiv (alpha a)). }
-  all:intros [F ?] [G ?] [alpha alnat]; cbn in *.
-  - exists (fun a => alpha a); assumption.
+  1: intros F G; exact (NatEquiv F G).
+  all: intros F G alpha; cbn in *.
+  - exact (forall a, CatIsEquiv (alpha a)).
+  - exact alpha.
   - intros a; exact _.
-  - intros ?.
-    snrapply Build_NatEquiv.
-    + intros a; exact (Build_CatEquiv (alpha a)).
-    + cbn. refine (is1natural_homotopic alpha _).
-      intros a; apply cate_buildequiv_fun.
+  - apply Build_NatEquiv'.
   - cbn; intros; apply cate_buildequiv_fun.
-  - exists (fun a => (alpha a)^-1$).
-    intros a b f.
-    refine ((cat_idr _)^$ $@ _).
-    refine ((_ $@L (cate_isretr (alpha a))^$) $@ _).
-    refine (cat_assoc _ _ _ $@ _).
-    refine ((_ $@L (cat_assoc_opp _ _ _)) $@ _).
-    refine ((_ $@L ((isnat (fun a => alpha a) f)^$ $@R _)) $@ _).
-    refine ((_ $@L (cat_assoc _ _ _)) $@ _).
-    refine (cat_assoc_opp _ _ _ $@ _).
-    refine ((cate_issect (alpha b) $@R _) $@ _).
-    exact (cat_idl _).
+  - exact (natequiv_inverse alpha).
   - intros; apply cate_issect.
   - intros; apply cate_isretr.
   - intros [gamma ?] r s a; cbn in *.

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -682,7 +682,8 @@ Section TwistConstruction.
   Proof.
     snrapply Build_Associator.
     - exact associator_twist'.
-    - simpl; intros [[a b] c] [[a' b'] c'] [[f g] h]; simpl in f, g, h.
+    - snrapply Build_Is1Natural'.
+      simpl; intros [[a b] c] [[a' b'] c'] [[f g] h]; simpl in f, g, h.
       (** To prove naturality it will be easier to reason about squares. *)
       change (?w $o ?x $== ?y $o ?z) with (Square z w x y).
       (** First we remove all the equivalences from the equation. *)
@@ -717,7 +718,8 @@ Section TwistConstruction.
     snrapply Build_NatEquiv'.
     - snrapply Build_NatTrans.
       + exact (fun a => right_unitor a $o braid cat_tensor_unit a).
-      + intros a b f.
+      + snrapply Build_Is1Natural'.
+        intros a b f.
         change (?w $o ?x $== ?y $o ?z) with (Square z w x y).
         nrapply vconcat.
         2: rapply (isnat right_unitor f).

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -31,14 +31,14 @@ Definition trans_comp {A B : Type} `{Is01Cat B}
   : F $=> K
   := fun a => gamma a $o alpha a.
 
-(** Transformations can be prewhiskered by a function. This means we precompose either side of the transformation with a function. *)
+(** Transformations can be prewhiskered by a function. This means we precompose both sides of the transformation with a function. *)
 Definition trans_prewhisker {A B : Type} {C : B -> Type} {F G : forall x, C x}
   `{Is01Cat B} `{!forall x, IsGraph (C x)}
   `{!forall x, Is01Cat (C x)} (gamma : F $=> G) (K : A -> B) 
   : F o K $=> G o K
   := gamma o K.
 
-(** Transformations can be postwhiskered by a function. This means we postcompose either side of the transformation with a function. *)
+(** Transformations can be postwhiskered by a function. This means we postcompose both sides of the transformation with a function. *)
 Definition trans_postwhisker {A B C : Type} {F G : A -> B}
   (K : B -> C) `{Is01Cat B, Is01Cat C, !Is0Functor K} (gamma : F $=> G)
   : K o F $=> K o G
@@ -221,7 +221,7 @@ Definition issig_NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
   (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
   : _ <~> NatEquiv F G := ltac:(issig).
 
-(** From a given natural transformation, we can get the underlying natural transformation. *)
+(** From a given natural equivalence, we can get the underlying natural transformation. *)
 Lemma nattrans_natequiv {A B : Type} `{IsGraph A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   : NatEquiv F G -> NatTrans F G.

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -4,8 +4,13 @@ Require Import WildCat.Equiv.
 Require Import WildCat.Square.
 Require Import WildCat.Opposite.
 
-(** ** Natural transformations *)
+(** * Wild Natural Transformations *)
 
+(** ** Transformations *)
+
+(** *** Definition *)
+
+(** A transformation is simply a family of 1-cells over some base type [A] between the sections of two dependent functions [F] and [G]. In most cases [F] and [G] will be non-dependent functors. *)
 Definition Transformation {A : Type} {B : A -> Type} `{forall x, IsGraph (B x)}
   (F G : forall (x : A), B x)
   := forall (a : A), F a $-> G a.
@@ -15,198 +20,192 @@ Identity Coercion fun_trans : Transformation >-> Funclass.
 
 Notation "F $=> G" := (Transformation F G).
 
-(** A 1-natural transformation is natural up to a 2-cell, so its codomain must be a 1-category. *)
-Class Is1Natural {A B : Type} `{IsGraph A} `{Is1Cat B}
-      (F : A -> B) `{!Is0Functor F} (G : A -> B) `{!Is0Functor G}
-      (alpha : F $=> G) :=
-  isnat : forall a a' (f : a $-> a'),
-     (alpha a') $o (fmap F f) $== (fmap G f) $o (alpha a).
-
-Arguments Is1Natural {A B} {isgraph_A}
-  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
-  F {is0functor_F} G {is0functor_G} alpha : rename.
-Arguments isnat {_ _ _ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
-
-Record NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} {F G : A -> B}
-  {ff : Is0Functor F} {fg : Is0Functor G} :=
-{
-  trans_nattrans : F $=> G ;
-  is1natural_nattrans : Is1Natural F G trans_nattrans ;
-}.
-
-Arguments NatTrans {A B} {isgraph_A}
-  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
-  F G {is0functor_F} {is0functor_G} : rename.
-Arguments Build_NatTrans {A B} {isgraph_A}
-  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
-  F G {is0functor_F} {is0functor_G} alpha isnat_alpha: rename.
-
-Global Existing Instance is1natural_nattrans.
-Coercion trans_nattrans : NatTrans >-> Transformation.
-
-Definition issig_NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
-  {ff : Is0Functor F} {fg : Is0Functor G}
-  : _ <~> NatTrans F G := ltac:(issig).
-
-(** The transposed natural square *)
-Definition isnat_tr {A B : Type} `{IsGraph A} `{Is1Cat B}
-      {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
-      (alpha : F $=> G) `{!Is1Natural F G alpha}
-      {a a' : A} (f : a $-> a')
-  : (fmap G f) $o (alpha a) $== (alpha a') $o (fmap F f)
-  := (isnat alpha f)^$.
-
-Definition id_transformation {A B : Type} `{Is01Cat B} (F : A -> B)
+(** The identity transformation between a functor and itself is the identity function at the section. *)
+Definition trans_id {A B : Type} `{Is01Cat B} (F : A -> B)
   : F $=> F
   := fun a => Id (F a).
 
-Global Instance is1natural_id {A B : Type} `{IsGraph A} `{Is1Cat B}
-       (F : A -> B) `{!Is0Functor F}
-  : Is1Natural F F (id_transformation F).
-Proof.
-  intros a b f; cbn.
-  refine (cat_idl _ $@ (cat_idr _)^$).
-Defined.
-
-Definition nattrans_id {A B : Type} (F : A -> B)
-  `{IsGraph A, Is1Cat B, !Is0Functor F}
-  : NatTrans F F.
-Proof.
-  nrapply Build_NatTrans.
-  rapply is1natural_id.
-Defined.
-
+(** Transformations can be composed pointwise. *)
 Definition trans_comp {A B : Type} `{Is01Cat B}
            {F G K : A -> B} (gamma : G $=> K) (alpha : F $=> G)
   : F $=> K
   := fun a => gamma a $o alpha a.
 
+(** Transformations can be prewhiskered by a function. This means we precompose either side of the transformation with a function. *)
 Definition trans_prewhisker {A B : Type} {C : B -> Type} {F G : forall x, C x}
   `{Is01Cat B} `{!forall x, IsGraph (C x)}
   `{!forall x, Is01Cat (C x)} (gamma : F $=> G) (K : A -> B) 
   : F o K $=> G o K
   := gamma o K.
 
+(** Transformations can be postwhiskered by a function. This means we postcompose either side of the transformation with a function. *)
 Definition trans_postwhisker {A B C : Type} {F G : A -> B}
   (K : B -> C) `{Is01Cat B, Is01Cat C, !Is0Functor K} (gamma : F $=> G)
   : K o F $=> K o G
   := fun a => fmap K (gamma a).
 
+(** A transformation in the opposite category is simply a transformation in the original category with the direction swapped. *)
+Definition trans_op {A} {B} `{Is01Cat B}
+  (F : A -> B) (G : A -> B) (alpha : F $=> G)
+  : Transformation (A:=A^op) (B:=fun _ => B^op) G (F : A^op -> B^op)
+  := alpha.
+
+(** ** Naturality *)
+
+(** A transformation is 1-natural if there exists a 2-cell witnessing the naturality square. The codomain of the transformation must be a wild 1-category. *)
+Class Is1Natural {A B : Type} `{IsGraph A, Is1Cat B}
+  (F : A -> B) `{!Is0Functor F} (G : A -> B) `{!Is0Functor G}
+  (alpha : F $=> G) := Build_Is1Natural' {
+  isnat {a a'} (f : a $-> a') : alpha a' $o fmap F f $== fmap G f $o alpha a;
+}.
+
+Arguments Is1Natural {A B} {isgraph_A}
+  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
+  F {is0functor_F} G {is0functor_G} alpha : rename.
+Arguments isnat {_ _ _ _ _ _ _ _ _ _ _} alpha {alnat _ _} f : rename.
+
+(** We coerce naturality proofs to their naturality square as the [isnat] projection can be unwieldy in certain situations where the transformation is difficult to write down. This allows for the naturality proof to be used directly. *)
+Coercion isnat : Is1Natural >-> Funclass.
+
+(** TODO: make this part of the data for definitional involution of op *)
+(** The transposed natural square. *)
+Definition isnat_tr {A B : Type} `{IsGraph A} `{Is1Cat B}
+  {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
+  (alpha : F $=> G) `{!Is1Natural F G alpha} {a a' : A} (f : a $-> a')
+  : fmap G f $o alpha a $== alpha a' $o fmap F f
+  := (isnat alpha f)^$.
+
+(** The identity transformation is 1-natural. *)
+Global Instance is1natural_id {A B : Type} `{IsGraph A} `{Is1Cat B}
+  (F : A -> B) `{!Is0Functor F}
+  : Is1Natural F F (trans_id F).
+Proof.
+  snrapply Build_Is1Natural'.
+  intros a b f; cbn.
+  refine (cat_idl _ $@ (cat_idr _)^$).
+Defined.
+
+(** The composite of 1-natural transformations is 1-natural. *)
 Global Instance is1natural_comp {A B : Type} `{IsGraph A} `{Is1Cat B}
-       {F G K : A -> B} `{!Is0Functor F} `{!Is0Functor G} `{!Is0Functor K}
-       (gamma : G $=> K) `{!Is1Natural G K gamma}
-       (alpha : F $=> G) `{!Is1Natural F G alpha}
+  {F G K : A -> B} `{!Is0Functor F} `{!Is0Functor G} `{!Is0Functor K}
+  (gamma : G $=> K) `{!Is1Natural G K gamma}
+  (alpha : F $=> G) `{!Is1Natural F G alpha}
   : Is1Natural F K (trans_comp gamma alpha).
 Proof.
+  snrapply Build_Is1Natural'.
   intros a b f; unfold trans_comp; cbn.
   refine (cat_assoc _ _ _ $@ (_ $@L isnat alpha f) $@ _).
   refine (cat_assoc_opp _ _ _ $@ (isnat gamma f $@R _) $@ _).
   apply cat_assoc.
 Defined.
 
+(** Prewhiskering a transformation preserves naturality. *)
 Global Instance is1natural_prewhisker {A B C : Type} {F G : B -> C} (K : A -> B)
   `{IsGraph A, Is01Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G, !Is0Functor K}
   (gamma : F $=> G) `{L : !Is1Natural F G gamma}
   : Is1Natural (F o K) (G o K) (trans_prewhisker gamma K).
 Proof.
+  snrapply Build_Is1Natural'.
   intros x y f; unfold trans_prewhisker; cbn.
-  exact (L _ _ _).
+  exact (isnat gamma _).
 Defined.
 
+(** Postwhiskering a transformation preserves naturality. *)
 Global Instance is1natural_postwhisker {A B C : Type} {F G : A -> B} (K : B -> C)
- `{IsGraph A, Is1Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G, !Is0Functor K, !Is1Functor K}
+  `{IsGraph A, Is1Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G,
+    !Is0Functor K, !Is1Functor K}
   (gamma : F $=> G) `{L : !Is1Natural F G gamma}
   : Is1Natural (K o F) (K o G) (trans_postwhisker K gamma).
 Proof.
+  snrapply Build_Is1Natural'.
   intros x y f; unfold trans_postwhisker; cbn.
   refine (_^$ $@ _ $@ _).
   1,3: rapply fmap_comp.
   rapply fmap2.
-  exact (L _ _ _).
-Defined.
-
-Definition nattrans_comp {A B : Type} {F G K : A -> B}
-  `{IsGraph A, Is1Cat B, !Is0Functor F, !Is0Functor G, !Is0Functor K}
-  : NatTrans G K -> NatTrans F G -> NatTrans F K.
-Proof.
-  intros alpha beta.
-  nrapply Build_NatTrans.
-  rapply (is1natural_comp alpha beta).
-Defined.
-
-Definition nattrans_prewhisker {A B C : Type} {F G : B -> C}
-  `{IsGraph A, Is1Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G}
-  (alpha : NatTrans F G) (K : A -> B) `{!Is0Functor K} 
-  : NatTrans (F o K) (G o K).
-Proof.
-  nrapply Build_NatTrans.
-  rapply (is1natural_prewhisker K alpha).
-Defined.
-
-Definition nattrans_postwhisker {A B C : Type} {F G : A -> B} (K : B -> C)
-  `{IsGraph A, Is1Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G,
-    !Is0Functor K, !Is1Functor K} 
-  : NatTrans F G -> NatTrans (K o F) (K o G).
-Proof.
-  intros alpha.
-  nrapply Build_NatTrans.
-  rapply (is1natural_postwhisker K alpha).
+  exact (isnat gamma _).
 Defined.
 
 (** Modifying a transformation to something pointwise equal preserves naturality. *)
 Definition is1natural_homotopic {A B : Type} `{Is01Cat A} `{Is1Cat B}
-      {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
-      {alpha : F $=> G} (gamma : F $=> G) `{!Is1Natural F G gamma}
-      (p : forall a, alpha a $== gamma a)
+  {F : A -> B} `{!Is0Functor F} {G : A -> B} `{!Is0Functor G}
+  {alpha : F $=> G} (gamma : F $=> G) `{!Is1Natural F G gamma}
+  (p : forall a, alpha a $== gamma a)
   : Is1Natural F G alpha.
 Proof.
+  snrapply Build_Is1Natural'.
   intros a b f.
   exact ((p b $@R _) $@ isnat gamma f $@ (_ $@L (p a)^$)).
 Defined.
 
-(** Opposite natural transformations *)
-
-Definition transformation_op {A} {B} `{Is01Cat B}
-           (F : A -> B) (G : A -> B) (alpha : F $=> G)
-  : @Transformation A^op (fun _ => B^op) _
-                     (G : A^op -> B^op) (F : A^op -> B^op).
-Proof.
-  unfold op in *.
-  cbn in *.
-  intro a.
-  apply (alpha a).
-Defined.
-
-Global Instance is1nat_op A B `{Is01Cat A} `{Is1Cat B}
-       (F : A -> B) `{!Is0Functor F}
-       (G : A -> B) `{!Is0Functor G}
-       (alpha : F $=> G) `{!Is1Natural F G alpha}
-  : Is1Natural (G : A^op -> B^op) (F : A^op -> B^op) (transformation_op F G alpha).
+(** The opposite of a natural transformation is natural. *)
+Global Instance is1natural_op A B `{Is01Cat A} `{Is1Cat B}
+  (F : A -> B) `{!Is0Functor F} (G : A -> B) `{!Is0Functor G}
+  (alpha : F $=> G) `{!Is1Natural F G alpha}
+  : Is1Natural (G : A^op -> B^op) (F : A^op -> B^op) (trans_op F G alpha).
 Proof.
   unfold op.
-  unfold transformation_op.
+  snrapply Build_Is1Natural'.
   intros a b f.
   srapply isnat_tr.
 Defined.
 
+(** ** Natural transformations *)
+
+(** Here we give the bundled definition of a natural transformation which can be more convenient to work with in certain situations. It forms the Hom type of the functor category. *)
+
+Record NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} {F G : A -> B}
+  {ff : Is0Functor F} {fg : Is0Functor G} := {
+  trans_nattrans :> F $=> G;
+  is1natural_nattrans : Is1Natural F G trans_nattrans;
+}.
+
+Arguments NatTrans {A B} {isgraph_A}
+  {isgraph_B} {is2graph_B} {is01cat_B} {is1cat_B}
+  F G {is0functor_F} {is0functor_G} : rename.
+Arguments Build_NatTrans {A B isgraph_A isgraph_B is2graph_B is01cat_B is1cat_B
+  F G is0functor_F is0functor_G} alpha isnat_alpha : rename.
+
+Global Existing Instance is1natural_nattrans.
+
+Definition issig_NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
+  {ff : Is0Functor F} {fg : Is0Functor G}
+  : _ <~> NatTrans F G := ltac:(issig).
+
+Definition nattrans_id {A B : Type} (F : A -> B)
+  `{IsGraph A, Is1Cat B, !Is0Functor F}
+  : NatTrans F F
+  := Build_NatTrans (trans_id F) _.
+
+Definition nattrans_comp {A B : Type} {F G K : A -> B}
+  `{IsGraph A, Is1Cat B, !Is0Functor F, !Is0Functor G, !Is0Functor K}
+  : NatTrans G K -> NatTrans F G -> NatTrans F K
+  := fun alpha beta => Build_NatTrans (trans_comp alpha beta) _.
+
+Definition nattrans_prewhisker {A B C : Type} {F G : B -> C}
+  `{IsGraph A, Is1Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G}
+  (alpha : NatTrans F G) (K : A -> B) `{!Is0Functor K} 
+  : NatTrans (F o K) (G o K)
+  := Build_NatTrans (trans_prewhisker alpha K) _.
+
+Definition nattrans_postwhisker {A B C : Type} {F G : A -> B} (K : B -> C)
+  `{IsGraph A, Is1Cat B, Is1Cat C, !Is0Functor F, !Is0Functor G,
+    !Is0Functor K, !Is1Functor K} 
+  : NatTrans F G -> NatTrans (K o F) (K o G)
+  := fun alpha => Build_NatTrans (trans_postwhisker K alpha) _.
+
 Definition nattrans_op {A B : Type} `{Is01Cat A} `{Is1Cat B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   : NatTrans F G
-  -> NatTrans (A:=A^op) (B:=B^op) (G : A^op -> B^op) (F : A^op -> B^op).
-Proof.
-  intros alpha.
-  snrapply Build_NatTrans.
-  - exact (transformation_op F G alpha).
-  - exact _.
-Defined.
+    -> NatTrans (A:=A^op) (B:=B^op) (G : A^op -> B^op) (F : A^op -> B^op)
+  := fun alpha => Build_NatTrans (trans_op F G alpha) _.
 
-(** Natural equivalences *)
+(** ** Natural equivalences *)
 
+(** Natural equivalences are families of equivlaences that are natural. *)
 Record NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
-  {F G : A -> B} `{!Is0Functor F, !Is0Functor G} :=
-{
-  cat_equiv_natequiv : forall a, F a $<~> G a ;
-  is1natural_natequiv : Is1Natural F G (fun a => cat_equiv_natequiv a) ;
+  {F G : A -> B} `{!Is0Functor F, !Is0Functor G} := {
+  cat_equiv_natequiv :> forall a, F a $<~> G a ;
+  is1natural_natequiv :: Is1Natural F G (fun a => cat_equiv_natequiv a) ;
 }.
 
 Arguments NatEquiv {A B} {isgraph_A}
@@ -220,9 +219,7 @@ Definition issig_NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
   (F G : A -> B) `{!Is0Functor F, !Is0Functor G}
   : _ <~> NatEquiv F G := ltac:(issig).
 
-Global Existing Instance is1natural_natequiv.
-Coercion cat_equiv_natequiv : NatEquiv >-> Funclass.
-
+(** From a given natural transformation, we can get the underlying natural transformation. *)
 Lemma nattrans_natequiv {A B : Type} `{IsGraph A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   : NatEquiv F G -> NatTrans F G.
@@ -236,12 +233,13 @@ Defined.
 Global Set Warnings "-ambiguous-paths".
 Coercion nattrans_natequiv : NatEquiv >-> NatTrans.
 
-(** The above coercion doesn't trigger when it should, so we add the following. *)
+(** The above coercion sometimes doesn't trigger when it should, so we add the following. *)
 Definition isnat_natequiv {A B : Type} `{IsGraph A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G} (alpha : NatEquiv F G)
   {a a' : A} (f : a $-> a')
   := isnat (nattrans_natequiv alpha) f.
 
+(** Often we wish to build a natural equivalence from a natural transformation and a pointwise proof that it is an equivalence. *)
 Definition Build_NatEquiv' {A B : Type} `{IsGraph A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   (alpha : NatTrans F G) `{forall a, CatIsEquiv (alpha a)}
@@ -250,10 +248,16 @@ Proof.
   snrapply Build_NatEquiv.
   - intro a.
     refine (Build_CatEquiv (alpha a)).
-  - intros a a' f.
+  - snrapply Build_Is1Natural'.
+    intros a a' f.
     refine (cate_buildequiv_fun _ $@R _ $@ _ $@ (_ $@L cate_buildequiv_fun _)^$).
     apply (isnat alpha).
 Defined.
+
+Definition natequiv_id {A B : Type} `{IsGraph A} `{HasEquivs B}
+  {F : A -> B} `{!Is0Functor F}
+  : NatEquiv F F
+  := Build_NatEquiv' (nattrans_id F).
 
 Definition natequiv_compose {A B} {F G H : A -> B} `{IsGraph A} `{HasEquivs B}
   `{!Is0Functor F, !Is0Functor G, !Is0Functor H}
@@ -277,30 +281,6 @@ Proof.
   all: exact _.
 Defined.
 
-Definition natequiv_inverse {A B : Type} `{IsGraph A} `{HasEquivs B}
-  {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
-  : NatEquiv F G -> NatEquiv G F.
-Proof.
-  intros [alpha I].
-  snrapply Build_NatEquiv.
-  1: intro a; symmetry; apply alpha.
-  intros X Y f.
-  apply vinverse, I.
-Defined.
-
-(** This lemma might seem unnecessery since as functions ((F o G) o K) and (F o (G o K)) are definitionally equal. But the functor instances of both sides are different. This can be a nasty trap since you cannot see this difference clearly. *)
-Definition natequiv_functor_assoc_ff_f {A B C D : Type}
-  `{IsGraph A, HasEquivs B, HasEquivs C, HasEquivs D} (** These are a lot of instances... *)
-  (F : C -> D) (G : B -> C) (K : A -> B) `{!Is0Functor F, !Is0Functor G, !Is0Functor K}
-  : NatEquiv ((F o G) o K) (F o (G o K)).
-Proof.
-  snrapply Build_NatEquiv.
-  1: intro; reflexivity.
-  intros X Y f.
-  refine (cat_prewhisker (id_cate_fun _) _ $@ cat_idl _ $@ _^$).
-  refine (cat_postwhisker _ (id_cate_fun _) $@ cat_idr _).
-Defined.
-
 Lemma natequiv_op {A B : Type} `{Is01Cat A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
   : NatEquiv F G -> NatEquiv (G : A^op -> B^op) F.
@@ -308,22 +288,50 @@ Proof.
   intros [a n].
   snrapply Build_NatEquiv.
   1: exact a.
-  rapply is1nat_op.
+  by rapply is1natural_op.
 Defined.
 
-(** *** Pointed natural transformations *)
+(** We can form the inverse natural equivalence by inverting each map in the family. The naturality proof follows from standard lemmas about inverses. *)
+Definition natequiv_inverse {A B : Type} `{IsGraph A} `{HasEquivs B}
+  {F G : A -> B} `{!Is0Functor F, !Is0Functor G}
+  : NatEquiv F G -> NatEquiv G F.
+Proof.
+  intros [alpha I].
+  snrapply Build_NatEquiv.
+  1: intro a; symmetry; apply alpha.
+  snrapply Build_Is1Natural'.
+  intros X Y f.
+  apply vinverse, I.
+Defined.
+
+(** This lemma might seem unnecessery since as functions ((F o G) o K) and (F o (G o K)) are definitionally equal. But the functor instances of both sides are different. This can be a nasty trap since you cannot see this difference clearly. *)
+Definition natequiv_functor_assoc_ff_f {A B C D : Type}
+  `{IsGraph A, HasEquivs B, HasEquivs C, HasEquivs D} 
+  (F : C -> D) (G : B -> C) (K : A -> B)
+  `{!Is0Functor F, !Is0Functor G, !Is0Functor K}
+  : NatEquiv ((F o G) o K) (F o (G o K)).
+Proof.
+  snrapply Build_NatEquiv.
+  1: intro; reflexivity.
+  snrapply Build_Is1Natural'.
+  intros X Y f.
+  refine (cat_prewhisker (id_cate_fun _) _ $@ cat_idl _ $@ _^$).
+  refine (cat_postwhisker _ (id_cate_fun _) $@ cat_idr _).
+Defined.
+
+(** ** Pointed natural transformations *)
 
 Definition PointedTransformation {B C : Type} `{Is1Cat B, Is1Gpd C}
-           `{IsPointed B, IsPointed C} (F G : B -->* C)
+  `{IsPointed B, IsPointed C} (F G : B -->* C)
   := {eta : F $=> G & eta (point _) $== bp_pointed F $@ (bp_pointed G)^$}.
 
 Notation "F $=>* G" := (PointedTransformation F G) (at level 70).
 
 Definition ptransformation_inverse {B C : Type} `{Is1Cat B, Is1Gpd C}
-           `{IsPointed B, IsPointed C} (F G : B -->* C)
+  `{IsPointed B, IsPointed C} (F G : B -->* C)
   : (F $=>* G) -> (G $=>* F).
 Proof.
-  intros [h p].
+intros [h p].
   exists (fun x => (h x)^$).
   refine (gpd_rev2 p $@ _).
   refine (gpd_rev_pp _ _ $@ _).
@@ -334,7 +342,7 @@ Defined.
 Notation "h ^*$" := (ptransformation_inverse _ _ h) (at level 5).
 
 Definition ptransformation_compose {B C : Type} `{Is1Cat B, Is1Gpd C}
-           `{IsPointed B, IsPointed C} {F0 F1 F2 : B -->* C}
+  `{IsPointed B, IsPointed C} {F0 F1 F2 : B -->* C}
   : (F0 $=>* F1) -> (F1 $=>* F2) -> (F0 $=>* F2).
 Proof.
   intros [h0 p0] [h1 p1].

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -155,6 +155,7 @@ Defined.
 
 Record NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} {F G : A -> B}
   {ff : Is0Functor F} {fg : Is0Functor G} := {
+  #[reversible=no]
   trans_nattrans :> F $=> G;
   is1natural_nattrans : Is1Natural F G trans_nattrans;
 }.
@@ -201,9 +202,10 @@ Definition nattrans_op {A B : Type} `{Is01Cat A} `{Is1Cat B}
 
 (** ** Natural equivalences *)
 
-(** Natural equivalences are families of equivlaences that are natural. *)
+(** Natural equivalences are families of equivalences that are natural. *)
 Record NatEquiv {A B : Type} `{IsGraph A} `{HasEquivs B}
   {F G : A -> B} `{!Is0Functor F, !Is0Functor G} := {
+  #[reversible=no]
   cat_equiv_natequiv :> forall a, F a $<~> G a ;
   is1natural_natequiv :: Is1Natural F G (fun a => cat_equiv_natequiv a) ;
 }.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -1,5 +1,5 @@
 Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids.
-Require Import WildCat.Core WildCat.TwoOneCat.
+Require Import WildCat.Core WildCat.TwoOneCat WildCat.NatTrans.
 
 (** * Path groupoids as wild categories *)
 
@@ -79,17 +79,27 @@ Proof.
       exact (whiskerL_pp p q r).
   - intros a b c q r s t h g.
     exact (concat_whisker q r s t h g)^.
-  - intros a b c d q r s t h.
+  - intros a b c d q r.
+    snrapply Build_Is1Natural'.
+    intros s t h.
     apply concat_p_pp_nat_r.
-  - intros a b c d q r s t h.
+  - intros a b c d q r.
+    snrapply Build_Is1Natural'.
+    intros s t h.
     apply concat_p_pp_nat_m.
-  - intros a b c d q r s t h.
+  - intros a b c d q r.
+    snrapply Build_Is1Natural'.
+    intros s t h.
     apply concat_p_pp_nat_l.
-  - intros a b p q h; cbn.
+  - intros a b.
+    snrapply Build_Is1Natural'.
+    intros p q h; cbn.
     apply moveL_Mp.
     lhs nrapply concat_p_pp.
     exact (whiskerR_p1 h).
-  - intros a b p q h.
+  - intros a b.
+    snrapply Build_Is1Natural'.
+    intros p q h.
     apply moveL_Mp.
     lhs rapply concat_p_pp.
     exact (whiskerL_1p h).

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -163,7 +163,8 @@ Proof.
     nrapply (cate_prod_0gpd ie).
     intros i.
     exact (natequiv_yon_equiv_0gpd (e i) _).
-  - intros a b f g j.
+  - snrapply Build_Is1Natural'.
+    intros a b f g j.
     cbn.
     destruct (eisretr ie j).
     exact (cat_assoc_opp _ _ _).
@@ -665,7 +666,8 @@ Section Symmetry.
     - snrapply Build_NatTrans.
       + intros [x y].
         exact (cat_binprod_swap x y).
-      + intros [a b] [c d] [f g]; cbn in f, g.
+      + snrapply Build_Is1Natural'.
+        intros [a b] [c d] [f g]; cbn in f, g.
         exact(cat_binprod_swap_nat f g).
     - exact cat_binprod_swap_cat_binprod_swap.
   Defined.
@@ -854,7 +856,8 @@ Section Associativity.
           exact (cat_idl _ $@ (cat_idr _)^$).
         * nrefine (cat_assoc_opp _ _ _ $@ (cat_binprod_beta_pr2 _ _ $@R _) $@ _).
           exact ((mor_terminal_unique _ _ _)^$ $@ mor_terminal_unique _ _ _).
-    - intros a b f.
+    - snrapply Build_Is1Natural'.
+      intros a b f.
       refine ((_ $@R _) $@ _ $@ (_ $@L _^$)).
       1,3: nrapply cate_buildequiv_fun.
       nrapply cat_binprod_beta_pr1.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -154,11 +154,17 @@ Proof.
   - intros a b c f g h k p q x; cbn.
     symmetry.
     apply concat_Ap.
-  - intros a b c d f g h i p x; cbn.
+  - intros a b c d f g.
+    snrapply Build_Is1Natural'.
+    intros h i p x; cbn.
     exact (concat_p1 _ @ ap_compose _ _ _ @ (concat_1p _)^).
-  - intros a b f g p x; cbn.
+  - intros a b.
+    snrapply Build_Is1Natural'.
+    intros f g p x; cbn.
     exact (concat_p1 _ @ ap_idmap _ @ (concat_1p _)^).
-  - intros a b f g p x; cbn.
+  - intros a b.
+    snrapply Build_Is1Natural'.
+    intros f g p x; cbn.
     exact (concat_p1 _ @ (concat_1p _)^).
   - reflexivity.
   - reflexivity.

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -143,6 +143,7 @@ Global Instance is1natural_opyoneda {A : Type} `{Is1Cat A}
   (a : A) (F : A -> Type) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : Is1Natural (opyon a) F (opyoneda a F x).
 Proof.
+  snrapply Build_Is1Natural'.
   unfold opyon, opyoneda; intros b c f g; cbn in *.
   exact (fmap_comp F g f x).
 Defined.
@@ -316,6 +317,7 @@ Global Instance is1natural_opyoneda_0gpd {A : Type} `{Is1Cat A}
   (a : A) (F : A -> ZeroGpd) `{!Is0Functor F, !Is1Functor F} (x : F a)
   : Is1Natural (opyon_0gpd a) F (opyoneda_0gpd a F x).
 Proof.
+  snrapply Build_Is1Natural'.
   unfold opyon_0gpd, opyoneda_0gpd; intros b c f g; cbn in *.
   exact (fmap_comp F g f x).
 Defined.


### PR DESCRIPTION
We cleanup NatTrans.v by doing the following:

- Transformations, natuarlity lemmas, and natural transformations each appear separately in their own sections making it easier to see what lemmas are available for each.
- There are now more comments explaining what is happening.
- Is1Natural is no longer a definitional typeclass in preperation for adding the transposed naturality condition to the data of a natural transformation.
- Whitespace style has been homogenized.
