### PR TITLE
prime factorization

### DIFF
--- a/theories/Basics.v
+++ b/theories/Basics.v
@@ -8,6 +8,7 @@ Require Export Basics.Utf8.
 Require Export Basics.Notations.
 Require Export Basics.Tactics.
 Require Export Basics.Classes.
+Require Export Basics.Iff.
 
 Require Export Basics.Nat.
 Require Export Basics.Numeral.

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -270,6 +270,11 @@ Proof.
   - apply ap, path_forall; intros p; elim (nd p).
 Defined.
 
+(** ** Logical Laws *)
+
+(** Various logical laws don't hold constructively as they do classically due to a required use of excluded middle. For us, this means that some laws require further assumptions on the decidability of propositions. *)
+
+(** Here we give the dual De Morgan Law which complements the one given in Iff.v *)
 Definition iff_not_prod A B `{Decidable A} `{Decidable B}
   : ~ (A * B) <-> ~ A + ~ B.
 Proof.

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -3,7 +3,8 @@ Require Import
   Basics.Overture
   Basics.PathGroupoids
   Basics.Trunc
-  Basics.Tactics.
+  Basics.Tactics
+  Basics.Iff.
 Local Open Scope trunc_scope.
 Local Open Scope path_scope.
 
@@ -267,4 +268,17 @@ Proof.
   - elim (nd' d).
   - elim (nd d').
   - apply ap, path_forall; intros p; elim (nd p).
+Defined.
+
+Definition iff_not_prod A B `{Decidable A} `{Decidable B}
+  : ~ (A * B) <-> ~ A + ~ B.
+Proof.
+  split.
+  - intros np.
+    destruct (dec A) as [a|na].
+    + exact (inr (fun b => np (a, b))).
+    + exact (inl na).
+  - intros [na|nb] [a b].
+    + exact (na a).
+    + exact (nb b).
 Defined.

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -129,21 +129,21 @@ Global Instance decidable_empty : Decidable Empty
 
 (** ** Transfer along equivalences *)
 
-Definition decidable_iff {A B} (f : A -> B) (f' : B -> A)
+Definition decidable_iff {A B} (f : A <-> B)
   : Decidable A -> Decidable B.
 Proof.
   intros [a|na].
-  - exact (inl (f a)).
-  - exact (inr (fun b => na (f' b))).
+  - exact (inl (fst f a)).
+  - exact (inr (fun b => na (snd f b))).
 Defined.
-
-Definition decidable_equiv (A : Type) {B : Type} (f : A -> B) `{IsEquiv A B f}
-  : Decidable A -> Decidable B
-  := decidable_iff f f^-1.
 
 Definition decidable_equiv' (A : Type) {B : Type} (f : A <~> B)
 : Decidable A -> Decidable B
-  := decidable_equiv A f.
+  := decidable_iff f.
+
+Definition decidable_equiv (A : Type) {B : Type} (f : A -> B) `{!IsEquiv f}
+: Decidable A -> Decidable B
+  := decidable_equiv' _ (Build_Equiv _ _ f _).
 
 Definition decidablepaths_equiv
            (A : Type) {B : Type} (f : A -> B) `{IsEquiv A B f}

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -274,8 +274,15 @@ Defined.
 
 (** Various logical laws don't hold constructively as they do classically due to a required use of excluded middle. For us, this means that some laws require further assumptions on the decidability of propositions. *)
 
-(** Here we give the dual De Morgan Law which complements the one given in Iff.v *)
-Definition iff_not_prod A B `{Decidable A} `{Decidable B}
+(** Here we give the dual De Morgan's Law which complements the one given in Iff.v.  One direction requires that one of the two propositions be decidable, while the other direction needs no assumption.  We state the latter property first, to avoid duplication in the proof. *)
+Definition not_prod_sum_not A B : ~ A + ~ B -> ~ (A * B).
+Proof.
+  intros [na|nb] [a b].
+  - exact (na a).
+  - exact (nb b).
+Defined.
+
+Definition iff_not_prod A B `{Decidable A}
   : ~ (A * B) <-> ~ A + ~ B.
 Proof.
   split.
@@ -283,7 +290,16 @@ Proof.
     destruct (dec A) as [a|na].
     + exact (inr (fun b => np (a, b))).
     + exact (inl na).
-  - intros [na|nb] [a b].
-    + exact (na a).
-    + exact (nb b).
+  - apply not_prod_sum_not.
+Defined.
+
+Definition iff_not_prod' A B `{Decidable B}
+  : ~ (A * B) <-> ~ A + ~ B.
+Proof.
+  split.
+  - intros np.
+    destruct (dec B) as [b|nb].
+    + exact (inl (fun a => np (a, b))).
+    + exact (inr nb).
+  - apply not_prod_sum_not.
 Defined.

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -85,6 +85,13 @@ Proof.
   exact (nnnp (fun np => np p)).
 Defined.
 
+Definition iff_stable P `(Stable P) : ~~P <-> P.
+Proof.
+  split.
+  - apply stable.
+  - exact (fun x f => f x).
+Defined.
+
 (**
   Because [vm_compute] evaluates terms in [PROP] eagerly
   and does not remove dead code we

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -80,9 +80,6 @@ Ltac change_apply_equiv_compose :=
     change ((f oE g) x) with (f (g x))
   end.
 
-Definition iff_equiv {A B : Type} (f : A <~> B)
-  : A <-> B := (equiv_fun f, f^-1).
-
 (** Transporting is an equivalence. *)
 Section EquivTransport.
 

--- a/theories/Basics/Iff.v
+++ b/theories/Basics/Iff.v
@@ -43,7 +43,7 @@ Coercion iff_equiv {A B : Type} (f : A <~> B)
 
 (** ** Logical Laws *)
 
-(** De Morgan Law, the dual statement about negating a product appears in Decidable.v due to decidability requirements. *)
+(** One of De Morgan's Laws.  The dual statement about negating a product appears in Decidable.v due to decidability requirements. *)
 Definition iff_not_sum A B : ~ (A + B) <-> ~ A * ~ B.
 Proof.
   split.

--- a/theories/Basics/Iff.v
+++ b/theories/Basics/Iff.v
@@ -1,0 +1,59 @@
+Require Import Basics.Overture Basics.Tactics.
+
+Local Set Universe Minimization ToSet.
+
+(** * If and only if *)
+
+(** ** Definition *)
+
+(** [iff A B], written [A <-> B], expresses the logical equivalence of [A] and [B] *)
+Definition iff (A B : Type) := prod (A -> B) (B -> A).
+
+Notation "A <-> B" := (iff A B) : type_scope.
+
+(** ** Basic Properties *)
+
+(** Everything is logically equivlaent to itself. *)
+Definition iff_refl {A} : A <-> A
+  := (idmap , idmap).
+
+(** [iff] is a reflexive relation. *)
+Global Instance iff_reflexive : Reflexive iff | 1
+  := @iff_refl.
+
+(** Logical equivalences can be inverted. *)
+Definition iff_inverse {A B} : (A <-> B) -> (B <-> A)
+  :=  fun f => (snd f , fst f).
+
+(** [iff] is a symmetric relation. *)
+Global Instance symmetric_iff : Symmetric iff | 1
+  := @iff_inverse.
+
+(** Logical equivalences can be composed. *)
+Definition iff_compose {A B C} (f : A <-> B) (g : B <-> C) : A <-> C
+  := (fst g o fst f , snd f o snd g).
+
+(** [iff] is a transitive relation. *)
+Global Instance transitive_iff : Transitive iff | 1
+  := @iff_compose.
+
+(** Any equivalence can be considered a logical equivalence by discarding everything but the maps. We make this a coercion so that equivalences can be used in place of logical equivalences. *)
+Coercion iff_equiv {A B : Type} (f : A <~> B)
+  : A <-> B := (equiv_fun f, f^-1).
+
+(** ** De Morgan Laws *)
+
+Definition iff_not_sum A B : ~ (A + B) <-> ~ A * ~ B.
+Proof.
+  split.
+  - intros ns.
+    exact (ns o inl, ns o inr).
+  - by intros []; snrapply sum_ind.
+Defined.
+
+Definition iff_contradiction A : A * ~A <-> Empty.
+Proof.
+  split.
+  - intros [a na]; exact (na a).
+  - intros e; exact (Empty_rec _ e).
+Defined.

--- a/theories/Basics/Iff.v
+++ b/theories/Basics/Iff.v
@@ -41,8 +41,9 @@ Global Instance transitive_iff : Transitive iff | 1
 Coercion iff_equiv {A B : Type} (f : A <~> B)
   : A <-> B := (equiv_fun f, f^-1).
 
-(** ** De Morgan Laws *)
+(** ** Logical Laws *)
 
+(** De Morgan Law, the dual statement about negating a product appears in Decidable.v due to decidability requirements. *)
 Definition iff_not_sum A B : ~ (A + B) <-> ~ A * ~ B.
 Proof.
   split.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -239,8 +239,11 @@ Global Instance symmetric_iff : Symmetric iff | 1
   := @iff_inverse.
 
 (** And reflexivity of them *)
+Definition iff_refl {A} : A <-> A
+  := (idmap , idmap).
+
 Global Instance iff_reflexive : Reflexive iff | 1
-  := fun A => (idmap , idmap).
+  := @iff_refl.
 
 (** Dependent composition of functions. *)
 Definition composeD {A B C} (g : forall b, C b) (f : A -> B) := fun x : A => g (f x).

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -73,13 +73,6 @@ Notation conj := pair (only parsing).
 
 #[export] Hint Resolve pair inl inr : core.
 
-(** If and only if *)
-
-(** [iff A B], written [A <-> B], expresses the logical equivalence of [A] and [B] *)
-Definition iff (A B : Type) := prod (A -> B) (B -> A).
-
-Notation "A <-> B" := (iff A B) : type_scope.
-
 (** ** Type classes *)
 
 (** This command prevents Coq from trying to guess the values of existential variables while doing typeclass resolution.  If you don't know what that means, ignore it. *)
@@ -223,27 +216,6 @@ Notation "g 'o' f" := (compose g%function f%function) : function_scope.
 
 (** This definition helps guide typeclass inference. *)
 Definition Compose {A B C : Type} (g : B -> C) (f : A -> B) : A -> C := compose g f.
-
-(** Composition of logical equivalences *)
-Definition iff_compose {A B C} (f : A <-> B) (g : B <-> C) : A <-> C
-  := (fst g o fst f , snd f o snd g).
-
-Global Instance transitive_iff : Transitive iff | 1
-  := @iff_compose.
-
-(** While we're at it, inverses of logical equivalences *)
-Definition iff_inverse {A B} : (A <-> B) -> (B <-> A)
-  :=  fun f => (snd f , fst f).
-
-Global Instance symmetric_iff : Symmetric iff | 1
-  := @iff_inverse.
-
-(** And reflexivity of them *)
-Definition iff_refl {A} : A <-> A
-  := (idmap , idmap).
-
-Global Instance iff_reflexive : Reflexive iff | 1
-  := @iff_refl.
 
 (** Dependent composition of functions. *)
 Definition composeD {A B C} (g : forall b, C b) (f : A -> B) := fun x : A => g (f x).
@@ -538,9 +510,6 @@ Notation "f ^-1" := (@equiv_inv _ _ f _) : function_scope.
 
 Definition ap10_equiv {A B : Type} {f g : A <~> B} (h : f = g) : f == g
   := ap10 (ap equiv_fun h).
-
-Coercion iff_equiv {A B : Type} (f : A <~> B)
-  : A <-> B := (equiv_fun f, f^-1).
 
 (** ** Contractibility and truncation levels *)
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -536,6 +536,9 @@ Notation "f ^-1" := (@equiv_inv _ _ f _) : function_scope.
 Definition ap10_equiv {A B : Type} {f g : A <~> B} (h : f = g) : f == g
   := ap10 (ap equiv_fun h).
 
+Coercion iff_equiv {A B : Type} (f : A <~> B)
+  : A <-> B := (equiv_fun f, f^-1).
+
 (** ** Contractibility and truncation levels *)
 
 (** Truncation measures how complicated a type is.  In this library, a witness that a type is n-truncated is formalized by the [IsTrunc n] typeclass.  In many cases, the typeclass machinery of Coq can automatically infer a witness for a type being n-truncated.  Because [IsTrunc n A] itself has no computational content (that is, all witnesses of n-truncation of a type are provably equal), it does not matter much which witness Coq infers.  Therefore, the primary concerns in making use of the typeclass machinery are coverage (how many goals can be automatically solved) and speed (how long does it take to solve a goal, and how long does it take to error on a goal we cannot automatically solve).  Careful use of typeclass instances and priorities, which determine the order of typeclass resolution, can be used to effectively increase both the coverage and the speed in cases where the goal is solvable.  Unfortunately, typeclass resolution tends to spin for a while before failing unless you're very, very, very careful.  We currently aim to achieve moderate coverage and fast speed in solvable cases.  How long it takes to fail typeclass resolution is not currently considered, though it would be nice someday to be even more careful about things.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -75,7 +75,7 @@ Notation conj := pair (only parsing).
 
 (** If and only if *)
 
-(** [iff A B], written [A <-> B], expresses the equivalence of [A] and [B] *)
+(** [iff A B], written [A <-> B], expresses the logical equivalence of [A] and [B] *)
 Definition iff (A B : Type) := prod (A -> B) (B -> A).
 
 Notation "A <-> B" := (iff A B) : type_scope.
@@ -225,14 +225,18 @@ Notation "g 'o' f" := (compose g%function f%function) : function_scope.
 Definition Compose {A B C : Type} (g : B -> C) (f : A -> B) : A -> C := compose g f.
 
 (** Composition of logical equivalences *)
-Global Instance iff_compose : Transitive iff | 1
-  := fun A B C f g => (fst g o fst f , snd f o snd g).
-Arguments iff_compose {A B C} f g : rename.
+Definition iff_compose {A B C} (f : A <-> B) (g : B <-> C) : A <-> C
+  := (fst g o fst f , snd f o snd g).
+
+Global Instance transitive_iff : Transitive iff | 1
+  := @iff_compose.
 
 (** While we're at it, inverses of logical equivalences *)
-Global Instance iff_inverse : Symmetric iff | 1
-  := fun A B f => (snd f , fst f).
-Arguments iff_inverse {A B} f : rename.
+Definition iff_inverse {A B} : (A <-> B) -> (B <-> A)
+  :=  fun f => (snd f , fst f).
+
+Global Instance symmetric_iff : Symmetric iff | 1
+  := @iff_inverse.
 
 (** And reflexivity of them *)
 Global Instance iff_reflexive : Reflexive iff | 1

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -7,7 +7,8 @@ Require Import
   Basics.Contractible
   Basics.Equivalences
   Basics.Tactics
-  Basics.Nat.
+  Basics.Nat
+  Basics.Iff.
 
 Local Set Universe Minimization ToSet.
 

--- a/theories/Categories/Structure/IdentityPrinciple.v
+++ b/theories/Categories/Structure/IdentityPrinciple.v
@@ -2,7 +2,7 @@
 Require Import Category.Core Category.Univalent Category.Morphisms.
 Require Import Structure.Core.
 Require Import Types.Sigma Trunc Equivalences.
-Require Import Basics.Tactics.
+Require Import Basics.Iff Basics.Tactics.
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/PropResizing/Nat.v
+++ b/theories/PropResizing/Nat.v
@@ -149,8 +149,7 @@ Section AssumeStuff.
     Qed.
 
     Definition graph_unsucc_equiv_vert@{} : vert A <~> vert B
-      := equiv_unfunctor_sum_l@{s s s s s  s Set Set Set Set}
-                              f Ha Hb.
+      := equiv_unfunctor_sum_l@{s s s s s s} f Ha Hb.
 
     Definition graph_unsucc_equiv_edge@{} (x y : vert A)
       : iff@{s s s} (edge A x y) (edge B (graph_unsucc_equiv_vert x) (graph_unsucc_equiv_vert y)).

--- a/theories/Spaces/Finite/Fin.v
+++ b/theories/Spaces/Finite/Fin.v
@@ -267,7 +267,7 @@ Proof.
   assert (p' := (moveL_equiv_V _ _ p)^).
   exists y.
   destruct y as [y|[]].
-  + simple refine (equiv_unfunctor_sum_l@{Set Set Set Set Set Set Set Set Set Set}
+  + simple refine (equiv_unfunctor_sum_l@{Set Set Set Set Set Set}
               (fin_transpose_last_with m (inl y) oE e)
               _ _ ; _).
     { intros a. ev_equiv.
@@ -286,7 +286,7 @@ Proof.
     * rewrite unfunctor_sum_l_beta.
       apply fin_transpose_last_with_invol.
     * refine (fin_transpose_last_with_last _ _ @ p^).
-  + simple refine (equiv_unfunctor_sum_l@{Set Set Set Set Set Set Set Set Set Set} e _ _ ; _).
+  + simple refine (equiv_unfunctor_sum_l@{Set Set Set Set Set Set} e _ _ ; _).
     { intros a.
       destruct (is_inl_or_is_inr (e (inl a))) as [l|r].
       - exact l.

--- a/theories/Spaces/Int.v
+++ b/theories/Spaces/Int.v
@@ -124,8 +124,9 @@ Proof.
   2-4,6-8: right; intros; discriminate.
   2: by left.
   1,2: nrapply decidable_iff.
-  1,4: nrapply ap.
-  1,3: intros H; by injection H.
+  1,3: split.
+  1,3: nrapply ap.
+  1,2: intros H; by injection H.
   1,2: exact _.
 Defined.
 

--- a/theories/Spaces/List/Core.v
+++ b/theories/Spaces/List/Core.v
@@ -193,3 +193,12 @@ Fixpoint for_all@{i j|} {A : Type@{i}} (P : A -> Type@{j}) l : Type@{j} :=
   | nil => Unit
   | x :: l => P x /\ for_all P l
   end.
+
+(** ** Exists *)
+
+(** Apply a predicate to all elements of a list and take their disjunction. *)
+Fixpoint list_exists@{i j|} {A : Type@{i}} (P : A -> Type@{j}) l : Type@{j} :=
+  match l with
+  | nil => Empty
+  | x :: l => P x + list_exists P l
+  end.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -737,29 +737,29 @@ Proof.
   - simpl.
     apply iff_inverse.
     apply iff_equiv.
-    snrapply prod_empty_l@{k}.
+    snrapply prod_empty_l@{v}.
   - simpl.
-    nrapply iff_compose@{k k k k k k}.
-    2: { apply iff_inverse@{k k k}.
-         apply iff_equiv@{k k k}.
-         exact (sum_distrib_r@{k k k k k k k k} _ _ _). }
+    nrapply iff_compose.
+    2: { apply iff_inverse.
+         apply iff_equiv.
+         exact (sum_distrib_r@{k k k _ _ _ k k} _ _ _). }
     destruct (dec a) as [p|p].
     + simpl.
-      snrapply iff_compose@{k k k k k k}.
-      1: exact (sum@{k k} (a = x) (prod@{k k} (InList@{u} x l) (P x))).
-      1: split; apply functor_sum@{k k k k}; only 1,3: exact idmap; apply IHl.
+      snrapply iff_compose.
+      1: exact (sum (a = x) (prod (InList@{u} x l) (P x))).
+      1: split; apply functor_sum; only 1,3: exact idmap; apply IHl.
       split; apply functor_sum@{k k k k}; only 2,4: apply idmap.
       * intros [].
         exact (idpath, p).
       * exact fst.
-    + nrapply iff_compose@{k k k k k k}. 
+    + nrapply iff_compose.
       1: apply IHl.
-      apply iff_inverse@{k k k}.
-      apply iff_equiv@{k k k}.
+      apply iff_inverse.
+      apply iff_equiv.
       nrefine (equiv_compose'@{k k k} (sum_empty_l@{k} _) _).
       snrapply equiv_functor_sum'@{k k k k k k}.
-      2: exact (equiv_idmap@{k}).
-      apply equiv_to_empty@{k}.
+      2: exact equiv_idmap.
+      apply equiv_to_empty.
       by intros [[] r].
 Defined.
 
@@ -997,7 +997,7 @@ Proof.
   by apply for_all_list_map.
 Defined.
 
-(** If a predicate [P] and a prediate [Q] together imply a predicate [R], then [for_all P l] and [for_all Q l] together imply [for_all R l]. There are also some side conditions for the default elements. *)
+(** If a predicate [P] and a predicate [Q] together imply a predicate [R], then [for_all P l] and [for_all Q l] together imply [for_all R l]. There are also some side conditions for the default elements. *)
 Lemma for_all_list_map2 {A B C : Type}
   (P : A -> Type) (Q : B -> Type) (R : C -> Type)
   (f : A -> B -> C) (Hf : forall x y, P x -> Q y -> R (f x y))

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -731,13 +731,13 @@ Fixpoint list_filter@{u v|} {A : Type@{u}} (l : list A) (P : A -> Type@{v})
 
 Definition inlist_filter@{u v k | u <= k, v <= k} {A : Type@{u}} (l : list A)
   (P : A -> Type@{v}) (dec : forall x, Decidable (P x)) (x : A)
-  : iff@{k k k} (InList@{k} x (list_filter@{u v} l P dec)) (InList@{u} x l /\ P x).
+  : iff@{u k k} (InList x (list_filter l P dec)) (InList x l /\ P x).
 Proof.
   simple_list_induction l a l IHl.
   - simpl.
-    apply iff_inverse@{k k k}.
-    apply iff_equiv@{k k k}.
-    snrapply prod_empty_l@{k k k}.
+    apply iff_inverse.
+    apply iff_equiv.
+    snrapply prod_empty_l@{k}.
   - simpl.
     nrapply iff_compose@{k k k k k k}.
     2: { apply iff_inverse@{k k k}.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -1,5 +1,5 @@
 Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Trunc
-  Basics.Equivalences Basics.Decidable.
+  Basics.Equivalences Basics.Decidable Basics.Iff.
 Require Import Types.Paths Types.Unit Types.Prod Types.Sigma Types.Sum
   Types.Empty Types.Option.
 Require Export Spaces.List.Core Spaces.Nat.Core.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -1151,3 +1151,31 @@ Proof.
   - intros H.
     by apply (IHl y).
 Defined.
+
+Definition list_exists_seq {n : nat} (P : nat -> Type)
+  (H : forall k, P k -> (k < n)%nat)
+  : (exists k, P k) <-> list_exists P (seq n).
+Proof.
+  split.
+  - intros [k p].
+    snrapply (list_exists_inlist P _ k _ p).
+    apply inlist_seq, H.
+    exact p.
+  - intros H1.
+    apply inlist_list_exists in H1.
+    destruct H1 as [k [Hk p]].
+    exists k.
+    exact p.
+Defined.
+
+(** An upper bound on witnesses of a decidable predicate makes the sigma type decidable. *)
+Definition decidable_exists_nat (n : nat) (P : nat -> Type)
+  (H1 : forall k, P k -> (k < n)%nat)
+  (H2 : forall k, Decidable (P k))
+  : Decidable (exists k, P k).
+Proof.
+  nrapply decidable_iff.
+  1: apply iff_inverse; nrapply list_exists_seq.
+  1: exact H1.
+  exact _.
+Defined.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -590,6 +590,7 @@ Hint Immediate leq_lt : typeclass_instances.
 
 Definition lt_trans {n m k} : n < m -> m < k -> n < k
   := fun H1 H2 => leq_lt (lt_leq_lt_trans H1 H2).
+Hint Immediate lt_trans : typeclass_instances.
 
 Global Instance transitive_lt : Transitive lt := @lt_trans.
 Global Instance ishprop_lt n m : IsHProp (n < m) := _.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids
   Basics.Decidable Basics.Trunc Basics.Equivalences Basics.Nat
-  Basics.Classes Types.Prod Types.Sum Types.Sigma.
+  Basics.Classes Basics.Iff Types.Prod Types.Sum Types.Sigma.
 Export Basics.Nat.
 
 Local Set Universe Minimization ToSet.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -487,6 +487,14 @@ Global Instance antisymmetric_leq : AntiSymmetric leq := @leq_antisym.
 Global Instance antisymemtric_geq : AntiSymmetric geq
   := fun _ _ p q => leq_antisym q p.
 
+(** Every natural number is zero or greater than zero. *)
+Definition nat_zero_or_gt_zero n : (0 = n) + (0 < n).
+Proof.
+  induction n as [|n IHn].
+  1: left; reflexivity.
+  right; exact _.
+Defined.
+
 (** Being less than or equal to [0] implies being [0]. *)
 Definition path_zero_leq_zero_r n : n <= 0 -> n = 0.
 Proof.

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -817,7 +817,7 @@ Class IsComposite n : Type0
 
 Definition gt_1_iscomposite@{} n : IsComposite n -> 1 < n.
 Proof.
-  intros [k [[H1 H2] H3]].
+  intros [a [[H1 H2] H3]].
   exact _.
 Defined.
 Hint Immediate gt_1_iscomposite : typeclass_instances.

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -368,7 +368,7 @@ Defined.
 Global Instance decidable_nat_divides n m : Decidable (n | m).
 Proof.
   nrapply decidable_iff.
-  1, 2: apply nat_mod_iff_divides.
+  1: apply nat_mod_iff_divides.
   exact _.
 Defined.
 
@@ -704,8 +704,8 @@ Proof.
   (** In order to show that this [forall] is decidable, we will exhibit it as a [for_all] statement over a given list. The predicate will be the conclusion we wish to reach here, and the list will consist of all numbers with a condition equivalent to the divisibility condition. *)
   pose (P := fun m => ((m = 1) + (m = n.+1))%type : Type0).
   pose (l := list_filter (seq n.+2) (fun x => (x | n.+1)) _).
-  snrapply decidable_iff.
-  - exact (for_all P l).
+  rapply (decidable_iff (A := for_all P l)).
+  split.
   - intros Pl x d.
     apply inlist_for_all with l x in Pl.
     1: exact Pl.
@@ -721,7 +721,6 @@ Proof.
     destruct H' as [p H'].
     apply inlist_seq in p.
     rapply H.
-  - exact _.
 Defined.
 
 (** We can show that the first 8 primes are prime as expected. *)
@@ -803,8 +802,8 @@ Class IsComposite n : Type0
 (** Being composite is a decidable property. *)
 Global Instance decidable_iscomposite@{} n : Decidable (IsComposite n).
 Proof.
-  snrapply decidable_iff.
-  - exact (list_exists (fun a => 1 < a < n /\ (a | n)) (seq n)).
+  rapply (decidable_iff (A := list_exists (fun a => 1 < a < n /\ (a | n)) (seq n))).
+  split.
   - intros x.
     apply inlist_list_exists in x.
     exists x.1.
@@ -815,7 +814,6 @@ Proof.
     + apply inlist_seq.
       exact (snd (fst c.2)).
     + exact c.2.
-  - exact _.
 Defined.
 
 (** For a number larger than [1], being prime is equivalent to not being composite. *)

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -893,7 +893,7 @@ Proof.
     1: nrapply sum_distrib_l.
     nrapply iff_compose.
     + nrapply iff_functor_sum.
-      1: apply iff_contradiciton.
+      1: apply iff_contradiction.
       nrapply iff_functor_prod.
       1: nrapply iff_refl.
       rapply iff_stable.

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -673,6 +673,22 @@ Class IsPrime (n : nat) : Type0 := {
 
 Definition issig_IsPrime n : _ <~> IsPrime n := ltac:(issig).
 
+Global Instance ishprop_isprime `{Funext} n : IsHProp (IsPrime n).
+Proof.
+  nrapply istrunc_equiv_istrunc.
+  1: apply issig_IsPrime.
+  rapply istrunc_sigma.
+  intros H1.
+  snrapply istrunc_forall.
+  intros m.
+  snrapply istrunc_forall.
+  intros d.
+  rapply ishprop_sum.
+  intros p q.
+  nrapply (snd neq_iff_lt_or_gt _ (p^ @ q)).
+  by left.
+Defined.
+
 (** [0] is not a prime number. *)
 Definition not_isprime_zero : ~ IsPrime 0.
 Proof.

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -895,23 +895,20 @@ Defined.
 
 (** Any natural number can either be written as a product of primes or is zero. *)
 Definition prime_factorization@{} n
-  : (exists (l : list Prime),
-      n = fold_right (fun (p : Prime) n => nat_mul p n) 1 l)
-    + (n = 0).
+  : 0 < n
+    -> exists (l : list Prime),
+      n = fold_right (fun (p : Prime) n => nat_mul p n) 1 l.
 Proof.
-  revert n; snrapply nat_ind_strong; hnf; intros n IHn.
-  destruct n.
-  1: right; reflexivity.
-  left.
-  destruct n.
+  revert n; snrapply nat_ind_strong; hnf; intros n IHn H.
+  destruct H as [|n IH].
   1: exists nil; reflexivity.
-  destruct (exists_prime_divisor n.+2 _) as [p d].
-  pose proof (l := lt_divides d.1 n.+2 _ _ _).
+  destruct (exists_prime_divisor n.+1 _) as [p d].
+  pose proof (l := lt_divides d.1 n.+1 _ _ _).
   destruct d as [k H].
-  destruct (IHn k l) as [[f r]| ].
-  2: { destruct p0^; clear p0; cbn in H.
-       destruct H.
-       contradiction (not_lt_zero_r _ l). }
+  destruct (IHn k l) as [f r].
+  { destruct H, k.
+    1: contradiction (lt_irrefl 0).
+    exact _. }
   exists (p :: f)%list.
   simpl; destruct r.
   symmetry.

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics Basics.Trunc Basics.Classes
   Basics.PathGroupoids Basics.Equivalences Types.Sigma Spaces.Nat.Core
-  Basics.Decidable Types.Prod List.Theory Types.Sum Types.Arrow.
+  Basics.Decidable Basics.Iff Types.Prod List.Theory Types.Sum Types.Arrow.
 
 Local Set Universe Minimization ToSet.
 Local Open Scope nat_scope.

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -802,18 +802,10 @@ Class IsComposite n : Type0
 (** Being composite is a decidable property. *)
 Global Instance decidable_iscomposite@{} n : Decidable (IsComposite n).
 Proof.
-  rapply (decidable_iff (A := list_exists (fun a => 1 < a < n /\ (a | n)) (seq n))).
-  split.
-  - intros x.
-    apply inlist_list_exists in x.
-    exists x.1.
-    exact (snd x.2).
-  - intros c.
-    snrapply list_exists_inlist.
-    + exact c.1.
-    + apply inlist_seq.
-      exact (snd (fst c.2)).
-    + exact c.2.
+  unfold IsComposite.
+  rapply (decidable_exists_nat n).
+  intros k c.
+  exact (snd (fst c)).
 Defined.
 
 (** For a number larger than [1], being prime is equivalent to not being composite. *)

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -2,7 +2,7 @@
 (** * Theorems about Non-dependent function types *)
 
 Require Import Basics.Overture Basics.PathGroupoids Basics.Decidable
-               Basics.Equivalences Basics.Trunc Basics.Tactics.
+               Basics.Equivalences Basics.Trunc Basics.Tactics Basics.Iff.
 Require Import Types.Forall.
 Local Open Scope path_scope.
 

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -6,6 +6,7 @@ Require Import Basics.Overture Basics.PathGroupoids Basics.Decidable
 Require Import Types.Forall.
 Local Open Scope path_scope.
 
+Local Set Universe Minimization ToSet.
 
 Generalizable Variables A B C D f g n.
 
@@ -207,6 +208,13 @@ Definition functor_arrow `(f : B -> A) `(g : C -> D)
 Definition not_contrapositive `(f : B -> A)
   : not A -> not B
   := functor_arrow f idmap.
+
+Definition iff_not@{u v k | u <= k, v <= k}
+  (A : Type@{u}) (B : Type@{v})
+  : A <-> B -> iff@{u v k} (~A) (~B).
+Proof.
+  intros e; split; apply not_contrapositive@{_ k}, e.
+Defined.
 
 Definition ap_functor_arrow `(f : B -> A) `(g : C -> D)
   (h h' : A -> C) (p : h == h')

--- a/theories/Types/Forall.v
+++ b/theories/Types/Forall.v
@@ -2,7 +2,7 @@
 (** * Theorems about dependent products *)
 
 Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids
-               Basics.Tactics Basics.Contractible.
+               Basics.Tactics Basics.Contractible Basics.Iff.
 
 Require Export Basics.Trunc (istrunc_forall).
 
@@ -314,12 +314,9 @@ Defined.
 (** At least over a fixed base *)
 Definition iff_functor_forall {A : Type} {P Q : A -> Type}
            (f : forall a, P a <-> Q a)
-  : (forall a, P a) <-> (forall a, Q a).
-Proof.
-  split.
-  - intros g a; exact (fst (f a) (g a)).
-  - intros h a; exact (snd (f a) (h a)).
-Defined.
+  : (forall a, P a) <-> (forall a, Q a)
+  := (functor_forall idmap (fun a => fst (f a)),
+    functor_forall idmap (fun a => snd (f a))).
 
 (** ** Two variable versions for function extensionality. *)
 

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -2,7 +2,7 @@
 (** * Theorems about cartesian products *)
 
 Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids
-               Basics.Tactics Basics.Trunc Basics.Decidable.
+               Basics.Tactics Basics.Trunc Basics.Decidable Basics.Iff.
 Require Import Types.Empty.
 Local Open Scope path_scope.
 

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -6,6 +6,8 @@ Require Import Basics.Overture Basics.Equivalences Basics.PathGroupoids
 Require Import Types.Empty.
 Local Open Scope path_scope.
 
+Local Set Universe Minimization ToSet.
+
 Generalizable Variables X A B f g n.
 
 Scheme prod_ind := Induction for prod Sort Type.
@@ -300,11 +302,11 @@ Defined.
 
 (** ** Unit and annihilation *)
 
-Definition prod_empty_r X : X * Empty <~> Empty
-  := (Build_Equiv _ _ snd _).
+Definition prod_empty_r@{u} (X : Type@{u}) : X * Empty <~> Empty
+  := (Build_Equiv@{u u} _ _ snd _).
 
-Definition prod_empty_l X : Empty * X <~> Empty
-  := (Build_Equiv _ _ fst _).
+Definition prod_empty_l@{u} (X : Type@{u}) : Empty * X <~> Empty
+  := (Build_Equiv@{u u} _ _ fst _).
 
 Definition prod_unit_r X : X * Unit <~> X.
 Proof.

--- a/theories/Types/Prod.v
+++ b/theories/Types/Prod.v
@@ -393,13 +393,13 @@ Global Instance contr_prod `{CA : Contr A} `{CB : Contr B} : Contr (A * B) | 100
 
 Global Instance decidable_prod {A B : Type}
        `{Decidable A} `{Decidable B}
-: Decidable (A * B).
+: Decidable@{k} (A * B).
 Proof.
   destruct (dec A) as [x1|y1]; destruct (dec B) as [x2|y2].
-  - exact (inl (x1,x2)).
-  - apply inr; intros [_ x2]; exact (y2 x2).
-  - apply inr; intros [x1 _]; exact (y1 x1).
-  - apply inr; intros [x1 _]; exact (y1 x1).
+  - exact (inl@{k k} (x1,x2)).
+  - apply inr@{k k}; intros [_ x2]; exact (y2 x2).
+  - apply inr@{k k}; intros [x1 _]; exact (y1 x1).
+  - apply inr@{k k}; intros [x1 _]; exact (y1 x1).
 Defined.
 
 (** Interaction of ap and uncurry *)

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -1043,33 +1043,3 @@ Proof.
                        | ].
   typeclasses eauto.
 Defined.
-
-(** ** De Morgan Laws *)
-
-Definition iff_not_sum A B : ~ (A + B) <-> ~ A * ~ B.
-Proof.
-  split.
-  - intros ns.
-    exact (ns o inl, ns o inr).
-  - nrapply sum_ind_uncurried.
-Defined.
-
-Definition iff_not_prod A B `{Decidable A} `{Decidable B}
-  : ~ (A * B) <-> ~ A + ~ B.
-Proof.
-  split.
-  - intros np.
-    destruct (dec A) as [a|na].
-    + exact (inr (fun b => np (a, b))).
-    + exact (inl na).
-  - intros [na|nb] [a b].
-    + exact (na a).
-    + exact (nb b).
-Defined.
-
-Definition iff_contradiction A : A * ~A <-> Empty.
-Proof.
-  split.
-  - intros [a na]; exact (na a).
-  - intros e; exact (Empty_rec e).
-Defined.

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -1050,12 +1050,8 @@ Definition iff_not_sum A B : ~ (A + B) <-> ~ A * ~ B.
 Proof.
   split.
   - intros ns.
-    split.
-    + exact (ns o inl).
-    + exact (ns o inr).
-  - intros [na nb] [a|b].
-    + exact (na a).
-    + exact (nb b).
+    exact (ns o inl, ns o inr).
+  - nrapply sum_ind_uncurried.
 Defined.
 
 Definition iff_not_prod A B `{Decidable A} `{Decidable B}
@@ -1064,10 +1060,8 @@ Proof.
   split.
   - intros np.
     destruct (dec A) as [a|na].
-    + destruct (dec B) as [b|nb].
-      * by contradiction np.
-      * by right.
-    + by left.
+    + exact (inr (fun b => np (a, b))).
+    + exact (inl na).
   - intros [na|nb] [a b].
     + exact (na a).
     + exact (nb b).

--- a/theories/Types/Sum.v
+++ b/theories/Types/Sum.v
@@ -1073,7 +1073,7 @@ Proof.
     + exact (nb b).
 Defined.
 
-Definition iff_contradiciton A : A * ~A <-> Empty.
+Definition iff_contradiction A : A * ~A <-> Empty.
 Proof.
   split.
   - intros [a na]; exact (na a).

--- a/theories/Utf8Minimal.v
+++ b/theories/Utf8Minimal.v
@@ -1,5 +1,4 @@
-Require Export HoTT.Basics.Utf8.
-Require Import HoTT.Basics.Overture.
+Require Export Basics.Utf8 Basics.Overture Basics.Iff.
 
 (** * Just enough Utf8/unicode for the Classes library to build, without depending on everything that HoTT.Utf8 depends on. *)
 

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -1,6 +1,6 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-Require Import Basics.Overture Basics.Tactics.
+Require Import Basics.Overture Basics.Tactics Basics.Iff.
 Require Import WildCat.Core.
 Require Import WildCat.NatTrans.
 Require Import WildCat.Sigma.


### PR DESCRIPTION
In this PR we prove the first part of the fundamental theorem of arithmetic outlined in #2059. We show that any natural number has a factorisation into primes.

In order to do this we define `IsComposite` which checks if a natural number has a proper divisor. Now this allows us to partition `nat` into 4 parts, zero, one (unit), primes and composites.

I noticed that in the classical setting, the line between being not prime and composite is blurred due to classical logic. This means texts on elementary number theory rarely distinguish between these two concepts. In the constructive setting, it can be shown that they are equivalent since we can apply classical reasoning to IsComposite and IsPrime precisely because they are decidable.

This allows us to show that any natural has a prime divisor which can be iterated to provide a prime factorisation of any natural number.

Decidability of IsComposite required me to introduce a new `list_exists` predicate on lists which checks for a witness in a list satisfying a given predicate, analogous to `for_all`. This allows us to show decidability of certain existential statements as long as witnesses can be collected in a list (related to enumerability).

Unfortunately, I needed to tweak a lot of universe levels for example in Sum.v as the default Coq ones introduced too many "phantom" universes which didn't appear to have any bearing on the terms but caused proofs to be left hanging.

Hopefully, this PR can be improved a bit, but I will be slightly less active over the coming days.

As mentioned in #2059, showing that any two factorisations are unique upto permutation will be left to future work. We are missing a lot of material on permutations of lists so this will have to wait.