### PR TITLE
ci: fix upload of documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
     - name: tar alectryon artifact
       run: tar -cf alectryon-html.tar alectryon-html
     - name: upload alectryon artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: alectryon-html
         path: alectryon-html.tar


### PR DESCRIPTION
The update in #2076 was incomplete. This fixes it and should make the main `master` CI upload the documentation correctly. We cannot see that in the PR.