### PR TITLE
1-Cat instance for MatrixCat

### DIFF
--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -4,6 +4,7 @@ Require Import Spaces.List.Core Spaces.List.Theory Spaces.List.Paths.
 Require Import Algebra.Rings.Ring Algebra.Rings.Module Algebra.Rings.CRing
   Algebra.Rings.KroneckerDelta Algebra.Rings.Vector.
 Require Import abstract_algebra.
+Require Import WildCat.
 
 Set Universe Minimization ToSet.
 
@@ -639,3 +640,95 @@ Proof.
   intros k l Hk Hl.
   by rewrite 4 entry_Build_Matrix.
 Defined.
+
+Section MatrixCatIs1Cat.
+
+  (** The wildcategory MatrixCat R of R-valued matrices. 
+  This category has natural numbers as objects, and m x n - dimensional matrices between m and n. *)
+  Definition MatrixCat (R : Ring) := nat.
+
+  Global Instance isgraph_matrixcat {R} : IsGraph (MatrixCat R).
+  Proof.
+    snrapply Build_IsGraph.
+    intros m n.
+    exact (Matrix R m n).
+  Defined.
+
+  Global Instance is01cat_matrixcat {R} : Is01Cat (MatrixCat R).
+  Proof.
+    snrapply Build_Is01Cat.
+    - intros a. 
+      exact (identity_matrix R a).
+    - intros a b c f g.
+      exact (matrix_mult g f).
+  Defined.
+
+  Global Instance is2graph_matrixcat {R} : Is2Graph (MatrixCat R).
+  Proof.
+    unfold Is2Graph.
+    intros M N. 
+    snrapply Build_IsGraph.
+    intros A B.
+    exact (A = B).
+  Defined.
+
+  Global Instance isgraph_morphismmatrix {R} (m n : MatrixCat R) : IsGraph (m $-> n).
+  Proof.
+    snrapply Build_IsGraph.
+    intros A B.
+    exact (A = B).
+  Defined.
+
+  Global Instance is01cat_morphismmatrix {R} (m n : MatrixCat R) : Is01Cat (m $-> n).
+  Proof.
+    snrapply Build_Is01Cat.
+    - intros a.
+      exact (idpath a).
+    - intros a b c A B.
+      exact (B @ A).
+  Defined.
+
+  Global Instance is0gpd_morphismmatrix {R} (m n : MatrixCat R) : Is0Gpd (m $-> n).
+  Proof.
+    snrapply Build_Is0Gpd.
+    intros a b A.
+    destruct A.
+    exact (idpath _).
+  Defined.
+
+  Global Instance is0functor_postcomp_morphismmatrix {R} {m n p : MatrixCat R} (h : n $-> p)
+    : Is0Functor (@cat_postcomp (MatrixCat R) _ _ m n p h).
+  Proof.
+    snrapply Build_Is0Functor.
+    intros a b f.
+    destruct f.
+    exact (idpath _).
+  Defined.
+
+  Global Instance is0functor_precomp_morphismmatrix {R} {m n p : MatrixCat R} (h : m $-> n)
+    : Is0Functor (@cat_precomp (MatrixCat R) _ _ m n p h).
+  Proof.
+    snrapply Build_Is0Functor.
+    intros a b f.
+    destruct f.
+    exact (idpath _).
+  Defined.
+  (** I don't know if we can do something smart with these 3 functions, as they are constructed identically. *)
+
+  (** MatrixCat R forms a strong 1-category. *)
+  Global Instance is1catstrong_matrixcat {R} : Is1Cat_Strong (MatrixCat R).
+  Proof.
+    snrapply Build_Is1Cat_Strong.
+    - apply is01cat_morphismmatrix.
+    - apply is0gpd_morphismmatrix.
+    - intros m n p h. exact (is0functor_postcomp_morphismmatrix h).
+    - intros m n p h. exact (is0functor_precomp_morphismmatrix h).
+    - apply (associative_matrix_mult R).
+    - intros m n p q A B C. apply inverse. apply (associative_matrix_mult R).
+    - apply right_identity_matrix_mult.
+    - apply left_identity_matrix_mult.
+  Defined.
+
+(** TODO: Define HasEquivs for MatrixCat.  *)
+
+End MatrixCatIs1Cat.


### PR DESCRIPTION
Defines a type MatrixCat R that consists of the natural numbers. We turn MatrixCat into a 1-category by considering the homsets (m,n) = M_{m╳n}(R) of m╳n-dimensional matrices.