### PR TITLE
Use congruence quotient for ab_coeq

### DIFF
--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -46,29 +46,58 @@ Defined.
 (** ** Coequalizers *)
 
 (** Using the cokernel and addition and negation for the homs of abelian groups, we can define the coequalizer of two group homomorphisms as the cokernel of their difference. *)
-Definition ab_coeq {A B : AbGroup} (f g : GroupHomomorphism A B)
-  := ab_cokernel (ab_homo_add g (negate_hom f)).
+Definition ab_coeq {A B : AbGroup} (f g : GroupHomomorphism A B) : AbGroup.
+Proof.
+  snrapply Build_AbGroup'.
+  1: exact (CongruenceQuotient (fun x y => exists z, f z + x = g z + y)).
+  4: snrapply isabgroup_congruencequotient.
+  - split; intros x x' y y' [z p] [z' q].
+    exists (z + z').
+    rewrite 2 grp_homo_op.
+    rewrite <- grp_assoc.
+    rewrite (ab_comm _ (x + y)). 
+    rewrite 2 grp_assoc, <- grp_assoc.
+    rewrite (ab_comm y).
+    rewrite p, q.
+    rewrite <- 2 grp_assoc.
+    apply ap.
+    rewrite 2 grp_assoc.
+    apply (ap (+ _)).
+    apply ab_comm.
+  - intros x.
+    exists 0.
+    apply (ap (+ _)).
+    exact (grp_homo_unit _ @ (grp_homo_unit _)^).
+Defined.
 
 Definition ab_coeq_in {A B} {f g : A $-> B} : B $-> ab_coeq f g.
 Proof.
-  snrapply grp_quotient_map.
+  snrapply Build_GroupHomomorphism.
+  - exact (class_of _).
+  - intros x y.
+    apply qglue.
+    exists 0.
+    apply (ap (+ _)).
+    exact (grp_homo_unit _ @ (grp_homo_unit _)^).
 Defined.
 
 Definition ab_coeq_rec {A B : AbGroup} {f g : A $-> B}
   {C : AbGroup} (i : B $-> C) (p : i $o f $== i $o g) 
   : ab_coeq f g $-> C.
 Proof.
-  snrapply (grp_quotient_rec _ _ i).
-  cbn.
-  intros b H.
-  strip_truncations.
-  destruct H as [a q].
-  destruct q; simpl.
-  lhs nrapply grp_homo_op.
-  lhs nrapply ap.
-  1: apply grp_homo_inv.
-  apply grp_moveL_1M^-1.
-  exact (p a)^.
+  snrapply Build_GroupHomomorphism.
+  - srapply Quotient_rec.
+    + exact i.
+    + simpl.
+      intros x y[z q].
+      apply (ap i) in q.
+      rewrite 2 grp_homo_op in q.
+      specialize (p z); simpl in p.
+      rewrite p in q.
+      by apply grp_cancelL in q.
+  - intros x; rapply Quotient_ind_hprop; intros y; revert x.
+    rapply Quotient_ind_hprop; intros x.
+    apply grp_homo_op.
 Defined.
 
 Definition ab_coeq_rec_beta_in {A B : AbGroup} {f g : A $-> B}

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -2,6 +2,7 @@ Require Import Basics Types.
 Require Import Spaces.Nat.Core Spaces.Int.
 Require Export Classes.interfaces.canonical_names (Zero, zero, Plus).
 Require Export Classes.interfaces.abstract_algebra (IsAbGroup(..), abgroup_group, abgroup_commutative).
+Require Import Algebra.Congruence.
 Require Export Algebra.Groups.Group.
 Require Export Algebra.Groups.Subgroup.
 Require Import Algebra.Groups.QuotientGroup.
@@ -43,6 +44,9 @@ Proof.
   lhs nrapply grp_inv_op.
   apply ab_comm.
 Defined.
+
+Definition Build_AbGroup' (G : Type) `(H : IsAbGroup G) : AbGroup
+  := Build_AbGroup (Build_Group G _ _ _ _) _. 
 
 (** ** Paths between abelian groups *)
 
@@ -86,10 +90,11 @@ Defined.
 
 (** ** Quotients of abelian groups *)
 
-Global Instance isabgroup_quotient (G : AbGroup) (H : Subgroup G)
-  : IsAbGroup (QuotientGroup' G H (isnormal_ab_subgroup G H)).
+Global Instance isabgroup_congruencequotient (G : AbGroup) (R : Relation G)
+  `{!IsCongruence R, !Reflexive R}
+  : IsAbGroup (CongruenceQuotient R).
 Proof.
-  nrapply Build_IsAbGroup.
+  snrapply Build_IsAbGroup.
   1: exact _.
   intro x.
   srapply Quotient_ind_hprop.
@@ -99,6 +104,9 @@ Proof.
   apply (ap (class_of _)).
   apply commutativity.
 Defined.
+
+Global Instance isabgroup_quotient (G : AbGroup) (H : Subgroup G)
+  : IsAbGroup (QuotientGroup' G H (isnormal_ab_subgroup G H)) := _.
 
 Definition QuotientAbGroup (G : AbGroup) (H : Subgroup G) : AbGroup
   := (Build_AbGroup (QuotientGroup' G H (isnormal_ab_subgroup G H)) _).

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -115,6 +115,8 @@ Section GroupCongruenceQuotient.
 
 End GroupCongruenceQuotient.
 
+Arguments CongruenceQuotient {G} R.
+
 (** Now we can define the quotient group by a normal subgroup. *)
 
 Section QuotientGroup.


### PR DESCRIPTION
In this PR we use `CongruenceQuotient` for `ab_coeq`. I've marked this as a draft for now in case we can improve it.

This was proposed in #2035.