### PR TITLE
fix universes in Vector.v

### DIFF
--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -13,7 +13,7 @@ Local Open Scope mc_scope.
 
 (** ** Definition *)
 
-Definition Matrix (R : Type@{i}) (m n : nat) : Type@{i}
+Definition Matrix@{i} (R : Type@{i}) (m n : nat) : Type@{i}
   := Vector (Vector R n) m.
 
 Global Instance istrunc_matrix (R : Type) k `{IsTrunc k.+2 R} m n

--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -7,14 +7,16 @@ Require Import abstract_algebra.
 
 Local Open Scope mc_scope.
 
+Set Universe Minimization ToSet.
+
 (** * Vectors *)
 
 (** A vector is simply a list with a specified length. This data structure has many uses, but here we will focus on lists of left module elements. *)
 
 (** ** Definition *)
 
-Definition Vector (A : Type) (n : nat)
- := { l : list A & length l = n }.
+Definition Vector@{i} (A : Type@{i}) (n : nat) : Type@{i}
+ := { l : list@{i} A & length l = n }.
 
 (** *** Constructors *)
 


### PR DESCRIPTION
This was creating too many universe variables before. We also make sure that `Matrix` only takes the universe of the type of elements.