### PR TITLE
fix nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717774105,
-        "narHash": "sha256-HV97wqUQv9wvptiHCb3Y0/YH0lJ60uZ8FYfEOIzYEqI=",
+        "lastModified": 1719436386,
+        "narHash": "sha256-NBGYaic5FLRg8AWSj6yr4g2IlMPUxNCVjRK6+RNuQBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d226935fd75012939397c83f6c385e4d6d832288",
+        "rev": "c66e984bda09e7230ea7b364e677c5ba4f0d36d0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -29,11 +29,11 @@
           useDune = true;
         };
 
-        devShells.default = makeDevShell { coq = pkgs.coq_8_19; };
+        devShells.default = makeDevShell { coq = pkgs.coq_8_19; } { };
 
         # To use, pass --impure to nix develop
         devShells.coq_master =
-          makeDevShell { coq = pkgs.coq.override { version = "master"; }; };
+          makeDevShell { coq = pkgs.coq.override { version = "master"; }; } { };
 
         formatter = pkgs.nixpkgs-fmt;
       });


### PR DESCRIPTION
I missed an extra argument here before which meant that the development shell didn't build. I've fixed this and updated the flake.