### PR TITLE
fix universes in list library

### DIFF
--- a/test/Spaces/List.v
+++ b/test/Spaces/List.v
@@ -38,11 +38,11 @@ Succeed Check fold_left_app@{_ _}.
 Succeed Check fold_right_app@{_ _}.
 Succeed Check length_list_map@{_ _}.
 Succeed Check inlist_map@{_ _}.
-Succeed Check inlist_map'@{_ _}.
+Succeed Check inlist_map'@{_ _ _}.
 Succeed Check list_map_id@{_}.
 Succeed Check list_map_compose@{_ _ _}.
 Succeed Check length_list_map2@{_ _ _}.
-Succeed Check inlist_map2@{_ _ _}.
+Succeed Check inlist_map2@{_ _ _ _}.
 Succeed Check list_map2_repeat_l@{_ _ _}.
 Succeed Check list_map2_repeat_r@{_ _ _}.
 Succeed Check length_reverse_acc@{_}.
@@ -101,11 +101,11 @@ Succeed Check length_repeat@{_}.
 Succeed Check inlist_repeat@{_}.
 Succeed Check for_all_inlist@{_ _}.
 Succeed Check inlist_for_all@{_ _}.
-Succeed Check for_all_list_map@{_ _ _ _ _}.
+Succeed Check for_all_list_map@{_ _ _ _}.
 Succeed Check for_all_list_map'@{_ _ _}.
-Succeed Check for_all_list_map2@{_ _ _ _ _ _ _}.
-Succeed Check for_all_list_map2'@{_ _ _ _ _ _ _}.
-Succeed Check fold_left_preserves@{_ _ _ _ _}.
+Succeed Check for_all_list_map2@{_ _ _ _ _ _}.
+Succeed Check for_all_list_map2'@{_ _ _ _ _ _}.
+Succeed Check fold_left_preserves@{_ _ _ _}.
 Succeed Check istrunc_for_all@{_ _}.
 Succeed Check istrunc_for_all'@{_ _}.
 Succeed Check for_all_repeat@{_ _}.

--- a/test/Spaces/List.v
+++ b/test/Spaces/List.v
@@ -1,0 +1,114 @@
+From HoTT Require Import Basics.
+From HoTT.Spaces.List Require Import Core Theory.
+
+(** Here we check the universe levels of the lemmas from List.Core *)
+Succeed Check list@{_}.
+Succeed Check nil@{_}.
+Succeed Check cons@{_}.
+Succeed Check list_rect@{_ _}.
+Succeed Check list_ind@{_ _}.
+Succeed Check list_rec@{_ _}.
+Succeed Check length@{_}.
+Succeed Check app@{_}.
+Succeed Check fold_left@{_ _}.
+Succeed Check fold_right@{_ _}.
+Succeed Check list_map@{_ _}.
+Succeed Check list_map2@{_ _ _}.
+Succeed Check reverse_acc@{_}.
+Succeed Check reverse@{_}.
+Succeed Check head@{_}.
+Succeed Check tail@{_}.
+Succeed Check last@{_}.
+Succeed Check nth@{_}.
+Succeed Check remove_last@{_}.
+Succeed Check seq_rev@{}.
+Succeed Check seq@{}.
+Succeed Check repeat@{_}.
+Succeed Check InList@{_}.
+Succeed Check for_all@{_ _}.
+
+(** Here we check the universe levels of the lemmas from List.Theory *)
+Succeed Check length_0@{_}.
+Succeed Check app_nil@{_}.
+Succeed Check app_assoc@{_}.
+Succeed Check list_pentagon@{_}.
+Succeed Check length_app@{_}.
+Succeed Check equiv_inlist_app@{_}.
+Succeed Check fold_left_app@{_ _}.
+Succeed Check fold_right_app@{_ _}.
+Succeed Check length_list_map@{_ _}.
+Succeed Check inlist_map@{_ _}.
+Succeed Check inlist_map'@{_ _}.
+Succeed Check list_map_id@{_}.
+Succeed Check list_map_compose@{_ _ _}.
+Succeed Check length_list_map2@{_ _ _}.
+Succeed Check inlist_map2@{_ _ _}.
+Succeed Check list_map2_repeat_l@{_ _ _}.
+Succeed Check list_map2_repeat_r@{_ _ _}.
+Succeed Check length_reverse_acc@{_}.
+Succeed Check length_reverse@{_}.
+Succeed Check list_map_reverse_acc@{_ _}.
+Succeed Check list_map_reverse@{_ _}.
+Succeed Check reverse_acc_cons@{_}.
+Succeed Check reverse_cons@{_}.
+Succeed Check nth_lt@{_}.
+Succeed Check nth'@{_}.
+Succeed Check nth'_nth'@{_}.
+Succeed Check inlist_nth'@{_}.
+Succeed Check nth_nth'@{_}.
+Succeed Check nth'_cons@{_}.
+Succeed Check index_of@{_}.
+Succeed Check nth_list_map@{_ _}.
+Succeed Check nth'_list_map@{_ _}.
+Succeed Check nth'_list_map2@{_ _ _}.
+Succeed Check nth'_repeat@{_}.
+Succeed Check path_list_nth'@{_}.
+Succeed Check nth_app@{_}.
+Succeed Check nth_last@{_}.
+Succeed Check last_app@{_}.
+Succeed Check drop@{_}.
+Succeed Check drop_0@{_}.
+Succeed Check drop_1@{_}.
+Succeed Check drop_nil@{_}.
+Succeed Check drop_length_leq@{_}.
+Succeed Check length_drop@{_}.
+Succeed Check drop_inlist@{_}.
+Succeed Check take@{_}.
+Succeed Check take_0@{_}.
+Succeed Check take_nil@{_}.
+Succeed Check take_length_leq@{_}.
+Succeed Check length_take@{_}.
+Succeed Check take_inlist@{_}.
+Succeed Check remove@{_}.
+Succeed Check remove_0@{_}.
+Succeed Check remove_length_leq@{_}.
+Succeed Check length_remove@{_}.
+Succeed Check remove_inlist@{_}.
+Succeed Check length_seq_rev@{}.
+Succeed Check length_seq@{}.
+Succeed Check seq_rev_cons@{}.
+Succeed Check seq_succ@{}.
+Succeed Check seq_rev'@{}.
+Succeed Check seq'@{}.
+Succeed Check length_seq_rev'@{}.
+Succeed Check length_seq'@{}.
+Succeed Check seq_rev_seq_rev'@{}.
+Succeed Check seq_seq'@{}.
+Succeed Check nth_seq_rev@{}.
+Succeed Check nth_seq@{}.
+Succeed Check nth'_seq'@{}.
+Succeed Check length_repeat@{_}.
+Succeed Check inlist_repeat@{_}.
+Succeed Check for_all_inlist@{_ _}.
+Succeed Check inlist_for_all@{_ _}.
+Succeed Check for_all_list_map@{_ _ _ _ _}.
+Succeed Check for_all_list_map'@{_ _ _}.
+Succeed Check for_all_list_map2@{_ _ _ _ _ _ _}.
+Succeed Check for_all_list_map2'@{_ _ _ _ _ _ _}.
+Succeed Check fold_left_preserves@{_ _ _ _ _}.
+Succeed Check istrunc_for_all@{_ _}.
+Succeed Check istrunc_for_all'@{_ _}.
+Succeed Check for_all_repeat@{_ _}.
+Succeed Check list_sigma@{_ _ _}.
+Succeed Check length_list_sigma@{_ _ _}.
+Succeed Check decidable_for_all@{_ _}.

--- a/test/Spaces/List.v
+++ b/test/Spaces/List.v
@@ -1,7 +1,7 @@
 From HoTT Require Import Basics.
 From HoTT.Spaces.List Require Import Core Theory.
 
-(** Here we check the universe levels of the lemmas from List.Core *)
+(** Here we check the number of universe variables for the definitions from List.Core *)
 Succeed Check list@{_}.
 Succeed Check nil@{_}.
 Succeed Check cons@{_}.
@@ -27,7 +27,7 @@ Succeed Check repeat@{_}.
 Succeed Check InList@{_}.
 Succeed Check for_all@{_ _}.
 
-(** Here we check the universe levels of the lemmas from List.Theory *)
+(** Here we check the number of universe variables for the definitions from List.Theory *)
 Succeed Check length_0@{_}.
 Succeed Check app_nil@{_}.
 Succeed Check app_assoc@{_}.

--- a/theories/Spaces/List/Core.v
+++ b/theories/Spaces/List/Core.v
@@ -1,6 +1,8 @@
 Require Import Basics.Overture.
 
-Unset Elimination Schemes.
+Local Unset Elimination Schemes.
+Local Set Universe Minimization ToSet.
+Local Set Polymorphic Inductive Cumulativity.
 
 (** * Lists *)
 

--- a/theories/Spaces/List/Core.v
+++ b/theories/Spaces/List/Core.v
@@ -30,6 +30,13 @@ Scheme list_rect := Induction for list Sort Type.
 Scheme list_ind := Induction for list Sort Type.
 Scheme list_rec := Minimality for list Sort Type.
 
+(** A tactic for doing induction over a list that avoids spurious universes. *)
+Ltac simple_list_induction l h t IH :=
+  try generalize dependent l;
+  fix IH 1;
+  intros [| h t];
+  [ clear IH | specialize (IH t) ].
+
 (** Syntactic sugar for creating lists. [ [a1, b2, ..., an] = a1 :: b2 :: ... :: an :: nil ]. *)
 Notation "[ x ]" := (x :: nil) : list_scope.
 Notation "[ x , y , .. , z ]" := (x :: (y :: .. (z :: nil) ..)) : list_scope.

--- a/theories/Spaces/List/Core.v
+++ b/theories/Spaces/List/Core.v
@@ -39,7 +39,7 @@ Notation "[ x , y , .. , z ]" := (x :: (y :: .. (z :: nil) ..)) : list_scope.
 (** Notice that the definition of a list looks very similar to the definition of [nat]. It is as if each [S] constructor from [nat] has an element of [A] attached to it. We can discard this extra element and get a list invariant that we call [length]. *)
 
 (** The length (number of elements) of a list. *)
-Fixpoint length@{i|} {A : Type@{i}} (l : list@{i} A) :=
+Fixpoint length {A : Type} (l : list A) :=
   match l with
   | nil => O
   | _ :: l => S (length l)
@@ -48,7 +48,7 @@ Fixpoint length@{i|} {A : Type@{i}} (l : list@{i} A) :=
 (** ** Concatenation *)
 
 (** Given two lists [ [a1; a2; ...; an] ] and [ [b1; b2; ...; bm] ], we can concatenate them to get [ [a1; a2; ...; an; b1; b2; ...; bm] ]. *)
-Definition app@{i|} {A : Type@{i}} : list A -> list A -> list A :=
+Definition app {A : Type} : list A -> list A -> list A :=
   fix app l m :=
   match l with
    | nil => m
@@ -62,16 +62,14 @@ Infix "++" := app : list_scope.
 (** Folding is a very important operation on lists. It is a way to reduce a list to a single value. The [fold_left] function starts from the left and the [fold_right] function starts from the right. *)
 
 (** [fold_left f l a0] computes [f (... (f (f a0 x1) x2) ...) xn] where [l = [x1; x2; ...; xn]]. *)
-Fixpoint fold_left@{i j|} {A : Type@{i}} {B : Type@{j}}
-  (f : A -> B -> A) (l : list B) (a0 : A) : A :=
+Fixpoint fold_left {A B} (f : A -> B -> A) (l : list B) (default : A) : A :=
   match l with
-    | nil => a0
-    | cons b l => fold_left f l (f a0 b)
+    | nil => default
+    | cons b l => fold_left f l (f default b)
   end.
 
 (** [fold_right f a0 l] computes [f x1 (f x2 ... (f xn a0) ...)] where [l = [x1; x2; ...; xn]]. *)
-Fixpoint fold_right@{i j|} {A : Type@{i}} {B : Type@{j}}
-  (f : B -> A -> A) (default : A) (l : list B) : A :=
+Fixpoint fold_right {A B} (f : B -> A -> A) (default : A) (l : list B) : A :=
   match l with
     | nil => default
     | cons b l => f b (fold_right f default l)
@@ -80,16 +78,15 @@ Fixpoint fold_right@{i j|} {A : Type@{i}} {B : Type@{j}}
 (** ** Maps - Functoriality of Lists *)
 
 (** The [list_map] function applies a function to each element of a list. In other words [ list_map f [a1; a2; ...; an] = [f a1; f a2; ...; f an] ]. *)
-Fixpoint list_map@{i j|} {A : Type@{i}} {B : Type@{j}} (f : A -> B) (l : list A) :=
+Fixpoint list_map {A B : Type} (f : A -> B) (l : list A) :=
   match l with
   | nil => nil
   | x :: l => (f x) :: (list_map f l)
   end.
 
 (** The [list_map2] function applies a binary function to corresponding elements of two lists. When one of the lists run out, it uses one of the default functions to fill in the rest. *)
-Fixpoint list_map2@{i j k|} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
-  (f : A -> B -> C) (def_l : list A -> list C) (def_r : list B -> list C)
-  l1 l2 :=
+Fixpoint list_map2 {A B C : Type} (f : A -> B -> C)
+  (def_l : list A -> list C) (def_r : list B -> list C) l1 l2 :=
   match l1, l2 with
   | nil, nil => nil
   | nil, _ => def_r l2
@@ -100,33 +97,33 @@ Fixpoint list_map2@{i j k|} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
 (** ** Reversal *)
 
 (** Tail-recursive list reversal. *)
-Fixpoint reverse_acc@{i|} {A : Type@{i}} (acc : list A) (l : list A) : list A :=
+Fixpoint reverse_acc {A : Type} (acc : list A) (l : list A) : list A :=
   match l with
   | nil => acc
   | x :: l => reverse_acc (x :: acc) l
   end.
 
 (** Reversing the order of a list. The list [ [a1; a2; ...; an] ] becomes [ [an; ...; a2; a1] ]. *)
-Definition reverse@{i|} {A : Type@{i}} (l : list A) : list A := reverse_acc nil l.
+Definition reverse {A : Type} (l : list A) : list A := reverse_acc nil l.
 
 (** ** Getting Elements *)
 
 (** The head of a list is its first element. Returns [None] If the list is empty. *)
-Definition head@{i|} {A : Type@{i}} (l : list A) : option A :=
+Definition head {A : Type} (l : list A) : option A :=
   match l with
   | nil => None
   | a :: _ => Some a
   end.
 
 (** The tail of a list is the list without its first element. *)
-Definition tail@{i|} {A : Type@{i}} (l : list A) : list A :=
+Definition tail {A : Type} (l : list A) : list A :=
   match l with
     | nil => nil
     | a :: m => m
   end.
 
 (** The last element of a list. If the list is empty, it returns [None]. *)
-Fixpoint last@{i|} {A : Type@{i}} (l : list A) : option A :=
+Fixpoint last {A : Type} (l : list A) : option A :=
   match l with
   | nil => None
   | a :: nil => Some a
@@ -134,7 +131,7 @@ Fixpoint last@{i|} {A : Type@{i}} (l : list A) : option A :=
   end.
 
 (** The [n]-th element of a list. If the list is too short, it returns [None]. *)
-Fixpoint nth@{i|} {A : Type@{i}} (l : list A) (n : nat) : option A :=
+Fixpoint nth {A : Type} (l : list A) (n : nat) : option A :=
   match n, l with
   | O, x :: _ => Some x
   | S n, _ :: l => nth l n
@@ -144,7 +141,7 @@ Fixpoint nth@{i|} {A : Type@{i}} (l : list A) (n : nat) : option A :=
 (** ** Removing Elements *)
 
 (** Remove the last element of a list and do nothing if it is empty. *)
-Fixpoint remove_last@{i|} {A : Type@{i}} (l : list A) : list A :=
+Fixpoint remove_last {A : Type} (l : list A) : list A :=
   match l with
   | nil => nil
   | _ :: nil => nil
@@ -166,7 +163,7 @@ Definition seq (n : nat) : list nat := reverse (seq_rev n).
 (** ** Repeat *)
 
 (** Repeat an element [n] times. *)
-Fixpoint repeat@{i|} {A : Type@{i}} (x : A) (n : nat) : list A :=
+Fixpoint repeat {A : Type} (x : A) (n : nat) : list A :=
   match n with
   | O => nil
   | S n => x :: repeat x n

--- a/theories/Spaces/List/Core.v
+++ b/theories/Spaces/List/Core.v
@@ -10,7 +10,7 @@ Declare Scope list_scope.
 Local Open Scope list_scope.
 
 (** A list is a sequence of elements from a type [A]. This is a very useful datatype and has many applications ranging from programming to algebra. It can be thought of a free monoid. *)
-Inductive list@{i} (A : Type@{i}) : Type@{i} :=
+Inductive list@{i|} (A : Type@{i}) : Type@{i} :=
 | nil : list A
 | cons : A -> list A -> list A.
 
@@ -37,7 +37,7 @@ Notation "[ x , y , .. , z ]" := (x :: (y :: .. (z :: nil) ..)) : list_scope.
 (** Notice that the definition of a list looks very similar to the definition of [nat]. It is as if each [S] constructor from [nat] has an element of [A] attached to it. We can discard this extra element and get a list invariant that we call [length]. *)
 
 (** The length (number of elements) of a list. *)
-Fixpoint length {A} (l : list A) :=
+Fixpoint length@{i|} {A : Type@{i}} (l : list@{i} A) :=
   match l with
   | nil => O
   | _ :: l => S (length l)
@@ -46,7 +46,7 @@ Fixpoint length {A} (l : list A) :=
 (** ** Concatenation *)
 
 (** Given two lists [ [a1; a2; ...; an] ] and [ [b1; b2; ...; bm] ], we can concatenate them to get [ [a1; a2; ...; an; b1; b2; ...; bm] ]. *)
-Definition app {A : Type} : list A -> list A -> list A :=
+Definition app@{i|} {A : Type@{i}} : list A -> list A -> list A :=
   fix app l m :=
   match l with
    | nil => m
@@ -60,14 +60,16 @@ Infix "++" := app : list_scope.
 (** Folding is a very important operation on lists. It is a way to reduce a list to a single value. The [fold_left] function starts from the left and the [fold_right] function starts from the right. *)
 
 (** [fold_left f l a0] computes [f (... (f (f a0 x1) x2) ...) xn] where [l = [x1; x2; ...; xn]]. *)
-Fixpoint fold_left {A B} (f : A -> B -> A) (l : list B) (a0 : A) : A :=
+Fixpoint fold_left@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B -> A) (l : list B) (a0 : A) : A :=
   match l with
     | nil => a0
     | cons b l => fold_left f l (f a0 b)
   end.
 
 (** [fold_right f a0 l] computes [f x1 (f x2 ... (f xn a0) ...)] where [l = [x1; x2; ...; xn]]. *)
-Fixpoint fold_right {A B} (f : B -> A -> A) (default : A) (l : list B) : A :=
+Fixpoint fold_right@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : B -> A -> A) (default : A) (l : list B) : A :=
   match l with
     | nil => default
     | cons b l => f b (fold_right f default l)
@@ -76,15 +78,15 @@ Fixpoint fold_right {A B} (f : B -> A -> A) (default : A) (l : list B) : A :=
 (** ** Maps - Functoriality of Lists *)
 
 (** The [list_map] function applies a function to each element of a list. In other words [ list_map f [a1; a2; ...; an] = [f a1; f a2; ...; f an] ]. *)
-Fixpoint list_map {A B} (f : A -> B) (l : list A) :=
+Fixpoint list_map@{i j|} {A : Type@{i}} {B : Type@{j}} (f : A -> B) (l : list A) :=
   match l with
   | nil => nil
   | x :: l => (f x) :: (list_map f l)
   end.
 
 (** The [list_map2] function applies a binary function to corresponding elements of two lists. When one of the lists run out, it uses one of the default functions to fill in the rest. *)
-Fixpoint list_map2 {A B C} (f : A -> B -> C)
-  (def_l : list A -> list C) (def_r : list B -> list C)
+Fixpoint list_map2@{i j k|} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B -> C) (def_l : list A -> list C) (def_r : list B -> list C)
   l1 l2 :=
   match l1, l2 with
   | nil, nil => nil
@@ -96,51 +98,51 @@ Fixpoint list_map2 {A B C} (f : A -> B -> C)
 (** ** Reversal *)
 
 (** Tail-recursive list reversal. *)
-Fixpoint reverse_acc {A} (acc : list A) (l : list A) : list A :=
+Fixpoint reverse_acc@{i|} {A : Type@{i}} (acc : list A) (l : list A) : list A :=
   match l with
   | nil => acc
   | x :: l => reverse_acc (x :: acc) l
   end.
 
 (** Reversing the order of a list. The list [ [a1; a2; ...; an] ] becomes [ [an; ...; a2; a1] ]. *)
-Definition reverse {A} (l : list A) : list A := reverse_acc nil l.
+Definition reverse@{i|} {A : Type@{i}} (l : list A) : list A := reverse_acc nil l.
 
 (** ** Getting Elements *)
 
 (** The head of a list is its first element. Returns [None] If the list is empty. *)
-Definition head {A} (l : list A) : option A :=
+Definition head@{i|} {A : Type@{i}} (l : list A) : option A :=
   match l with
   | nil => None
   | a :: _ => Some a
   end.
 
 (** The tail of a list is the list without its first element. *)
-Definition tail {A} (l : list A) : list A :=
+Definition tail@{i|} {A : Type@{i}} (l : list A) : list A :=
   match l with
     | nil => nil
     | a :: m => m
   end.
 
 (** The last element of a list. If the list is empty, it returns [None]. *)
-Fixpoint last {A} (l : list A) : option A :=
+Fixpoint last@{i|} {A : Type@{i}} (l : list A) : option A :=
   match l with
-  | nil => None 
+  | nil => None
   | a :: nil => Some a
   | _ :: l => last l
   end.
 
 (** The [n]-th element of a list. If the list is too short, it returns [None]. *)
-Fixpoint nth {A} (l : list A) (n : nat) : option A :=
+Fixpoint nth@{i|} {A : Type@{i}} (l : list A) (n : nat) : option A :=
   match n, l with
   | O, x :: _ => Some x
-  | S n, _ :: l => nth l n 
+  | S n, _ :: l => nth l n
   | _, _ => None
   end.
 
 (** ** Removing Elements *)
 
 (** Remove the last element of a list and do nothing if it is empty. *)
-Fixpoint remove_last {A} (l : list A) : list A :=
+Fixpoint remove_last@{i|} {A : Type@{i}} (l : list A) : list A :=
   match l with
   | nil => nil
   | _ :: nil => nil
@@ -162,7 +164,7 @@ Definition seq (n : nat) : list nat := reverse (seq_rev n).
 (** ** Repeat *)
 
 (** Repeat an element [n] times. *)
-Fixpoint repeat {A} (x : A) (n : nat) : list A :=
+Fixpoint repeat@{i|} {A : Type@{i}} (x : A) (n : nat) : list A :=
   match n with
   | O => nil
   | S n => x :: repeat x n
@@ -171,16 +173,16 @@ Fixpoint repeat {A} (x : A) (n : nat) : list A :=
 (** ** Membership Predicate *)
 
 (** The "In list" predicate *)
-Fixpoint InList {A : Type@{i}} (a : A) (l : list A) : Type@{i} :=
+Fixpoint InList@{i|} {A : Type@{i}} (a : A) (l : list A) : Type@{i} :=
   match l with
-    | nil => Empty 
+    | nil => Empty
     | b :: m => (b = a) + InList a m
   end.
 
 (** ** Forall *)
 
 (** Apply a predicate to all elements of a list and take their conjunction. *)
-Fixpoint for_all {A} (P : A -> Type) l : Type :=
+Fixpoint for_all@{i j|} {A : Type@{i}} (P : A -> Type@{j}) l : Type@{j} :=
   match l with
   | nil => Unit
   | x :: l => P x /\ for_all P l

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -3,7 +3,8 @@ Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Trunc
 Require Import Types.Paths Types.Unit Types.Prod Types.Sigma Types.Sum Types.Option.
 Require Export Spaces.List.Core Spaces.Nat.Core Spaces.Nat.Arithmetic.
 
-Set Universe Minimization ToSet.
+Local Set Universe Minimization ToSet.
+Local Set Polymorphic Inductive Cumulativity.
 
 (** * Theory of Lists and List Operations *)
 

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -3,6 +3,8 @@ Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Trunc
 Require Import Types.Paths Types.Unit Types.Prod Types.Sigma Types.Sum Types.Option.
 Require Export Spaces.List.Core Spaces.Nat.Core Spaces.Nat.Arithmetic.
 
+Set Universe Minimization ToSet.
+
 (** * Theory of Lists and List Operations *)
 
 (** In this file we collect lemmas about lists and their operations. We don't include those in [List.Core] so that file can stay lightweight on dependencies. *)
@@ -14,7 +16,7 @@ Local Open Scope list_scope.
 (** ** Length *)
 
 (** A list of length zero must be the empty list. *)
-Definition length_0 {A} (l : list A) (H : length l = 0%nat)
+Definition length_0@{i|} {A : Type@{i}} (l : list A) (H : length l = 0%nat)
   : l = nil.
 Proof.
   destruct l.
@@ -25,7 +27,7 @@ Defined.
 (** ** Concatenation *)
 
 (** Concatenating the empty list on the right is the identity. *)
-Definition app_nil {A} (l : list A)
+Definition app_nil@{i|} {A : Type@{i}} (l : list A)
   : l ++ nil = l.
 Proof.
   induction l as [|a l IHl].
@@ -34,7 +36,7 @@ Proof.
 Defined.
 
 (** Associativity of list concatenation. *)
-Definition app_assoc {A} (x y z : list A)
+Definition app_assoc@{i|} {A : Type@{i}} (x y z : list A)
   : app x (app y z) = app (app x y) z.
 Proof.
   induction x as [|a x IHx] in |- *.
@@ -43,7 +45,7 @@ Proof.
 Defined.
 
 (** The type of lists has a monoidal structure given by concatenation. *)
-Definition list_pentagon {A} (w x y z : list A)
+Definition list_pentagon@{i|} {A : Type@{i}} (w x y z : list A)
   : app_assoc w x (y ++ z) @ app_assoc (w ++ x) y z
     = ap (fun l => w ++ l) (app_assoc x y z)
     @ app_assoc w (x ++ y) z
@@ -68,17 +70,17 @@ Proof.
 Defined.
 
 (** The length of a concatenated list is the sum of the lengths of the two lists. *)
-Definition length_app {A} (l l' : list A)
+Definition length_app@{i|} {A : Type@{i}} (l l' : list A)
   : length (l ++ l') = (length l + length l')%nat.
 Proof.
-  induction l as [|a l IHl].
+  induction l as [|a l IHl] using list_ind.
   1: reflexivity.
   simpl.
   exact (ap S IHl).
 Defined.
 
 (** An element of a concatenated list is equivalently either in the first list or in the second list. *)
-Definition equiv_inlist_app {A} (l l' : list A) (x : A)
+Definition equiv_inlist_app@{i|} {A : Type@{i}} (l l' : list A) (x : A)
   : InList x l + InList x l' <~> InList x (l ++ l').
 Proof.
   induction l as [|a l IHl].
@@ -90,7 +92,8 @@ Defined.
 (** ** Folding *)
 
 (** A left fold over a concatenated list is equivalent to folding over the first followed by folding over the second. *)
-Lemma fold_left_app {A B} (f : A -> B -> A) (l l' : list B) (i : A)
+Lemma fold_left_app@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B -> A) (l l' : list B) (i : A)
   : fold_left f (l ++ l') i = fold_left f l' (fold_left f l i).
 Proof.
   induction l in i |- *.
@@ -99,7 +102,8 @@ Proof.
 Defined.
 
 (** A right fold over a concatenated list is equivalent to folding over the second followed by folding over the first. *)
-Lemma fold_right_app {A B} (f : B -> A -> A) (i : A) (l l' : list B)
+Lemma fold_right_app@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : B -> A -> A) (i : A) (l l' : list B)
   : fold_right f i (l ++ l') = fold_right f (fold_right f i l') l.
 Proof.
   induction l in i |- *.
@@ -110,21 +114,23 @@ Defined.
 (** ** Maps *)
 
 (** The length of a mapped list is the same as the length of the original list. *)
-Definition length_list_map {A B} (f : A -> B) (l : list A)
+Definition length_list_map@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l : list A)
   : length (list_map f l) = length l.
 Proof.
-  induction l as [|x l IHl].
+  induction l as [|x l IHl] using list_ind.
   - reflexivity.
   - simpl.
     exact (ap S IHl).
 Defined.
 
 (** A function applied to an element of a list is an element of the mapped list. *)
-Definition inlist_map {A B} (f : A -> B) (l : list A) (x : A)
+Definition inlist_map@{i j | i <= j} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l : list A) (x : A)
   : InList x l -> InList (f x) (list_map f l).
 Proof.
   intros H.
-  induction l as [|y l IHl] in H |- *.
+  induction l as [|y l IHl] in H |- * using list_ind@{i j}.
   1: contradiction.
   destruct H as [p | i].
   - destruct p.
@@ -134,8 +140,9 @@ Proof.
 Defined.
 
 (** An element of a mapped list is equal to the function applied to some element of the original list. *)
-Definition inlist_map' {A B} (f : A -> B) (l : list A) (x : B)
-  : InList x (list_map f l) -> { y : A & (x = f y) * InList y l }.
+Definition inlist_map'@{i j} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l : list A) (x : B)
+  : InList x (list_map f l) -> sig@{i j} (fun y => (x = f y) * InList y l ).
 Proof.
   intros H.
   induction l as [|y l IHl] in H |- *.
@@ -152,7 +159,8 @@ Proof.
 Defined.
 
 (** A function that acts as the identity on the elements of a list is the identity on the mapped list. *)
-Lemma list_map_id {A} (f : A -> A) (l : list A) (Hf : forall x, InList x l -> f x = x)
+Lemma list_map_id@{i|} {A : Type@{i}} (f : A -> A) (l : list A)
+  (Hf : forall x, InList x l -> f x = x)
   :  list_map f l = l.
 Proof.
   induction l as [|x l IHl].
@@ -167,7 +175,8 @@ Proof.
 Defined.
 
 (** A [list_map] of a composition is the composition of the maps. *)
-Definition list_map_compose {A B C} (f : A -> B) (g : B -> C) (l : list A)
+Definition list_map_compose@{i j k|} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B) (g : B -> C) (l : list A)
   : list_map (fun x => g (f x)) l = list_map g (list_map f l).
 Proof.
   induction l as [|a l IHl].
@@ -177,12 +186,13 @@ Defined.
 
 (** TODO: generalize as max *)
 (** The length of a [list_map2] is the same as the length of the original lists. *)
-Definition length_list_map2 {A B C} (f : A -> B -> C) defl defr l1 l2
+Definition length_list_map2@{i j k|} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B -> C) defl defr l1 l2
   : length l1 = length l2
     -> length (list_map2 f defl defr l1 l2) = length l1.
 Proof.
   intros p.
-  induction l1 as [|x l1 IHl1] in l2, p |- *.
+  induction l1 as [|x l1 IHl1] in l2, p |- * using list_ind@{i j}.
   - destruct l2.
     + reflexivity.
     + inversion p.
@@ -192,13 +202,18 @@ Proof.
       by apply IHl1, path_nat_S.
 Defined.
 
+(** TODO: why are notations so problematic with the universe variables here. *)
 (** An element of a [list_map2] is the result of applying the function to some elements of the original lists. *)
-Definition inlist_map2 {A B C} (f : A -> B -> C) defl defr l1 l2 x
+Definition inlist_map2@{i j k | i <= k, j <= k}
+  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B -> C) defl defr l1 l2 x
   : InList x (list_map2 f defl defr l1 l2) -> length l1 = length l2
-    -> { y : A & { z : B & (f y z = x) * (InList y l1 * InList z l2) } }.
+    -> sig@{i k} (fun y : A
+      => sig@{j k} (fun z : B
+        => prod@{k k} (paths@{k} (f y z) x) (InList y l1 * InList z l2))).
 Proof.
   intros H p.
-  induction l1 as [|y l1 IHl1] in l2, x, H, p |- *.
+  induction l1 as [|y l1 IHl1] in l2, x, H, p |- * using list_ind@{i k}.
   - destruct l2.
     1: contradiction.
     inversion p.
@@ -211,62 +226,10 @@ Proof.
     exact (y'; z'; (q, (inr r, inr s))).
 Defined.
 
-(** If an operation given to [list_map2] is heteroassociative, then [list_map2] is also heteroassociative with the caveat that the lists must be the same length. *)
-Definition heteroassociative_list_map2 {A B C AB BC ABC}
-  (fA_BC: A -> BC -> ABC) (fBC: B -> C -> BC)
-  (fAB_C: AB -> C -> ABC) (fAB : A -> B -> AB)
-  (** These arguments end up not being used so are dummy arguments to [list_map2]. *)
-  {a_abc bc_abc b_bc c_bc ab_abc c_abc a_ab b_ab}
-  : forall x y z, length x = length y -> length y = length z
-    -> (forall x' y' z', InList x' x -> InList y' y -> InList z' z
-        -> fA_BC x' (fBC y' z') = fAB_C (fAB x' y') z')
-    -> list_map2 fA_BC a_abc bc_abc x (list_map2 fBC b_bc c_bc y z)
-      = list_map2 fAB_C ab_abc c_abc (list_map2 fAB a_ab b_ab x y) z.
-Proof.
-  intros x y z p q H.
-  induction x as [|a x IHx] in y, z, p, q, H |- *.
-  - destruct y as [|b y].
-    + destruct z as [|c z].
-      * reflexivity.
-      * inversion q.
-    + inversion p.
-  - destruct y as [|b y].
-    1: inversion p.
-    destruct z as [|c z].
-    1: inversion q.
-    cbn; f_ap.
-    1: apply H; by left.
-    apply IHx.
-    1,2: by apply path_nat_S.
-    intros x' y' z' in_x in_y in_z.
-    apply H; by right.
-Defined.
-
-(** If an operation given to [list_map2] is commutative, then [list_map2] is also commutative with the caveat that the lists must be the same length. *)
-Definition commutative_list_map2 {A B} (f : A -> A -> B) (x y : list A)
-  {defl defr defl' defr'}
-  : length x = length y
-    -> (forall x' y', InList x' x -> InList y' y -> f x' y' = f y' x')
-    -> list_map2 f defl defr x y = list_map2 f defl' defr' y x.
-Proof.
-  intros p H.
-  induction x as [|a x IHx] in y, p, H |- *.
-  - destruct y as [|b y].
-    + reflexivity.
-    + inversion p.
-  - destruct y as [|b y].
-    + inversion p.
-    + cbn; f_ap.
-      1: apply H; by left.
-      apply IHx.
-      1: apply path_nat_S, p.
-      intros x' y' in_x in_y.
-      apply H; by right.
-Defined.
-
 (** [list_map2] is a [list_map] if the first list is a repeated value. *)
-Definition list_map2_repeat_l {A B C} (f : A -> B -> C) (x : A) (l : list B)
-  {defl defr}
+Definition list_map2_repeat_l@{i j k|}
+  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B -> C) (x : A) (l : list B) {defl defr}
   : list_map2 f defl defr (repeat x (length l)) l = list_map (f x) l.
 Proof.
   induction l as [|y l IHl].
@@ -275,8 +238,9 @@ Proof.
 Defined.
 
 (** [list_map2] is a [list_map] if the second list is a repeated value. *)
-Definition list_map2_repeat_r {A B C} (f : A -> B -> C) (y : B) (l : list A)
-  {defl defr}
+Definition list_map2_repeat_r@{i j k|}
+  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}} 
+  (f : A -> B -> C) (y : B) (l : list A) {defl defr}
   : list_map2 f defl defr l (repeat y (length l)) = list_map (fun x => f x y) l.
 Proof.
   induction l as [|x l IHl].
@@ -287,40 +251,42 @@ Defined.
 (** ** Reversal *)
 
 (** The length of [reverse_acc] is the sum of the lengths of the two lists. *)
-Definition length_reverse_acc {A} (acc l : list A)
+Definition length_reverse_acc@{i|} {A : Type@{i}} (acc l : list A)
   : length (reverse_acc acc l) = (length acc + length l)%nat.
 Proof.
-  induction l as [|x l IHl] in acc |- *.
+  induction l as [|x l IHl] in acc |- * using list_ind@{i i}.
   - apply add_n_O.
   - lhs nrapply IHl.
     apply nat_add_n_Sm.
 Defined.
 
 (** The length of [reverse] is the same as the length of the original list. *)
-Definition length_reverse {A} (l : list A)
+Definition length_reverse@{i|} {A : Type@{i}} (l : list A)
   : length (reverse l) = length l.
 Proof.
   rapply length_reverse_acc.
 Defined.
 
 (** The [list_map] of a [reverse_acc] is the [reverse_acc] of the [list_map] of the two lists. *)
-Definition list_map_reverse_acc {A B} (f : A -> B) (l l' : list A)
+Definition list_map_reverse_acc@{i j | i <= j} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l l' : list A)
   : list_map f (reverse_acc l' l) = reverse_acc (list_map f l') (list_map f l).
 Proof.
-  induction l as [|a l IHl] in l' |- *.
+  induction l as [|a l IHl] in l' |- * using list_ind@{i j}.
   1: reflexivity.
   apply IHl.
 Defined.
 
 (** The [list_map] of a reversed list is the reversed [list_map]. *)
-Definition list_map_reverse {A B} (f : A -> B) (l : list A)
+Definition list_map_reverse@{i j | i <= j} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l : list A)
   : list_map f (reverse l) = reverse (list_map f l).
 Proof.
   nrapply list_map_reverse_acc.
 Defined.
 
 (** [reverse_acc] is the same as concatenating the reversed list with the accumulator. *)
-Definition reverse_acc_cons {A} (l l' : list A)
+Definition reverse_acc_cons@{i|} {A : Type@{i}} (l l' : list A)
   : reverse_acc l' l = reverse l ++ l'.
 Proof.
   induction l as [|a l IHl] in l' |- *.
@@ -332,7 +298,7 @@ Proof.
 Defined.
 
 (** The [reverse] of a [cons] is the concatenation of the [reverse] with the head. *) 
-Definition reverse_cons {A} (a : A) (l : list A)
+Definition reverse_cons@{i|} {A : Type@{i}} (a : A) (l : list A)
   : reverse (a :: l) = reverse l ++ [a].
 Proof.
   induction l as [|b l IHl] in a |- *.
@@ -345,10 +311,11 @@ Defined.
 (** ** Getting elements *)
 
 (** A variant of [nth] that returns an element of the list and a proof that it is the [n]-th element. *)
-Definition nth_lt {A} (l : list A) (n : nat) (H : (n < length l)%nat)
+Definition nth_lt@{i|} {A : Type@{i}} (l : list A) (n : nat)
+  (H : (n < length l)%nat)
   : { x : A & nth l n = Some x }.
 Proof.
-  induction l as [|a l IHa] in n, H |- *.
+  induction l as [|a l IHa] in n, H |- * using list_ind@{i i}.
   1: destruct (not_leq_Sn_0 _ H).
   destruct n.
   1: by exists a.
@@ -358,21 +325,24 @@ Proof.
 Defined.
 
 (** A variant of [nth] that always returns an element when we know that the index is in the list. *)
-Definition nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat) : A
+Definition nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
+  (H : (n < length l)%nat) : A
   := pr1 (nth_lt l n H).
 
 (** The [nth'] element doesn't depend on the proof that [n < length l]. *)
-Definition nth'_nth' {A} (l : list A) (n : nat) (H H' : (n < length l)%nat)
+Definition nth'_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
+  (H H' : (n < length l)%nat)
   : nth' l n H = nth' l n H'.
 Proof.
   apply ap, path_ishprop.
 Defined.
 
 (** The [nth'] element of a list is in the list. *)
-Definition inlist_nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat)
+Definition inlist_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
+  (H : (n < length l)%nat)
   : InList (nth' l n H) l.
 Proof.
-  induction l as [|a l IHa] in n, H |- *.
+  induction l as [|a l IHa] in n, H |- * using list_ind@{i i}.
   1: destruct (not_leq_Sn_0 _ H).
   destruct n.
   1: by left.
@@ -381,14 +351,15 @@ Proof.
 Defined.
 
 (** The [nth'] element of a list is the same as the one given by [nth]. *)
-Definition nth_nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat)
+Definition nth_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
+  (H : (n < length l)%nat)
   : nth l n = Some (nth' l n H).
 Proof.
   exact (nth_lt l n H).2.
 Defined.
 
 (** The [nth'] element of a [cons] indexed at [n.+1] is the same as the [nth'] element of the tail indexed at [n]. *)
-Definition nth'_cons {A} (l : list A) (n : nat) (x : A)
+Definition nth'_cons@{i|} {A : Type@{i}} (l : list A) (n : nat) (x : A)
   (H : (n < length l)%nat) (H' : (n.+1 < length (x :: l))%nat)
   : nth' (x :: l) n.+1 H' = nth' l n H.
 Proof.
@@ -399,18 +370,23 @@ Proof.
 Defined.
 
 (** The index of an element in a list is the [n] such that the [nth'] element is the element. *)
-Definition index_of {A} (l : list A) (x : A)
-  : InList x l -> { n : nat & { H : (n < length l)%nat & nth' l n H = x } }.
+Definition index_of@{i|} {A : Type@{i}} (l : list A) (x : A)
+  : InList x l
+    -> sig@{Set i} (fun n : nat
+      => sig (fun H : (n < length l)%nat
+        => nth' l n H = x)).
 Proof.
-  induction l as [|a l IHl].
-  1: contradiction.
-  intros [-> | i].
-  - exists 0%nat.
-    snrefine (_; idpath).
+  induction l as [|a l IHl] using list_ind@{i i}.
+  1: intros x'; destruct x'.
+  intros [| i].
+  - revert a p.
+    snrapply paths_ind_r@{i i}.
+    snrefine (exist@{i i} _ 0%nat _).
+    snrefine (exist@{i i} _ _ idpath@{i}). 
     apply leq_S_n'.
     exact _.
   - destruct (IHl i) as [n [H H']].
-    exists (S n); cbn.
+    snrefine (exist@{i i} _ n.+1%nat _).
     snrefine (_; _); cbn.
     1: apply leq_S_n', H.
     refine (_ @ H').
@@ -418,10 +394,11 @@ Proof.
 Defined.
 
 (** The [nth] element of a map is the function applied optionally to the [nth] element of the original list. *)
-Definition nth_list_map {A B} (f : A -> B) (l : list A) (n : nat)
+Definition nth_list_map@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l : list A) (n : nat)
   : nth (list_map f l) n = functor_option f (nth l n).
 Proof.
-  induction l as [|a l IHl] in n |- *.
+  induction l as [|a l IHl] in n |- * using list_ind@{i j}.
   1: by destruct n.
   destruct n.
   1: reflexivity.
@@ -429,11 +406,12 @@ Proof.
 Defined.
 
 (** The [nth'] element of a [list_map] is the function applied to the [nth'] element of the original list. *)
-Definition nth'_list_map {A B} (f : A -> B) (l : list A) (n : nat) (H : (n < length l)%nat)
+Definition nth'_list_map@{i j|} {A : Type@{i}} {B : Type@{j}}
+  (f : A -> B) (l : list A) (n : nat) (H : (n < length l)%nat)
   (H' : (n < length (list_map f l))%nat)
   : nth' (list_map f l) n H' = f (nth' l n H).
 Proof.
-  induction l as [|a l IHl] in n, H, H' |- *.
+  induction l as [|a l IHl] in n, H, H' |- * using list_ind@{i j}.
   1: destruct (not_leq_Sn_0 _ H).
   destruct n.
   1: reflexivity.
@@ -441,13 +419,16 @@ Proof.
 Defined.
 
 (** The [nth'] element of a [list_map2] is the function applied to the [nth'] elements of the original lists. The length of the two lists is required to be the same. *)
-Definition nth'_list_map2 {A B C} (f : A -> B -> C) (l1 : list A) (l2 : list B)
+Definition nth'_list_map2@{i j k|i <= k, j <= k}
+  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (f : A -> B -> C) (l1 : list A) (l2 : list B)
   (n : nat) defl defr (H : (n < length l1)%nat) (H' : (n < length l2)%nat)
   (H'' : (n < length (list_map2 f defl defr l1 l2))%nat)
   (p : length l1 = length l2)
   : f (nth' l1 n H) (nth' l2 n H') = nth' (list_map2 f defl defr l1 l2) n H''.
 Proof.
-  induction l1 as [|a l1 IHl1] in l2, n, defl, defr, H, H', H'', p |- *.
+  induction l1 as [|a l1 IHl1] in l2, n, defl, defr, H, H', H'', p |- *
+    using list_ind@{i k}.
   - destruct l2 as [|b l2].
     + destruct (not_leq_Sn_0 _ H).
     + inversion p.
@@ -466,10 +447,11 @@ Proof.
 Defined.
 
 (** The [nth'] element of a [repeat] is the repeated value. *)
-Definition nth'_repeat {A} (x : A) (i n : nat) (H : (i < length (repeat x n))%nat)
+Definition nth'_repeat@{i|} {A : Type@{i}} (x : A) (i n : nat)
+  (H : (i < length (repeat x n))%nat)
   : nth' (repeat x n) i H = x.
 Proof.
-  induction n as [|n IHn] in i, H |- *.
+  induction n as [|n IHn] in i, H |- * using nat_ind@{i}.
   1: destruct (not_leq_Sn_0 _ H).
   destruct i.
   1: reflexivity.
@@ -477,12 +459,13 @@ Proof.
 Defined.
 
 (** Two lists are equal if their [nth'] elements are equal. *)
-Definition path_list_nth' {A} (l l' : list A) (p : length l = length l')
+Definition path_list_nth'@{i|} {A : Type@{i}} (l l' : list A)
+  (p : length l = length l')
   : (forall n (H : (n < length l)%nat), nth' l n H = nth' l' n (p # H))
     -> l = l'.
 Proof.
   intros H.
-  induction l as [|a l IHl] in l', p, H |- *.
+  induction l as [|a l IHl] in l', p, H |- * using list_ind@{i i}.
   { destruct l'.
     - reflexivity.
     - discriminate. }
@@ -500,10 +483,11 @@ Proof.
 Defined.
 
 (** The [nth n] element of a concatenated list [l ++ l'] where [n < length l] is the [nth] element of [l]. *)
-Definition nth_app {A} (l l' : list A) (n : nat) (H : (n < length l)%nat)
+Definition nth_app@{i|} {A : Type@{i}} (l l' : list A) (n : nat)
+  (H : (n < length l)%nat)
   : nth (l ++ l') n = nth l n.
 Proof.
-  induction l as [|a l IHl] in l', n, H |- *.
+  induction l as [|a l IHl] in l', n, H |- * using list_ind@{i i}.
   1: destruct (not_leq_Sn_0 _ H).
   destruct n.
   1: reflexivity.
@@ -511,7 +495,8 @@ Proof.
 Defined.
 
 (** The [nth i] element where [pred (length l) = i] is the last element of the list. *)
-Definition nth_last {A} (l : list A) (i : nat) (p : pred (length l) = i)
+Definition nth_last@{i|} {A : Type@{i}} (l : list A) (i : nat)
+  (p : pred (length l) = i)
   : nth l i = last l. 
 Proof.
   destruct p.
@@ -523,7 +508,7 @@ Proof.
 Defined.
 
 (** The last element of a list with an element appended is the appended element. *)
-Definition last_app {A} (l : list A) (x : A)
+Definition last_app@{i|} {A : Type@{i}} (l : list A) (x : A)
   : last (l ++ [x]) = Some x.
 Proof.
   induction l as [|a l IHl] in x |- *.
@@ -540,21 +525,21 @@ Defined.
 (** *** Drop *)
 
 (** [drop n l] removes the first [n] elements of [l]. *)
-Fixpoint drop {A} (n : nat) (l : list A) : list A :=
+Fixpoint drop@{i|} {A : Type@{i}} (n : nat) (l : list A) : list A :=
   match l, n with
   | _ :: l, n.+1%nat => drop n l
   | _, _ => l
   end.
 
 (** A [drop] of zero elements is the identity. *)
-Definition drop_0 {A} (l : list A)
+Definition drop_0@{i|} {A : Type@{i}} (l : list A)
   : drop 0 l = l.
 Proof.
   by destruct l.
 Defined.
 
 (** A [drop] of one element is the tail of the list. *)
-Definition drop_1 {A} (l : list A)
+Definition drop_1@{i|} {A : Type@{i}} (l : list A)
   : drop 1 l = tail l.
 Proof.
   induction l.
@@ -563,17 +548,18 @@ Proof.
 Defined.
 
 (** A [drop] of the empty list is the empty list. *)
-Definition drop_nil {A} (n : nat)
+Definition drop_nil@{i|} {A : Type@{i}} (n : nat)
   : drop n (@nil A) = nil.
 Proof.
   by destruct n.
 Defined.
 
 (** A [drop] of [n] elements with [length l <= n] is the empty list. *)
-Definition drop_length_leq {A} (n : nat) (l : list A) (H : (length l <= n)%nat)
+Definition drop_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
+  (H : (length l <= n)%nat)
   : drop n l = nil.
 Proof.
-  induction l as [|a l IHl] in H, n |- *.
+  induction l as [|a l IHl] in H, n |- * using list_ind@{i i}.
   1: apply drop_nil.
   destruct n.
   1: destruct (not_leq_Sn_0 _ H).
@@ -583,10 +569,10 @@ Proof.
 Defined.
 
 (** The length of a [drop n] is the length of the original list minus [n]. *)
-Definition length_drop {A} (n : nat) (l : list A)
+Definition length_drop@{i|} {A : Type@{i}} (n : nat) (l : list A)
   : length (drop n l) = (length l - n)%nat.
 Proof.
-  induction l as [|a l IHl] in n |- *.
+  induction l as [|a l IHl] in n |- * using list_ind@{i i}.
   1: by rewrite drop_nil.
   destruct n.
   1: reflexivity.
@@ -594,11 +580,11 @@ Proof.
 Defined.
 
 (** An element of a [drop] is an element of the original list. *)
-Definition drop_inlist {A} (n : nat) (l : list A) (x : A)
+Definition drop_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)
   : InList x (drop n l) -> InList x l.
 Proof.
   intros H.
-  induction l as [|a l IHl] in n, H, x |- *.
+  induction l as [|a l IHl] in n, H, x |- * using list_ind@{i i}.
   1: rewrite drop_nil in H; contradiction.
   destruct n.
   1: rewrite drop_0 in H; assumption.
@@ -608,29 +594,30 @@ Defined.
 (** *** Take *)
 
 (** [take n l] keeps the first [n] elements of [l] and returns [l] if [n >= length l]. *)
-Fixpoint take {A} (n : nat) (l : list A) : list A :=
+Fixpoint take@{i|} {A : Type@{i}} (n : nat) (l : list A) : list A :=
   match l, n with
   | x :: l, n.+1%nat => x :: take n l
   | _, _ => nil
   end.
 
 (** A [take] of zero elements is the empty list. *)
-Definition take_0 {A} (l : list A) : take 0 l = nil.
+Definition take_0@{i|} {A : Type@{i}} (l : list A) : take 0 l = nil.
 Proof.
   by destruct l.
 Defined.
 
 (** A [take] of the empty list is the empty list. *)
-Definition take_nil {A} (n : nat) : take n (@nil A) = nil.
+Definition take_nil@{i|} {A : Type@{i}} (n : nat) : take n (@nil A) = nil.
 Proof.
   by destruct n.
 Defined.
 
 (** A [take] of [n] elements with [length l <= n] is the original list. *)
-Definition take_length_leq {A} (n : nat) (l : list A) (H : (length l <= n)%nat)
+Definition take_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
+  (H : (length l <= n)%nat)
   : take n l = l.
 Proof.
-  induction l as [|a l IHl] in H, n |- *.
+  induction l as [|a l IHl] in H, n |- * using list_ind@{i i}.
   1: apply take_nil.
   destruct n.
   1: destruct (not_leq_Sn_0 _ H).
@@ -639,10 +626,10 @@ Proof.
 Defined.
 
 (** The length of a [take n] is the minimum of [n] and the length of the original list. *)
-Definition length_take {A} (n : nat) (l : list A)
+Definition length_take@{i|} {A : Type@{i}} (n : nat) (l : list A)
   : length (take n l) = min n (length l).
 Proof.
-  induction l as [|a l IHl] in n |- *.
+  induction l as [|a l IHl] in n |- * using list_ind@{i i}.
   { rewrite take_nil.
     rewrite min_r.
     1: reflexivity.
@@ -653,11 +640,11 @@ Proof.
 Defined.
 
 (** An element of a [take] is an element of the original list. *)
-Definition take_inlist {A} (n : nat) (l : list A) (x : A)
+Definition take_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)
   : InList x (take n l) -> InList x l.
 Proof.
   intros H.
-  induction l as [|a l IHl] in n, H, x |- *.
+  induction l as [|a l IHl] in n, H, x |- * using list_ind@{i i}.
   1: rewrite take_nil in H; contradiction.
   destruct n.
   1: rewrite take_0 in H; contradiction.
@@ -669,18 +656,19 @@ Defined.
 (** *** Remove *)
 
 (** [remove n l] removes the [n]-th element of [l]. *)
-Definition remove {A} (n : nat) (l : list A) : list A
+Definition remove@{i|} {A : Type@{i}} (n : nat) (l : list A) : list A
   := take n l ++ drop n.+1 l.
 
 (** Removing the first element of a list is the tail of the list. *)
-Definition remove_0 {A} (l : list A) : remove 0 l = tail l.
+Definition remove_0@{i|} {A : Type@{i}} (l : list A) : remove 0 l = tail l.
 Proof.
   unfold remove.
   by rewrite take_0, drop_1.
 Defined.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)
-Definition remove_length_leq {A} (n : nat) (l : list A) (H : (length l <= n)%nat)
+Definition remove_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
+  (H : (length l <= n)%nat)
   : remove n l = l.
 Proof.
   unfold remove.
@@ -692,25 +680,26 @@ Proof.
 Defined.
 
 (** The length of a [remove n] is the length of the original list minus one. *)
-Definition length_remove {A} (n : nat) (l : list A) (H : (n < length l)%nat)
-  : length (remove n l) = pred (length l)%nat.
+Definition length_remove@{i|} {A : Type@{i}} (n : nat) (l : list A)
+  (H : (n < length l)%nat)
+  : length (remove@{i} n l) = pred (length@{i} l)%nat.
 Proof.
   unfold remove.
-  rewrite length_app.
+  rewrite length_app@{i}.
   rewrite length_take.
   rewrite length_drop.
   rewrite min_l.
   - rewrite nataddsub_assoc.
     2: exact H.
     rewrite <- predeqminus1.
-    induction n in |- *.
+    induction n in |- * using nat_ind@{Set}.
     1: reflexivity.
     cbn; assumption.
   - exact (leq_trans _ H).
 Defined. 
 
 (** An element of a [remove] is an element of the original list. *)
-Definition remove_inlist {A} (n : nat) (l : list A) (x : A)
+Definition remove_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)
   : InList x (remove n l) -> InList x l.
 Proof.
   unfold remove.
@@ -725,16 +714,16 @@ Defined.
 (** ** Sequences *)
 
 (** The length of a reverse sequence of [n] numbers is [n]. *)
-Definition length_seq_rev (n : nat)
+Definition length_seq_rev@{} (n : nat)
   : length (seq_rev n) = n.
 Proof.
-  induction n as [|n IHn].
+  induction n as [|n IHn] using nat_ind@{Set}.
   1: reflexivity.
   cbn; f_ap.
 Defined.
 
 (** The length of a sequence of [n] numbers is [n]. *)
-Definition length_seq (n : nat)
+Definition length_seq@{} (n : nat)
   : length (seq n) = n.
 Proof.
   lhs nrapply length_reverse.
@@ -742,23 +731,23 @@ Proof.
 Defined.
 
 (** The reversed sequence of [n.+1] numbers is the [n] followed by the rest of the reversed sequence. *)
-Definition seq_rev_cons (n : nat)
+Definition seq_rev_cons@{} (n : nat)
   : seq_rev n.+1 = n :: seq_rev n.
 Proof.
-  induction n as [|n IHn].
+  induction n as [|n IHn] using nat_ind@{Set}.
   1: reflexivity.
   cbn; f_ap.
 Defined.
 
 (** The sequence of [n.+1] numbers is the sequence of [n] numbers concatenated with [[n]]. *)
-Definition seq_succ (n : nat)
+Definition seq_succ@{} (n : nat)
   : seq n.+1 = seq n ++ [n].
 Proof.
   apply reverse_cons.
 Defined.
 
 (** Alternate definition of [seq_rev] that keeps the proofs of the entries being [< n]. *)
-Definition seq_rev' (n : nat) : list {k : nat & (k < n)%nat}.
+Definition seq_rev'@{} (n : nat) : list {k : nat & (k < n)%nat}.
 Proof.
   transparent assert (f : (forall n, {k : nat & (k < n)%nat}
     -> {k : nat & (k < n.+1)%nat})).
@@ -766,21 +755,21 @@ Proof.
     snrapply (functor_sigma idmap).
     intros k H.
     exact (leq_S _ _ H). }
-  induction n as [|n IHn].
+  induction n as [|n IHn] using nat_ind@{Set}.
   1: exact nil.
   nrefine ((n; _) :: list_map (f n) IHn).
   exact _.
 Defined.
 
 (** Alternate definition of [seq] that keeps the proofs of the entries being [< n]. *)
-Definition seq' (n : nat) : list {k : nat & (k < n)%nat}
+Definition seq'@{} (n : nat) : list {k : nat & (k < n)%nat}
   := reverse (seq_rev' n).
 
 (** The length of [seq_rev' n] is [n]. *) 
-Definition length_seq_rev' (n : nat)
+Definition length_seq_rev'@{} (n : nat)
   : length (seq_rev' n) = n.
 Proof.
-  induction n as [|n IHn].
+  induction n as [|n IHn] using nat_ind@{Set}.
   1: reflexivity.
   cbn; f_ap.
   lhs nrapply length_list_map.
@@ -788,7 +777,7 @@ Proof.
 Defined.
 
 (** The length of [seq' n] is [n]. *)
-Definition length_seq' (n : nat)
+Definition length_seq'@{} (n : nat)
   : length (seq' n) = n.
 Proof.
   lhs nrapply length_reverse.
@@ -796,10 +785,10 @@ Proof.
 Defined.
 
 (** The [list_map] of first projections on [seq_rev' n] is [seq_rev n]. *)
-Definition seq_rev_seq_rev' (n : nat)
+Definition seq_rev_seq_rev'@{} (n : nat)
   : list_map pr1 (seq_rev' n) = seq_rev n.
 Proof.
-  induction n as [|n IHn].
+  induction n as [|n IHn] using nat_ind@{Set}.
   1: reflexivity.
   simpl; f_ap.
   lhs_V nrapply list_map_compose.
@@ -807,7 +796,7 @@ Proof.
 Defined.
 
 (** The [list_map] of first projections on [seq' n] is [seq n]. *)
-Definition seq_seq' (n : nat)
+Definition seq_seq'@{} (n : nat)
   : list_map pr1 (seq' n) = seq n.
 Proof.
   lhs nrapply list_map_reverse_acc.
@@ -816,23 +805,23 @@ Proof.
 Defined.
 
 (** The [nth] element of a [seq_rev] is [n - i.+1]. *)
-Definition nth_seq_rev {n i} (H : (i < n)%nat)
+Definition nth_seq_rev@{} {n i} (H : (i < n)%nat)
   : nth (seq_rev n) i = Some (n - i.+1)%nat.
 Proof.
-  induction i as [|i IHi] in n, H |- *.
-  - induction n.
+  induction i as [|i IHi] in n, H |- * using nat_ind@{Set}.
+  - induction n using nat_ind@{Set}.
     1: destruct (not_leq_Sn_0 _ H).
     cbn; by rewrite sub_n_0.
-  - induction n as [|n IHn].
+  - induction n as [|n IHn] using nat_ind@{Set}.
     1: destruct (not_leq_Sn_0 _ H).
     by apply IHi, leq_S_n.
 Defined.
 
 (** The [nth] element of a [seq] is [i]. *)
-Definition nth_seq {n i} (H : (i < n)%nat)
+Definition nth_seq@{} {n i} (H : (i < n)%nat)
   : nth (seq n) i = Some i.
 Proof.
-  induction n.
+  induction n using nat_ind@{Set}.
   1: destruct (not_leq_Sn_0 _ H).
   rewrite seq_succ.
   destruct (dec (i < n)%nat) as [H'|H'].
@@ -853,7 +842,7 @@ Proof.
 Defined.
 
 (** The [nth'] element of a [seq'] is [i]. *)
-Definition nth'_seq' (n i : nat) (H : (i < length (seq' n))%nat)
+Definition nth'_seq'@{} (n i : nat) (H : (i < length (seq' n))%nat)
   : (nth' (seq' n) i H).1 = i.
 Proof.
   unshelve lhs_V nrapply nth'_list_map.
@@ -869,16 +858,16 @@ Defined.
 (** ** Repeat *)
 
 (** The length of a repeated list is the number of repetitions. *)
-Definition length_repeat {A} (n : nat) (x : A)
+Definition length_repeat@{i|} {A : Type@{i}} (n : nat) (x : A)
   : length (repeat x n) = n.
 Proof.
-  induction n.
+  induction n using nat_ind@{i}.
   - reflexivity.
   - exact (ap S IHn).
 Defined.
 
 (** An element of a repeated list is equal to the repeated element. *)
-Definition inlist_repeat {A} (n : nat) (x y : A)
+Definition inlist_repeat@{i|} {A : Type@{i}} (n : nat) (x y : A)
   : InList y (repeat x n) -> y = x.
 Proof.
   induction n as [|n IHn].
@@ -891,11 +880,11 @@ Defined.
 (** ** Forall *)
 
 (** If a predicate holds for all elements of a list, the the [for_all] predicate holds for the list. *)
-Definition for_all_inlist {A} (P : A -> Type) l
+Definition for_all_inlist@{i j | i <= j} {A : Type@{i}} (P : A -> Type@{j}) l
   : (forall x, InList x l -> P x) -> for_all P l.
 Proof.
   intros H.
-  induction l as [|x l IHl] in H |- *; cbn; trivial; split.
+  induction l as [|x l IHl] in H |- * using list_ind@{i j}; cbn; trivial; split.
   - apply H.
     by left.
   - apply IHl.
@@ -905,7 +894,8 @@ Proof.
 Defined.
 
 (** Conversely, if [for_all P l] then each element of the list satisfies [P]. *)
-Definition inlist_for_all {A} {P : A -> Type} (l : list A)
+Definition inlist_for_all@{i j | i <= j} {A : Type@{i}} {P : A -> Type@{j}}
+  (l : list A)
   : for_all P l -> forall x, InList x l -> P x.
 Proof.
   induction l as [|x l IHl].
@@ -918,24 +908,28 @@ Proof.
 Defined.
 
 (** If a predicate [P] implies a predicate [Q] composed with a function [f], then [for_all P l] implies [for_all Q (list_map f l)]. *)
-Definition for_all_list_map {A B} P Q (f : A -> B) (Hf : forall x, P x -> Q (f x))
+Definition for_all_list_map@{i j k u v|k <= v, u <= v}
+  {A : Type@{i}} {B : Type@{j}} (P : A -> Type@{k}) (Q : B -> Type@{u})
+  (f : A -> B) (Hf : forall x, P x -> Q (f x))
  : forall l, for_all P l -> for_all Q (list_map f l).
 Proof.
-  intros l; induction l as [|x l IHl]; simpl; trivial.
+  intros l; induction l as [|x l IHl] using list_ind@{_ v}; simpl; trivial.
   intros [Hx Hl].
   split; auto.
 Defined.
 
 (** A variant of [for_all_map P Q f] where [Q] is [P o f]. *)
-Definition for_all_list_map' {A B} P (f : A -> B) 
+Definition for_all_list_map'@{i j k|} {A : Type@{i}} {B : Type@{j}}
+  (P : B -> Type@{k}) (f : A -> B) 
   : forall l, for_all (P o f) l -> for_all P (list_map f l).
 Proof.
   by apply for_all_list_map.
 Defined.
 
 (** If a predicate [P] and a prediate [Q] together imply a predicate [R], then [for_all P l] and [for_all Q l] together imply [for_all R l]. There are also some side conditions for the default elements. *)
-Lemma for_all_list_map2 {A B C}
-  (P : A -> Type) (Q : B -> Type) (R : C -> Type)
+Lemma for_all_list_map2@{i j k u v w x}
+  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (P : A -> Type@{u}) (Q : B -> Type@{v}) (R : C -> Type@{w})
   (f : A -> B -> C) (Hf : forall x y, P x -> Q y -> R (f x y))
   def_l (Hdefl : forall l1, for_all P l1 -> for_all R (def_l l1))
   def_r (Hdefr : forall l2, for_all Q l2 -> for_all R (def_r l2))
@@ -943,7 +937,7 @@ Lemma for_all_list_map2 {A B C}
   : for_all P l1 -> for_all Q l2
     -> for_all R (list_map2 f def_l def_r l1 l2).
 Proof.
-  induction l1 as [|x l1 IHl1] in l2 |- *.
+  induction l1 as [|x l1 IHl1] in l2 |- * using list_ind@{j x}.
   - destruct l2 as [|y l2]; cbn; auto.
   - simpl. destruct l2 as [|y l2]; intros [Hx Hl1];
       [intros _ | intros [Hy Hl2] ]; simpl; auto.
@@ -952,14 +946,16 @@ Proof.
 Defined.
 
 (** A simpler variant of [for_all_map2] where both lists have the same length and the side conditions on the default elements can be avoided. *)
-Definition for_all_list_map2' {A B C} (P : A -> Type) (Q : B -> Type) (R : C -> Type)
+Definition for_all_list_map2'@{i j k u v w x}
+  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
+  (P : A -> Type@{u}) (Q : B -> Type@{v}) (R : C -> Type@{w})
   (f : A -> B -> C) (Hf : forall x y, P x -> Q y -> R (f x y))
   {def_l def_r} {l1 : list A} {l2 : list B}
   (p : length l1 = length l2)
   : for_all P l1 -> for_all Q l2
     -> for_all R (list_map2 f def_l def_r l1 l2).
 Proof.
-  induction l1 as [|x l1 IHl1] in l2, p |- *. 
+  induction l1 as [|x l1 IHl1] in l2, p |- * using list_ind@{_ x}. 
   - destruct l2.
     + reflexivity.
     + discriminate.
@@ -970,12 +966,13 @@ Proof.
 Defined.
 
 (** The left fold of [f] on a list [l] for which [for_all Q l] satisfies [P] if [P] and [Q] imply [P] composed with [f]. *)
-Lemma fold_left_preserves {A B} P Q (f : A -> B -> A)
+Lemma fold_left_preserves@{i j u v x} {A : Type@{i}} {B : Type@{j}}
+  (P : A -> Type@{u}) (Q : B -> Type@{v}) (f : A -> B -> A)
   (Hf : forall x y, P x -> Q y -> P (f x y))
   (acc : A) (Ha : P acc) (l : list B) (Hl : for_all Q l)
   : P (fold_left f l acc).
 Proof.
-  induction l as [|x l IHl] in acc, Ha, Hl |- *.
+  induction l as [|x l IHl] in acc, Ha, Hl |- * using list_ind@{_ x}.
   - exact Ha.
   - simpl.
     destruct Hl as [Qx Hl].
@@ -983,7 +980,8 @@ Proof.
 Defined.
 
 (** [for_all] preserves the truncation predicate. *)
-Definition istrunc_for_all {A} {n} (P : A -> Type) (l : list A)
+Definition istrunc_for_all@{i j|} {A : Type@{i}}
+  {n : trunc_index} (P : A -> Type@{j}) (l : list A)
   : for_all (fun x => IsTrunc n (P x)) l -> IsTrunc n (for_all P l).
 Proof.
   induction l as [|x l IHl]; simpl.
@@ -993,7 +991,8 @@ Proof.
     exact _.
 Defined.
 
-Global Instance istrunc_for_all' {A} {n} (P : A -> Type) (l : list A)
+Global Instance istrunc_for_all'@{i j | i <= j} {A : Type@{i}} {n : trunc_index}
+  (P : A -> Type@{j}) (l : list A)
   `{forall x, IsTrunc n (P x)}
   : IsTrunc n (for_all P l).
 Proof.
@@ -1001,7 +1000,8 @@ Proof.
 Defined.
 
 (** If a predicate holds for an element, then it holds [for_all] the elements of the repeated list. *)
-Definition for_all_repeat {A} {n} (P : A -> Type) (x : A)
+Definition for_all_repeat@{i j|} {A : Type@{i}} {n : nat}
+  (P : A -> Type@{j}) (x : A)
   : P x -> for_all P (repeat x n).
 Proof.
   intros H.
@@ -1011,8 +1011,10 @@ Proof.
 Defined.
 
 (** We can form a list of pairs of a sigma type given a list and a for_all predicate over it. *)
-Definition list_sigma {A} (P : A -> Type) (l : list A) (p : for_all P l)
-  : list {x : A & P x}.
+Definition list_sigma@{i j k | i <= k, j <= k}
+  {A : Type@{i}} (P : A -> Type@{j}) (l : list A)
+  (p : for_all P l)
+  : list@{k} {x : A & P x}.
 Proof.
   induction l as [|x l IHl] in p |- *.
   1: exact nil.
@@ -1021,10 +1023,11 @@ Proof.
 Defined.
 
 (** The length of a list of sigma types is the same as the original list. *)
-Definition length_list_sigma {A} {P : A -> Type} {l} {p}
-  : length (list_sigma P l p) = length l.
+Definition length_list_sigma@{i j k | i <= k, j <= k}
+  {A : Type@{i}} {P : A -> Type@{j}} {l : list A} {p : for_all P l}
+  : length (list_sigma@{i j k} P l p) = length l.
 Proof.
-  induction l as [|x l IHl] in p |- *.
+  induction l as [|x l IHl] in p |- * using list_ind@{i j}.
   1: reflexivity.
   destruct p as [Hx Hl].
   cbn; f_ap.
@@ -1032,7 +1035,7 @@ Proof.
 Defined.
 
 (** If a predicate [P] is decidable then so is [for_all P]. *)
-Global Instance decidable_for_all {A : Type} (P : A -> Type)
+Global Instance decidable_for_all@{i j|} {A : Type@{i}} (P : A -> Type@{j})
   `{forall x, Decidable (P x)} (l : list A)
   : Decidable (for_all P l).
 Proof.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -17,7 +17,7 @@ Local Open Scope list_scope.
 (** ** Length *)
 
 (** A list of length zero must be the empty list. *)
-Definition length_0@{i|} {A : Type@{i}} (l : list A) (H : length l = 0%nat)
+Definition length_0 {A : Type} (l : list A) (H : length l = 0%nat)
   : l = nil.
 Proof.
   destruct l.
@@ -28,7 +28,7 @@ Defined.
 (** ** Concatenation *)
 
 (** Concatenating the empty list on the right is the identity. *)
-Definition app_nil@{i|} {A : Type@{i}} (l : list A)
+Definition app_nil {A : Type} (l : list A)
   : l ++ nil = l.
 Proof.
   induction l as [|a l IHl].
@@ -37,7 +37,7 @@ Proof.
 Defined.
 
 (** Associativity of list concatenation. *)
-Definition app_assoc@{i|} {A : Type@{i}} (x y z : list A)
+Definition app_assoc {A : Type} (x y z : list A)
   : app x (app y z) = app (app x y) z.
 Proof.
   induction x as [|a x IHx] in |- *.
@@ -46,7 +46,7 @@ Proof.
 Defined.
 
 (** The type of lists has a monoidal structure given by concatenation. *)
-Definition list_pentagon@{i|} {A : Type@{i}} (w x y z : list A)
+Definition list_pentagon {A : Type} (w x y z : list A)
   : app_assoc w x (y ++ z) @ app_assoc (w ++ x) y z
     = ap (fun l => w ++ l) (app_assoc x y z)
     @ app_assoc w (x ++ y) z
@@ -71,7 +71,7 @@ Proof.
 Defined.
 
 (** The length of a concatenated list is the sum of the lengths of the two lists. *)
-Definition length_app@{i|} {A : Type@{i}} (l l' : list A)
+Definition length_app {A : Type} (l l' : list A)
   : length (l ++ l') = (length l + length l')%nat.
 Proof.
   induction l as [|a l IHl] using list_ind.
@@ -81,7 +81,7 @@ Proof.
 Defined.
 
 (** An element of a concatenated list is equivalently either in the first list or in the second list. *)
-Definition equiv_inlist_app@{i|} {A : Type@{i}} (l l' : list A) (x : A)
+Definition equiv_inlist_app {A : Type} (l l' : list A) (x : A)
   : InList x l + InList x l' <~> InList x (l ++ l').
 Proof.
   induction l as [|a l IHl].
@@ -93,8 +93,7 @@ Defined.
 (** ** Folding *)
 
 (** A left fold over a concatenated list is equivalent to folding over the first followed by folding over the second. *)
-Lemma fold_left_app@{i j|} {A : Type@{i}} {B : Type@{j}}
-  (f : A -> B -> A) (l l' : list B) (i : A)
+Lemma fold_left_app {A B : Type} (f : A -> B -> A) (l l' : list B) (i : A)
   : fold_left f (l ++ l') i = fold_left f l' (fold_left f l i).
 Proof.
   induction l in i |- *.
@@ -103,8 +102,7 @@ Proof.
 Defined.
 
 (** A right fold over a concatenated list is equivalent to folding over the second followed by folding over the first. *)
-Lemma fold_right_app@{i j|} {A : Type@{i}} {B : Type@{j}}
-  (f : B -> A -> A) (i : A) (l l' : list B)
+Lemma fold_right_app {A B : Type} (f : B -> A -> A) (i : A) (l l' : list B)
   : fold_right f i (l ++ l') = fold_right f (fold_right f i l') l.
 Proof.
   induction l in i |- *.
@@ -115,8 +113,7 @@ Defined.
 (** ** Maps *)
 
 (** The length of a mapped list is the same as the length of the original list. *)
-Definition length_list_map@{i j|} {A : Type@{i}} {B : Type@{j}}
-  (f : A -> B) (l : list A)
+Definition length_list_map {A B : Type} (f : A -> B) (l : list A)
   : length (list_map f l) = length l.
 Proof.
   induction l as [|x l IHl] using list_ind.
@@ -160,7 +157,7 @@ Proof.
 Defined.
 
 (** A function that acts as the identity on the elements of a list is the identity on the mapped list. *)
-Lemma list_map_id@{i|} {A : Type@{i}} (f : A -> A) (l : list A)
+Lemma list_map_id {A : Type} (f : A -> A) (l : list A)
   (Hf : forall x, InList x l -> f x = x)
   :  list_map f l = l.
 Proof.
@@ -176,8 +173,7 @@ Proof.
 Defined.
 
 (** A [list_map] of a composition is the composition of the maps. *)
-Definition list_map_compose@{i j k|} {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
-  (f : A -> B) (g : B -> C) (l : list A)
+Definition list_map_compose {A B C} (f : A -> B) (g : B -> C) (l : list A)
   : list_map (fun x => g (f x)) l = list_map g (list_map f l).
 Proof.
   induction l as [|a l IHl].
@@ -228,9 +224,7 @@ Proof.
 Defined.
 
 (** [list_map2] is a [list_map] if the first list is a repeated value. *)
-Definition list_map2_repeat_l@{i j k|}
-  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}}
-  (f : A -> B -> C) (x : A) (l : list B) {defl defr}
+Definition list_map2_repeat_l {A B C} (f : A -> B -> C) (x : A) l {defl defr}
   : list_map2 f defl defr (repeat x (length l)) l = list_map (f x) l.
 Proof.
   induction l as [|y l IHl].
@@ -239,9 +233,7 @@ Proof.
 Defined.
 
 (** [list_map2] is a [list_map] if the second list is a repeated value. *)
-Definition list_map2_repeat_r@{i j k|}
-  {A : Type@{i}} {B : Type@{j}} {C : Type@{k}} 
-  (f : A -> B -> C) (y : B) (l : list A) {defl defr}
+Definition list_map2_repeat_r {A B C} (f : A -> B -> C) (y : B) l {defl defr}
   : list_map2 f defl defr l (repeat y (length l)) = list_map (fun x => f x y) l.
 Proof.
   induction l as [|x l IHl].
@@ -262,7 +254,7 @@ Proof.
 Defined.
 
 (** The length of [reverse] is the same as the length of the original list. *)
-Definition length_reverse@{i|} {A : Type@{i}} (l : list A)
+Definition length_reverse {A : Type} (l : list A)
   : length (reverse l) = length l.
 Proof.
   rapply length_reverse_acc.
@@ -279,15 +271,14 @@ Proof.
 Defined.
 
 (** The [list_map] of a reversed list is the reversed [list_map]. *)
-Definition list_map_reverse@{i j | i <= j} {A : Type@{i}} {B : Type@{j}}
-  (f : A -> B) (l : list A)
+Definition list_map_reverse {A B} (f : A -> B) (l : list A)
   : list_map f (reverse l) = reverse (list_map f l).
 Proof.
   nrapply list_map_reverse_acc.
 Defined.
 
 (** [reverse_acc] is the same as concatenating the reversed list with the accumulator. *)
-Definition reverse_acc_cons@{i|} {A : Type@{i}} (l l' : list A)
+Definition reverse_acc_cons {A : Type} (l l' : list A)
   : reverse_acc l' l = reverse l ++ l'.
 Proof.
   induction l as [|a l IHl] in l' |- *.
@@ -299,7 +290,7 @@ Proof.
 Defined.
 
 (** The [reverse] of a [cons] is the concatenation of the [reverse] with the head. *) 
-Definition reverse_cons@{i|} {A : Type@{i}} (a : A) (l : list A)
+Definition reverse_cons {A : Type} (a : A) (l : list A)
   : reverse (a :: l) = reverse l ++ [a].
 Proof.
   induction l as [|b l IHl] in a |- *.
@@ -326,13 +317,11 @@ Proof.
 Defined.
 
 (** A variant of [nth] that always returns an element when we know that the index is in the list. *)
-Definition nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
-  (H : (n < length l)%nat) : A
+Definition nth' {A : Type} (l : list A) (n : nat) (H : (n < length l)%nat) : A
   := pr1 (nth_lt l n H).
 
 (** The [nth'] element doesn't depend on the proof that [n < length l]. *)
-Definition nth'_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
-  (H H' : (n < length l)%nat)
+Definition nth'_nth' {A} (l : list A) (n : nat) (H H' : (n < length l)%nat)
   : nth' l n H = nth' l n H'.
 Proof.
   apply ap, path_ishprop.
@@ -352,15 +341,14 @@ Proof.
 Defined.
 
 (** The [nth'] element of a list is the same as the one given by [nth]. *)
-Definition nth_nth'@{i|} {A : Type@{i}} (l : list A) (n : nat)
-  (H : (n < length l)%nat)
+Definition nth_nth' {A} (l : list A) (n : nat) (H : (n < length l)%nat)
   : nth l n = Some (nth' l n H).
 Proof.
   exact (nth_lt l n H).2.
 Defined.
 
 (** The [nth'] element of a [cons] indexed at [n.+1] is the same as the [nth'] element of the tail indexed at [n]. *)
-Definition nth'_cons@{i|} {A : Type@{i}} (l : list A) (n : nat) (x : A)
+Definition nth'_cons {A : Type} (l : list A) (n : nat) (x : A)
   (H : (n < length l)%nat) (H' : (n.+1 < length (x :: l))%nat)
   : nth' (x :: l) n.+1 H' = nth' l n H.
 Proof.
@@ -496,8 +484,7 @@ Proof.
 Defined.
 
 (** The [nth i] element where [pred (length l) = i] is the last element of the list. *)
-Definition nth_last@{i|} {A : Type@{i}} (l : list A) (i : nat)
-  (p : pred (length l) = i)
+Definition nth_last {A : Type} (l : list A) (i : nat) (p : pred (length l) = i)
   : nth l i = last l. 
 Proof.
   destruct p.
@@ -509,7 +496,7 @@ Proof.
 Defined.
 
 (** The last element of a list with an element appended is the appended element. *)
-Definition last_app@{i|} {A : Type@{i}} (l : list A) (x : A)
+Definition last_app {A : Type} (l : list A) (x : A)
   : last (l ++ [x]) = Some x.
 Proof.
   induction l as [|a l IHl] in x |- *.
@@ -526,21 +513,21 @@ Defined.
 (** *** Drop *)
 
 (** [drop n l] removes the first [n] elements of [l]. *)
-Fixpoint drop@{i|} {A : Type@{i}} (n : nat) (l : list A) : list A :=
+Fixpoint drop {A : Type} (n : nat) (l : list A) : list A :=
   match l, n with
   | _ :: l, n.+1%nat => drop n l
   | _, _ => l
   end.
 
 (** A [drop] of zero elements is the identity. *)
-Definition drop_0@{i|} {A : Type@{i}} (l : list A)
+Definition drop_0 {A : Type} (l : list A)
   : drop 0 l = l.
 Proof.
   by destruct l.
 Defined.
 
 (** A [drop] of one element is the tail of the list. *)
-Definition drop_1@{i|} {A : Type@{i}} (l : list A)
+Definition drop_1 {A : Type} (l : list A)
   : drop 1 l = tail l.
 Proof.
   induction l.
@@ -549,7 +536,7 @@ Proof.
 Defined.
 
 (** A [drop] of the empty list is the empty list. *)
-Definition drop_nil@{i|} {A : Type@{i}} (n : nat)
+Definition drop_nil {A : Type} (n : nat)
   : drop n (@nil A) = nil.
 Proof.
   by destruct n.
@@ -595,20 +582,20 @@ Defined.
 (** *** Take *)
 
 (** [take n l] keeps the first [n] elements of [l] and returns [l] if [n >= length l]. *)
-Fixpoint take@{i|} {A : Type@{i}} (n : nat) (l : list A) : list A :=
+Fixpoint take {A : Type} (n : nat) (l : list A) : list A :=
   match l, n with
   | x :: l, n.+1%nat => x :: take n l
   | _, _ => nil
   end.
 
 (** A [take] of zero elements is the empty list. *)
-Definition take_0@{i|} {A : Type@{i}} (l : list A) : take 0 l = nil.
+Definition take_0 {A : Type} (l : list A) : take 0 l = nil.
 Proof.
   by destruct l.
 Defined.
 
 (** A [take] of the empty list is the empty list. *)
-Definition take_nil@{i|} {A : Type@{i}} (n : nat) : take n (@nil A) = nil.
+Definition take_nil {A : Type} (n : nat) : take n (@nil A) = nil.
 Proof.
   by destruct n.
 Defined.
@@ -657,18 +644,18 @@ Defined.
 (** *** Remove *)
 
 (** [remove n l] removes the [n]-th element of [l]. *)
-Definition remove@{i|} {A : Type@{i}} (n : nat) (l : list A) : list A
+Definition remove {A : Type} (n : nat) (l : list A) : list A
   := take n l ++ drop n.+1 l.
 
 (** Removing the first element of a list is the tail of the list. *)
-Definition remove_0@{i|} {A : Type@{i}} (l : list A) : remove 0 l = tail l.
+Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l.
 Proof.
   unfold remove.
   by rewrite take_0, drop_1.
 Defined.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)
-Definition remove_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
+Definition remove_length_leq {A : Type} (n : nat) (l : list A)
   (H : (length l <= n)%nat)
   : remove n l = l.
 Proof.
@@ -683,7 +670,7 @@ Defined.
 (** The length of a [remove n] is the length of the original list minus one. *)
 Definition length_remove@{i|} {A : Type@{i}} (n : nat) (l : list A)
   (H : (n < length l)%nat)
-  : length (remove@{i} n l) = pred (length@{i} l)%nat.
+  : length (remove n l) = pred (length l)%nat.
 Proof.
   unfold remove.
   rewrite length_app@{i}.
@@ -700,7 +687,7 @@ Proof.
 Defined. 
 
 (** An element of a [remove] is an element of the original list. *)
-Definition remove_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)
+Definition remove_inlist {A : Type} (n : nat) (l : list A) (x : A)
   : InList x (remove n l) -> InList x l.
 Proof.
   unfold remove.
@@ -1036,7 +1023,7 @@ Proof.
 Defined.
 
 (** If a predicate [P] is decidable then so is [for_all P]. *)
-Global Instance decidable_for_all@{i j|} {A : Type@{i}} (P : A -> Type@{j})
+Global Instance decidable_for_all {A : Type} (P : A -> Type)
   `{forall x, Decidable (P x)} (l : list A)
   : Decidable (for_all P l).
 Proof.


### PR DESCRIPTION
We explicitly annotate all the lemmas in the list library in order to make sure there is no universe blow up. The universe blow up stems from poor implementation of various tactics with respect to universe polymorphism.

I will get onto cleaning up universes in the linear algebra library too, but that is also affected by a more critical universe blow up which will have to be considered separately.