### PR TITLE
better looking terms in presentation test

### DIFF
--- a/test/Algebra/Groups/Presentation.v
+++ b/test/Algebra/Groups/Presentation.v
@@ -1,5 +1,5 @@
 From HoTT Require Import Basics Spaces.Finite.Fin Spaces.Finite.FinSeq.
-From HoTT.Algebra.Groups Require Import Group Presentation.
+From HoTT.Algebra.Groups Require Import Group Presentation FreeGroup.
 
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.

--- a/test/Algebra/Groups/Presentation.v
+++ b/test/Algebra/Groups/Presentation.v
@@ -1,3 +1,4 @@
+From HoTT Require Import Basics Spaces.Finite.Fin Spaces.Finite.FinSeq.
 From HoTT.Algebra.Groups Require Import Group Presentation.
 
 Local Open Scope mc_scope.


### PR DESCRIPTION
Previously these were harder to read. They are still not so easy, but at least a bit clearer.

```coq
Check ⟨ x | x * x * x , -x ⟩.
 
Build_Finite_GroupPresentation 1 2
  (fscons
  ((fun x : FreeGroup (Fin 1) => x * x * x : FreeGroup (Fin 1))
  ((freegroup_in o fin_nat) 0%nat))
  (fscons
  ((fun x : FreeGroup (Fin 1) => - x : FreeGroup (Fin 1)) ((freegroup_in o fin_nat) 0%nat))
  fsnil))
     : GroupPresentation
```

```coq
Check ⟨ x , y | x * y ,  x * y * x , x * (-y) * x * x * x⟩.

Build_Finite_GroupPresentation 2 3
  (fscons
  ((fun x y : FreeGroup (Fin 2) => x * y : FreeGroup (Fin 2))
  ((freegroup_in o fin_nat) 0%nat) ((freegroup_in o fin_nat) 1%nat))
  (fscons
  ((fun x y : FreeGroup (Fin 2) => x * y * x : FreeGroup (Fin 2))
  ((freegroup_in o fin_nat) 0%nat) ((freegroup_in o fin_nat) 1%nat))
  (fscons
  ((fun x y : FreeGroup (Fin 2) => x * - y * x * x * x : FreeGroup (Fin 2))
  ((freegroup_in o fin_nat) 0%nat) ((freegroup_in o fin_nat) 1%nat))
  fsnil)))
     : GroupPresentation
```

```coq
Check ⟨ x , y , z | x * y * z , x * -z , x * y⟩.

Build_Finite_GroupPresentation 3 3
  (fscons
  ((fun x y z : FreeGroup (Fin 3) => x * y * z : FreeGroup (Fin 3))
  ((freegroup_in o fin_nat) 0%nat) ((freegroup_in o fin_nat) 1%nat)
  ((freegroup_in o fin_nat) 2%nat))
  (fscons
  ((fun x _ z : FreeGroup (Fin 3) => x * - z : FreeGroup (Fin 3))
  ((freegroup_in o fin_nat) 0%nat) ((freegroup_in o fin_nat) 1%nat)
  ((freegroup_in o fin_nat) 2%nat))
  (fscons
  ((fun x y _ : FreeGroup (Fin 3) => x * y : FreeGroup (Fin 3))
  ((freegroup_in o fin_nat) 0%nat) ((freegroup_in o fin_nat) 1%nat)
  ((freegroup_in o fin_nat) 2%nat))
  fsnil)))
     : GroupPresentation
```