### PR TITLE
move SuccessorStructure.v over to using Int

### DIFF
--- a/theories/Homotopy/PinSn.v
+++ b/theories/Homotopy/PinSn.v
@@ -18,7 +18,6 @@ Local Open Scope pointed_scope.
 Section Pi1S1.
   Context `{Univalence}.
 
-  Local Open Scope binint_scope.
   Local Open Scope pointed_scope.
 
   Theorem pi1_circle : Pi 1 [Circle, base] ≅ abgroup_Z.

--- a/theories/Homotopy/SuccessorStructure.v
+++ b/theories/Homotopy/SuccessorStructure.v
@@ -1,6 +1,6 @@
 Require Import Basics.
 Require Import Nat.Core.
-Require Import Spaces.BinInt.Core.
+Require Import Spaces.Int.
 Require Import Spaces.Finite.Fin.
 Require Import WildCat.Core.
 
@@ -30,7 +30,7 @@ Notation "x .+1" := (ss_succ x) : succ_scope.
 Definition NatSucc : SuccStr := Build_SuccStr nat Nat.Core.succ.
 
 (** Successor structure of integers *)
-Definition BinIntSucc : SuccStr := Build_SuccStr BinInt binint_succ.
+Definition BinIntSucc : SuccStr := Build_SuccStr Int int_succ.
 
 Notation "'+N'" := NatSucc : succ_scope.
 Notation "'+Z'" := BinIntSucc : succ_scope.


### PR DESCRIPTION
SuccessorStructure.v was still using `BinInt` we switch it over to `Int`.