### PR TITLE
drop extra universe in istrunc_sigma

### DIFF
--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -375,9 +375,6 @@ Section AssumeStuff.
       apply path_N; reflexivity.
   Qed.
 
-  (** Sometimes we just need a bigger fish. *)
-  Universe large.
-
   (** A first application *)
   Definition N_neq_succ@{} (n : N) : n <> succ n.
   Proof.
@@ -794,7 +791,7 @@ Section AssumeStuff.
       - refine (_ oE equiv_inverse (equiv_sigma_assoc _ _)).
         apply equiv_functor_sigma_id; intros f.
         cbn; apply equiv_sigma_prod0.
-      - refine (@istrunc_sigma@{nr nr large nr} _ _ _ _ _).
+      - refine (@istrunc_sigma@{nr nr nr} _ _ _ _ _).
         + srefine (Build_Contr _ _ _).
           * exists (fun _ => x0); reflexivity.
           * intros [g H].

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -613,7 +613,7 @@ Global Instance istrunc_sigma `{P : A -> Type}
 : IsTrunc n (sig P) | 100.
 Proof.
   generalize dependent A.
-  induction n; simpl; intros A P ac Pc.
+  simple_induction' n; simpl; intros A P ac Pc.
   { apply (Build_Contr _ (center A; center (P (center A)))).
     intros [a ?].
     refine (path_sigma' P (contr a) (path_contr _ _)). }


### PR DESCRIPTION
This was quite difficult to fix, but I worked it out in the end.

The previous proof was using the generated polymorphic induction principle which is actually less general than what we could be. This meant that we required an extra strictly larger universe for the induction hypothesis to work.

Rewriting the proof using a fixpoint allows us to use the most general version of the "induction principle", i.e. the rules of the underlying fixpoint. This allows us to remain in the same universe, simplifying the universe requirements elsewhere too.

The main motivation for this patch was to reduce the universes in `istrunc_vector` and now we don't need a superfluous larger universe.

cc @mikeshulman who participated in the corresponding Zulip discussion: https://hott.zulipchat.com/#narrow/stream/228519-general/topic/.E2.9C.94.20Truncation.20level.20of.20sigma.20type