### PR TITLE
free abelian groups

### DIFF
--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -23,6 +23,22 @@ Class IsAbelianization {G : Group} (G_ab : AbGroup)
       IsSurjInj (group_precomp A eta).
 Global Existing Instance issurjinj_isabel.
 
+Definition isequiv_group_precomp_isabelianization `{Funext}
+  {G : Group} {G_ab : AbGroup} (eta : GroupHomomorphism G G_ab)
+  `{!IsAbelianization G_ab eta} (A : AbGroup)
+  : IsEquiv (group_precomp A eta).
+Proof.
+  snrapply isequiv_adjointify.
+  - intros g.
+    rapply (surjinj_inv (group_precomp A eta) g).
+  - intros f.
+    snrapply equiv_path_grouphomomorphism.
+    exact (eisretr0gpd_inv (group_precomp A eta) f).
+  - intros f.
+    snrapply equiv_path_grouphomomorphism.
+    exact (eissect0gpd_inv (group_precomp A eta) f).
+Defined.
+
 (** Here we define abelianization as a HIT. Specifically as a set-coequalizer of the following two maps: (a, b, c) |-> a (b c) and (a, b, c) |-> a (c b).
 
 From this we can show that Abel G is an abelian group.
@@ -287,23 +303,29 @@ Proof.
   + exact _.
 Defined.
 
+Definition grp_homo_abel_rec {G : Group} {A : AbGroup} (f : G $-> A)
+  : abel G $-> A.
+Proof.
+  snrapply Build_GroupHomomorphism.
+  { srapply (Abel_rec _ _ f).
+    intros x y z.
+    refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
+    apply (ap (_ *.)).
+    refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
+    apply commutativity. }
+  intros y.
+  Abel_ind_hprop x; revert y.
+  Abel_ind_hprop y.
+  apply grp_homo_op.
+Defined.
+
 (** Finally we can prove that our construction abel is an abelianization. *)
 Global Instance isabelianization_abel {G : Group}
   : IsAbelianization (abel G) (abel_unit G).
 Proof.
   intros A. constructor.
-  { intros h. srefine (_;_).
-    { snrapply @Build_GroupHomomorphism.
-      { srapply (Abel_rec _ _ h).
-        intros x y z.
-        refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
-        apply (ap (_ *.)).
-        refine (grp_homo_op _ _ _ @ _ @ (grp_homo_op _ _ _)^).
-        apply commutativity. }
-      intros y.
-      Abel_ind_hprop x; revert y.
-      Abel_ind_hprop y.
-      apply grp_homo_op. }
+  { intros h.
+    snrefine (grp_homo_abel_rec h; _).
     cbn. reflexivity. }
   intros g h p.
   Abel_ind_hprop x.

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -39,6 +39,12 @@ Proof.
     exact (eissect0gpd_inv (group_precomp A eta) f).
 Defined.
 
+Definition equiv_group_precomp_isabelianization `{Funext}
+  {G : Group} {G_ab : AbGroup} (eta : GroupHomomorphism G G_ab)
+  `{!IsAbelianization G_ab eta} (A : AbGroup)
+  : (G_ab $-> A) <~> (G $-> A)
+  := Build_Equiv _ _ _ (isequiv_group_precomp_isabelianization eta A).
+
 (** Here we define abelianization as a HIT. Specifically as a set-coequalizer of the following two maps: (a, b, c) |-> a (b c) and (a, b, c) |-> a (c b).
 
 From this we can show that Abel G is an abelian group.

--- a/theories/Algebra/AbGroups/FreeAbelianGroup.v
+++ b/theories/Algebra/AbGroups/FreeAbelianGroup.v
@@ -35,30 +35,21 @@ Global Instance isfreeabgroupon_isabelianization_isfreegroup `{Funext}
   {H1 : IsAbelianization A g} {H2 : IsFreeGroupOn S G f}
   : IsFreeAbGroupOn S A (g o f).
 Proof.
-  unfold IsFreeAbGroup.
+  unfold IsFreeAbGroupOn.
   intros B h.
   specialize (H2 B h).
-  unfold FactorsThroughFreeGroup in H2.
-  unfold FactorsThroughFreeAbGroup.
   revert H2.
+  unfold FactorsThroughFreeGroup, FactorsThroughFreeAbGroup.
   snrapply contr_equiv'.
-  snrapply equiv_functor_sigma'.
-  - symmetry.
-    nrapply Build_Equiv. 
-    exact (isequiv_group_precomp_isabelianization g B).
-  - intros r.
-    snrapply equiv_functor_forall_id.
-    intros x.
-    apply equiv_concat_l.
-    exact (eisretr0gpd_inv (group_precomp B g) r (f x)).
+  symmetry.
+  exact (equiv_functor_sigma_pb (equiv_group_precomp_isabelianization g B)).
 Defined.
 
-(** As a sepcial case, the free abelian group is a free abelian group. *)
+(** As a special case, the free abelian group is a free abelian group. *)
 Global Instance isfreeabgroup_freeabgroup `{Funext} (S : Type)
   : IsFreeAbGroup (FreeAbGroup S).
 Proof.
   exists S.
   exists (abel_unit (FreeGroup S) o freegroup_in).
-  snrapply isfreeabgroupon_isabelianization_isfreegroup.
-  1,2: exact _.
+  srapply isfreeabgroupon_isabelianization_isfreegroup.
 Defined.

--- a/theories/Algebra/AbGroups/FreeAbelianGroup.v
+++ b/theories/Algebra/AbGroups/FreeAbelianGroup.v
@@ -1,0 +1,64 @@
+Require Import Basics.Overture Basics.Tactics Basics.Equivalences.
+Require Import Types.Sigma Types.Forall Types.Paths.
+Require Import WildCat.Core WildCat.EquivGpd.
+Require Import Algebra.AbGroups.AbelianGroup Algebra.AbGroups.Abelianization.
+Require Import Algebra.Groups.FreeGroup.
+
+(** * Free Abelian Groups *)
+
+Definition FactorsThroughFreeAbGroup (S : Type) (F_S : AbGroup)
+  (i : S -> F_S) (A : AbGroup) (g : S -> A) : Type
+  := {f : F_S $-> A & f o i == g}.
+
+(** Universal property of a free abelian group on a set (type). *)
+Class IsFreeAbGroupOn (S : Type) (F_S : AbGroup) (i : S -> F_S)
+  := contr_isfreeabgroupon : forall (A : AbGroup) (g : S -> A),
+      Contr (FactorsThroughFreeAbGroup S F_S i A g).
+Global Existing Instance contr_isfreeabgroupon.
+
+(** A abelian group is free if there exists a generating type on which it is a free group (a basis). *)
+Class IsFreeAbGroup (F_S : AbGroup)
+  := isfreegroup : {S : _ & {i : _ & IsFreeAbGroupOn S F_S i}}.
+
+Global Instance isfreeabgroup_isfreeabgroupon (S : Type) (F_S : AbGroup) (i : S -> F_S)
+  {H : IsFreeAbGroupOn S F_S i}
+  : IsFreeAbGroup F_S
+  := (S; i; H).
+
+(** The abelianization of the free group on a set is the free abelian group. *)
+Definition FreeAbGroup (S : Type) : AbGroup
+  := abel (FreeGroup S).
+
+(** The abelianization of a free group on a set is a free abelian group on that set. *)
+Global Instance isfreeabgroupon_isabelianization_isfreegroup `{Funext}
+  {S : Type} {G : Group} {A : AbGroup} (f : S -> G) (g : G $-> A)
+  {H1 : IsAbelianization A g} {H2 : IsFreeGroupOn S G f}
+  : IsFreeAbGroupOn S A (g o f).
+Proof.
+  unfold IsFreeAbGroup.
+  intros B h.
+  specialize (H2 B h).
+  unfold FactorsThroughFreeGroup in H2.
+  unfold FactorsThroughFreeAbGroup.
+  revert H2.
+  snrapply contr_equiv'.
+  snrapply equiv_functor_sigma'.
+  - symmetry.
+    nrapply Build_Equiv. 
+    exact (isequiv_group_precomp_isabelianization g B).
+  - intros r.
+    snrapply equiv_functor_forall_id.
+    intros x.
+    apply equiv_concat_l.
+    exact (eisretr0gpd_inv (group_precomp B g) r (f x)).
+Defined.
+
+(** As a sepcial case, the free abelian group is a free abelian group. *)
+Global Instance isfreeabgroup_freeabgroup `{Funext} (S : Type)
+  : IsFreeAbGroup (FreeAbGroup S).
+Proof.
+  exists S.
+  exists (abel_unit (FreeGroup S) o freegroup_in).
+  snrapply isfreeabgroupon_isabelianization_isfreegroup.
+  1,2: exact _.
+Defined.


### PR DESCRIPTION
In this PR we:
- Characterise the universal property of the free abelian group on a type S.
- Show that an abelianization of a free group produces a free abelian group.
- As a special case, construct the free abelian group on a type S as the abelianization of the free group on the set.

This construction will be important in the theory of modules as we will be taking quotients of free abelian groups to produce constructions such as tensor products of abelian groups.

I had a bit of trouble managing funext. I tried to see if it was possible to stay funext free but I didn't see a way.

Classically, the free abelian group is defined as a fucntion from the generating set into Z together with a finite support. This definition is very appealing for us but would also require a lot of funext in order to equate terms. It is also not clear how to constructively reason about finite supports as their definition contains an awkward negation that means basic lemmas require decidablility or LEM in general.