### PR TITLE
more theory about matrix traces

### DIFF
--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -319,7 +319,8 @@ Proof.
 Defined.
 
 (** The trace of a matrix multiplication is the same as the trace of the reverse multiplication. This holds only in a commutative ring. *)
-Definition matrix_trace_mult {R : CRing} {n} (M N : Matrix R n n)
+Definition matrix_trace_mult {R : CRing} {m n : nat}
+  (M : Matrix R m n) (N : Matrix R n m)
   : matrix_trace (matrix_mult M N) = matrix_trace (matrix_mult N M).
 Proof.
   lhs nrapply path_ab_sum.
@@ -336,7 +337,8 @@ Proof.
 Defined.
 
 (** More generally, the trace of a matrix is invariant under cyclic permutations. This fails for other permutations. *)
-Definition matrix_trace_mult_triple {R : CRing} {n} (M N P : Matrix R n n)
+Definition matrix_trace_mult_triple {R : CRing} {m n p}
+  (M : Matrix R m n) (N : Matrix R n p) (P : Matrix R p m)
   : matrix_trace (matrix_mult (matrix_mult M N) P)
     = matrix_trace (matrix_mult (matrix_mult P M) N).
 Proof.

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -336,30 +336,6 @@ Proof.
   reflexivity.
 Defined.
 
-(** More generally, the trace of a matrix is invariant under cyclic permutations. This fails for other permutations. *)
-Definition matrix_trace_mult_triple {R : CRing} {m n p}
-  (M : Matrix R m n) (N : Matrix R n p) (P : Matrix R p m)
-  : matrix_trace (matrix_mult (matrix_mult M N) P)
-    = matrix_trace (matrix_mult (matrix_mult P M) N).
-Proof.
-  nrefine (_ @ _ @ _^).
-  1,3: nrapply path_ab_sum.
-  1,2: intros i Hi.
-  1,2: cbn; rewrite entry_Build_Matrix.
-  1,2: nrapply path_ab_sum.
-  1,2: intros j Hj.
-  1,2: cbn; rewrite entry_Build_Matrix.
-  1,2: rewrite rng_sum_dist_r.
-  1,2: nrapply path_ab_sum.
-  1,2: intros k Hk.
-  2: rewrite <- rng_mult_assoc, rng_mult_comm.
-  1,2: reflexivity.
-  rewrite ab_sum_sum.
-  lhs snrapply path_ab_sum.
-  1: intros i Hi; by rewrite ab_sum_sum.
-  by rewrite ab_sum_sum.
-Defined.
-
 (** The trace of the transpose of a matrix is the same as the trace of the matrix. *)
 Definition trace_transpose {R : Ring} {n} (M : Matrix R n n)
   : matrix_trace (matrix_transpose M) = matrix_trace M.

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -296,7 +296,29 @@ Defined.
 Definition matrix_trace {R : Ring} {n} (M : Matrix R n n) : R
   := ab_sum n (fun i Hi => entry M i i).
 
-(** The trace of a matrix multiplication is the same as the trace of the reverse multiplication. *)
+(** The trace of a matrix preserves addition. *)
+Definition matrix_trace_plus {R : Ring} {n} (M N : Matrix R n n)
+  : matrix_trace (matrix_plus M N) = (matrix_trace M) + (matrix_trace N).
+Proof.
+  unfold matrix_trace.
+  lhs nrapply path_ab_sum.
+  { intros i Hi.
+    by rewrite entry_Build_Matrix. }
+  by rewrite ab_sum_plus.
+Defined.
+
+(** The trace of a matrix preserves scalar multiplication. *)
+Definition matrix_trace_lact {R : Ring} {n} (r : R) (M : Matrix R n n)
+  : matrix_trace (matrix_lact r M) = r * matrix_trace M.
+Proof.
+  unfold matrix_trace.
+  rewrite rng_sum_dist_l.
+  apply path_ab_sum.
+  intros i Hi.
+  by rewrite entry_Build_Matrix.
+Defined.
+
+(** The trace of a matrix multiplication is the same as the trace of the reverse multiplication. This holds only in a commutative ring. *)
 Definition matrix_trace_mult {R : CRing} {n} (M N : Matrix R n n)
   : matrix_trace (matrix_mult M N) = matrix_trace (matrix_mult N M).
 Proof.
@@ -304,13 +326,36 @@ Proof.
   { intros i Hi.
     lhs nrapply entry_Build_Matrix.
     nrapply path_ab_sum.
-    { intros j Hj.
-      apply rng_mult_comm. } }
-  lhs nrapply ab_sum_sum. 
+    intros j Hj.
+    apply rng_mult_comm. }
+  lhs nrapply ab_sum_sum.
   apply path_ab_sum.
   intros i Hi.
   rhs nrapply entry_Build_Matrix.
   reflexivity.
+Defined.
+
+(** More generally, the trace of a matrix is invariant under cyclic permutations. This fails for other permutations. *)
+Definition matrix_trace_mult_triple {R : CRing} {n} (M N P : Matrix R n n)
+  : matrix_trace (matrix_mult (matrix_mult M N) P)
+    = matrix_trace (matrix_mult (matrix_mult P M) N).
+Proof.
+  nrefine (_ @ _ @ _^).
+  1,3: nrapply path_ab_sum.
+  1,2: intros i Hi.
+  1,2: cbn; rewrite entry_Build_Matrix.
+  1,2: nrapply path_ab_sum.
+  1,2: intros j Hj.
+  1,2: cbn; rewrite entry_Build_Matrix.
+  1,2: rewrite rng_sum_dist_r.
+  1,2: nrapply path_ab_sum.
+  1,2: intros k Hk.
+  2: rewrite <- rng_mult_assoc, rng_mult_comm.
+  1,2: reflexivity.
+  rewrite ab_sum_sum.
+  lhs snrapply path_ab_sum.
+  1: intros i Hi; by rewrite ab_sum_sum.
+  by rewrite ab_sum_sum.
 Defined.
 
 (** The trace of the transpose of a matrix is the same as the trace of the matrix. *)


### PR DESCRIPTION
We prove that:
- The trace of a matrix sum is the sum of traces.
- The trace preserves scalar multiplication (it is a linear map)
- In a commutative ring, a cyclic permutation of a product of matrices has invariant trace.