### PR TITLE
update nix flake to 8.20

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719436386,
-        "narHash": "sha256-NBGYaic5FLRg8AWSj6yr4g2IlMPUxNCVjRK6+RNuQBc=",
+        "lastModified": 1726042813,
+        "narHash": "sha256-LnNKCCxnwgF+575y0pxUdlGZBO/ru1CtGHIqQVfvjlA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c66e984bda09e7230ea7b364e677c5ba4f0d36d0",
+        "rev": "159be5db480d1df880a0135ca0bfed84c2f88353",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
         };
 
         devShells.default = makeDevShell { coq = pkgs.coq_8_20; } { };
+        devShells.coq_8_19 = makeDevShell { coq = pkgs.coq_8_19; } { };
 
         # To use, pass --impure to nix develop
         devShells.coq_master =

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           useDune = true;
         };
 
-        devShells.default = makeDevShell { coq = pkgs.coq_8_19; } { };
+        devShells.default = makeDevShell { coq = pkgs.coq_8_20; } { };
 
         # To use, pass --impure to nix develop
         devShells.coq_master =


### PR DESCRIPTION
We update the nix flake to use Coq 8.20 and add a 8.19 shell for when we need to use that.

This also has the added bonus of using coq-lsp 0.2.0 which has jump-to-definition support across files!

