### PR TITLE
switch to Int in cring_Z

### DIFF
--- a/test/Algebra/Rings/Matrix.v
+++ b/test/Algebra/Rings/Matrix.v
@@ -1,7 +1,7 @@
 From HoTT Require Import Basics.
 From HoTT Require Import Algebra.Rings.Matrix.
 From HoTT Require Import Spaces.Nat.Core Spaces.List.Core.
-From HoTT Require Import Algebra.Rings.Z Spaces.BinInt.Core Algebra.Rings.CRing.
+From HoTT Require Import Algebra.Rings.Z Spaces.Int Algebra.Rings.CRing.
 From HoTT Require Import Classes.interfaces.canonical_names.
 
 Local Open Scope mc_scope.
@@ -38,7 +38,7 @@ Definition test2_B := Build_Matrix' nat 4 4
 
 Definition test2 : entries test2_A = entries test2_B := idpath.
 
-Local Open Scope binint_scope.
+Local Open Scope int_scope.
 
 (** Matrices with ring entries can be multiplied *)
 

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -258,10 +258,11 @@ Proof.
       exact IHn.
 Defined.
 
-Definition ab_mul_homo {A B : AbGroup}
+(** [ab_mul n] is natural. *)
+Definition ab_mul_natural {A B : AbGroup}
   (f : GroupHomomorphism A B) (n : Int)
   : f o ab_mul n == ab_mul n o f
-  := grp_pow_homo f n.
+  := grp_pow_natural f n.
 
 (** The image of an inclusion is a normal subgroup. *)
 Definition ab_image_embedding {A B : AbGroup} (f : A $-> B) `{IsEmbedding f} : NormalSubgroup B
@@ -303,17 +304,17 @@ Proof.
 Defined.
 
 (** If the function is constant in the range of a finite sum then the sum is equal to the constant times [n]. This is a group power in the underlying group. *)
-Definition ab_sum_const {A : AbGroup} (n : nat) (r : A)
-  (f : forall k, (k < n)%nat -> A) (p : forall k Hk, f k Hk = r)
-  : ab_sum n f = grp_pow r n.
+Definition ab_sum_const {A : AbGroup} (n : nat) (a : A)
+  (f : forall k, (k < n)%nat -> A) (p : forall k Hk, f k Hk = a)
+  : ab_sum n f = ab_mul n a.
 Proof.
   induction n as [|n IHn] in f, p |- *.
   - reflexivity.
-  - rewrite int_of_nat_succ_commute, grp_pow_int_add_1.
+  - rewrite int_of_nat_succ_commute.
+    rhs nrapply grp_pow_int_add_1.
     simpl. f_ap.
-    rewrite IHn.
-    + reflexivity.
-    + intros. apply p.
+    apply IHn.
+    intros. apply p.
 Defined.
 
 (** If the function is zero in the range of a finite sum then the sum is zero. *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -228,6 +228,20 @@ Proof.
     1-2: exact negate_involutive.
 Defined.
 
+(** This goal comes up twice in the proof of [ab_mul], so we factor it out. *)
+Local Definition ab_mul_helper {A : AbGroup} (a b x y z : A)
+  (p : x = y + z)
+  : a + b + x = a + y + (b + z).
+Proof.
+  lhs_V srapply grp_assoc.
+  rhs_V srapply grp_assoc.
+  apply grp_cancelL.
+  rhs srapply grp_assoc.
+  rhs nrapply (ap (fun g => g + z) (ab_comm y b)).
+  rhs_V srapply grp_assoc.
+  apply grp_cancelL, p.
+Defined.
+
 (** Multiplication by [n : Int] defines an endomorphism of any abelian group [A]. *)
 Definition ab_mul {A : AbGroup} (n : Int) : GroupHomomorphism A A.
 Proof.
@@ -236,26 +250,11 @@ Proof.
   intros a b.
   induction n; cbn.
   - exact (grp_unit_l _)^.
-  - destruct n.
-    + reflexivity.
-    + rhs_V srapply (associativity a).
-      rhs srapply (ap _ (associativity _ b _)).
-      rewrite (commutativity (nat_iter _ _ _) b).
-      rhs_V srapply (ap _ (associativity b _ _)).
-      rhs srapply (associativity a).
-      apply grp_cancelL.
-      exact IHn.
-  - destruct n.
-    + rewrite (commutativity (-a)).
-      exact (grp_inv_op a b).
-    + rhs_V srapply (associativity (-a)).
-      rhs srapply (ap _ (associativity _ (-b) _)).
-      rewrite (commutativity (nat_iter _ _ _) (-b)).
-      rhs_V srapply (ap _ (associativity (-b) _ _)).
-      rhs srapply (associativity (-a)).
-      rewrite (commutativity (-a) (-b)), <- (grp_inv_op a b).
-      apply grp_cancelL.
-      exact IHn.
+  - rewrite 3 grp_pow_int_add_1.
+    by apply ab_mul_helper.
+  - rewrite 3 grp_pow_int_sub_1.
+    rewrite (grp_inv_op a b), (commutativity (-b) (-a)).
+    by apply ab_mul_helper.
 Defined.
 
 (** [ab_mul n] is natural. *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -250,9 +250,9 @@ Proof.
   intros a b.
   induction n; cbn.
   - exact (grp_unit_l _)^.
-  - rewrite 3 grp_pow_int_add_1.
+  - rewrite 3 grp_pow_succ.
     by apply ab_mul_helper.
-  - rewrite 3 grp_pow_int_sub_1.
+  - rewrite 3 grp_pow_pred.
     rewrite (grp_inv_op a b), (commutativity (-b) (-a)).
     by apply ab_mul_helper.
 Defined.
@@ -310,7 +310,7 @@ Proof.
   induction n as [|n IHn] in f, p |- *.
   - reflexivity.
   - rhs nrapply (ap@{Set _} _ (int_of_nat_succ_commute n)).
-    rhs nrapply grp_pow_int_add_1.
+    rhs nrapply grp_pow_succ.
     simpl. f_ap.
     apply IHn.
     intros. apply p.

--- a/theories/Algebra/AbGroups/Cyclic.v
+++ b/theories/Algebra/AbGroups/Cyclic.v
@@ -1,6 +1,6 @@
 Require Import Basics Types WildCat.Core Truncations.Core
   AbelianGroup AbHom Centralizer AbProjective
-  Groups.FreeGroup AbGroups.Z BinInt.Core Spaces.Int.
+  Groups.FreeGroup AbGroups.Z Spaces.Int.
 
 (** * Cyclic groups *)
 
@@ -71,7 +71,7 @@ Defined.
 
 (** The map sending the generator to [1 : Int]. *)
 Definition Z1_to_Z `{Funext} : ab_Z1 $-> abgroup_Z
-  := Z1_rec (G:=abgroup_Z) 1%binint.
+  := Z1_rec (G:=abgroup_Z) 1%int.
 
 (** TODO:  Prove that [Z1_to_Z] is a group isomorphism. *)
 

--- a/theories/Algebra/AbGroups/Cyclic.v
+++ b/theories/Algebra/AbGroups/Cyclic.v
@@ -48,7 +48,7 @@ Lemma Z1_mul_nat_beta {A : AbGroup} (a : A) (n : nat)
 Proof.
   induction n as [|n H].
   1: easy.
-  refine (grp_pow_homo _ _ _ @ _); simpl.
+  refine (grp_pow_natural _ _ _ @ _); simpl.
   by rewrite grp_unit_r.
 Defined.
 

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -10,7 +10,6 @@ Local Set Universe Minimization ToSet.
 
 Local Open Scope int_scope.
 
-(** TODO: switch to [Int] *)
 Definition abgroup_Z@{} : AbGroup@{Set}.
 Proof.
   snrapply Build_AbGroup.

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -22,3 +22,35 @@ Proof.
     + exact int_add_neg_r.
   - exact int_add_comm.
 Defined.
+
+Local Open Scope mc_scope.
+
+(** Every element of an abelian group can be multiplied by an integer. *)
+Definition abgroup_int_mult (A : AbGroup) (x : A) (z : abgroup_Z) : A
+  := grp_pow x z.
+
+(** [abgroup_int_mult A r] preserves addition. *)
+Global Instance issemigrouppreserving_plus_abgroup_int_mult (A : AbGroup) (x : A)
+  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (abgroup_int_mult A x).
+Proof.
+  intros y z.
+  apply grp_pow_int_add.
+Defined.
+
+(** [abgroup_int_mult A r] sends [0 : Int] to [0 : R] definitionally. *)
+Global Instance isunitpreserving_plus_abgroup_int_mult (A : AbGroup) (x : A)
+  : IsUnitPreserving (Aunit:=zero) (Bunit:=canonical_names.zero)
+      (abgroup_int_mult A x)
+  := idpath.
+
+(** [abgroup_int_mult R r] preserves addition and zero. *)
+Global Instance ismonoidpreserving_plus_abgroup_int_mult (A : AbGroup) (x : A)
+  : IsMonoidPreserving (Aop:=(+)) (Bop:=(+)) (abgroup_int_mult A x)
+  := {}.
+
+(** [abgroup_int_mult R r] commutes with negation. *)
+Definition abgroup_int_mult_neg (A : AbGroup) (x : A) z
+  : abgroup_int_mult A x (- z) = - abgroup_int_mult A x z.
+Proof.
+  snrapply (groups.preserves_negate _); exact _.
+Defined.

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -24,32 +24,16 @@ Defined.
 
 Local Open Scope mc_scope.
 
-(** Every element of an abelian group can be multiplied by an integer. *)
-Definition abgroup_int_mult (A : AbGroup) (x : A) (z : abgroup_Z) : A
-  := grp_pow x z.
-
-(** [abgroup_int_mult A r] preserves addition. *)
-Global Instance issemigrouppreserving_plus_abgroup_int_mult (A : AbGroup) (x : A)
-  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (abgroup_int_mult A x).
+(** For every group [G] and element [g : G], the map sending an integer to that power of [g] is a homomorphism. *)
+Definition grp_pow_homo {G : Group} (g : G)
+  : GroupHomomorphism abgroup_Z G.
 Proof.
-  intros y z.
-  apply grp_pow_int_add.
+  snrapply Build_GroupHomomorphism.
+  1: exact (grp_pow g).
+  intros m n; apply grp_pow_int_add.
 Defined.
 
-(** [abgroup_int_mult A r] sends [0 : Int] to [0 : R] definitionally. *)
-Global Instance isunitpreserving_plus_abgroup_int_mult (A : AbGroup) (x : A)
-  : IsUnitPreserving (Aunit:=zero) (Bunit:=canonical_names.zero)
-      (abgroup_int_mult A x)
-  := idpath.
-
-(** [abgroup_int_mult R r] preserves addition and zero. *)
-Global Instance ismonoidpreserving_plus_abgroup_int_mult (A : AbGroup) (x : A)
-  : IsMonoidPreserving (Aop:=(+)) (Bop:=(+)) (abgroup_int_mult A x)
-  := {}.
-
-(** [abgroup_int_mult R r] commutes with negation. *)
-Definition abgroup_int_mult_neg (A : AbGroup) (x : A) z
-  : abgroup_int_mult A x (- z) = - abgroup_int_mult A x z.
-Proof.
-  snrapply (groups.preserves_negate _); exact _.
-Defined.
+(** The special case for an abelian group, which gives multiplication by an integer. *)
+Definition abgroup_int_mult (A : AbGroup) (a : A)
+  : GroupHomomorphism abgroup_Z A
+  := grp_pow_homo a.

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -30,7 +30,7 @@ Definition grp_pow_homo {G : Group} (g : G)
 Proof.
   snrapply Build_GroupHomomorphism.
   1: exact (grp_pow g).
-  intros m n; apply grp_pow_int_add.
+  intros m n; apply grp_pow_add.
 Defined.
 
 (** The special case for an abelian group, which gives multiplication by an integer. *)

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -22,8 +22,6 @@ Proof.
   - exact int_add_comm.
 Defined.
 
-Local Open Scope mc_scope.
-
 (** For every group [G] and element [g : G], the map sending an integer to that power of [g] is a homomorphism. *)
 Definition grp_pow_homo {G : Group} (g : G)
   : GroupHomomorphism abgroup_Z G.
@@ -32,8 +30,3 @@ Proof.
   1: exact (grp_pow g).
   intros m n; apply grp_pow_add.
 Defined.
-
-(** The special case for an abelian group, which gives multiplication by an integer. *)
-Definition abgroup_int_mult (A : AbGroup) (a : A)
-  : GroupHomomorphism abgroup_Z A
-  := grp_pow_homo a.

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -1,5 +1,5 @@
 Require Import Basics.
-Require Import Spaces.Pos.Core Spaces.BinInt.
+Require Import Spaces.Pos.Core Spaces.Int.
 Require Import Algebra.AbGroups.AbelianGroup.
 
 Local Set Universe Minimization ToSet.
@@ -8,17 +8,17 @@ Local Set Universe Minimization ToSet.
 
 (** See also Cyclic.v for a definition of the integers as the free group on one generator. *)
 
-Local Open Scope binint_scope.
+Local Open Scope int_scope.
 
 (** TODO: switch to [Int] *)
 Definition abgroup_Z@{} : AbGroup@{Set}.
 Proof.
   snrapply Build_AbGroup.
-  - refine (Build_Group BinInt binint_add 0 binint_negation _); repeat split.
+  - refine (Build_Group Int int_add 0 int_neg _); repeat split.
     + exact _.
-    + exact binint_add_assoc.
-    + exact binint_add_0_r.
-    + exact binint_add_negation_l.
-    + exact binint_add_negation_r.
-  - exact binint_add_comm.
+    + exact int_add_assoc.
+    + exact int_add_0_r.
+    + exact int_add_neg_l.
+    + exact int_add_neg_r.
+  - exact int_add_comm.
 Defined.

--- a/theories/Algebra/AbSES/SixTerm.v
+++ b/theories/Algebra/AbSES/SixTerm.v
@@ -211,7 +211,7 @@ Proof.
     apply moveR_equiv_V; symmetry.
     refine (ap f _ @ _).
     1: apply Z1_rec_beta.
-    exact (ab_mul_homo f n Z1_gen).
+    exact (ab_mul_natural f n Z1_gen).
   - (* we get rid of [equiv_Z1_hom] *)
     apply isexact_equiv_fiber.
     apply isexact_ext_cyclic_ab_iii.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -476,7 +476,7 @@ End GroupMovement.
 
 (** ** Power operation *)
 
-(** For a given [n : nat] we can define the [n]th power of a group element. *)
+(** For a given [g : G] we can define the function [Int -> G] sending an integer to that power of [g]. *)
 Definition grp_pow {G : Group} (g : G) (n : Int) : G
   := match n with
      | posS n => nat_iter n (g *.) g
@@ -484,8 +484,8 @@ Definition grp_pow {G : Group} (g : G) (n : Int) : G
      | negS n => nat_iter n ((- g) *.) (- g)
      end.
 
-(** Any homomorphism respects [grp_pow]. *)
-Lemma grp_pow_homo {G H : Group} (f : GroupHomomorphism G H) (n : Int) (g : G)
+(** Any homomorphism respects [grp_pow]. In other words, [fun g => grp_pow g n] is natural. *)
+Lemma grp_pow_natural {G H : Group} (f : GroupHomomorphism G H) (n : Int) (g : G)
   : f (grp_pow g n) = grp_pow (f g) n.
 Proof.
   induction n.
@@ -559,7 +559,7 @@ Proof.
   - destruct n; simpl; rewrite grp_inv_inv; reflexivity.
 Defined.
 
-(** [grp_pow] satisfies a law of exponents. *)
+(** [grp_pow] satisfies an additive law of exponents. *)
 Definition grp_pow_int_add {G : Group} (m n : Int) (g : G)
   : grp_pow g (n + m)%int = grp_pow g n * grp_pow g m.
 Proof.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -478,98 +478,61 @@ End GroupMovement.
 
 (** For a given [g : G] we can define the function [Int -> G] sending an integer to that power of [g]. *)
 Definition grp_pow {G : Group} (g : G) (n : Int) : G
-  := match n with
-     | posS n => nat_iter n (g *.) g
-     | zero => mon_unit
-     | negS n => nat_iter n ((- g) *.) (- g)
-     end.
+  := int_iter (g *.) n mon_unit.
 
 (** Any homomorphism respects [grp_pow]. In other words, [fun g => grp_pow g n] is natural. *)
 Lemma grp_pow_natural {G H : Group} (f : GroupHomomorphism G H) (n : Int) (g : G)
   : f (grp_pow g n) = grp_pow (f g) n.
 Proof.
-  induction n.
-  - apply grp_homo_unit.
-  - destruct n; simpl in IHn |- *.
-    + reflexivity.
-    + lhs snrapply grp_homo_op.
-      apply ap.
-      exact IHn.
-  - destruct n; simpl in IHn |- *.
-    + apply grp_homo_inv.
-    + lhs snrapply grp_homo_op.
-      apply ap011.
-      * apply grp_homo_inv.
-      * exact IHn.
+  lhs snrapply (int_iter_commute_map _ ((f g) *.)).
+  1: nrapply grp_homo_op.
+  apply (ap (int_iter _ n)), grp_homo_unit.
 Defined.
 
 (** All powers of the unit are the unit. *)
 Definition grp_pow_unit {G : Group} (n : Int)
   : grp_pow (G:=G) mon_unit n = mon_unit.
 Proof.
-  induction n.
+  snrapply (int_iter_invariant n _ (fun g => g = mon_unit)); cbn.
+  1, 2: apply paths_ind_r.
+  - apply grp_unit_r.
+  - lhs nrapply grp_unit_r. apply grp_inv_unit.
   - reflexivity.
-  - destruct n; simpl. 
-    + reflexivity.
-    + by lhs nrapply grp_unit_l.
-  - destruct n; simpl in IHn |- *.
-    + apply grp_inv_unit.
-    + destruct IHn^.
-      rhs_V apply (@grp_inv_unit G).
-      apply grp_unit_r.
 Defined.
 
 (** Note that powers don't preserve the group operation as it is not commutative. This does hold in an abelian group so such a result will appear later. *)
 
-(** Helper functions for [grp_pow_int_add]. This is how we can unfold [grp_pow] once. *)
-
+(** The next two results tell us how [grp_pow] unfolds. *)
 Definition grp_pow_int_add_1 {G : Group} (n : Int) (g : G)
-  : grp_pow g (n.+1)%int = g * grp_pow g n.
-Proof.
-  induction n; simpl.
-  - exact (grp_unit_r g)^.
-  - destruct n; reflexivity.
-  - destruct n.
-    + apply (grp_inv_r g)^.
-    + rhs srapply associativity.
-      rewrite grp_inv_r. 
-      apply (grp_unit_l _)^.
-Defined.
+  : grp_pow g (n.+1)%int = g * grp_pow g n
+  := int_iter_succ_l _ _ _.
 
 Definition grp_pow_int_sub_1 {G : Group} (n : Int) (g : G)
-  : grp_pow g (n.-1)%int = (- g) * grp_pow g n.
-Proof.
-  induction n; simpl.
-  - exact (grp_unit_r (-g))^.
-  - destruct n.
-    + apply (grp_inv_l g)^.
-    + rhs srapply associativity.
-      rewrite grp_inv_l.
-      apply (grp_unit_l _)^.
-  - destruct n; reflexivity.
-Defined.
+  : grp_pow g (n.-1)%int = (- g) * grp_pow g n
+  := int_iter_pred_l _ _ _.
 
 (** [grp_pow] commutes negative exponents to powers of the inverse *)
 Definition grp_pow_int_sign_commute {G : Group} (n : Int) (g : G)
   : grp_pow g (int_neg n) = grp_pow (- g) n.
 Proof.
-  induction n.
+  lhs nrapply int_iter_neg.
+  destruct n.
+  - cbn. by rewrite grp_inv_inv.
   - reflexivity.
-  - destruct n; reflexivity.
-  - destruct n; simpl; rewrite grp_inv_inv; reflexivity.
+  - reflexivity.
 Defined.
 
 (** [grp_pow] satisfies an additive law of exponents. *)
 Definition grp_pow_int_add {G : Group} (m n : Int) (g : G)
   : grp_pow g (n + m)%int = grp_pow g n * grp_pow g m.
 Proof.
+  lhs nrapply int_iter_add.
   induction n; cbn.
   1: exact (grp_unit_l _)^.
-  1: rewrite int_add_succ_l, 2 grp_pow_int_add_1.
-  2: rewrite int_add_pred_l, 2 grp_pow_int_sub_1.
-  1,2: rhs_V srapply associativity; 
-       snrapply (ap (_ *.));
-       exact IHn.
+  1: rewrite int_iter_succ_l, grp_pow_int_add_1.
+  2: rewrite int_iter_pred_l, grp_pow_int_sub_1; cbn.
+  1,2 : rhs_V srapply associativity;
+        apply ap, IHn.
 Defined.
 
 (** ** The category of Groups *)

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -503,16 +503,29 @@ Defined.
 (** Note that powers don't preserve the group operation as it is not commutative. This does hold in an abelian group so such a result will appear later. *)
 
 (** The next two results tell us how [grp_pow] unfolds. *)
-Definition grp_pow_int_add_1 {G : Group} (n : Int) (g : G)
+Definition grp_pow_succ {G : Group} (n : Int) (g : G)
   : grp_pow g (n.+1)%int = g * grp_pow g n
   := int_iter_succ_l _ _ _.
 
-Definition grp_pow_int_sub_1 {G : Group} (n : Int) (g : G)
+Definition grp_pow_pred {G : Group} (n : Int) (g : G)
   : grp_pow g (n.-1)%int = (- g) * grp_pow g n
   := int_iter_pred_l _ _ _.
 
+(** [grp_pow] satisfies an additive law of exponents. *)
+Definition grp_pow_add {G : Group} (m n : Int) (g : G)
+  : grp_pow g (n + m)%int = grp_pow g n * grp_pow g m.
+Proof.
+  lhs nrapply int_iter_add.
+  induction n; cbn.
+  1: exact (grp_unit_l _)^.
+  1: rewrite int_iter_succ_l, grp_pow_succ.
+  2: rewrite int_iter_pred_l, grp_pow_pred; cbn.
+  1,2 : rhs_V srapply associativity;
+        apply ap, IHn.
+Defined.
+
 (** [grp_pow] commutes negative exponents to powers of the inverse *)
-Definition grp_pow_int_sign_commute {G : Group} (n : Int) (g : G)
+Definition grp_pow_neg {G : Group} (n : Int) (g : G)
   : grp_pow g (int_neg n) = grp_pow (- g) n.
 Proof.
   lhs nrapply int_iter_neg.
@@ -520,19 +533,6 @@ Proof.
   - cbn. by rewrite grp_inv_inv.
   - reflexivity.
   - reflexivity.
-Defined.
-
-(** [grp_pow] satisfies an additive law of exponents. *)
-Definition grp_pow_int_add {G : Group} (m n : Int) (g : G)
-  : grp_pow g (n + m)%int = grp_pow g n * grp_pow g m.
-Proof.
-  lhs nrapply int_iter_add.
-  induction n; cbn.
-  1: exact (grp_unit_l _)^.
-  1: rewrite int_iter_succ_l, grp_pow_int_add_1.
-  2: rewrite int_iter_pred_l, grp_pow_int_sub_1; cbn.
-  1,2 : rhs_V srapply associativity;
-        apply ap, IHn.
 Defined.
 
 (** ** The category of Groups *)

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -26,12 +26,12 @@ Local Open Scope mc_scope.
 
 (** Every ring has a unique ring map from the integers. *)
 (** TODO: rename? *)
-Definition rng_int_mult (R : Ring) (z : cring_Z) : R
-  := int_iter (fun x => 1 + x) z 0.
+Definition rng_int_mult (R : Ring) (r : R) (z : cring_Z) : R
+  := int_iter (fun x => r + x) z 0.
 
 (** Preservation of + *)
 Global Instance issemigrouppreserving_plus_rng_int_mult (R : Ring)
-  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R).
+  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R 1).
 Proof.
   intros x y.
   induction x as [|x|x].
@@ -55,19 +55,23 @@ Proof.
     f_ap.
 Defined.
 
+Global Instance isunitpreserving_plus_rng_int_mult (R : Ring)
+  : IsUnitPreserving (Aunit:=zero) (Bunit:= canonical_names.zero) (rng_int_mult R 1)
+  := idpath.
+
+Global Instance ismonoidpreserving_plus_rng_int_mult (R : Ring)
+  : IsMonoidPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R 1)
+  := {}.
+
 Lemma rng_int_mult_neg {R} x
-  : rng_int_mult R (- x) = - rng_int_mult R x.
+  : rng_int_mult R 1 (- x) = - rng_int_mult R 1 x.
 Proof.
-  snrapply (groups.preserves_negate _).
-  1-6: typeclasses eauto.
-  snrapply Build_IsMonoidPreserving.
-  1: exact _.
-  split.
+  snrapply (groups.preserves_negate _); exact _.
 Defined.
 
 (** Preservation of * (multiplication) *)
 Global Instance issemigrouppreserving_mult_rng_int_mult (R : Ring)
-  : IsSemiGroupPreserving (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R).
+  : IsSemiGroupPreserving (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R 1).
 Proof.
   intros x y.
   induction x as [|x|x].
@@ -98,7 +102,7 @@ Defined.
 Definition rng_homo_int (R : Ring) : (cring_Z : Ring) $-> R.
 Proof.
   snrapply Build_RingHomomorphism.
-  1: exact (rng_int_mult R).
+  1: exact (rng_int_mult R 1).
   repeat split.
   1,2: exact _.
   hnf.

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -37,14 +37,14 @@ Proof.
   - simpl.
     by rhs nrapply rng_mult_zero_l.
   - rewrite int_mul_succ_l.
-    rewrite grp_pow_int_add.
-    rewrite grp_pow_int_add_1.
+    rewrite grp_pow_add.
+    rewrite grp_pow_succ.
     rhs nrapply rng_dist_r.
     rewrite rng_mult_one_l.
     f_ap.
   - rewrite int_mul_pred_l.
-    rewrite grp_pow_int_add.
-    rewrite grp_pow_int_sub_1.
+    rewrite grp_pow_add.
+    rewrite grp_pow_pred.
     rhs nrapply rng_dist_r.
     rewrite IHx.
     f_ap.
@@ -72,12 +72,12 @@ Proof.
   unfold rng_homo_int, rng_int_mult; cbn.
   induction x as [|x|x].
   - by rhs nrapply (grp_homo_unit g).
-  - rewrite grp_pow_int_add_1.
+  - rewrite grp_pow_succ.
     change (x.+1%int) with (1 + x)%int.
     rewrite (rng_homo_plus g 1 x).
     rewrite rng_homo_one.
     f_ap.
-  - rewrite grp_pow_int_sub_1.
+  - rewrite grp_pow_pred.
     rewrite IHx.
     clear IHx.
     rewrite <- (rng_homo_one g).

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -24,36 +24,31 @@ Defined.
 
 Local Open Scope mc_scope.
 
-Definition rng_int_mult (R : Ring) := abgroup_int_mult R. 
+(** Given a ring element [r], we get a map [Int -> R] sending an integer to that multiple of [r]. *)
+Definition rng_int_mult (R : Ring) := grp_pow_homo : R -> Int -> R.
 
 (** [rng_int_mult R 1] preserves multiplication.  This requires that the specified ring element is the unit. *)
 Global Instance issemigrouppreserving_mult_rng_int_mult (R : Ring)
   : IsSemiGroupPreserving (A:=cring_Z) (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R 1).
 Proof.
   intros x y.
+  cbn.
   induction x as [|x|x].
   - simpl.
     by rhs nrapply rng_mult_zero_l.
-  - cbn.
-    rewrite int_mul_succ_l.
-    unfold rng_int_mult in *.
-    rewrite issemigrouppreserving_plus_abgroup_int_mult.
-    unfold abgroup_int_mult in *.
+  - rewrite int_mul_succ_l.
+    rewrite grp_pow_int_add.
     rewrite grp_pow_int_add_1.
     rhs nrapply rng_dist_r.
     rewrite rng_mult_one_l.
-    rewrite IHx.
-    reflexivity.
-  - cbn.
-    rewrite int_mul_pred_l.
-    unfold rng_int_mult in *.
-    rewrite issemigrouppreserving_plus_abgroup_int_mult.
-    unfold abgroup_int_mult in *.
+    f_ap.
+  - rewrite int_mul_pred_l.
+    rewrite grp_pow_int_add.
     rewrite grp_pow_int_sub_1.
     rhs nrapply rng_dist_r.
     rewrite IHx.
     f_ap.
-    lhs rapply abgroup_int_mult_neg.
+    lhs rapply (grp_homo_inv (grp_pow_homo 1)).
     symmetry; apply rng_mult_negate.
 Defined.
 
@@ -73,19 +68,15 @@ Proof.
   intro R.
   exists (rng_homo_int R).
   intros g x.
+  unfold rng_homo_int, rng_int_mult; cbn.
   induction x as [|x|x].
   - by rhs nrapply (grp_homo_unit g).
-  - unfold rng_homo_int, rng_int_mult; cbn.
-    unfold abgroup_int_mult.
-    rewrite grp_pow_int_add_1.
+  - rewrite grp_pow_int_add_1.
     change (x.+1%int) with (1 + x)%int.
     rewrite (rng_homo_plus g 1 x).
     rewrite rng_homo_one.
     f_ap.
-  - unfold rng_homo_int, rng_int_mult in IHx |- *; cbn in IHx |- *.
-    unfold abgroup_int_mult in *.
-    rewrite grp_pow_int_sub_1.
-    cbn.
+  - rewrite grp_pow_int_sub_1.
     rewrite IHx.
     clear IHx.
     rewrite <- (rng_homo_one g).

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -32,7 +32,7 @@ Global Instance issemigrouppreserving_mult_rng_int_mult (R : Ring)
   : IsSemiGroupPreserving (A:=cring_Z) (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R 1).
 Proof.
   intros x y.
-  cbn.
+  cbn; unfold sg_op.
   induction x as [|x|x].
   - simpl.
     by rhs nrapply rng_mult_zero_l.
@@ -59,6 +59,7 @@ Proof.
   1: exact (rng_int_mult R 1).
   repeat split.
   1,2: exact _.
+  apply rng_plus_zero_r.
 Defined.
 
 (** The integers are the initial commutative ring *)

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -24,7 +24,8 @@ Defined.
 
 Local Open Scope mc_scope.
 
-(** Multiplication of a ring element by an integer. *)
+(** Every ring has a unique ring map from the integers. *)
+(** TODO: rename? *)
 Definition rng_int_mult (R : Ring) (z : cring_Z) : R
   := int_iter (fun x => 1 + x) z 0.
 

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -1,7 +1,7 @@
 Require Import Classes.interfaces.canonical_names.
 Require Import Algebra.AbGroups.
 Require Import Algebra.Rings.CRing.
-Require Import Spaces.BinInt Spaces.Pos.
+Require Import Spaces.Int Spaces.Pos.
 Require Import WildCat.Core.
 
 (** In this file we define the ring Z of integers. The underlying abelian group is already defined in Algebra.AbGroups.Z. Many of the ring axioms are proven and made opaque. Typically, everything inside IsCRing can be opaque since we will only ever rewrite along them and they are hprops. This also means we don't have to be too careful with how our proofs are structured. This allows us to freely use tactics such as rewrite. It would perhaps be possible to shorten many of the proofs here, but it would probably be unneeded due to the opacicty. *)
@@ -10,155 +10,52 @@ Require Import WildCat.Core.
 Definition cring_Z : CRing.
 Proof.
   snrapply Build_CRing'.
+  6: repeat split.
   - exact abgroup_Z.
-  - exact 1%binint.
-  - exact binint_mul.
-  - exact binint_mul_comm.
-  - exact binint_mul_add_distr_l.
-  - split.
-    + split.
-      * exact _.
-      * exact binint_mul_assoc.
-    + exact binint_mul_1_l.
-    + exact binint_mul_1_r.
+  - exact 1%int.
+  - exact int_mul.
+  - exact int_mul_comm.
+  - exact int_dist_l.
+  - exact _.
+  - exact int_mul_assoc.
+  - exact int_mul_1_l.
+  - exact int_mul_1_r.
 Defined.
 
 Local Open Scope mc_scope.
 
 (** Multiplication of a ring element by an integer. *)
-(** We call this a "catamorphism" which is the name of the map from an initial object. It seems to be a more common terminology in computer science. *)
-Definition cring_catamorphism_fun (R : CRing) (z : cring_Z) : R
-  := match z with
-     | neg z => pos_peano_rec R (-1) (fun n nr => -1 + nr) z
-     | 0%binint => 0
-     | pos z => pos_peano_rec R 1 (fun n nr => 1 + nr) z
-     end.
-
-(** TODO: remove these (they will be cleaned up in the future)*)
-(** Left multiplication is an equivalence *)
-Local Instance isequiv_group_left_op {G} `{IsGroup G}
-  : forall (x : G), IsEquiv (fun t => sg_op x t).
-Proof.
-  intro x.
-  srapply isequiv_adjointify.
-  1: exact (sg_op (-x)).
-  all: intro y.
-  all: refine (associativity _ _ _ @ _ @ left_identity y).
-  all: refine (ap (fun x => x * y) _).
-  1: apply right_inverse.
-  apply left_inverse.
-Defined.
-
-(** Right multiplication is an equivalence *)
-Local Instance isequiv_group_right_op {G} `{IsGroup G}
-  : forall x:G, IsEquiv (fun y => sg_op y x).
-Proof.
-  intro x.
-  srapply isequiv_adjointify.
-  1: exact (fun y => sg_op y (- x)).
-  all: intro y.
-  all: refine ((associativity _ _ _)^ @ _ @ right_identity y).
-  all: refine (ap (y *.) _).
-  1: apply left_inverse.
-  apply right_inverse.
-Defined.
+Definition rng_int_mult (R : Ring) (z : cring_Z) : R
+  := int_iter (fun x => 1 + x) z 0.
 
 (** Preservation of + *)
-Global Instance issemigrouppreserving_cring_catamorphism_fun_plus (R : CRing)
-  : IsSemiGroupPreserving (Aop:=cring_plus) (Bop:=cring_plus)
-      (cring_catamorphism_fun R : cring_Z -> R).
+Global Instance issemigrouppreserving_plus_rng_int_mult (R : Ring)
+  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R).
 Proof.
-  (** Unfortunately, due to how we have defined things we need to seperate this out into 9 cases. *)
-  hnf. intros [x| |x] [y| |y].
-  (** Some of these cases are easy however *)
-  2,5,8: cbn; by rewrite right_identity.
-  3,4: symmetry; apply left_identity.
-  (** This leaves us with four cases to consider *)
-  (** x < 0 , y < 0 *)
-  { change (cring_catamorphism_fun R ((neg x) + (neg y))%binint
-      = (cring_catamorphism_fun R (neg x)) + (cring_catamorphism_fun R (neg y))).
-    induction y as [|y IHy] using pos_peano_ind.
-    { simpl.
-      rewrite pos_add_1_r.
-      rewrite pos_peano_rec_beta_pos_succ.
-      apply commutativity. }
-    simpl.
-    rewrite pos_add_succ_r.
-    rewrite 2 pos_peano_rec_beta_pos_succ.
-    rewrite simple_associativity.
-    rewrite (commutativity _ (-1)).
-    rewrite <- simple_associativity.
-    f_ap. }
-  (** x < 0 , y > 0 *)
-  { cbn.
-    revert x.
-    induction y as [|y IHy] using pos_peano_ind; intro x.
-    { cbn.
-      induction x as [|x] using pos_peano_ind.
-      1: symmetry; cbn; apply left_inverse.
-      rewrite pos_peano_rec_beta_pos_succ.
-      rewrite binint_pos_sub_succ_r.
-      cbn; rewrite <- simple_associativity.
-      apply (rng_moveL_Vr (R:=R)).
-      apply commutativity. }
-    induction x as [|x IHx] using pos_peano_ind.
-    { rewrite binint_pos_sub_succ_l.
-      cbn; apply (rng_moveL_Vr (R:=R)).
-      by rewrite pos_peano_rec_beta_pos_succ. }
-    rewrite binint_pos_sub_succ_succ.
-    rewrite IHy.
-    rewrite 2 pos_peano_rec_beta_pos_succ.
-    rewrite (commutativity (-1)).
-    rewrite simple_associativity.
-    rewrite <- (simple_associativity _ _ 1).
-    rewrite left_inverse.
-    f_ap.
-    symmetry.
-    apply right_identity. }
-  - cbn.
-    revert x.
-    induction y as [|y IHy] using pos_peano_ind; intro x.
-    { induction x as [|x] using pos_peano_ind.
-      1: symmetry; cbn; apply right_inverse.
-      rewrite pos_peano_rec_beta_pos_succ.
-      rewrite (commutativity 1).
-      rewrite <- simple_associativity.
-      rewrite binint_pos_sub_succ_l.
-      cbn; by rewrite right_inverse, right_identity. }
-    induction x as [|x IHx] using pos_peano_ind.
-    { rewrite binint_pos_sub_succ_r.
-      rewrite pos_peano_rec_beta_pos_succ.
-      rewrite simple_associativity.
-      cbn.
-      rewrite (right_inverse 1).
-      symmetry.
-      apply left_identity. }
-    rewrite binint_pos_sub_succ_succ.
-    rewrite IHy.
-    rewrite 2 pos_peano_rec_beta_pos_succ.
-    rewrite (commutativity 1).
-    rewrite simple_associativity.
-    rewrite <- (simple_associativity _ _ (-1)).
-    rewrite (right_inverse 1).
-    f_ap; symmetry.
-    apply right_identity.
-  - cbn.
-    induction y as [|y IHy] using pos_peano_ind.
-    { cbn.
-      rewrite pos_add_1_r.
-      rewrite pos_peano_rec_beta_pos_succ.
-      apply commutativity. }
-    rewrite pos_add_succ_r.
-    rewrite 2 pos_peano_rec_beta_pos_succ.
-    rewrite simple_associativity.
-    rewrite IHy.
-    rewrite simple_associativity.
-    rewrite (commutativity 1).
+  intros x y.
+  induction x as [|x|x].
+  - simpl.
+    rhs nrapply left_identity.
+    2: exact _.
     reflexivity.
-Qed.
+  - cbn.
+    rewrite int_add_succ_l.
+    unfold rng_int_mult.
+    rewrite 2 int_iter_succ_l.
+    rhs_V nrapply simple_associativity.
+    2: exact _.
+    f_ap.
+  - cbn.
+    rewrite int_add_pred_l.
+    unfold rng_int_mult.
+    rewrite 2 int_iter_pred_l.
+    rhs_V nrapply simple_associativity.
+    2: exact _.
+    f_ap.
+Defined.
 
-Lemma cring_catamorphism_fun_negate {R} x
-  : cring_catamorphism_fun R (- x) = - cring_catamorphism_fun R x.
+Lemma rng_int_mult_neg {R} x
+  : rng_int_mult R (- x) = - rng_int_mult R x.
 Proof.
   snrapply (groups.preserves_negate _).
   1-6: typeclasses eauto.
@@ -167,59 +64,44 @@ Proof.
   split.
 Defined.
 
-Lemma cring_catamorphism_fun_pos_mult {R} x y
-  : cring_catamorphism_fun R (pos x * pos y)%binint
-    = cring_catamorphism_fun R (pos x) * cring_catamorphism_fun R (pos y).
-Proof.
-  revert y.
-  induction x as [|x IHx] using pos_peano_ind; intro y.
-  { symmetry.
-    apply left_identity. }
-  change (cring_catamorphism_fun R (pos (pos_succ x * y)%pos)
-    = cring_catamorphism_fun R (pos (pos_succ x)) * cring_catamorphism_fun R (pos y)).
-  rewrite pos_mul_succ_l.
-  refine (issemigrouppreserving_cring_catamorphism_fun_plus
-    R (pos (x * y)%pos) (pos y) @ _).
-  rewrite IHx.
-  transitivity ((1 + cring_catamorphism_fun R (pos x)) * cring_catamorphism_fun R (pos y)).
-  2: simpl; by rewrite pos_peano_rec_beta_pos_succ.
-  rewrite (rng_dist_r (A:=R)).
-  rewrite rng_mult_one_l.
-  apply commutativity.
-Qed.
-
 (** Preservation of * (multiplication) *)
-Global Instance issemigrouppreserving_cring_catamorphism_fun_mult (R : CRing)
-  : IsSemiGroupPreserving (Aop:=(.*.)) (Bop:=(.*.))
-      (cring_catamorphism_fun R : cring_Z -> R).
+Global Instance issemigrouppreserving_mult_rng_int_mult (R : Ring)
+  : IsSemiGroupPreserving (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R).
 Proof.
-  hnf. intros [x| |x] [y| |y].
-  2,5,8: symmetry; apply (rng_mult_zero_r (A:=R)).
-  3,4: cbn; symmetry; rewrite (commutativity 0); apply (rng_mult_zero_r (A:=R)).
-  { change (cring_catamorphism_fun R (pos (x * y)%pos)
-      = cring_catamorphism_fun R (- (pos x : cring_Z))
-        * cring_catamorphism_fun R (- (pos y : cring_Z))).
-    by rewrite 2 cring_catamorphism_fun_negate, cring_catamorphism_fun_pos_mult,
-      (rng_mult_negate_negate (A:=R)). }
-  { change (cring_catamorphism_fun R (- (pos (x * y)%pos : cring_Z))
-      = cring_catamorphism_fun R (- (pos x : cring_Z))
-        * cring_catamorphism_fun R (pos y)).
-    by rewrite 2 cring_catamorphism_fun_negate, cring_catamorphism_fun_pos_mult,
-      (rng_mult_negate_l (A:=R)). }
-  { change (cring_catamorphism_fun R (- (pos (x * y)%pos : cring_Z))
-      = cring_catamorphism_fun R (pos x)
-        * cring_catamorphism_fun R (- (pos y : cring_Z))).
-    by rewrite 2 cring_catamorphism_fun_negate, cring_catamorphism_fun_pos_mult,
-      (rng_mult_negate_r (A:=R)). }
-  apply cring_catamorphism_fun_pos_mult.
-Qed.
+  intros x y.
+  induction x as [|x|x].
+  - simpl.
+    by rhs nrapply rng_mult_zero_l.
+  - cbn.
+    rewrite int_mul_succ_l.
+    rewrite issemigrouppreserving_plus_rng_int_mult.
+    unfold rng_int_mult in *.
+    rewrite int_iter_succ_l.
+    rhs nrapply rng_dist_r.
+    rewrite rng_mult_one_l.
+    rewrite IHx.
+    reflexivity.
+  - cbn.
+    rewrite int_mul_pred_l.
+    rewrite issemigrouppreserving_plus_rng_int_mult.
+    unfold rng_int_mult in *.
+    rewrite int_iter_pred_l.
+    rhs nrapply rng_dist_r.
+    rewrite IHx.
+    f_ap.
+    lhs rapply rng_int_mult_neg.
+    symmetry; apply rng_mult_negate.
+Defined.
 
 (** This is a ring homomorphism *)
-Definition rng_homo_int (R : CRing) : cring_Z $-> R.
+Definition rng_homo_int (R : Ring) : (cring_Z : Ring) $-> R.
 Proof.
   snrapply Build_RingHomomorphism.
-  1: exact (cring_catamorphism_fun R).
-  repeat split; exact _.
+  1: exact (rng_int_mult R).
+  repeat split.
+  1,2: exact _.
+  hnf.
+  apply rng_plus_zero_r.
 Defined.
 
 (** The integers are the initial commutative ring *)
@@ -229,28 +111,21 @@ Proof.
   intro R.
   exists (rng_homo_int R).
   intros g x.
-  destruct x as [n| |p].
-  + induction n using pos_peano_ind.
-    { cbn. symmetry; rapply (rng_homo_minus_one (B:=R)). }
-    simpl.
-    rewrite pos_peano_rec_beta_pos_succ.
-    rewrite binint_neg_pos_succ.
-    unfold binint_pred.
-    rewrite binint_add_comm.
-    rewrite rng_homo_plus.
-    rewrite rng_homo_minus_one.
-    apply ap.
-    exact IHn.
-  + by rewrite 2 rng_homo_zero.
-  + induction p using pos_peano_ind.
-    { cbn. symmetry; rapply (rng_homo_one g). }
-    simpl.
-    rewrite pos_peano_rec_beta_pos_succ.
-    rewrite binint_pos_pos_succ.
-    unfold binint_succ.
-    rewrite binint_add_comm.
-    rewrite rng_homo_plus.
+  induction x as [|x|x].
+  - by rhs nrapply (grp_homo_unit g).
+  - unfold rng_homo_int, rng_int_mult; cbn.
+    rewrite int_iter_succ_l.
+    change (x.+1%int) with (1 + x)%int.
+    rewrite (rng_homo_plus g 1 x).
     rewrite rng_homo_one.
-    apply ap.
-    exact IHp.
+    f_ap.
+  - unfold rng_homo_int, rng_int_mult in IHx |- *; cbn in IHx |- *.
+    rewrite int_iter_pred_l.
+    cbn.
+    rewrite IHx.
+    clear IHx.
+    rewrite <- (rng_homo_one g).
+    rewrite <- (rng_homo_negate g).
+    lhs_V nrapply (rng_homo_plus g).
+    f_ap.
 Defined.

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -4,7 +4,7 @@ Require Import Algebra.Rings.CRing.
 Require Import Spaces.Int Spaces.Pos.
 Require Import WildCat.Core.
 
-(** In this file we define the ring Z of integers. The underlying abelian group is already defined in Algebra.AbGroups.Z. Many of the ring axioms are proven and made opaque. Typically, everything inside IsCRing can be opaque since we will only ever rewrite along them and they are hprops. This also means we don't have to be too careful with how our proofs are structured. This allows us to freely use tactics such as rewrite. It would perhaps be possible to shorten many of the proofs here, but it would probably be unneeded due to the opacicty. *)
+(** * In this file we define the ring [cring_Z] of integers with underlying abelian group [abroup_Z] defined in Algebra.AbGroups.Z. We also define multiplication by an integer in a general ring, and show that [cring_Z] is initial. *)
 
 (** The ring of integers *)
 Definition cring_Z : CRing.
@@ -24,14 +24,13 @@ Defined.
 
 Local Open Scope mc_scope.
 
-(** Every ring has a unique ring map from the integers. *)
-(** TODO: rename? *)
+(** Every ring element can be multiplied by an integer. *)
 Definition rng_int_mult (R : Ring) (r : R) (z : cring_Z) : R
   := int_iter (fun x => r + x) z 0.
 
-(** Preservation of + *)
-Global Instance issemigrouppreserving_plus_rng_int_mult (R : Ring)
-  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R 1).
+(** [rng_int_mult R r] preserves addition. *)
+Global Instance issemigrouppreserving_plus_rng_int_mult (R : Ring) (r : R)
+  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R r).
 Proof.
   intros x y.
   induction x as [|x|x].
@@ -55,21 +54,24 @@ Proof.
     f_ap.
 Defined.
 
-Global Instance isunitpreserving_plus_rng_int_mult (R : Ring)
-  : IsUnitPreserving (Aunit:=zero) (Bunit:= canonical_names.zero) (rng_int_mult R 1)
+(** [rng_int_mult R r] sends [0 : Int] to [0 : R] definitionally. *)
+Global Instance isunitpreserving_plus_rng_int_mult (R : Ring) (r : R)
+  : IsUnitPreserving (Aunit:=zero) (Bunit:=canonical_names.zero) (rng_int_mult R r)
   := idpath.
 
-Global Instance ismonoidpreserving_plus_rng_int_mult (R : Ring)
-  : IsMonoidPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R 1)
+(** [rng_int_mult R r] preserves addition and zero. *)
+Global Instance ismonoidpreserving_plus_rng_int_mult (R : Ring) (r : R)
+  : IsMonoidPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R r)
   := {}.
 
-Lemma rng_int_mult_neg {R} x
-  : rng_int_mult R 1 (- x) = - rng_int_mult R 1 x.
+(** [rng_int_mult R r] commutes with negation. *)
+Lemma rng_int_mult_neg (R : Ring) (r : R) x
+  : rng_int_mult R r (- x) = - rng_int_mult R r x.
 Proof.
   snrapply (groups.preserves_negate _); exact _.
 Defined.
 
-(** Preservation of * (multiplication) *)
+(** [rng_int_mult R 1] preserves multiplication.  This requires that the specified ring element is the unit. *)
 Global Instance issemigrouppreserving_mult_rng_int_mult (R : Ring)
   : IsSemiGroupPreserving (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R 1).
 Proof.
@@ -98,7 +100,7 @@ Proof.
     symmetry; apply rng_mult_negate.
 Defined.
 
-(** This is a ring homomorphism *)
+(** [rng_int_mult R 1] is a ring homomorphism *)
 Definition rng_homo_int (R : Ring) : (cring_Z : Ring) $-> R.
 Proof.
   snrapply Build_RingHomomorphism.

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -24,56 +24,11 @@ Defined.
 
 Local Open Scope mc_scope.
 
-(** Every ring element can be multiplied by an integer. *)
-Definition rng_int_mult (R : Ring) (r : R) (z : cring_Z) : R
-  := int_iter (fun x => r + x) z 0.
-
-(** [rng_int_mult R r] preserves addition. *)
-Global Instance issemigrouppreserving_plus_rng_int_mult (R : Ring) (r : R)
-  : IsSemiGroupPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R r).
-Proof.
-  intros x y.
-  induction x as [|x|x].
-  - simpl.
-    rhs nrapply left_identity.
-    2: exact _.
-    reflexivity.
-  - cbn.
-    rewrite int_add_succ_l.
-    unfold rng_int_mult.
-    rewrite 2 int_iter_succ_l.
-    rhs_V nrapply simple_associativity.
-    2: exact _.
-    f_ap.
-  - cbn.
-    rewrite int_add_pred_l.
-    unfold rng_int_mult.
-    rewrite 2 int_iter_pred_l.
-    rhs_V nrapply simple_associativity.
-    2: exact _.
-    f_ap.
-Defined.
-
-(** [rng_int_mult R r] sends [0 : Int] to [0 : R] definitionally. *)
-Global Instance isunitpreserving_plus_rng_int_mult (R : Ring) (r : R)
-  : IsUnitPreserving (Aunit:=zero) (Bunit:=canonical_names.zero) (rng_int_mult R r)
-  := idpath.
-
-(** [rng_int_mult R r] preserves addition and zero. *)
-Global Instance ismonoidpreserving_plus_rng_int_mult (R : Ring) (r : R)
-  : IsMonoidPreserving (Aop:=(+)) (Bop:=(+)) (rng_int_mult R r)
-  := {}.
-
-(** [rng_int_mult R r] commutes with negation. *)
-Lemma rng_int_mult_neg (R : Ring) (r : R) x
-  : rng_int_mult R r (- x) = - rng_int_mult R r x.
-Proof.
-  snrapply (groups.preserves_negate _); exact _.
-Defined.
+Definition rng_int_mult (R : Ring) := abgroup_int_mult R. 
 
 (** [rng_int_mult R 1] preserves multiplication.  This requires that the specified ring element is the unit. *)
 Global Instance issemigrouppreserving_mult_rng_int_mult (R : Ring)
-  : IsSemiGroupPreserving (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R 1).
+  : IsSemiGroupPreserving (A:=cring_Z) (Aop:=(.*.)) (Bop:=(.*.)) (rng_int_mult R 1).
 Proof.
   intros x y.
   induction x as [|x|x].
@@ -81,22 +36,24 @@ Proof.
     by rhs nrapply rng_mult_zero_l.
   - cbn.
     rewrite int_mul_succ_l.
-    rewrite issemigrouppreserving_plus_rng_int_mult.
     unfold rng_int_mult in *.
-    rewrite int_iter_succ_l.
+    rewrite issemigrouppreserving_plus_abgroup_int_mult.
+    unfold abgroup_int_mult in *.
+    rewrite grp_pow_int_add_1.
     rhs nrapply rng_dist_r.
     rewrite rng_mult_one_l.
     rewrite IHx.
     reflexivity.
   - cbn.
     rewrite int_mul_pred_l.
-    rewrite issemigrouppreserving_plus_rng_int_mult.
     unfold rng_int_mult in *.
-    rewrite int_iter_pred_l.
+    rewrite issemigrouppreserving_plus_abgroup_int_mult.
+    unfold abgroup_int_mult in *.
+    rewrite grp_pow_int_sub_1.
     rhs nrapply rng_dist_r.
     rewrite IHx.
     f_ap.
-    lhs rapply rng_int_mult_neg.
+    lhs rapply abgroup_int_mult_neg.
     symmetry; apply rng_mult_negate.
 Defined.
 
@@ -107,8 +64,6 @@ Proof.
   1: exact (rng_int_mult R 1).
   repeat split.
   1,2: exact _.
-  hnf.
-  apply rng_plus_zero_r.
 Defined.
 
 (** The integers are the initial commutative ring *)
@@ -121,13 +76,15 @@ Proof.
   induction x as [|x|x].
   - by rhs nrapply (grp_homo_unit g).
   - unfold rng_homo_int, rng_int_mult; cbn.
-    rewrite int_iter_succ_l.
+    unfold abgroup_int_mult.
+    rewrite grp_pow_int_add_1.
     change (x.+1%int) with (1 + x)%int.
     rewrite (rng_homo_plus g 1 x).
     rewrite rng_homo_one.
     f_ap.
   - unfold rng_homo_int, rng_int_mult in IHx |- *; cbn in IHx |- *.
-    rewrite int_iter_pred_l.
+    unfold abgroup_int_mult in *.
+    rewrite grp_pow_int_sub_1.
     cbn.
     rewrite IHx.
     clear IHx.

--- a/theories/HIT/FreeIntQuotient.v
+++ b/theories/HIT/FreeIntQuotient.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*- *)
 Require Import HoTT.Basics HoTT.Types.
-Require Import Spaces.BinInt Spaces.Circle.
+Require Import Spaces.Int Spaces.Circle.
 Require Import Colimits.Coeq HIT.Flattening Truncations.Core Truncations.Connectedness.
 
 Local Open Scope path_scope.
@@ -16,8 +16,8 @@ Section FreeIntAction.
 
   (** A free action by [Int] is the same as a single autoequivalence [f] (the action of [1]) whose iterates are all pointwise distinct. *)
   Context (f : R <~> R)
-          (f_free : forall (r : R) (n m : BinInt),
-                      (binint_iter f n r = binint_iter f m r) -> (n = m)).
+          (f_free : forall (r : R) (n m : Int),
+                      (int_iter f n r = int_iter f m r) -> (n = m)).
 
   (** We can then define the quotient to be the coequalizer of [f] and the identity map.  This gives it the desired universal property for all types; it remains to show that this definition gives a set. *)
   Let RmodZ := Coeq f idmap.

--- a/theories/Homotopy/PinSn.v
+++ b/theories/Homotopy/PinSn.v
@@ -2,7 +2,7 @@ Require Import Basics Types.
 Require Import WildCat.
 Require Import Pointed.
 Require Import Truncations.Core Truncations.Connectedness.
-Require Import Spaces.BinInt Spaces.Circle Spaces.Spheres.
+Require Import Spaces.Int Spaces.Circle Spaces.Spheres.
 Require Import Algebra.AbGroups.
 Require Import Homotopy.HomotopyGroup.
 Require Import Homotopy.HSpaceS1.

--- a/theories/Spaces/Int.v
+++ b/theories/Spaces/Int.v
@@ -614,10 +614,11 @@ Proof.
     f_ap.
 Defined.
 
-(** If the maps [f] and [g] commute, then the order of application doesn't matter *)
-Definition int_iter_commute_function_application {A} (f : A -> A) `{!IsEquiv f}
-  (g : A -> A) (p : g o f == f o g) (n : Int) (a : A)
-  : g (int_iter f n a) = int_iter f n (g a).
+(** If [g : A -> A'] commutes with automorphisms of [A] and [A'], then it commutes with iteration. *)
+Definition int_iter_commute_map {A A'} (f : A -> A) `{!IsEquiv f}
+  (f' : A' -> A') `{!IsEquiv f'}
+  (g : A -> A') (p : g o f == f' o g) (n : Int) (a : A)
+  : g (int_iter f n a) = int_iter f' n (g a).
 Proof.
   induction n as [|n IHn|n IHn] in a |- *.
   - reflexivity.
@@ -679,15 +680,8 @@ Defined.
 Definition ap_loopexp {A B} (f : A -> B) {x : A} (p : x = x) (z : Int)
   : ap f (loopexp p z) = loopexp (ap f p) z.
 Proof.
-  induction z as [|z|z].
-  - reflexivity.
-  - rewrite 2 loopexp_succ_l.
-    cbn; lhs nrapply ap_pp.
-    f_ap.
-  - rewrite 2 loopexp_pred_l.
-    cbn; lhs nrapply ap_pp.
-    f_ap.
-    apply ap_V.
+  nrapply int_iter_commute_map.
+  intro q; apply ap_pp.
 Defined.
 
 Definition loopexp_add {A : Type} {x : A} (p : x = x) m n
@@ -708,16 +702,9 @@ Defined.
 Definition equiv_path_loopexp {A : Type} (p : A = A) (z : Int) (a : A)
   : equiv_path A A (loopexp p z) a = int_iter (equiv_path A A p) z a.
 Proof.
-  induction z as [|z|z].
-  - reflexivity.
-  - rewrite loopexp_succ_r.
-    cbn; rewrite transport_pp.
-    rewrite int_iter_succ_l.
-    f_ap.
-  - rewrite loopexp_pred_r.
-    cbn; rewrite transport_pp.
-    rewrite int_iter_pred_l.
-    f_ap.
+  refine (int_iter_commute_map _ _ (fun p => equiv_path A A p a) _ _ _).
+  intro q; cbn.
+  nrapply transport_pp.
 Defined.
 
 Definition loopexp_path_universe `{Univalence} {A : Type} (f : A <~> A)

--- a/theories/Spaces/Int.v
+++ b/theories/Spaces/Int.v
@@ -617,37 +617,23 @@ Proof.
     f_ap.
 Defined.
 
-(** This is a general lemma about commutativity of monoid units. Don't know what file this should belong to. *)
-Lemma inverse_commute_commute {A} (f : A -> A) `{!IsEquiv f} (g : A -> A) (p : g o f == f o g)
-  : g o f^-1 == f^-1 o g.
-Proof.
-  intros a.
-  lhs_V apply (eissect f ((g o f^-1) a)).
-  lhs_V apply (ap f^-1 (p (f^-1 a))).
-  lhs apply (ap (f^-1 o g) (eisretr f a)).
-  reflexivity.
-Defined.
-
 (** If the maps f and g commutes, then the order of application doesn't matter *)
-Definition int_iter_commute_function_application {A} (f : A -> A) `{!IsEquiv f} (g : A -> A) (p : g o f == f o g) (n : Int) (a : A)
+Definition int_iter_commute_function_application {A} (f : A -> A) `{!IsEquiv f}
+  (g : A -> A) (p : g o f == f o g) (n : Int) (a : A)
   : g (int_iter f n a) = int_iter f n (g a).
 Proof.
-  destruct n.
-  - induction n.
-    + simpl.
-      exact (inverse_commute_commute f g p a).
-    + simpl.
-      lhs apply (inverse_commute_commute f g p).
-      lhs apply (ap f^-1 IHn).
-      reflexivity.
+  induction n as [|n IHn|n IHn] in a |- *.
   - reflexivity.
-  - induction n.
-    + simpl.
-      exact (p a).
-    + simpl.
-      lhs apply p.
-      lhs apply (ap f IHn).
-      reflexivity.
+  - rewrite 2 int_iter_succ_r.
+    rewrite IHn.
+    f_ap.
+  - rewrite 2 int_iter_pred_r.
+    rewrite IHn.
+    f_ap.
+    apply moveL_equiv_V.
+    lhs_V nrapply p.
+    f_ap.
+    apply eisretr.
 Defined.
 
 (** ** Exponentiation of loops *)

--- a/theories/Spaces/Int.v
+++ b/theories/Spaces/Int.v
@@ -617,6 +617,39 @@ Proof.
     f_ap.
 Defined.
 
+(** This is a general lemma about commutativity of monoid units. Don't know what file this should belong to. *)
+Lemma inverse_commute_commute {A} (f : A -> A) `{!IsEquiv f} (g : A -> A) (p : g o f == f o g)
+  : g o f^-1 == f^-1 o g.
+Proof.
+  intros a.
+  lhs_V apply (eissect f ((g o f^-1) a)).
+  lhs_V apply (ap f^-1 (p (f^-1 a))).
+  lhs apply (ap (f^-1 o g) (eisretr f a)).
+  reflexivity.
+Defined.
+
+(** If the maps f and g commutes, then the order of application doesn't matter *)
+Definition int_iter_commute_function_application {A} (f : A -> A) `{!IsEquiv f} (g : A -> A) (p : g o f == f o g) (n : Int) (a : A)
+  : g (int_iter f n a) = int_iter f n (g a).
+Proof.
+  destruct n.
+  - induction n.
+    + simpl.
+      exact (inverse_commute_commute f g p a).
+    + simpl.
+      lhs apply (inverse_commute_commute f g p).
+      lhs apply (ap f^-1 IHn).
+      reflexivity.
+  - reflexivity.
+  - induction n.
+    + simpl.
+      exact (p a).
+    + simpl.
+      lhs apply p.
+      lhs apply (ap f IHn).
+      reflexivity.
+Defined.
+
 (** ** Exponentiation of loops *)
 
 Definition loopexp {A : Type} {x : A} (p : x = x) (z : Int) : (x = x)

--- a/theories/Spaces/Int.v
+++ b/theories/Spaces/Int.v
@@ -634,6 +634,22 @@ Proof.
     apply eisretr.
 Defined.
 
+Definition int_iter_invariant (n : Int) {A} (f : A -> A) `{!IsEquiv f}
+  (P : A -> Type)
+  (Psucc : forall x, P x -> P (f x))
+  (Ppred : forall x, P x -> P (f^-1 x))
+  : forall x, P x -> P (int_iter f n x).
+Proof.
+  induction n as [|n IHn|n IHn]; intro x.
+  - exact idmap.
+  - intro H.
+    rewrite int_iter_succ_l.
+    apply Psucc, IHn, H.
+  - intro H.
+    rewrite int_iter_pred_l.
+    apply Ppred, IHn, H.
+Defined.
+
 (** ** Exponentiation of loops *)
 
 Definition loopexp {A : Type} {x : A} (p : x = x) (z : Int) : (x = x)

--- a/theories/Spaces/Torus/TorusHomotopy.v
+++ b/theories/Spaces/Torus/TorusHomotopy.v
@@ -4,7 +4,7 @@ Require Import Modalities.ReflectiveSubuniverse Truncations.Core.
 Require Import Algebra.AbGroups.
 Require Import Homotopy.HomotopyGroup.
 Require Import Homotopy.PinSn.
-Require Import Spaces.BinInt.Core Spaces.Circle.
+Require Import Spaces.Int Spaces.Circle.
 
 Require Import Spaces.Torus.Torus.
 Require Import Spaces.Torus.TorusEquivCircles.
@@ -55,7 +55,7 @@ Proof.
 Defined.
 
 (** Loop space of torus *)
-Theorem loops_torus `{Univalence} : loops T <~>* BinInt * BinInt.
+Theorem loops_torus `{Univalence} : loops T <~>* Int * Int.
 Proof.
   (* Since [T] is 1-truncated, [loops T] is 0-truncated, and is therefore equivalent to its 0-truncation. *)
   refine (_ o*E pequiv_ptr (n:=0)).


### PR DESCRIPTION
This was a bit more work than I anticipated but I seem to have something workable. It could use some more cleanup as I think some of these proofs could be slicker.

In this PR we port the remaining uses of BinInt to Int and introduce `int_iter` with standard exponentiation results on equivalences and loops.

Feel free to push any commits.

@ThomatoTomato this should help you with #1992.