### PR TITLE
Make some WildCat.Path instances Global, and use them

### DIFF
--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -4,8 +4,7 @@ Require Import Spaces.List.Core Spaces.List.Theory Spaces.List.Paths.
 Require Import Algebra.Rings.Ring Algebra.Rings.Module Algebra.Rings.CRing
   Algebra.Rings.KroneckerDelta Algebra.Rings.Vector.
 Require Import abstract_algebra.
-Require Import WildCat.Core.
-Require Import WildCat.Paths.
+Require Import WildCat.Core WildCat.Paths.
 
 Set Universe Minimization ToSet.
 
@@ -658,34 +657,15 @@ Section MatrixCat.
       exact (matrix_mult N M).
   Defined.
 
-  Global Instance is2graph_matrixcat {R : Ring} : Is2Graph (MatrixCat R).
-  Proof.
-    unfold Is2Graph.
-    intros.
-    apply isgraph_paths.
-  Defined.
-
-  Global Instance is01cat_matrixcat_hom {R : Ring} (m n : MatrixCat R) : Is01Cat (m $-> n)
-    := is01cat_paths _.
-
-  Global Instance is0gpd_matrixcat_hom {R : Ring} (m n : MatrixCat R) : Is0Gpd (m $-> n)
-    := is0gpd_paths _.
-
-  Global Instance is0functor_postcomp_matrixcat_hom {R : Ring} {l m n : MatrixCat R} (P : m $-> n)
-    : Is0Functor (@cat_postcomp (MatrixCat R) _ _ l m n P)
-    := is0functor_cat_postcomp_paths _ _ _ _ _.
-  
-  Global Instance is0functor_precomp_matrixcat_hom {R : Ring} {l m n : MatrixCat R} (P : l $-> m)
-    : Is0Functor (@cat_precomp (MatrixCat R) _ _ l m n P)
-    := is0functor_cat_precomp_paths _ _ _ _ _.
+  Global Instance is2graph_matrixcat {R : Ring} : Is2Graph (MatrixCat R)
+    := is2graph_paths _.
 
   (** MatrixCat R forms a strong 1-category. *)
   Global Instance is1catstrong_matrixcat {R : Ring} : Is1Cat_Strong (MatrixCat R).
   Proof.
     snrapply Build_Is1Cat_Strong.
-    1,2,4: exact _.
-    (* I'm not sure why typeclass search doesn't find the next one.  Something must be slightly broken. *)
-    - snrapply @is0functor_postcomp_matrixcat_hom.
+    (* Most of the structure comes from typeclasses in WildCat.Paths. *)
+    1-4: exact _.
     - apply (associative_matrix_mult R).
     - intros k l m n M N P. apply inverse. apply (associative_matrix_mult R).
     - apply right_identity_matrix_mult.

--- a/theories/Colimits/CoeqUnivProp.v
+++ b/theories/Colimits/CoeqUnivProp.v
@@ -16,10 +16,9 @@ Require Import WildCat.ZeroGroupoid.
 Section UnivProp.
   Context {B A : Type} (f g : B -> A) (P : Coeq f g -> Type).
 
-  (** This allows Coq to infer 0-groupoid structures of the form [@isgraph_forall C P (fun c => isgraph_paths (P c))] on any type of the form [forall c, P c]. *)
-  Local Existing Instances isgraph_forall is01cat_forall is0gpd_forall | 1.
-  Local Existing Instances isgraph_total is01cat_total is0gpd_total | 1.
-  Local Existing Instances isgraph_paths is01cat_paths is0gpd_paths | 2.
+  (** This allows Coq to infer 0-groupoid structures of the form [@isgraph_forall C P (fun c => isgraph_paths (P c))] on any type of the form [forall c, P c].  [isgraph_paths] is not a global instance.  [isgraph_total] is, but we need to adjust the priority.  The other needed ingredients are all global instances. *)
+  Local Existing Instances isgraph_total | 1.
+  Local Existing Instances isgraph_paths | 2.
 
   (** The codomain of the equivalence is a sigma-groupoid of this family. *)
   Definition Coeq_ind_data (h : forall a : A, P (coeq a))

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -205,36 +205,20 @@ Section UnivProp.
   (** Here is the domain of the equivalence: sections of [P] over [Susp X]. *)
   Definition Susp_ind_type := forall z:Susp X, P z.
 
+  (** [isgraph_paths] is not a global instance, so we define this by hand.  The fact that this is a 01cat and a 0gpd is obtained using global instances. *)
   Local Instance isgraph_Susp_ind_type : IsGraph Susp_ind_type.
   Proof. apply isgraph_forall; intros; apply isgraph_paths. Defined.
-
-  Local Instance is01cat_Susp_ind_type : Is01Cat Susp_ind_type.
-  Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
-
-  Local Instance is0gpd_Susp_ind_type : Is0Gpd Susp_ind_type.
-  Proof. apply is0gpd_forall; intros; apply is0gpd_paths. Defined.
 
   (** The codomain is a sigma-groupoid of this family, consisting of input data for [Susp_ind]. *)
   Definition Susp_ind_data' (NS : P North * P South)
     := forall x:X, DPath P (merid x) (fst NS) (snd NS).
 
+  (** Again, the rest of the wild category structure is obtained using global instances. *)
   Local Instance isgraph_Susp_ind_data' NS : IsGraph (Susp_ind_data' NS).
   Proof. apply isgraph_forall; intros; apply isgraph_paths. Defined.
 
-  Local Instance is01cat_Susp_ind_data' NS : Is01Cat (Susp_ind_data' NS).
-  Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
-
-  Local Instance is0gpd_Susp_ind_data' NS : Is0Gpd (Susp_ind_data' NS).
-  Proof. apply is0gpd_forall; intros; apply is0gpd_paths. Defined.
-
-  (** Here is the codomain itself. *)
+  (** Here is the codomain itself.  This is a 01cat and a 0gpd via global instances. *)
   Definition Susp_ind_data := sig Susp_ind_data'.
-
-  Local Instance is01cat_Susp_ind_data : Is01Cat Susp_ind_data.
-  Proof. rapply is01cat_sigma. Defined.
-
-  Local Instance is0gpd_Susp_ind_data : Is0Gpd Susp_ind_data.
-  Proof. rapply is0gpd_sigma. Defined.
 
   (** Here is the functor. *)
   Definition Susp_ind_inv : Susp_ind_type -> Susp_ind_data.
@@ -287,21 +271,16 @@ Section UnivPropNat.
   (** We will show that [Susp_ind_inv] for [X] and [Y] commute with precomposition with [f] and [functor_susp f]. *)
   Context {X Y : Type} (f : X -> Y) (P : Susp Y -> Type).
 
-  (** We recall all those instances from the previous section. *)
-  Local Existing Instances isgraph_Susp_ind_type is01cat_Susp_ind_type is0gpd_Susp_ind_type isgraph_Susp_ind_data' is01cat_Susp_ind_data' is0gpd_Susp_ind_data' is01cat_Susp_ind_data is0gpd_Susp_ind_data.
+  (** We recall these instances from the previous section. *)
+  Local Existing Instances isgraph_Susp_ind_type isgraph_Susp_ind_data'.
 
   (** Here is an intermediate family of groupoids that we have to use, since precomposition with [f] doesn't land in quite the right place. *)
   Definition Susp_ind_data'' (NS : P North * P South)
     := forall x:X, DPath P (merid (f x)) (fst NS) (snd NS).
 
+  (** This is a 01cat and a 0gpd via global instances. *)
   Local Instance isgraph_Susp_ind_data'' NS : IsGraph (Susp_ind_data'' NS).
   Proof. apply isgraph_forall; intros; apply isgraph_paths. Defined.
-
-  Local Instance is01cat_Susp_ind_data'' NS : Is01Cat (Susp_ind_data'' NS).
-  Proof. apply is01cat_forall; intros; apply is01cat_paths. Defined.
-
-  Local Instance is0gpd_Susp_ind_data'' NS : Is0Gpd (Susp_ind_data'' NS).
-  Proof. apply is0gpd_forall; intros; apply is0gpd_paths. Defined.
 
   (** We decompose "precomposition with [f]" into a functor_sigma of two fiberwise functors.  Here is the first. *)
   Definition functor_Susp_ind_data'' (NS : P North * P South)

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -23,15 +23,15 @@ Definition is3graph_paths (A : Type) `{Is2Graph A} : Is3Graph A
 Local Existing Instances isgraph_paths is2graph_paths is3graph_paths | 10.
 
 (** Any type has composition and identity morphisms given by path concatenation and reflexivity. *)
-Local Instance is01cat_paths (A : Type) : Is01Cat A
+Global Instance is01cat_paths (A : Type) : Is01Cat A
   := {| Id := @idpath _ ; cat_comp := fun _ _ _ x y => concat y x |}.
 
 (** Any type has a 0-groupoid structure with inverse morphisms given by path inversion. *)
-Local Instance is0gpd_paths (A : Type) : Is0Gpd A
+Global Instance is0gpd_paths (A : Type) : Is0Gpd A
   := {| gpd_rev := @inverse _ |}.
 
 (** Postcomposition is a 0-functor when the 2-cells are paths. *)
-Local Instance is0functor_cat_postcomp_paths (A : Type) `{Is01Cat A}
+Global Instance is0functor_cat_postcomp_paths (A : Type) `{Is01Cat A}
   (a b c : A) (g : b $-> c)
   : Is0Functor (cat_postcomp a g).
 Proof.
@@ -40,7 +40,7 @@ Proof.
 Defined.
 
 (** Precomposition is a 0-functor when the 2-cells are paths. *)
-Local Instance is0functor_cat_precomp_paths (A : Type) `{Is01Cat A}
+Global Instance is0functor_cat_precomp_paths (A : Type) `{Is01Cat A}
   (a b c : A) (f : a $-> b)
   : Is0Functor (cat_precomp c f).
 Proof.
@@ -49,7 +49,7 @@ Proof.
 Defined.
 
 (** Any type is a 1-category with n-morphisms given by paths. *)
-Local Instance is1cat_paths {A : Type} : Is1Cat A.
+Global Instance is1cat_paths {A : Type} : Is1Cat A.
 Proof.
   snrapply Build_Is1Cat.
   - exact _.
@@ -63,7 +63,7 @@ Proof.
 Defined.
 
 (** Any type is a 1-groupoid with morphisms given by paths. *)
-Local Instance is1gpd_paths {A : Type} : Is1Gpd A.
+Global Instance is1gpd_paths {A : Type} : Is1Gpd A.
 Proof.
   snrapply Build_Is1Gpd.
   - exact (@concat_pV A).
@@ -71,7 +71,7 @@ Proof.
 Defined.
 
 (** Any type is a 2-category with higher morphhisms given by paths. *)
-Local Instance is21cat_paths {A : Type} : Is21Cat A.
+Global Instance is21cat_paths {A : Type} : Is21Cat A.
 Proof.
   snrapply Build_Is21Cat.
   - exact _.


### PR DESCRIPTION
We don't want `isgraph_paths`, `is2graph_paths`, or `is3graph_paths` to be global instances, as then Coq could apply them in situations where we prefer a different wild category structure.  But the further instances that require having these ones already applied can safely be global instances, so that's what this PR does. 

This allows us to simplify things in the three files that currently use WildCat.Paths:  Suspension.v, CoeqUnivProp.v and Matrix.v.

I have checked that the build time is unchanged within the noise.