### PR TITLE
Fix: proof of equiv_leq_lt_or_eq

### DIFF
--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -854,8 +854,9 @@ Defined.
 Definition equiv_leq_lt_or_eq {n m} : (n <= m) <~> (n < m) + (n = m).
 Proof.
   srapply equiv_iff_hprop.
-  - rapply ishprop_sum.
-    intros H1 H2.
+  - nrapply ishprop_sum.
+    1,2: exact _.
+    intros H1 p; destruct p.
     contradiction (lt_irrefl _ _).
   - intro l; induction l.
     + now right.


### PR DESCRIPTION
The proof I pushed in #2042 was incorrect. I also merged a bit fast. This fixes the proof in the final commit. I will merge this quickly so that master builds.