### PR TITLE
notations for left and right module actions

### DIFF
--- a/theories/Algebra/Rings/Module.v
+++ b/theories/Algebra/Rings/Module.v
@@ -17,7 +17,7 @@ Local Open Scope module_scope.
 
 (** An abelian group [M] is a left [R]-module when equipped with the following data: *) 
 Class IsLeftModule (R : Ring) (M : AbGroup) := {
-  (** A function [lact] (left-action) that takes an element [r : R] and an element [m : M] and returns an element [r *L m : M]. *)
+  (** A function [lact] (left-action) that takes an element [r : R] and an element [m : M] and returns an element [lact r m : M], which we also denote [r *L m]. *)
   lact : R -> M -> M;
   (** Actions distribute on the left over addition in the abelian group. That is [r *L (m + n) = r *L m + r *L n]. *)
   lact_left_dist :: LeftHeteroDistribute lact (+) (+);

--- a/theories/Algebra/Rings/Module.v
+++ b/theories/Algebra/Rings/Module.v
@@ -110,7 +110,7 @@ Defined.
 Class IsRightModule (R : Ring) (M : AbGroup)
   := isleftmodule_op_isrightmodule :: IsLeftModule (rng_op R) M.
   
-(** [ract] (right-action) that takes an element [m : M] and an element [r : R] and returns an element [ract r m : M]. *)
+(** [ract] (right-action) that takes an element [m : M] and an element [r : R] and returns an element [ract m r : M] which we also denote [m *R r]. *)
 Definition ract {R : Ring} {M : AbGroup} `{!IsRightModule R M}
   : M -> R -> M
   := fun m r => lact (R:=rng_op R) r m.

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -192,6 +192,10 @@ Reserved Infix "++" (right associativity, at level 60).
 Reserved Notation "[ u ]" (at level 0).
 Reserved Notation " [ u , v ] " (at level 0).
 
+(** Algebra *)
+Reserved Infix "*L" (at level 40).
+Reserved Infix "*R" (at level 40).
+
 (** Other / Not sorted yet *)
 
 Reserved Infix "<=>" (at level 70).


### PR DESCRIPTION
In this PR we introduce notations `r *L m` for `lact r m` and `m *R r` for `ract m r`. If we don't like them, then we can drop this PR.