### PR TITLE
fix notation warnings in 8.20

### DIFF
--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -80,17 +80,17 @@ Reserved Notation "{ x : A  & P  & Q }" (at level 0, x at level 99).
 
  
 (** Numeric *)
-Reserved Notation "n .+1" (at level 2, left associativity, format "n .+1").
-Reserved Notation "n .+2" (at level 2, left associativity, format "n .+2").
-Reserved Notation "n .+3" (at level 2, left associativity, format "n .+3").
-Reserved Notation "n .+4" (at level 2, left associativity, format "n .+4").
-Reserved Notation "n .+5" (at level 2, left associativity, format "n .+5").
-Reserved Notation "n '.-1'" (at level 2, left associativity, format "n .-1").
-Reserved Notation "n '.-2'" (at level 2, left associativity, format "n .-2").
+Reserved Notation "n .+1" (at level 1, left associativity, format "n .+1").
+Reserved Notation "n .+2" (at level 1, left associativity, format "n .+2").
+Reserved Notation "n .+3" (at level 1, left associativity, format "n .+3").
+Reserved Notation "n .+4" (at level 1, left associativity, format "n .+4").
+Reserved Notation "n .+5" (at level 1, left associativity, format "n .+5").
+Reserved Notation "n '.-1'" (at level 1, left associativity, format "n .-1").
+Reserved Notation "n '.-2'" (at level 1, left associativity, format "n .-2").
 Reserved Notation "m +2+ n" (at level 50, left associativity).
 Reserved Infix "mod" (at level 40, no associativity).
-Reserved Notation "p ~ 1" (at level 7, left associativity, format "p '~' '1'").
-Reserved Notation "p ~ 0" (at level 7, left associativity, format "p '~' '0'").
+Reserved Notation "p ~ 1" (at level 1, left associativity, format "p '~' '1'").
+Reserved Notation "p ~ 0" (at level 1, left associativity, format "p '~' '0'").
 
 (** Pointed *)
 Reserved Infix "@*" (at level 30).
@@ -100,19 +100,19 @@ Reserved Infix "->*" (at level 99).
 Reserved Infix "->**" (at level 99).
 Reserved Infix "o*" (at level 40, left associativity).
 Reserved Infix "==*" (at level 70, no associativity).
-Reserved Notation "g ^*'" (at level 20).
-Reserved Notation "f ^*" (at level 3, format "f '^*'").
-Reserved Notation "f ^-1*" (at level 3, format "f '^-1*'").
+Reserved Notation "g ^*'" (at level 1).
+Reserved Notation "f ^*" (at level 1, format "f '^*'").
+Reserved Notation "f ^-1*" (at level 1, format "f '^-1*'").
 Reserved Notation "g o*E f" (at level 40, left associativity).
 Reserved Notation "'ppforall'  x .. y , P"
      (at level 200, x binder, y binder, right associativity).
 
 (** Sigma type *)
-Reserved Notation "x .1" (at level 3, format "x '.1'").
-Reserved Notation "x .2" (at level 3, format "x '.2'").
+Reserved Notation "x .1" (at level 1, format "x '.1'").
+Reserved Notation "x .2" (at level 1, format "x '.2'").
 
 (** Paths *)
-Reserved Notation "p ^" (at level 3, format "p '^'").
+Reserved Notation "p ^" (at level 1, format "p '^'").
 Reserved Notation "p @ q" (at level 20).
 Reserved Notation "p # x" (right associativity, at level 65).
 Reserved Notation "p # x" (right associativity, at level 65).
@@ -123,8 +123,7 @@ Reserved Notation "f == g" (at level 70, no associativity).
 
 (** Equivalences *)
 Reserved Notation "A <~> B" (at level 85).
-Reserved Notation "f ^-1" (at level 3, format "f '^-1'").
-Reserved Notation "m ^-1" (at level 3, format "m '^-1'").
+Reserved Notation "f ^-1" (at level 1, format "f '^-1'").
 Reserved Notation "g 'oE' f" (at level 40, left associativity).
 Reserved Notation "f *E g" (at level 40, left associativity).
 Reserved Notation "f +E g" (at level 50, left associativity).
@@ -132,11 +131,11 @@ Reserved Notation "f +E g" (at level 50, left associativity).
 (** Categories *)
 Reserved Infix "-|" (at level 60, right associativity).
 Reserved Infix "<~=~>" (at level 70, no associativity).
-Reserved Notation "a // 'CAT'" (at level 40, left associativity).
-Reserved Notation "a \\ 'CAT'" (at level 40, left associativity).
+Reserved Notation "a // 'CAT'" (at level 1, left associativity).
+Reserved Notation "a \\ 'CAT'" (at level 1, left associativity).
 Reserved Notation "'CAT' // a" (at level 40, left associativity).
 Reserved Notation "'CAT' \\ a" (at level 40, left associativity).
-Reserved Notation "C ^op" (at level 3, format "C '^op'").
+Reserved Notation "C ^op" (at level 1, format "C '^op'").
 
 (** Universal algebra *)
 Reserved Notation "u .# A" (at level 3, format "u '.#' A").
@@ -156,17 +155,17 @@ Reserved Infix "$@L" (at level 30).
 Reserved Infix "$@R" (at level 30).
 Reserved Infix "$@@" (at level 30).
 Reserved Infix "$=>" (at level 99).
-Reserved Notation "T ^op" (at level 3, format "T ^op").
-Reserved Notation "f ^-1$" (at level 3, format "f '^-1$'").
-Reserved Notation "f ^$" (at level 3, format "f '^$'").
+Reserved Notation "T ^op" (at level 1, format "T ^op").
+Reserved Notation "f ^-1$" (at level 1, format "f '^-1$'").
+Reserved Notation "f ^$" (at level 1, format "f '^$'").
 Reserved Infix "$@h" (at level 35).
 Reserved Infix "$@v" (at level 35).
 Reserved Infix "$@hR" (at level 34).
 Reserved Infix "$@hL" (at level 34).
 Reserved Infix "$@vR" (at level 34).
 Reserved Infix "$@vL" (at level 34).
-Reserved Notation "s ^h$" (at level 20).
-Reserved Notation "s ^v$" (at level 20).
+Reserved Notation "s ^h$" (at level 1).
+Reserved Notation "s ^v$" (at level 1).
 
 (** Displayed wild cat *)
 Reserved Infix "$o'" (at level 40, left associativity).
@@ -175,8 +174,8 @@ Reserved Infix "$@L'" (at level 30).
 Reserved Infix "$@R'" (at level 30).
 Reserved Infix "$@@'" (at level 30).
 Reserved Infix "$oE'" (at level 40, left associativity).
-Reserved Notation "f ^$'" (at level 3, format "f '^$''").
-Reserved Notation "f ^-1$'" (at level 3, format "f '^-1$''").
+Reserved Notation "f ^$'" (at level 1, format "f '^$''").
+Reserved Notation "f ^-1$'" (at level 1, format "f '^-1$''").
 
 (** Cubical *)
 Reserved Infix "@@h" (at level 30).
@@ -185,7 +184,7 @@ Reserved Infix "@lr" (at level 30).
 Reserved Notation "x '@Dp' y"  (at level 20).
 Reserved Notation "x '@Dr' y" (at level 20).
 Reserved Notation "x '@Dl' y" (at level 20).
-Reserved Notation "x '^D'" (at level 3).
+Reserved Notation "x '^D'" (at level 1).
 
 (** Lists *)
 Reserved Infix "::" (at level 60, right associativity).
@@ -211,14 +210,14 @@ Reserved Notation "D '_f' g" (at level 10).
 Reserved Notation "F '_0' x" (at level 10, no associativity).
 Reserved Notation "F '_0' x" (at level 10, no associativity).
 Reserved Notation "F '_1' m" (at level 10, no associativity).
-Reserved Notation "F ^op" (at level 3, format "F ^op").
+Reserved Notation "F ^op" (at level 1, format "F ^op").
 Reserved Notation "'forall'  x .. y , P" (at level 200, x binder, y binder, right associativity).
 Reserved Notation "g 'oD' f" (at level 40, left associativity).
 Reserved Notation "g 'o' f" (at level 40, left associativity).
 Reserved Notation "m <= n" (at level 70, no associativity).
 Reserved Notation "n -Type" (at level 1).
-Reserved Notation "p ..1" (at level 3).
-Reserved Notation "p ..2" (at level 3).
+Reserved Notation "p ..1" (at level 1).
+Reserved Notation "p ..2" (at level 1).
 Reserved Notation "!! P" (at level 35, right associativity).
 Reserved Notation "u ~~ v" (at level 30).
 Reserved Notation "! x" (at level 3, format "'!' x").
@@ -234,16 +233,16 @@ Reserved Notation "x (-> y" (at level 99, right associativity, y at level 200).
 Reserved Notation "x <> y  :>  T" (at level 70, y at next level, no associativity).
 Reserved Notation "Z ** W" (at level 30, right associativity).
 
-Reserved Notation "'+N'" (at level 55).
-Reserved Notation "'+Z'" (at level 55).
-Reserved Notation "'N3'" (at level 55).
-Reserved Notation "'Z3'" (at level 55).
+Reserved Notation "'+N'" (at level 0).
+Reserved Notation "'+Z'" (at level 0).
+Reserved Notation "'N3'" (at level 0).
+Reserved Notation "'Z3'" (at level 0).
 
-Reserved Notation "a ^+" (at level 0).
-Reserved Notation "a ^+ k" (at level 0).
-Reserved Notation "x ^++" (at level 0).
-Reserved Notation "x ^++ k" (at level 0).
-Reserved Notation "b ^+f" (at level 0).
+Reserved Notation "a ^+" (at level 1).
+Reserved Notation "a ^+ k" (at level 1).
+Reserved Notation "x ^++" (at level 1).
+Reserved Notation "x ^++ k" (at level 1).
+Reserved Notation "b ^+f" (at level 1).
 
 (** Mathclasses *)
 Reserved Notation "' x" (at level 20).

--- a/theories/Basics/Utf8.v
+++ b/theories/Basics/Utf8.v
@@ -19,19 +19,18 @@ Reserved Infix "∘ˡ" (at level 40, left associativity).
 Reserved Infix "∘ʳ" (at level 40, left associativity).
 Reserved Infix "⊣" (at level 60, right associativity).
 Reserved Infix "≅" (at level 70, no associativity).
-Reserved Notation "A 'ᵒᵖ'" (at level 3).
+Reserved Notation "A 'ᵒᵖ'" (at level 1).
 Reserved Notation "A × B" (at level 40, left associativity).
 Reserved Notation "a ≤ b" (at level 70, no associativity).
 Reserved Notation "A ≃ B" (at level 85).
-Reserved Notation "a ⇓ 'CAT'" (at level 40, left associativity).
-Reserved Notation "a ⇑ 'CAT'" (at level 40, left associativity).
+Reserved Notation "a ⇓ 'CAT'" (at level 1, left associativity).
+Reserved Notation "a ⇑ 'CAT'" (at level 1, left associativity).
 Reserved Notation "a ≤_{ x } b" (at level 70, no associativity).
 Reserved Notation "C ↓ a" (at level 70, no associativity).
 Reserved Notation "'CAT' ⇓ a" (at level 40, left associativity).
 Reserved Notation "'CAT' ⇑ a" (at level 40, left associativity).
-Reserved Notation "C 'ᵒᵖ'" (at level 3).
 Reserved Notation "C → D" (at level 99, D at level 200, right associativity).
-Reserved Notation "f '⁻¹'" (at level 3, format "f '⁻¹'").
+Reserved Notation "f '⁻¹'" (at level 1, format "f '⁻¹'").
 (* Reserved Notation "f ×ᴱ g" (at level 40, no associativity). *)
 (* Reserved Notation "f *ᴱ g" (at level 40, no associativity). *)
 Reserved Notation "f +ᴱ g" (at level 50, left associativity).
@@ -39,13 +38,11 @@ Reserved Notation "F ₁ m" (at level 10, no associativity).
 Reserved Notation "F ₀ x" (at level 10, no associativity).
 Reserved Notation "g ∘ f" (at level 40, left associativity).
 Reserved Notation "g ∘ᴱ f" (at level 40, left associativity).
-Reserved Notation "m ⁻¹" (at level 3, format "m '⁻¹'").
 Reserved Notation "m ≤ n" (at level 70, no associativity).
-Reserved Notation "p '⁻¹'" (at level 3, format "p '⁻¹'").
 Reserved Notation "p • q" (at level 20).
 Reserved Notation "p •' q" (at level 21, left associativity, format "'[v' p '/' '•''  q ']'").
-Reserved Notation "x ₁" (at level 3).
-Reserved Notation "x ₂" (at level 3).
+Reserved Notation "x ₁" (at level 1).
+Reserved Notation "x ₂" (at level 1).
 Reserved Notation "¬ x" (at level 35, right associativity).
 Reserved Notation "x ⇓ F" (at level 40, left associativity).
 Reserved Notation "x ⇑ F" (at level 40, left associativity).

--- a/theories/Modalities/Fracture.v
+++ b/theories/Modalities/Fracture.v
@@ -107,7 +107,7 @@ It may sometimes happen that in addition, the "intersection" of [O1] and [O2] is
                      (O_functor O2 (to O1 (Pullback f (to O2 B)))
                                 ((O_rec (f^* (to O2 B)))^-1 c)));
         [ apply ap11; repeat apply ap
-        | transitivity (O_functor O2 (O_rec (to O2 B^*' f))
+        | transitivity (O_functor O2 (O_rec ((to O2 B)^*' f))
                           (O_functor O2 (to O1 (Pullback f (to O2 B)))
                                      ((O_rec (f^* (to O2 B)))^-1 c))) ].
       + refine (pr1_path_sigma_uncurried _ @ eisretr pr1 _).


### PR DESCRIPTION
Newer versions of Coq warn when a postfix or a closed notation doesn't have level 1 or 0 respectively. We fix all such occurences here. We also remove a few redundant reservations.