### PR TITLE
interaction of scalar and matrix multiplication

### DIFF
--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -225,7 +225,7 @@ Proof.
   - exact (right_identity_matrix_mult R n n).
 Defined.
 
-(** Matrix multiplication on the right preserves scalar multiplication. *)
+(** Matrix multiplication on the right preserves scalar multiplication in the sense that [matrix_lact r (matrix_mult M N) = matrix_mult (matrix_lact r M) N] for [r] a ring element and [M] and [N] matrices of compatible sizes. *)
 Definition matrix_mult_lact_l {R : Ring} {m n p : nat}
   : HeteroAssociative (@matrix_lact R m p) (@matrix_mult R m n p)
       (@matrix_mult R m n p) (@matrix_lact R m n).

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -208,7 +208,7 @@ Proof.
   nrapply rng_sum_kronecker_delta_r'.
 Defined.
 
-(** TODO: define this as an R-algebra *)
+(** TODO: define this as an R-algebra. What is an R-algebra over a non-commutative right however? (Here we have a bimodule which might be important) *)
 (** Matrices over a ring form a (generally) non-commutative ring. *)
 Definition matrix_ring (R : Ring@{i}) (n : nat) : Ring.
 Proof.
@@ -224,6 +224,24 @@ Proof.
   - exact (left_identity_matrix_mult R n n).
   - exact (right_identity_matrix_mult R n n).
 Defined.
+
+(** Matrix multiplication on the right preserves scalar multiplication. *)
+Definition matrix_mult_lact_l {R : Ring} {m n p}
+  : HeteroAssociative (@matrix_lact R m p) (@matrix_mult R m n p)
+      (@matrix_mult R m n p) (@matrix_lact R m n).
+Proof.
+  intros r M N.
+  snrapply path_matrix.
+  intros i j Hi Hj.
+  rewrite !entry_Build_Matrix, !entry_Build_Vector. 
+  lhs nrapply rng_sum_dist_l.
+  snrapply path_ab_sum.
+  intros k Hk; cbn.
+  rewrite !entry_Build_Matrix.
+  snrapply rng_mult_assoc.
+Defined.
+
+(** The same doesn't hold for the right matrix, since the ring is not commutative. However we could say an analagous statement for the right action. We haven't yet stated a definition of right module yet though. *)
 
 (** ** Transpose *)
 

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -226,7 +226,7 @@ Proof.
 Defined.
 
 (** Matrix multiplication on the right preserves scalar multiplication. *)
-Definition matrix_mult_lact_l {R : Ring} {m n p}
+Definition matrix_mult_lact_l {R : Ring} {m n p : nat}
   : HeteroAssociative (@matrix_lact R m p) (@matrix_mult R m n p)
       (@matrix_mult R m n p) (@matrix_lact R m n).
 Proof.


### PR DESCRIPTION
We show that scalar multiplication distributes over the first factor of matrix multiplication. We also clarify that something similar should hold for right multiplication and the right factor.

We also clarify an earlier comment about an R-algebra over a noncommutative ring R. It's not a priori clear what the definition should be in this case. R-matrices form an R-bimodule with a product that interacts with the left and right actions nicely. This might be a good candidate for a definition, but it is not clear if it is standard.

When the ring R is commutative then it is clear that this becomes the usual definition of an associative algebra. Equivalently, a map `R -> Z(A)` where A is the algebra and Z is the center.