### PR TITLE
bump min version to 8.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ concurrency:
 
 # We set the supported coq-version from here. In order to use this environment variable correctly, look at how they are used in the following jobs.
 env:
-  coq-version-supported: '8.18'
+  coq-version-supported: '8.19'
   ocaml-version: '4.14-flambda'
   deployment-branch: 'gh-pages'
 
@@ -36,7 +36,6 @@ jobs:
       matrix:
         coq-version-dummy:
         - 'supported'
-        - '8.18'
         - 'latest'
         - 'dev'
         os:
@@ -273,7 +272,7 @@ jobs:
           mv HoTT.svg HoTTCore.svg dep-graphs/
 
           ## Install coq-dpdgraph
-          opam install coq-dpdgraph.1.0+8.18 -y
+          opam install coq-dpdgraph.1.0+8.19 -y
 
           # For some reason, we get a stackoverflow. So we are lax
           # with making these.

--- a/coq-hott.opam
+++ b/coq-hott.opam
@@ -17,7 +17,7 @@ homepage: "http://homotopytypetheory.org/"
 bug-reports: "https://github.com/HoTT/HoTT/issues"
 depends: [
   "dune" {>= "3.13"}
-  "coq" {>= "8.18.0"}
+  "coq" {>= "8.19.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -26,4 +26,4 @@
   "To use the HoTT library, the following flags must be passed to coqc:\n  -noinit -indices-matter\nTo use the HoTT library in a project, add the following to _CoqProject:\n  -arg -noinit\n  -arg -indices-matter\n")
  (depends
   (coq
-   (>= 8.18.0))))
+   (>= 8.19.0))))

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713968665,
-        "narHash": "sha256-kiNvy1g5tyC6ZItTbPmFUnSug4t/I4bLne9OdKnd4sM=",
+        "lastModified": 1717774105,
+        "narHash": "sha256-HV97wqUQv9wvptiHCb3Y0/YH0lJ60uZ8FYfEOIzYEqI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0cadba85e907b8e2d6ae549d25535da3b1b6d5e",
+        "rev": "d226935fd75012939397c83f6c385e4d6d832288",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,6 @@
         };
 
         devShells.default = makeDevShell "8_19";
-        devShells.coq_8_18 = makeDevShell "8_18";
 
         formatter = pkgs.nixpkgs-fmt;
       });

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       in {
         packages.default = pkgs.coqPackages.mkCoqDerivation {
           pname = "hott";
-          version = "8.18";
+          version = "8.19";
           src = self;
           useDune = true;
         };

--- a/theories/Colimits/Quotient.v
+++ b/theories/Colimits/Quotient.v
@@ -322,8 +322,7 @@ Section Kernel.
       IsHSet C * IsSurjection e * IsEmbedding m * (f = m o e).
   Proof.
     exists (Quotient R).
-    (* [exists (class_of R)] works, but the next line reduces the universe variables in a way that makes Coq 8.18 and 8.19 compatible. *)
-    refine (exist@{ar abr} _ (class_of R) _).
+    exists (class_of R).
     srefine (_;_).
     { refine (Quotient_ind R (fun _ => B) f _).
       intros x y p.
@@ -348,7 +347,7 @@ Section Kernel.
   (** We clean up the universe variables here, using only those declared in this Section. *)
   Definition quotient_kernel_factor_general@{|}
     := Eval unfold quotient_kernel_factor_internal in
-      quotient_kernel_factor_internal@{ar' ar abr abr ab}.
+      quotient_kernel_factor_internal@{ar' ar abr abr ab abr abr}.
 
 End Kernel.
 

--- a/theories/Spaces/No/Core.v
+++ b/theories/Spaces/No/Core.v
@@ -1067,7 +1067,7 @@ Section RaiseSort.
       strip_truncations.
       destruct sh as [[l sh]|[r sh]].
       + apply lt_l with l.
-        apply IHL0, (@No_decode_le ua). (* Need to pass in [Univalence] to make this fast. TODO: should be fast without ua with Coq 8.19.  If so, remove this when 8.19 is our minimum version. *)
+        apply IHL0, No_decode_le.
         rewrite p; exact sh.
       + apply lt_r with r.
         apply IHR, No_decode_le.


### PR DESCRIPTION
We bump our minimal Coq version to 8.19.

This version appears to have some better universe inference and will be useful for #1984.

I did a compatibility cleanup in `No/Core.v`.

I noticed that there is an 8.19 compatibility comment in Quotient.v but I couldn't work out what exactly could change. @jdchristensen would you mind taking a look at that file and dropping the 8.18 compat? (Alternatively, we can do that in a later PR it doesn't seem too pressing).

The draft PR #1862 can be undrafted after this.
