### PR TITLE
free abelian groups take products to tensor products

### DIFF
--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -423,7 +423,7 @@ Proof.
   snrapply Build_Is0Functor.
   intros A B f.
   snrapply grp_homo_abel_rec.
-  refine (abel_unit $o f).
+  exact (abel_unit $o f).
 Defined.
 
 Global Instance is1functor_abel : Is1Functor abel.

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -324,7 +324,7 @@ Arguments abel G : simpl never.
 
 (** The unit of this map is the map [abel_in] which typeclasses can pick up to be a homomorphism. We write it out explicitly here. *)
 Definition abel_unit {G : Group}
-  : GroupHomomorphism G (abel G)
+  : G $-> (abel G)
   := @Build_GroupHomomorphism G (abel G) abel_in _.
 
 Definition grp_homo_abel_rec {G : Group} {A : AbGroup} (f : G $-> A)
@@ -423,8 +423,7 @@ Proof.
   snrapply Build_Is0Functor.
   intros A B f.
   snrapply grp_homo_abel_rec.
-  refine (_ $o f).
-  exact abel_unit.
+  refine (abel_unit $o f).
 Defined.
 
 Global Instance is1functor_abel : Is1Functor abel.

--- a/theories/Algebra/AbGroups/FreeAbelianGroup.v
+++ b/theories/Algebra/AbGroups/FreeAbelianGroup.v
@@ -35,6 +35,14 @@ Arguments FreeAbGroup S : simpl never.
 Definition freeabgroup_in {S : Type} : S -> FreeAbGroup S
   := abel_unit o freegroup_in.
 
+Definition FreeAbGroup_rec {S : Type} {A : AbGroup} (f : S -> A)
+  : FreeAbGroup S $-> A
+  := grp_homo_abel_rec (FreeGroup_rec _ _ f).
+
+Definition FreeAbGroup_rec_beta_in {S : Type} {A : AbGroup} (f : S -> A)
+  : FreeAbGroup_rec f o freeabgroup_in == f
+  := fun _ => idpath.
+
 (** The abelianization of a free group on a set is a free abelian group on that set. *)
 Global Instance isfreeabgroupon_isabelianization_isfreegroup `{Funext}
   {S : Type} {G : Group} {A : AbGroup} (f : S -> G) (g : G $-> A)
@@ -55,8 +63,7 @@ Defined.
 Global Instance isfreeabgroup_freeabgroup `{Funext} (S : Type)
   : IsFreeAbGroup (FreeAbGroup S).
 Proof.
-  exists S.
-  exists (abel_unit (G:=FreeGroup S) o freegroup_in).
+  exists S, freeabgroup_in.
   srapply isfreeabgroupon_isabelianization_isfreegroup.
 Defined.
 

--- a/theories/Algebra/AbGroups/TensorProduct.v
+++ b/theories/Algebra/AbGroups/TensorProduct.v
@@ -757,26 +757,25 @@ Defined.
 Definition equiv_ab_tensor_prod_freeabgroup X Y
   : FreeAbGroup (X * Y) $<~> ab_tensor_prod (FreeAbGroup X) (FreeAbGroup Y).
 Proof.
-  transparent assert (f : (FreeAbGroup (X * Y) $-> ab_tensor_prod (FreeAbGroup X) (FreeAbGroup Y))).
-  { snrapply grp_homo_abel_rec.
+  srefine (let f:=_ in let g:=_ in cate_adjointify f g _ _).
+  - snrapply grp_homo_abel_rec.
     snrapply FreeGroup_rec.
     intros [x y].
-    exact (tensor (freeabgroup_in x) (freeabgroup_in y)). }
-  transparent assert (g : (ab_tensor_prod (FreeAbGroup X) (FreeAbGroup Y) $-> FreeAbGroup (X * Y))).
-  { snrapply ab_tensor_prod_rec.
+    exact (tensor (freeabgroup_in x) (freeabgroup_in y)).
+  - snrapply ab_tensor_prod_rec.
     + intros x.
       snrapply grp_homo_abel_rec.
       snrapply FreeGroup_rec.
       intros y; revert x.
       unfold FreeAbGroup.
-      snrapply grp_homo_abel_rec.    
+      snrapply grp_homo_abel_rec.
       snrapply FreeGroup_rec.
       intros x.
       apply abel_unit.
       apply freegroup_in.
       exact (x, y).
     + intros x y y'.
-      snrapply grp_homo_op.    
+      snrapply grp_homo_op.
     + intros x x'.
       rapply Abel_ind_hprop.
       snrapply (FreeGroup_ind_homotopy _ (f' := ab_homo_add _ _)).
@@ -784,8 +783,7 @@ Proof.
       lhs nrapply FreeGroup_rec_beta.
       lhs nrapply grp_homo_op.
       snrapply (ap011 (+) _^ _^).
-      1,2: nrapply FreeGroup_rec_beta. }
-  snrapply (cate_adjointify f g).
+      1,2: nrapply FreeGroup_rec_beta.
   - snrapply ab_tensor_prod_ind_homotopy.
     intros x.
     change (f $o g $o grp_homo_tensor_l x $== grp_homo_tensor_l x).

--- a/theories/Algebra/AbGroups/TensorProduct.v
+++ b/theories/Algebra/AbGroups/TensorProduct.v
@@ -175,8 +175,7 @@ Definition ab_tensor_prod_rec {A B C : AbGroup}
 Proof.
   unfold ab_tensor_prod.
   snrapply grp_quotient_rec.
-  - snrapply grp_homo_abel_rec.
-    snrapply FreeGroup_rec.
+  - snrapply FreeAbGroup_rec.
     exact (uncurry f).
   - unfold normalsubgroup_subgroup.
     apply ab_tensor_prod_rec_helper; assumption.
@@ -758,18 +757,15 @@ Definition equiv_ab_tensor_prod_freeabgroup X Y
   : FreeAbGroup (X * Y) $<~> ab_tensor_prod (FreeAbGroup X) (FreeAbGroup Y).
 Proof.
   srefine (let f:=_ in let g:=_ in cate_adjointify f g _ _).
-  - snrapply grp_homo_abel_rec.
-    snrapply FreeGroup_rec.
+  - snrapply FreeAbGroup_rec.
     intros [x y].
     exact (tensor (freeabgroup_in x) (freeabgroup_in y)).
   - snrapply ab_tensor_prod_rec.
     + intros x.
-      snrapply grp_homo_abel_rec.
-      snrapply FreeGroup_rec.
+      snrapply FreeAbGroup_rec.
       intros y; revert x.
       unfold FreeAbGroup.
-      snrapply grp_homo_abel_rec.
-      snrapply FreeGroup_rec.
+      snrapply FreeAbGroup_rec.
       intros x.
       apply abel_unit.
       apply freegroup_in.


### PR DESCRIPTION
We show that the tensor product of free abelian groups is the free abelian group on the cartesian product of the generating sets.

The proof could be prettier. It was quite difficult to get right due to the subtle distinction between `Hom (A:=Group)` and `Hom (A:=AbGroup)`.