### PR TITLE
Basics and Types cleanup

### DIFF
--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -1,6 +1,8 @@
 (* -*- mode: coq; mode: visual-line -*-  *)
 
-(** * Basic definitions of homotopy type theory, particularly the groupoid structure of identity types *)
+(** * Basic definitions of homotopy type theory *)
+
+(** This file defines some of the most basic types and type formers, such as sums, products, Sigma types and path types.  It defines the action of functions on paths [ap], transport, equivalences, and function extensionality.  It also defines truncatedness, and a number of other fundamental definitions used throughout the library. *)
 
 (** Import the file of reserved notations so we maintain consistent level notations throughout the library. *)
 Require Export Basics.Settings Basics.Notations.
@@ -21,8 +23,8 @@ Notation "A -> B" := (forall (_ : A), B) : type_scope.
 
 (** [option A] is the extension of [A] with an extra element [None] *)
 Inductive option (A : Type) : Type :=
-  | Some : A -> option A
-  | None : option A.
+| Some : A -> option A
+| None : option A.
 
 Scheme option_rect := Induction for option Sort Type.
 
@@ -35,8 +37,8 @@ Register option as core.option.type.
 
 (** [sum A B], written [A + B], is the disjoint sum of [A] and [B] *)
 Inductive sum (A B : Type) : Type :=
-  | inl : A -> sum A B
-  | inr : B -> sum A B.
+| inl : A -> sum A B
+| inr : B -> sum A B.
 
 Scheme sum_rect := Induction for sum Sort Type.
 Scheme sum_ind := Induction for sum Sort Type.
@@ -578,8 +580,8 @@ Local Open Scope trunc_scope.
 (** We define truncatedness using an inductive type [IsTrunc_internal A n].  We use a notation [IsTrunc n A] simply to swap the orders of arguments, and notations [Contr], [IsHProp] and [IsHSet] which specialize to [n] being [-2], [-1] and [0], respectively.  An alternative is to use a [Fixpoint], and that was done in the past.  The advantages of the inductive approach are:  [IsTrunc_internal] is cumulative; typeclass inherence works smoothly; the library builds faster.  Some disadvantages are that we need to manually apply the constructors when proving that something is truncated, and that the induction principle is awkward to work with. *)
 
 Inductive IsTrunc_internal (A : Type@{u}) : trunc_index -> Type@{u} :=
-  | Build_Contr : forall (center : A) (contr : forall y, center = y), IsTrunc_internal A minus_two
-  | istrunc_S : forall {n:trunc_index}, (forall x y:A, IsTrunc_internal (x = y) n) -> IsTrunc_internal A (trunc_S n).
+| Build_Contr : forall (center : A) (contr : forall y, center = y), IsTrunc_internal A minus_two
+| istrunc_S : forall {n:trunc_index}, (forall x y:A, IsTrunc_internal (x = y) n) -> IsTrunc_internal A (trunc_S n).
 
 Existing Class IsTrunc_internal.
 

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -657,17 +657,6 @@ Coercion istrunc_fun : IsTrunc >-> Funclass.
 (** Hprop-valued relations.  Making this a [Notation] rather than a [Definition] enables typeclass resolution to pick it up easily.  We include the base type [A] in the notation since otherwise e.g. [forall (x y : A) (z : B x y), IsHProp (C x y z)] will get displayed as [forall (x : A), is_mere_relation (C x)].  *)
 Notation is_mere_relation A R := (forall (x y : A), IsHProp (R x y)).
 
-(** *** Tactics *)
-
-(** We declare some more [Hint Resolve] hints, now in the "hint database" [path_hints].  In general various hints (resolve, rewrite, unfold hints) can be grouped into "databases". This is necessary as sometimes different kinds of hints cannot be mixed, for example because they would cause a combinatorial explosion or rewriting cycles.
-
-   A specific [Hint Resolve] database [db] can be used with [auto with db].
-
-   The hints in [path_hints] are designed to push concatenation *outwards*, eliminate identities and inverses, and associate to the left as far as  possible. *)
-
-(** TODO: think more carefully about this.  Perhaps associating to the right would be more convenient? *)
-#[export] Hint Resolve idpath inverse : path_hints.
-
 (** ** Natural numbers *)
 
 Inductive nat : Type0 :=

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -381,6 +381,18 @@ Register ap as core.identity.congr.
 
 Notation ap01 := ap (only parsing).
 
+(** Similarly, dependent functions act on paths; but the type is a bit more subtle. If [f : forall a:A, B a] and [p : x = y] is a path in [A], then [apD f p] should somehow be a path between [f x : B x] and [f y : B y]. Since these live in different types, we use transport along [p] to make them comparable: [apD f p : p # f x = f y].
+
+  The type [p # f x = f y] can profitably be considered as a heterogeneous or dependent equality type, of "paths from [f x] to [f y] over [p]". *)
+
+Definition apD {A:Type} {B:A->Type} (f:forall a:A, B a) {x y:A} (p:x=y):
+  p # (f x) = f y
+  :=
+  match p with idpath => idpath end.
+
+(** See above for the meaning of [simpl nomatch]. *)
+Arguments apD {A%_type_scope B} f%_function_scope {x y} p%_path_scope : simpl nomatch.
+
 Definition pointwise_paths A (P : A -> Type) (f g : forall x, P x)
   := forall x, f x = g x.
 
@@ -440,18 +452,6 @@ Global Arguments ap11 {A B}%_type_scope {f g}%_function_scope h%_path_scope {x y
 
 (** See above for the meaning of [simpl nomatch]. *)
 Arguments ap {A B} f {x y} p : simpl nomatch.
-
-(** Similarly, dependent functions act on paths; but the type is a bit more subtle. If [f : forall a:A, B a] and [p : x = y] is a path in [A], then [apD f p] should somehow be a path between [f x : B x] and [f y : B y]. Since these live in different types, we use transport along [p] to make them comparable: [apD f p : p # f x = f y].
-
-  The type [p # f x = f y] can profitably be considered as a heterogeneous or dependent equality type, of "paths from [f x] to [f y] over [p]". *)
-
-Definition apD {A:Type} {B:A->Type} (f:forall a:A, B a) {x y:A} (p:x=y):
-  p # (f x) = f y
-  :=
-  match p with idpath => idpath end.
-
-(** See above for the meaning of [simpl nomatch]. *)
-Arguments apD {A%_type_scope B} f%_function_scope {x y} p%_path_scope : simpl nomatch.
 
 (** ** Equivalences *)
 

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -66,6 +66,9 @@ Local Open Scope path_scope.
 
 (** ** The 1-dimensional groupoid structure. *)
 
+(** [concat], with arguments flipped. Useful mainly in the idiom [apply (concatR (expression))]. Given as a notation not a definition so that the resultant terms are literally instances of [concat], with no unfolding required. *)
+Notation concatR := (fun p q => concat q p).
+
 (** The identity path is a right unit. *)
 Definition concat_p1 {A : Type} {x y : A} (p : x = y) :
   p @ 1 = p
@@ -1415,13 +1418,15 @@ Proof.
   by path_induction.
 Defined.
 
-(** ** Tactics, hints, and aliases *)
+(** ** Hints *)
 
-(** [concat], with arguments flipped. Useful mainly in the idiom [apply (concatR (expression))]. Given as a notation not a definition so that the resultant terms are literally instances of [concat], with no unfolding required. *)
-Notation concatR := (fun p q => concat q p).
+(** We declare some more [Hint Resolve] hints, now in the "hint database" [path_hints].  In general various hints (resolve, rewrite, unfold hints) can be grouped into "databases". This is necessary as sometimes different kinds of hints cannot be mixed, for example because they would cause a combinatorial explosion or rewriting cycles.  A specific [Hint Resolve] database [db] can be used with [auto with db].
+
+    The hints in [path_hints] are designed to push concatenation *outwards*, eliminate identities and inverses, and associate to the left as far as possible. *)
 
 #[export]
 Hint Resolve
+  inverse
   concat_1p concat_p1 concat_p_pp
   inv_pp inv_V
  : path_hints.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -182,7 +182,6 @@ Definition inv_V {A : Type} {x y : A} (p : x = y) :
   :=
   match p with idpath => 1 end.
 
-
 (** *** Theorems for moving things around in equations. *)
 
 Definition moveR_Mp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
@@ -369,7 +368,6 @@ Definition moveL_transport_p_V {A : Type} (P : A -> Type) {x y : A}
 Proof.
   destruct p; reflexivity.
 Defined.
-
 
 (** *** Functoriality of functions *)
 
@@ -972,7 +970,6 @@ Proof.
   destruct p; reflexivity.
 Defined.
 
-
 (** *** Transporting in particular fibrations. *)
 
 (** One frequently needs lemmas showing that transport in a certain dependent type is equal to some more explicitly defined operation, defined according to the structure of that dependent type.  For most dependent types, we prove these lemmas in the appropriate file in the types/ subdirectory.  Here we consider only the most basic cases. *)
@@ -1429,42 +1426,41 @@ Hint Resolve
   inverse
   concat_1p concat_p1 concat_p_pp
   inv_pp inv_V
- : path_hints.
+  : path_hints.
 
-(* First try at a paths db
-We want the RHS of the equation to become strictly simpler *)
+(* First try at a paths db.  We want the RHS of the equation to become strictly simpler. *)
 #[export]
 Hint Rewrite
-@concat_p1
-@concat_1p
-@concat_p_pp (* there is a choice here !*)
-@concat_pV
-@concat_Vp
-@concat_V_pp
-@concat_p_Vp
-@concat_pp_V
-@concat_pV_p
-(*@inv_pp*) (* I am not sure about this one *)
-@inv_V
-@moveR_Mp
-@moveR_pM
-@moveL_Mp
-@moveL_pM
-@moveL_1M
-@moveL_M1
-@moveR_M1
-@moveR_1M
-@ap_1
-(* @ap_pp
-@ap_p_pp ?*)
-@inverse_ap
-@ap_idmap
-(* @ap_compose
-@ap_compose'*)
-@ap_const
-(* Unsure about naturality of [ap], was absent in the old implementation*)
-@apD10_1
-:paths.
+  @concat_p1
+  @concat_1p
+  @concat_p_pp (* there is a choice here !*)
+  @concat_pV
+  @concat_Vp
+  @concat_V_pp
+  @concat_p_Vp
+  @concat_pp_V
+  @concat_pV_p
+  (*@inv_pp*) (* I am not sure about this one *)
+  @inv_V
+  @moveR_Mp
+  @moveR_pM
+  @moveL_Mp
+  @moveL_pM
+  @moveL_1M
+  @moveL_M1
+  @moveR_M1
+  @moveR_1M
+  @ap_1
+  (* @ap_pp
+  @ap_p_pp ?*)
+  @inverse_ap
+  @ap_idmap
+  (* @ap_compose
+  @ap_compose'*)
+  @ap_const
+  (* Unsure about naturality of [ap], was absent in the old implementation. *)
+  @apD10_1
+  : paths.
 
 Ltac hott_simpl :=
   autorewrite with paths in * |- * ; auto with path_hints.

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -16,10 +16,10 @@ Local Open Scope trunc_scope.
 Local Open Scope path_scope.
 Generalizable Variables A B m n f.
 
-(** Notation for truncation-levels. *)
+(** ** Notation for truncation-levels *)
 Open Scope trunc_scope.
 
-(* Increase a truncation index by a natural number. *)
+(** Increase a truncation index by a natural number. *)
 Fixpoint trunc_index_inc@{} (k : trunc_index) (n : nat)
   : trunc_index
   := match n with
@@ -27,7 +27,7 @@ Fixpoint trunc_index_inc@{} (k : trunc_index) (n : nat)
       | S m => (trunc_index_inc k m).+1
     end.
 
-(* This is a variation that inserts the successor operations in the other order.  This is sometimes convenient. *)
+(** This is a variation that inserts the successor operations in the other order.  This is sometimes convenient. *)
 Fixpoint trunc_index_inc'@{} (k : trunc_index) (n : nat)
   : trunc_index
   := match n with
@@ -102,6 +102,7 @@ Definition trunc_index_to_int@{} n :=
 Definition trunc_index_to_num_int@{} n :=
   Numeral.IntDec (trunc_index_to_int n).
 
+(** This allows us to use notation like (-2) and 42 for a [trunc_index]. *)
 Number Notation trunc_index num_int_to_trunc_index trunc_index_to_num_int
   : trunc_scope.
 

--- a/theories/Types/Arrow.v
+++ b/theories/Types/Arrow.v
@@ -49,7 +49,7 @@ Definition path_arrow_1 {A B : Type} (f : A -> B)
   := eta_path_arrow f f 1.
 
 Definition equiv_ap10 {A B : Type} f g
-: (f = g) <~> (f == g)
+  : (f = g) <~> (f == g)
   := Build_Equiv _ _ (@ap10 A B f g) _.
 
 Global Instance isequiv_path_arrow {A B : Type} (f g : A -> B)
@@ -83,9 +83,9 @@ Defined.
 (** ** Path algebra *)
 
 Definition path_arrow_pp {A B : Type} (f g h : A -> B)
-           (p : f == g) (q : g == h)
-: path_arrow f h (fun x => p x @ q x) = path_arrow f g p @ path_arrow g h q
-:= path_forall_pp f g h p q.
+  (p : f == g) (q : g == h)
+  : path_arrow f h (fun x => p x @ q x) = path_arrow f g p @ path_arrow g h q
+  := path_forall_pp f g h p q.
 
 (** ** Transport *)
 
@@ -133,13 +133,12 @@ Defined.
 Definition ap_transport_arrow_toconst {A : Type} {B : A -> Type} {C : Type}
   {x1 x2 : A} (p : x1 = x2) (f : B x1 -> C) {y1 y2 : B x2} (q : y1 = y2)
   : ap (transport (fun x => B x -> C) p f) q
-    @ transport_arrow_toconst p f y2
+      @ transport_arrow_toconst p f y2
     = transport_arrow_toconst p f y1
-    @ ap (fun y => f (p^ # y)) q.
+        @ ap (fun y => f (p^ # y)) q.
 Proof.
   destruct p, q; reflexivity.
 Defined.
-
 
 (** ** Dependent paths *)
 
@@ -149,22 +148,21 @@ Definition dpath_arrow
   {A:Type} (B C : A -> Type) {x1 x2:A} (p:x1=x2)
   (f : B x1 -> C x1) (g : B x2 -> C x2)
   : (forall (y1:B x1), transport C p (f y1) = g (transport B p y1))
-  <~>
-  (transport (fun x => B x -> C x) p f = g).
+      <~> (transport (fun x => B x -> C x) p f = g).
 Proof.
   destruct p.
   apply equiv_path_arrow.
 Defined.
 
 Definition ap10_dpath_arrow
-  {A:Type} (B C : A -> Type) {x1 x2:A} (p:x1=x2)
+  {A : Type} (B C : A -> Type) {x1 x2 : A} (p : x1 = x2)
   (f : B x1 -> C x1) (g : B x2 -> C x2)
-  (h : forall (y1:B x1), transport C p (f y1) = g (transport B p y1))
+  (h : forall (y1 : B x1), transport C p (f y1) = g (transport B p y1))
   (u : B x1)
   : ap10 (dpath_arrow B C p f g h) (p # u)
-  = transport_arrow p f (p # u)
-  @ ap (fun x => p # (f x)) (transport_Vp B p u)
-  @ h u.
+    = transport_arrow p f (p # u)
+        @ ap (fun x => p # (f x)) (transport_Vp B p u)
+        @ h u.
 Proof.
   destruct p; simpl; unfold ap10.
   exact (apD10_path_forall f g h u @ (concat_1p _)^).
@@ -173,26 +171,26 @@ Defined.
 (** ** Maps on paths *)
 
 (** The action of maps given by application. *)
-Definition ap_apply_l {A B : Type} {x y : A -> B} (p : x = y) (z : A) :
-  ap (fun f => f z) p = ap10 p z
-:= 1.
+Definition ap_apply_l {A B : Type} {x y : A -> B} (p : x = y) (z : A)
+  : ap (fun f => f z) p = ap10 p z
+  := 1.
 
-Definition ap_apply_Fl {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) (z : B) :
-  ap (fun a => (M a) z) p = ap10 (ap M p) z
-:= match p with 1 => 1 end.
+Definition ap_apply_Fl {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) (z : B)
+  : ap (fun a => (M a) z) p = ap10 (ap M p) z
+  := match p with 1 => 1 end.
 
-Definition ap_apply_Fr {A B C : Type} {x y : A} (p : x = y) (z : B -> C) (N : A -> B) :
-  ap (fun a => z (N a)) p = ap01 z (ap N p)
-:= (ap_compose N _ _).
+Definition ap_apply_Fr {A B C : Type} {x y : A} (p : x = y) (z : B -> C) (N : A -> B)
+  : ap (fun a => z (N a)) p = ap01 z (ap N p)
+  := (ap_compose N _ _).
 
-Definition ap_apply_FlFr {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) (N : A -> B) :
-  ap (fun a => (M a) (N a)) p = ap11 (ap M p) (ap N p)
-:= match p with 1 => 1 end.
+Definition ap_apply_FlFr {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) (N : A -> B)
+  : ap (fun a => (M a) (N a)) p = ap11 (ap M p) (ap N p)
+  := match p with 1 => 1 end.
 
 (** The action of maps given by lambda. *)
-Definition ap_lambda {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C) :
-  ap (fun a b => M a b) p =
-  path_arrow _ _ (fun b => ap (fun a => M a b) p).
+Definition ap_lambda {A B C : Type} {x y : A} (p : x = y) (M : A -> B -> C)
+  : ap (fun a b => M a b) p
+    = path_arrow _ _ (fun b => ap (fun a => M a b) p).
 Proof.
   destruct p;
   symmetry;
@@ -219,9 +217,9 @@ Defined.
 Definition ap_functor_arrow `(f : B -> A) `(g : C -> D)
   (h h' : A -> C) (p : h == h')
   : ap (functor_arrow f g) (path_arrow _ _ p)
-  = path_arrow _ _ (fun b => ap g (p (f b)))
+    = path_arrow _ _ (fun b => ap g (p (f b)))
   := @ap_functor_forall _ A (fun _ => C) B (fun _ => D)
-  f (fun _ => g) h h' p.
+      f (fun _ => g) h h' p.
 
 (** ** Truncatedness: functions into an n-type is an n-type *)
 
@@ -255,17 +253,15 @@ Global Instance isequiv_functor_arrow `{IsEquiv B A f} `{IsEquiv C D g}
 Definition equiv_functor_arrow `{IsEquiv B A f} `{IsEquiv C D g}
   : (A -> C) <~> (B -> D)
   := @equiv_functor_forall _ A (fun _ => C) B (fun _ => D)
-  f _ (fun _ => g) _.
+      f _ (fun _ => g) _.
 
 Definition equiv_functor_arrow' `(f : B <~> A) `(g : C <~> D)
   : (A -> C) <~> (B -> D)
   := @equiv_functor_forall' _ A (fun _ => C) B (fun _ => D)
-  f (fun _ => g).
+      f (fun _ => g).
 
 (* We could do something like this notation, but it's not clear that it would be that useful, and might be confusing. *)
 (* Notation "f -> g" := (equiv_functor_arrow' f g) : equiv_scope. *)
-
-(** What remains is really identical to that in [Forall].  *)
 
 End AssumeFunext.
 
@@ -273,8 +269,8 @@ End AssumeFunext.
 
 (** This doesn't require funext *)
 Global Instance decidable_arrow {A B : Type}
-       `{Decidable A} `{Decidable B}
-: Decidable (A -> B).
+  `{Decidable A} `{Decidable B}
+  : Decidable (A -> B).
 Proof.
   destruct (dec B) as [x2|y2].
   - exact (inl (fun _ => x2)).

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -1,16 +1,16 @@
 (* -*- mode: coq; mode: visual-line -*- *)
+
 (** * Theorems about Sigma-types (dependent sums) *)
 
 Require Import HoTT.Basics.
 Require Import Types.Arrow Types.Paths.
 Local Open Scope path_scope.
 
-
 Generalizable Variables X A B C f g n.
 
-(** In homotopy type theory, We think of elements of [Type] as spaces, homotopy types, or weak omega-groupoids. A type family [P : A -> Type] corresponds to a fibration whose base is [A] and whose fiber over [x] is [P x].
+(** In homotopy type theory, we think of elements of [Type] as spaces, homotopy types, or weak omega-groupoids. A type family [P : A -> Type] corresponds to a fibration whose base is [A] and whose fiber over [x] is [P x].
 
-From such a [P] we can build a total space over the base space [A] so that the fiber over [x : A] is [P x]. This is just Coq's dependent sum construction, written as [sig P] or [{x : A & P x}]. The elements of [{x : A & P x}] are pairs, written [exist P x y] in Coq, where [x : A] and [y : P x].  In [Common.v] we defined the notation [(x;y)] to mean [exist _ x y].
+From such a [P] we can build a total space over the base space [A] so that the fiber over [x : A] is [P x]. This is just Coq's dependent sum construction, written as [sig P] or [{x : A & P x}]. The elements of [{x : A & P x}] are pairs, written [exist P x y] in Coq, where [x : A] and [y : P x].  In [Overture.v], we defined the notation [(x; y)] to mean [exist _ x y].
 
 The base and fiber components of a point in the total space are extracted with the two projections [pr1] and [pr2]. *)
 
@@ -52,8 +52,8 @@ Arguments eta3_sigma / .
 
 (** With this version of the function, we often have to give [u] and [v] explicitly, so we make them explicit arguments. *)
 Definition path_sigma_uncurried {A : Type} (P : A -> Type) (u v : sig P)
-           (pq : {p : u.1 = v.1 & p # u.2 = v.2})
-: u = v
+  (pq : {p : u.1 = v.1 & p # u.2 = v.2})
+  : u = v
   := match pq.2 in (_ = v2) return u = (v.1; v2) with
        | 1 => match pq.1 as p in (_ = v1) return u = (v1; p # u.2) with
                 | 1 => 1
@@ -62,50 +62,43 @@ Definition path_sigma_uncurried {A : Type} (P : A -> Type) (u v : sig P)
 
 (** This is the curried one you usually want to use in practice.  We define it in terms of the uncurried one, since it's the uncurried one that is proven below to be an equivalence. *)
 Definition path_sigma {A : Type} (P : A -> Type) (u v : sig P)
-           (p : u.1 = v.1) (q : p # u.2 = v.2)
-: u = v
+  (p : u.1 = v.1) (q : p # u.2 = v.2)
+  : u = v
   := path_sigma_uncurried P u v (p;q).
 
 (** A contravariant instance of [path_sigma_uncurried] *)
 Definition path_sigma_uncurried_contra {A : Type} (P : A -> Type) (u v : sig P)
-           (pq : {p : u.1 = v.1 & u.2 = p^ # v.2})
-: u = v
+  (pq : {p : u.1 = v.1 & u.2 = p^ # v.2})
+  : u = v
   := (path_sigma_uncurried P v u (pq.1^;pq.2^))^.
 
 (** A variant of [Forall.dpath_forall] from which uses dependent sums to package things. It cannot go into [Forall] because [Sigma] depends on [Forall]. *)
-
 Definition dpath_forall'
-           {A : Type } (P : A -> Type) (Q: sig P -> Type) {x y : A} (h : x = y)
-           (f : forall p, Q (x ; p)) (g : forall p, Q (y ; p))
-:
-  (forall p, transport Q (path_sigma P (x ; p) (y; _) h 1) (f p) = g (h # p))
-    <~>
-    (forall p, transportD P (fun x => fun p => Q ( x ; p)) h p (f p) = g (transport P h p)).
+  {A : Type } (P : A -> Type) (Q: sig P -> Type) {x y : A} (h : x = y)
+  (f : forall p, Q (x ; p)) (g : forall p, Q (y ; p))
+  : (forall p, transport Q (path_sigma P (x ; p) (y; _) h 1) (f p) = g (h # p))
+    <~> (forall p, transportD P (fun x => fun p => Q ( x ; p)) h p (f p) = g (transport P h p)).
 Proof.
   destruct h.
   apply 1%equiv.
 Defined.
 
-
 (** This version produces only paths between pairs, as opposed to paths between arbitrary inhabitants of dependent sum types.  But it has the advantage that the components of those pairs can more often be inferred, so we make them implicit arguments. *)
 Definition path_sigma' {A : Type} (P : A -> Type) {x x' : A} {y : P x} {y' : P x'}
-           (p : x = x') (q : p # y = y')
-: (x;y) = (x';y')
+  (p : x = x') (q : p # y = y')
+  : (x;y) = (x';y')
   := path_sigma P (x;y) (x';y') p q.
 
-
 (** Projections of paths from a total space. *)
-
 Definition pr1_path `{P : A -> Type} {u v : sig P} (p : u = v)
-: u.1 = v.1
-  :=
-    ap pr1 p.
+  : u.1 = v.1
+  := ap pr1 p.
 (* match p with idpath => 1 end. *)
 
 Notation "p ..1" := (pr1_path p) : fibration_scope.
 
 Definition pr2_path `{P : A -> Type} {u v : sig P} (p : u = v)
-: p..1 # u.2 = v.2
+  : p..1 # u.2 = v.2
   := (transport_compose P pr1 p u.2)^
      @ (@apD {x:A & P x} _ pr2 _ _ p).
 
@@ -114,8 +107,8 @@ Notation "p ..2" := (pr2_path p) : fibration_scope.
 (** Now we show how these things compute. *)
 
 Definition pr1_path_sigma_uncurried `{P : A -> Type} {u v : sig P}
-           (pq : { p : u.1 = v.1 & p # u.2 = v.2 })
-: (path_sigma_uncurried _ _ _ pq)..1 = pq.1.
+  (pq : { p : u.1 = v.1 & p # u.2 = v.2 })
+  : (path_sigma_uncurried _ _ _ pq)..1 = pq.1.
 Proof.
   destruct u as [u1 u2]; destruct v as [v1 v2]; simpl in *.
   destruct pq as [p q].
@@ -123,8 +116,8 @@ Proof.
 Defined.
 
 Definition pr2_path_sigma_uncurried `{P : A -> Type} {u v : sig P}
-           (pq : { p : u.1 = v.1 & p # u.2 = v.2 })
-: (path_sigma_uncurried _ _ _ pq)..2
+  (pq : { p : u.1 = v.1 & p # u.2 = v.2 })
+  : (path_sigma_uncurried _ _ _ pq)..2
   = ap (fun s => transport P s u.2) (pr1_path_sigma_uncurried pq) @ pq.2.
 Proof.
   destruct u as [u1 u2]; destruct v as [v1 v2]; simpl in *.
@@ -133,18 +126,18 @@ Proof.
 Defined.
 
 Definition eta_path_sigma_uncurried `{P : A -> Type} {u v : sig P}
-           (p : u = v)
-: path_sigma_uncurried _ _ _ (p..1; p..2) = p.
+  (p : u = v)
+  : path_sigma_uncurried _ _ _ (p..1; p..2) = p.
 Proof.
   destruct p. reflexivity.
 Defined.
 
 Lemma transport_pr1_path_sigma_uncurried
-      `{P : A -> Type} {u v : sig P}
-      (pq : { p : u.1 = v.1 & transport P p u.2 = v.2 })
-      Q
-: transport (fun x => Q x.1) (@path_sigma_uncurried A P u v pq)
-  = transport _ pq.1.
+  `{P : A -> Type} {u v : sig P}
+  (pq : { p : u.1 = v.1 & transport P p u.2 = v.2 })
+  Q
+  : transport (fun x => Q x.1) (@path_sigma_uncurried A P u v pq)
+    = transport _ pq.1.
 Proof.
   destruct pq as [p q], u, v; simpl in *.
   destruct p, q; simpl in *.
@@ -152,38 +145,38 @@ Proof.
 Defined.
 
 Definition pr1_path_sigma `{P : A -> Type} {u v : sig P}
-           (p : u.1 = v.1) (q : p # u.2 = v.2)
-: (path_sigma _ _ _ p q)..1 = p
+  (p : u.1 = v.1) (q : p # u.2 = v.2)
+  : (path_sigma _ _ _ p q)..1 = p
   := pr1_path_sigma_uncurried (p; q).
 
 (* Writing it the other way can help [rewrite]. *)
 Definition ap_pr1_path_sigma {A:Type} {P : A -> Type} {u v : sig P}
-           (p : u.1 = v.1) (q : p # u.2 = v.2)
+  (p : u.1 = v.1) (q : p # u.2 = v.2)
   : ap pr1 (path_sigma _ _ _ p q) = p
   := pr1_path_sigma p q.
 
 Definition pr2_path_sigma `{P : A -> Type} {u v : sig P}
-           (p : u.1 = v.1) (q : p # u.2 = v.2)
-: (path_sigma _ _ _ p q)..2
-  = ap (fun s => transport P s u.2) (pr1_path_sigma p q) @ q
+  (p : u.1 = v.1) (q : p # u.2 = v.2)
+  : (path_sigma _ _ _ p q)..2
+    = ap (fun s => transport P s u.2) (pr1_path_sigma p q) @ q
   := pr2_path_sigma_uncurried (p; q).
 
 Definition eta_path_sigma `{P : A -> Type} {u v : sig P} (p : u = v)
-: path_sigma _ _ _ (p..1) (p..2) = p
+  : path_sigma _ _ _ (p..1) (p..2) = p
   := eta_path_sigma_uncurried p.
 
 Definition transport_pr1_path_sigma
-           `{P : A -> Type} {u v : sig P}
-           (p : u.1 = v.1) (q : p # u.2 = v.2)
-           Q
-: transport (fun x => Q x.1) (@path_sigma A P u v p q)
-  = transport _ p
+  `{P : A -> Type} {u v : sig P}
+  (p : u.1 = v.1) (q : p # u.2 = v.2)
+  Q
+  : transport (fun x => Q x.1) (@path_sigma A P u v p q)
+    = transport _ p
   := transport_pr1_path_sigma_uncurried (p; q) Q.
 
 (** This lets us identify the path space of a sigma-type, up to equivalence. *)
 
 Global Instance isequiv_path_sigma `{P : A -> Type} {u v : sig P}
-: IsEquiv (path_sigma_uncurried P u v) | 0.
+  : IsEquiv (path_sigma_uncurried P u v) | 0.
 Proof.
   simple refine (Build_IsEquiv
             _ _
@@ -197,19 +190,20 @@ Proof.
 Defined.
 
 Definition equiv_path_sigma `(P : A -> Type) (u v : sig P)
-: {p : u.1 = v.1 &  p # u.2 = v.2} <~> (u = v)
+  : {p : u.1 = v.1 &  p # u.2 = v.2} <~> (u = v)
   := Build_Equiv _ _ (path_sigma_uncurried P u v) _.
 
 (* A contravariant version of [isequiv_path_sigma'] *)
 Global Instance isequiv_path_sigma_contra `{P : A -> Type} {u v : sig P}
   : IsEquiv (path_sigma_uncurried_contra P u v) | 0.
+Proof.
   apply (isequiv_adjointify (path_sigma_uncurried_contra P u v)
         (fun r => match r with idpath => (1; 1) end)).
-- by intro r; induction r; destruct u as [u1 u2]; reflexivity.
-- destruct u, v; intros [p q].
-  simpl in *.
-  destruct p; simpl in q.
-  destruct q; reflexivity.
+  - by intro r; induction r; destruct u as [u1 u2]; reflexivity.
+  - destruct u, v; intros [p q].
+    simpl in *.
+    destruct p; simpl in q.
+    destruct q; reflexivity.
 Defined.
 
 (* A contravariant version of [equiv_path_sigma] *)
@@ -220,11 +214,11 @@ Definition equiv_path_sigma_contra {A : Type} `(P : A -> Type) (u v : sig P)
 (** This identification respects path concatenation. *)
 
 Definition path_sigma_pp_pp {A : Type} (P : A -> Type) {u v w : sig P}
-           (p1 : u.1 = v.1) (q1 : p1 # u.2 = v.2)
-           (p2 : v.1 = w.1) (q2 : p2 # v.2 = w.2)
-: path_sigma P u w (p1 @ p2)
-             (transport_pp P p1 p2 u.2 @ ap (transport P p2) q1 @ q2)
-  = path_sigma P u v p1 q1 @ path_sigma P v w p2 q2.
+  (p1 : u.1 = v.1) (q1 : p1 # u.2 = v.2)
+  (p2 : v.1 = w.1) (q2 : p2 # v.2 = w.2)
+  : path_sigma P u w (p1 @ p2)
+      (transport_pp P p1 p2 u.2 @ ap (transport P p2) q1 @ q2)
+    = path_sigma P u v p1 q1 @ path_sigma P v w p2 q2.
 Proof.
   destruct u, v, w. simpl in *.
   destruct p1, p2, q1, q2.
@@ -232,19 +226,19 @@ Proof.
 Defined.
 
 Definition path_sigma_pp_pp' {A : Type} (P : A -> Type)
-           {u1 v1 w1 : A} {u2 : P u1} {v2 : P v1} {w2 : P w1}
-           (p1 : u1 = v1) (q1 : p1 # u2 = v2)
-           (p2 : v1 = w1) (q2 : p2 # v2 = w2)
-: path_sigma' P (p1 @ p2)
-              (transport_pp P p1 p2 u2 @ ap (transport P p2) q1 @ q2)
-  = path_sigma' P p1 q1 @ path_sigma' P p2 q2
+  {u1 v1 w1 : A} {u2 : P u1} {v2 : P v1} {w2 : P w1}
+  (p1 : u1 = v1) (q1 : p1 # u2 = v2)
+  (p2 : v1 = w1) (q2 : p2 # v2 = w2)
+  : path_sigma' P (p1 @ p2)
+      (transport_pp P p1 p2 u2 @ ap (transport P p2) q1 @ q2)
+    = path_sigma' P p1 q1 @ path_sigma' P p2 q2
   := @path_sigma_pp_pp A P (u1;u2) (v1;v2) (w1;w2) p1 q1 p2 q2.
 
 Definition path_sigma_p1_1p' {A : Type} (P : A -> Type)
-           {u1 v1 : A} {u2 : P u1} {v2 : P v1}
-           (p : u1 = v1) (q : p # u2 = v2)
-: path_sigma' P p q
-  = path_sigma' P p 1 @ path_sigma' P 1 q.
+  {u1 v1 : A} {u2 : P u1} {v2 : P v1}
+  (p : u1 = v1) (q : p # u2 = v2)
+  : path_sigma' P p q
+    = path_sigma' P p 1 @ path_sigma' P 1 q.
 Proof.
   destruct p, q.
   reflexivity.
@@ -253,46 +247,42 @@ Defined.
 (** [pr1_path] also commutes with the groupoid structure. *)
 
 Definition pr1_path_1 {A : Type} {P : A -> Type} (u : sig P)
-: (idpath u) ..1 = idpath (u .1)
+  : (idpath u) ..1 = idpath (u .1)
   := 1.
 
 Definition pr1_path_pp {A : Type} {P : A -> Type} {u v w : sig P}
-           (p : u = v) (q : v = w)
-: (p @ q) ..1 = (p ..1) @ (q ..1)
+  (p : u = v) (q : v = w)
+  : (p @ q) ..1 = (p ..1) @ (q ..1)
   := ap_pp _ _ _.
 
 Definition pr1_path_V {A : Type} {P : A -> Type} {u v : sig P} (p : u = v)
-: p^ ..1 = (p ..1)^
+  : p^ ..1 = (p ..1)^
   := ap_V _ _.
 
 (** Applying [exist] to one argument is the same as [path_sigma] with reflexivity in the first place. *)
-
 Definition ap_exist {A : Type} (P : A -> Type) (x : A) (y1 y2 : P x)
-           (q : y1 = y2)
-: ap (exist P x) q = path_sigma' P 1 q.
+  (q : y1 = y2)
+  : ap (exist P x) q = path_sigma' P 1 q.
 Proof.
   destruct q; reflexivity.
 Defined.
 
 (** Dependent transport is the same as transport along a [path_sigma]. *)
-
 Definition transportD_is_transport
-           {A:Type} (B:A->Type) (C:sig B -> Type)
-           (x1 x2:A) (p:x1=x2) (y:B x1) (z:C (x1;y))
-: transportD B (fun a b => C (a;b)) p y z
-  = transport C (path_sigma' B p 1) z.
+  {A:Type} (B:A->Type) (C:sig B -> Type)
+  (x1 x2:A) (p:x1=x2) (y:B x1) (z:C (x1;y))
+  : transportD B (fun a b => C (a;b)) p y z
+    = transport C (path_sigma' B p 1) z.
 Proof.
   destruct p. reflexivity.
 Defined.
 
-
 (** Applying a two variable function to a [path_sigma]. *)
-
 Definition ap_path_sigma {A B} (P : A -> Type) (F : forall a : A, P a -> B)
-           {x x' : A} {y : P x} {y' : P x'} (p : x = x') (q : p # y = y')
+  {x x' : A} {y : P x} {y' : P x'} (p : x = x') (q : p # y = y')
   : ap (fun w => F w.1 w.2) (path_sigma' P p q)
     = ap _ (moveL_transport_V _ p _ _ q)
-         @ (transport_arrow_toconst _ _ _)^ @ ap10 (apD F p) y'.
+        @ (transport_arrow_toconst _ _ _)^ @ ap10 (apD F p) y'.
 Proof.
   destruct p, q; reflexivity.
 Defined.
@@ -300,39 +290,35 @@ Defined.
 (*     = ap10 (apD F p^)^ y @ transport_arrow_toconst _ _ _ *)
 (*                          @ ap (F x') (transport2 _ (inv_V p) y @ q). *)
 
-
-
 (** And we can simplify when the first equality is [1]. *)
 Lemma ap_path_sigma_1p {A B : Type} {P : A -> Type} (F : forall a, P a -> B)
-      (a : A) {x y : P a} (p : x = y)
+  (a : A) {x y : P a} (p : x = y)
   : ap (fun w => F w.1 w.2) (path_sigma' P 1 p) = ap (fun z => F a z) p.
 Proof.
   destruct p; reflexivity.
 Defined.
 
-
 (** Applying a function constructed with [sig_rec] to a [path_sigma] can be computed.  Technically this computation should probably go by way of a 2-variable [ap], and should be done in the dependently typed case. *)
 Definition ap_sig_rec_path_sigma {A : Type} (P : A -> Type) {Q : Type}
-           (x1 x2:A) (p:x1=x2) (y1:P x1) (y2:P x2) (q:p # y1 = y2)
-           (d : forall a, P a -> Q)
-: ap (sig_rec _ _ Q d) (path_sigma' P p q)
-  = (transport_const p _)^
-    @ (ap ((transport (fun _ => Q) p) o (d x1)) (transport_Vp _ p y1))^
-    @ (transport_arrow p _ _)^
-    @ ap10 (apD d p) (p # y1)
-      @ ap (d x2) q.
+  (x1 x2 : A) (p : x1 = x2) (y1 : P x1) (y2 : P x2) (q : p # y1 = y2)
+  (d : forall a, P a -> Q)
+  : ap (sig_rec _ _ Q d) (path_sigma' P p q)
+    = (transport_const p _)^
+        @ (ap ((transport (fun _ => Q) p) o (d x1)) (transport_Vp _ p y1))^
+          @ (transport_arrow p _ _)^
+            @ ap10 (apD d p) (p # y1)
+              @ ap (d x2) q.
 Proof.
   destruct p. destruct q. reflexivity.
 Defined.
-
 
 (** A path between paths in a total space is commonly shown component wise. *)
 
 (** With this version of the function, we often have to give [u] and [v] explicitly, so we make them explicit arguments. *)
 Definition path_path_sigma_uncurried {A : Type} (P : A -> Type) (u v : sig P)
-           (p q : u = v)
-           (rs : {r : p..1 = q..1 & transport (fun x => transport P x u.2 = v.2) r p..2 = q..2})
-: p = q.
+  (p q : u = v)
+  (rs : {r : p..1 = q..1 & transport (fun x => transport P x u.2 = v.2) r p..2 = q..2})
+  : p = q.
 Proof.
   destruct rs, p, u.
   etransitivity; [ | apply eta_path_sigma ].
@@ -342,10 +328,10 @@ Defined.
 
 (** This is the curried one you usually want to use in practice.  We define it in terms of the uncurried one, since it's the uncurried one that is proven below to be an equivalence. *)
 Definition path_path_sigma {A : Type} (P : A -> Type) (u v : sig P)
-           (p q : u = v)
-           (r : p..1 = q..1)
-           (s : transport (fun x => transport P x u.2 = v.2) r p..2 = q..2)
-: p = q
+  (p q : u = v)
+  (r : p..1 = q..1)
+  (s : transport (fun x => transport P x u.2 = v.2) r p..2 = q..2)
+  : p = q
   := path_path_sigma_uncurried P u v p q (r; s).
 
 (** ** Transport *)
@@ -355,30 +341,29 @@ Definition path_path_sigma {A : Type} (P : A -> Type) (u v : sig P)
   In particular, this indicates why "transport" alone cannot be fully defined by induction on the structure of types, although Id-elim/transportD can be (cf. Observational Type Theory).  A more thorough set of lemmas, along the lines of the present ones but dealing with Id-elim rather than just transport, might be nice to have eventually? *)
 
 Definition transport_sigma {A : Type} {B : A -> Type} {C : forall a:A, B a -> Type}
-           {x1 x2 : A} (p : x1 = x2) (yz : { y : B x1 & C x1 y })
-: transport (fun x => { y : B x & C x y }) p yz
-  = (p # yz.1 ; transportD _ _ p yz.1 yz.2).
+  {x1 x2 : A} (p : x1 = x2) (yz : { y : B x1 & C x1 y })
+  : transport (fun x => { y : B x & C x y }) p yz
+    = (p # yz.1 ; transportD _ _ p yz.1 yz.2).
 Proof.
   destruct p.  destruct yz as [y z]. reflexivity.
 Defined.
 
 (** The special case when the second variable doesn't depend on the first is simpler. *)
 Definition transport_sigma' {A B : Type} {C : A -> B -> Type}
-           {x1 x2 : A} (p : x1 = x2) (yz : { y : B & C x1 y })
-: transport (fun x => { y : B & C x y }) p yz =
-  (yz.1 ; transport (fun x => C x yz.1) p yz.2).
+  {x1 x2 : A} (p : x1 = x2) (yz : { y : B & C x1 y })
+  : transport (fun x => { y : B & C x y }) p yz =
+      (yz.1 ; transport (fun x => C x yz.1) p yz.2).
 Proof.
   destruct p. destruct yz. reflexivity.
 Defined.
 
 (** Or if the second variable contains a first component that doesn't depend on the first.  Need to think about the naming of these. *)
-
 Definition transport_sigma_' {A : Type} {B C : A -> Type}
-           {D : forall a:A, B a -> C a -> Type}
-           {x1 x2 : A} (p : x1 = x2)
-           (yzw : { y : B x1 & { z : C x1 & D x1 y z } })
-: transport (fun x => { y : B x & { z : C x & D x y z } }) p yzw
-  = (p # yzw.1 ; p # yzw.2.1 ; transportD2 _ _ _ p yzw.1 yzw.2.1 yzw.2.2).
+  {D : forall a:A, B a -> C a -> Type}
+  {x1 x2 : A} (p : x1 = x2)
+  (yzw : { y : B x1 & { z : C x1 & D x1 y z } })
+  : transport (fun x => { y : B x & { z : C x & D x y z } }) p yzw
+    = (p # yzw.1 ; p # yzw.2.1 ; transportD2 _ _ _ p yzw.1 yzw.2.1 yzw.2.2).
 Proof.
   destruct p. reflexivity.
 Defined.
@@ -386,19 +371,19 @@ Defined.
 (** ** Functorial action *)
 
 Definition functor_sigma `{P : A -> Type} `{Q : B -> Type}
-           (f : A -> B) (g : forall a, P a -> Q (f a))
-: sig P -> sig Q
+  (f : A -> B) (g : forall a, P a -> Q (f a))
+  : sig P -> sig Q
   := fun u => (f u.1 ; g u.1 u.2).
 
 Definition ap_functor_sigma `{P : A -> Type} `{Q : B -> Type}
-           (f : A -> B) (g : forall a, P a -> Q (f a))
-           (u v : sig P) (p : u.1 = v.1) (q : p # u.2 = v.2)
-: ap (functor_sigma f g) (path_sigma P u v p q)
+  (f : A -> B) (g : forall a, P a -> Q (f a))
+  (u v : sig P) (p : u.1 = v.1) (q : p # u.2 = v.2)
+  : ap (functor_sigma f g) (path_sigma P u v p q)
   = path_sigma Q (functor_sigma f g u) (functor_sigma f g v)
-               (ap f p)
-               ((transport_compose Q f p (g u.1 u.2))^
-                @ (@ap_transport _ P (fun x => Q (f x)) _ _ p g u.2)^
-                @ ap (g v.1) q).
+      (ap f p)
+      ((transport_compose Q f p (g u.1 u.2))^
+         @ (@ap_transport _ P (fun x => Q (f x)) _ _ p g u.2)^
+           @ ap (g v.1) q).
 Proof.
   destruct u as [u1 u2]; destruct v as [v1 v2]; simpl in p, q.
   destruct p; simpl in q.
@@ -409,8 +394,8 @@ Defined.
 (** ** Equivalences *)
 
 Global Instance isequiv_functor_sigma `{P : A -> Type} `{Q : B -> Type}
-         `{IsEquiv A B f} `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
-: IsEquiv (functor_sigma f g) | 1000.
+  `{IsEquiv A B f} `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
+  : IsEquiv (functor_sigma f g) | 1000.
 Proof.
   refine (isequiv_adjointify (functor_sigma f g)
                              (functor_sigma (f^-1)
@@ -431,33 +416,32 @@ Proof.
 Defined.
 
 Definition equiv_functor_sigma `{P : A -> Type} `{Q : B -> Type}
-           (f : A -> B) `{IsEquiv A B f}
-           (g : forall a, P a -> Q (f a))
-           `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
-: sig P <~> sig Q
+  (f : A -> B) `{IsEquiv A B f}
+  (g : forall a, P a -> Q (f a))
+  `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
+  : sig P <~> sig Q
   := Build_Equiv _ _ (functor_sigma f g) _.
 
 Definition equiv_functor_sigma' `{P : A -> Type} `{Q : B -> Type}
-           (f : A <~> B)
-           (g : forall a, P a <~> Q (f a))
-: sig P <~> sig Q
+  (f : A <~> B)
+  (g : forall a, P a <~> Q (f a))
+  : sig P <~> sig Q
   := equiv_functor_sigma f g.
 
 Definition equiv_functor_sigma_id `{P : A -> Type} `{Q : A -> Type}
-           (g : forall a, P a <~> Q a)
-: sig P <~> sig Q
+  (g : forall a, P a <~> Q a)
+  : sig P <~> sig Q
   := equiv_functor_sigma' 1 g.
 
 Definition equiv_functor_sigma_pb {A B : Type} {Q : B -> Type}
-           (f : A <~> B)
-: sig (Q o f) <~> sig Q
+  (f : A <~> B)
+  : sig (Q o f) <~> sig Q
   := equiv_functor_sigma f (fun a => 1%equiv).
 
 (** Lemma 3.11.9(i): Summing up a contractible family of types does nothing. *)
-
 Global Instance isequiv_pr1_contr {A} {P : A -> Type}
-         `{forall a, Contr (P a)}
-: IsEquiv (@pr1 A P) | 100.
+  `{forall a, Contr (P a)}
+  : IsEquiv (@pr1 A P) | 100.
 Proof.
   refine (isequiv_adjointify (@pr1 A P)
                              (fun a => (a ; center (P a))) _ _).
@@ -467,14 +451,13 @@ Proof.
 Defined.
 
 Definition equiv_sigma_contr {A : Type} (P : A -> Type)
-           `{forall a, Contr (P a)}
-: sig P <~> A
+  `{forall a, Contr (P a)}
+  : sig P <~> A
   := Build_Equiv _ _ pr1 _.
 
 (** Lemma 3.11.9(ii): Dually, summing up over a contractible type does nothing. *)
-
 Definition equiv_contr_sigma {A : Type} (P : A -> Type) `{Contr A}
-: { x : A & P x } <~> P (center A).
+  : { x : A & P x } <~> P (center A).
 Proof.
   refine (equiv_adjointify (fun xp => (contr xp.1)^ # xp.2)
                            (fun p => (center A ; p)) _ _).
@@ -484,7 +467,6 @@ Proof.
     refine (path_sigma' _ (contr a) _).
     apply transport_pV.
 Defined.
-
 
 (** ** Associativity *)
 
@@ -551,9 +533,8 @@ Defined.
 (** ** Universal mapping properties *)
 
 (** *** The positive universal property. *)
-Global Instance isequiv_sig_ind `{P : A -> Type}
-         (Q : sig P -> Type)
-: IsEquiv (sig_ind Q) | 0
+Global Instance isequiv_sig_ind `{P : A -> Type} (Q : sig P -> Type)
+  : IsEquiv (sig_ind Q) | 0
   := Build_IsEquiv
        _ _
        (sig_ind Q)
@@ -562,34 +543,32 @@ Global Instance isequiv_sig_ind `{P : A -> Type}
        (fun _ => 1)
        (fun _ => 1).
 
-Definition equiv_sig_ind `{P : A -> Type}
-           (Q : sig P -> Type)
-: (forall (x:A) (y:P x), Q (x;y)) <~> (forall xy, Q xy)
+Definition equiv_sig_ind `{P : A -> Type} (Q : sig P -> Type)
+  : (forall (x:A) (y:P x), Q (x;y)) <~> (forall xy, Q xy)
   := Build_Equiv _ _ (sig_ind Q) _.
 
 (** And a curried version *)
-Definition equiv_sig_ind' `{P : A -> Type}
-           (Q : forall a, P a -> Type)
-: (forall (x:A) (y:P x), Q x y) <~> (forall xy, Q xy.1 xy.2)
+Definition equiv_sig_ind' `{P : A -> Type} (Q : forall a, P a -> Type)
+  : (forall (x:A) (y:P x), Q x y) <~> (forall xy, Q xy.1 xy.2)
   := equiv_sig_ind (fun xy => Q xy.1 xy.2).
 
 (** *** The negative universal property. *)
 
 Definition sig_coind_uncurried
-           `{A : X -> Type} (P : forall x, A x -> Type)
-: { f : forall x, A x & forall x, P x (f x) }
-  -> (forall x, sig (P x))
+  `{A : X -> Type} (P : forall x, A x -> Type)
+  : { f : forall x, A x & forall x, P x (f x) }
+    -> (forall x, sig (P x))
   := fun fg => fun x => (fg.1 x ; fg.2 x).
 
 Definition sig_coind
-           `{A : X -> Type} (P : forall x, A x -> Type)
-           (f : forall x, A x) (g : forall x, P x (f x))
-: (forall x, sig (P x))
+  `{A : X -> Type} (P : forall x, A x -> Type)
+  (f : forall x, A x) (g : forall x, P x (f x))
+  : (forall x, sig (P x))
   := sig_coind_uncurried P (f;g).
 
 Global Instance isequiv_sig_coind
-         `{A : X -> Type} {P : forall x, A x -> Type}
-: IsEquiv (sig_coind_uncurried P) | 0
+  `{A : X -> Type} {P : forall x, A x -> Type}
+  : IsEquiv (sig_coind_uncurried P) | 0
   := Build_IsEquiv
        _ _
        (sig_coind_uncurried P)
@@ -601,16 +580,16 @@ Global Instance isequiv_sig_coind
        (fun _ => 1).
 
 Definition equiv_sig_coind
-           `(A : X -> Type) (P : forall x, A x -> Type)
-: { f : forall x, A x & forall x, P x (f x) }
-    <~> (forall x, sig (P x))
+  `(A : X -> Type) (P : forall x, A x -> Type)
+  : { f : forall x, A x & forall x, P x (f x) }
+      <~> (forall x, sig (P x))
   := Build_Equiv _ _ (sig_coind_uncurried P) _.
 
 (** ** Sigmas preserve truncation *)
 
 Global Instance istrunc_sigma `{P : A -> Type}
-         `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
-: IsTrunc n (sig P) | 100.
+  `{IsTrunc n A} `{forall a, IsTrunc n (P a)}
+  : IsTrunc n (sig P) | 100.
 Proof.
   generalize dependent A.
   simple_induction' n; simpl; intros A P ac Pc.
@@ -624,8 +603,8 @@ Defined.
 
 (** The sigma of an arbitrary family of *disjoint* hprops is an hprop. *)
 Definition ishprop_sigma_disjoint
-           `{P : A -> Type} `{forall a, IsHProp (P a)}
-: (forall x y, P x -> P y -> x = y) -> IsHProp { x : A & P x }.
+  `{P : A -> Type} `{forall a, IsHProp (P a)}
+  : (forall x y, P x -> P y -> x = y) -> IsHProp { x : A & P x }.
 Proof.
   intros dj; apply hprop_allpath; intros [x px] [y py].
   refine (path_sigma' P (dj x y px py) _).
@@ -636,27 +615,26 @@ Defined.
 
 (** To prove equality in a subtype, we only need equality of the first component. *)
 Definition path_sigma_hprop {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)}
-           (u v : sig P)
-: u.1 = v.1 -> u = v
+  `{forall x, IsHProp (P x)}
+  (u v : sig P)
+  : u.1 = v.1 -> u = v
   := path_sigma_uncurried P u v o pr1^-1.
 
 Global Instance isequiv_path_sigma_hprop {A P} `{forall x : A, IsHProp (P x)} {u v : sig P}
-: IsEquiv (@path_sigma_hprop A P _ u v) | 100
+  : IsEquiv (@path_sigma_hprop A P _ u v) | 100
   := isequiv_compose.
 
 #[export]
 Hint Immediate isequiv_path_sigma_hprop : typeclass_instances.
 
 Definition equiv_path_sigma_hprop {A : Type} {P : A -> Type}
-           {HP : forall a, IsHProp (P a)} (u v : sig P)
-: (u.1 = v.1) <~> (u = v)
+  {HP : forall a, IsHProp (P a)} (u v : sig P)
+  : (u.1 = v.1) <~> (u = v)
   := Build_Equiv _ _ (path_sigma_hprop _ _) _.
 
 Definition isequiv_pr1_path_hprop {A} {P : A -> Type}
-         `{forall a, IsHProp (P a)}
-         x y
-: IsEquiv (@pr1_path A P x y)
+  `{forall a, IsHProp (P a)} (x y : sig P)
+  : IsEquiv (@pr1_path A P x y)
   := _ : IsEquiv (path_sigma_hprop x y)^-1.
 
 #[export]
@@ -664,16 +642,14 @@ Hint Immediate isequiv_pr1_path_hprop : typeclass_instances.
 
 (** We define this for ease of [SearchAbout IsEquiv ap pr1] *)
 Definition isequiv_ap_pr1_hprop {A} {P : A -> Type}
-           `{forall a, IsHProp (P a)}
-           x y
-: IsEquiv (@ap _ _ (@pr1 A P) x y)
+  `{forall a, IsHProp (P a)} (x y : sig P)
+  : IsEquiv (@ap _ _ (@pr1 A P) x y)
   := _.
-
 
 (** [path_sigma_hprop] is functorial *)
 Definition path_sigma_hprop_1 {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)} (u : sig P)
-: path_sigma_hprop u u 1 = 1.
+  `{forall x, IsHProp (P x)} (u : sig P)
+  : path_sigma_hprop u u 1 = 1.
 Proof.
   unfold path_sigma_hprop.
   unfold isequiv_pr1_contr; simpl.
@@ -683,25 +659,22 @@ Proof.
 Defined.
 
 Definition path_sigma_hprop_V {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)} {a b : A} (p : a = b)
-           (x : P a) (y : P b)
-: path_sigma_hprop (b;y) (a;x) p^ = (path_sigma_hprop (a;x) (b;y) p)^.
+  `{forall x, IsHProp (P x)} {a b : A} (p : a = b)
+  (x : P a) (y : P b)
+  : path_sigma_hprop (b;y) (a;x) p^ = (path_sigma_hprop (a;x) (b;y) p)^.
 Proof.
   destruct p; simpl.
   rewrite (path_ishprop x y).
   refine (path_sigma_hprop_1 _ @ (ap inverse (path_sigma_hprop_1 _))^).
 Qed.
 
-Definition path_sigma_hprop_pp
-           {A : Type}
-           {P : A -> Type}
-           `{forall x, IsHProp (P x)}
-           {a b c : A}
-           (p : a = b) (q : b = c)
-           (x : P a) (y : P b) (z : P c)
-: path_sigma_hprop (a;x) (c;z) (p @ q)
-    =
-  path_sigma_hprop (a;x) (b;y) p @ path_sigma_hprop (b;y) (c;z) q.
+Definition path_sigma_hprop_pp {A : Type} {P : A -> Type}
+  `{forall x, IsHProp (P x)}
+  {a b c : A}
+  (p : a = b) (q : b = c)
+  (x : P a) (y : P b) (z : P c)
+  : path_sigma_hprop (a;x) (c;z) (p @ q)
+    = path_sigma_hprop (a;x) (b;y) p @ path_sigma_hprop (b;y) (c;z) q.
 Proof.
   destruct p, q.
   rewrite (path_ishprop y x).
@@ -712,28 +685,31 @@ Qed.
 
 (** The inverse of [path_sigma_hprop] has its own name, so we give special names to the section and retraction homotopies to help [rewrite] out. *)
 Definition path_sigma_hprop_ap_pr1 {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)} (u v : sig P) (p : u = v)
-: path_sigma_hprop u v (ap pr1 p) = p
+  `{forall x, IsHProp (P x)} (u v : sig P) (p : u = v)
+  : path_sigma_hprop u v (ap pr1 p) = p
   := eisretr (path_sigma_hprop u v) p.
+
 Definition path_sigma_hprop_pr1_path {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)} (u v : sig P) (p : u = v)
-: path_sigma_hprop u v p..1 = p
+  `{forall x, IsHProp (P x)} (u v : sig P) (p : u = v)
+  : path_sigma_hprop u v p..1 = p
   := eisretr (path_sigma_hprop u v) p.
+
 Definition ap_pr1_path_sigma_hprop {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)} (u v : sig P) (p : u.1 = v.1)
-: ap pr1 (path_sigma_hprop u v p) = p
+  `{forall x, IsHProp (P x)} (u v : sig P) (p : u.1 = v.1)
+  : ap pr1 (path_sigma_hprop u v p) = p
   := eissect (path_sigma_hprop u v) p.
+
 Definition pr1_path_path_sigma_hprop {A : Type} {P : A -> Type}
-           `{forall x, IsHProp (P x)} (u v : sig P) (p : u.1 = v.1)
-: (path_sigma_hprop u v p)..1 = p
+  `{forall x, IsHProp (P x)} (u v : sig P) (p : u.1 = v.1)
+  : (path_sigma_hprop u v p)..1 = p
   := eissect (path_sigma_hprop u v) p.
 
 (** ** Fibers of [functor_sigma] *)
 Definition hfiber_functor_sigma {A B} (P : A -> Type) (Q : B -> Type)
-           (f : A -> B) (g : forall a, P a -> Q (f a))
-           (b : B) (v : Q b)
-: (hfiber (functor_sigma f g) (b; v)) <~>
-  {w : hfiber f b & hfiber (g w.1) ((w.2)^ # v)}.
+  (f : A -> B) (g : forall a, P a -> Q (f a))
+  (b : B) (v : Q b)
+  : (hfiber (functor_sigma f g) (b; v)) <~>
+      {w : hfiber f b & hfiber (g w.1) ((w.2)^ # v)}.
 Proof.
   unfold hfiber, functor_sigma.
   refine (_ oE equiv_functor_sigma_id _).
@@ -746,8 +722,8 @@ Proof.
 Defined.
 
 Global Instance istruncmap_functor_sigma n {A B P Q}
-       (f : A -> B) (g : forall a, P a -> Q (f a))
-       {Hf : IsTruncMap n f} {Hg : forall a, IsTruncMap n (g a)}
+  (f : A -> B) (g : forall a, P a -> Q (f a))
+  {Hf : IsTruncMap n f} {Hg : forall a, IsTruncMap n (g a)}
   : IsTruncMap n (functor_sigma f g).
 Proof.
   intros [a b].
@@ -756,10 +732,10 @@ Defined.
 
 (** Theorem 4.7.6 *)
 Definition hfiber_functor_sigma_idmap {A} (P Q : A -> Type)
-           (g : forall a, P a -> Q a)
-           (b : A) (v : Q b)
-: (hfiber (functor_sigma idmap g) (b; v)) <~>
-   hfiber (g b) v.
+  (g : forall a, P a -> Q a)
+  (b : A) (v : Q b)
+  : (hfiber (functor_sigma idmap g) (b; v))
+      <~> hfiber (g b) v.
 Proof.
   refine (_ oE hfiber_functor_sigma P Q idmap g b v).
   exact (equiv_contr_sigma
@@ -768,8 +744,8 @@ Defined.
 
 (** The converse and Theorem 4.7.7 can be found in Types/Equiv.v *)
 Definition istruncmap_from_functor_sigma n {A P Q}
-           (g : forall a : A, P a -> Q a)
-           `{!IsTruncMap n (functor_sigma idmap g)}
+  (g : forall a : A, P a -> Q a)
+  `{!IsTruncMap n (functor_sigma idmap g)}
   : forall a, IsTruncMap n (g a).
 Proof.
   intros a v.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -14,16 +14,6 @@ From such a [P] we can build a total space over the base space [A] so that the f
 
 The base and fiber components of a point in the total space are extracted with the two projections [pr1] and [pr2]. *)
 
-(** ** Unpacking *)
-
-(** Sometimes we would like to prove [Q u] where [u : {x : A & P x}] by writing [u] as a pair [(pr1 u ; pr2 u)]. This is accomplished by [sig_unpack]. We want tight control over the proof, so we just write it down even though is looks a bit scary. *)
-
-Definition unpack_sigma `{P : A -> Type} (Q : sig P -> Type) (u : sig P)
-: Q (u.1; u.2) -> Q u
-  := idmap.
-
-Arguments unpack_sigma / .
-
 (** ** Eta conversion *)
 
 Definition eta_sigma `{P : A -> Type} (u : sig P)

--- a/theories/Types/Universe.v
+++ b/theories/Types/Universe.v
@@ -1,4 +1,5 @@
 (* -*- mode: coq; mode: visual-line -*- *)
+
 (** * Theorems about the universe, including the Univalence Axiom. *)
 
 Require Import HoTT.Basics.
@@ -55,11 +56,10 @@ Definition eta_path_universe_uncurried {A B : Type} (p : A = B)
 
 Definition isequiv_path_universe {A B : Type}
   : IsEquiv (@path_universe_uncurried A B)
- := _.
+  := _.
 
 Definition equiv_path_universe (A B : Type) : (A <~> B) <~> (A = B)
   := Build_Equiv _ _ (@path_universe_uncurried A B) isequiv_path_universe.
-
 
 Definition equiv_equiv_path  (A B : Type) : (A = B) <~> (A <~> B)
   := (equiv_path_universe A B)^-1%equiv.
@@ -94,16 +94,16 @@ Definition transport_idmap_path_universe_uncurried {A B : Type} (f : A <~> B)
 
 (* We explicitly assume [Funext] here, since this result doesn't use [Univalence]. *)
 Definition equiv_path_pp `{Funext} {A B C : Type} (p : A = B) (q : B = C)
-: equiv_path A C (p @ q) = equiv_path B C q oE equiv_path A B p.
+  : equiv_path A C (p @ q) = equiv_path B C q oE equiv_path A B p.
 Proof.
   apply path_equiv, path_arrow.
   nrapply transport_pp.
 Defined.
 
 Definition path_universe_compose_uncurried {A B C : Type}
-           (f : A <~> B) (g : B <~> C)
-: path_universe_uncurried (equiv_compose g f)
-= path_universe_uncurried f @ path_universe_uncurried g.
+  (f : A <~> B) (g : B <~> C)
+  : path_universe_uncurried (equiv_compose g f)
+    = path_universe_uncurried f @ path_universe_uncurried g.
 Proof.
   revert f. equiv_intro (equiv_path A B) f.
   revert g. equiv_intro (equiv_path B C) g.
@@ -113,7 +113,7 @@ Proof.
 Defined.
 
 Definition path_universe_compose {A B C : Type}
-           (f : A <~> B) (g : B <~> C)
+  (f : A <~> B) (g : B <~> C)
   : path_universe (g o f) = path_universe f @ path_universe g
   := path_universe_compose_uncurried f g.
 
@@ -140,7 +140,7 @@ Definition path_universe_V `(f : A -> B) `{IsEquiv A B f}
 
 (** [ap (Equiv A)] behaves like postcomposition. *)
 Definition ap_equiv_path_universe A {B C} (f : B <~> C)
-: equiv_path (A <~> B) (A <~> C) (ap (Equiv A) (path_universe f))
+  : equiv_path (A <~> B) (A <~> C) (ap (Equiv A) (path_universe f))
   = equiv_functor_equiv (equiv_idmap A) f.
 Proof.
   revert f. equiv_intro (equiv_path B C) f.
@@ -177,7 +177,7 @@ Defined.
 
 (** There are two ways we could define [transport_path_universe]: we could give an explicit definition, or we could reduce it to paths by [equiv_ind] and give an explicit definition there.  The two should be equivalent, but we choose the second for now as it makes the currently needed coherence lemmas easier to prove. *)
 Definition transport_path_universe_uncurried
-           {A B : Type} (f : A <~> B) (z : A)
+  {A B : Type} (f : A <~> B) (z : A)
   : transport (fun X:Type => X) (path_universe_uncurried f) z = f z.
 Proof.
   revert f.  equiv_intro (equiv_path A B) p.
@@ -186,15 +186,15 @@ Defined.
 (* Alternatively, [apply ap10, transport_idmap_path_universe_uncurried.], but then some later proofs would have to change. *)
 
 Definition transport_path_universe
-           {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
+  {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
   : transport (fun X:Type => X) (path_universe f) z = f z
   := transport_path_universe_uncurried (Build_Equiv A B f feq) z.
 (* Alternatively, [ap10_equiv (eisretr (equiv_path A B) (Build_Equiv _ _ f feq)) z]. *)
 
 Definition transport_path_universe_equiv_path
-           {A B : Type} (p : A = B) (z : A)
+  {A B : Type} (p : A = B) (z : A)
   : transport_path_universe (equiv_path A B p) z =
-    (ap (fun s => transport idmap s z) (eissect _ p))
+      (ap (fun s => transport idmap s z) (eissect _ p))
   := equiv_ind_comp _ _ _.
 
 (* This somewhat fancier version is useful when working with HITs. *)
@@ -203,13 +203,13 @@ Definition transport_path_universe'
   (f : P x <~> P y) (q : ap P p = path_universe f) (u : P x)
   : transport P p u = f u
   := transport_compose idmap P p u
-   @ ap10 (ap (transport idmap) q) u
-   @ transport_path_universe f u.
+      @ ap10 (ap (transport idmap) q) u
+      @ transport_path_universe f u.
 
 (** And a version for transporting backwards. *)
 
 Definition transport_path_universe_V_uncurried
-           {A B : Type} (f : A <~> B) (z : B)
+  {A B : Type} (f : A <~> B) (z : B)
   : transport (fun X:Type => X) (path_universe_uncurried f)^ z = f^-1 z.
 Proof.
   revert f. equiv_intro (equiv_path A B) p.
@@ -217,25 +217,25 @@ Proof.
 Defined.
 
 Definition transport_path_universe_V
-           {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : B)
+  {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : B)
   : transport (fun X:Type => X) (path_universe f)^ z = f^-1 z
   := transport_path_universe_V_uncurried (Build_Equiv _ _ f feq) z.
 (* Alternatively, [(transport2 idmap (path_universe_V f) z)^ @ (transport_path_universe (f^-1) z)]. *)
 
 Definition transport_path_universe_V_equiv_path
-           {A B : Type} (p : A = B) (z : B)
-  : transport_path_universe_V (equiv_path A B p) z =
-    ap (fun s => transport idmap s z) (inverse2 (eissect _ p))
+  {A B : Type} (p : A = B) (z : B)
+  : transport_path_universe_V (equiv_path A B p) z
+    = ap (fun s => transport idmap s z) (inverse2 (eissect _ p))
   := equiv_ind_comp _ _ _.
 
 (** And some coherence for it. *)
 
 Definition transport_path_universe_Vp_uncurried
-           {A B : Type} (f : A <~> B) (z : A)
-: ap (transport idmap (path_universe f)^) (transport_path_universe f z)
-  @ transport_path_universe_V f (f z)
-  @ eissect f z
-  = transport_Vp idmap (path_universe f) z.
+  {A B : Type} (f : A <~> B) (z : A)
+  : ap (transport idmap (path_universe f)^) (transport_path_universe f z)
+      @ transport_path_universe_V f (f z)
+      @ eissect f z
+    = transport_Vp idmap (path_universe f) z.
 Proof.
   pattern f.
   refine (equiv_ind (equiv_path A B) _ _ _); intros p.
@@ -248,11 +248,11 @@ Proof.
 Defined.
 
 Definition transport_path_universe_Vp
-           {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
-: ap (transport idmap (path_universe f)^) (transport_path_universe f z)
-  @ transport_path_universe_V f (f z)
-  @ eissect f z
-  = transport_Vp idmap (path_universe f) z
+  {A B : Type} (f : A -> B) {feq : IsEquiv f} (z : A)
+  : ap (transport idmap (path_universe f)^) (transport_path_universe f z)
+      @ transport_path_universe_V f (f z)
+      @ eissect f z
+    = transport_Vp idmap (path_universe f) z
   := transport_path_universe_Vp_uncurried (Build_Equiv A B f feq) z.
 
 (** *** Transporting in particular type families *)
@@ -269,8 +269,8 @@ Defined.
 (** ** 2-paths *)
 
 Definition equiv_path2_universe
-           {A B : Type} (f g : A <~> B)
-: (f == g) <~> (path_universe f = path_universe g).
+  {A B : Type} (f g : A <~> B)
+  : (f == g) <~> (path_universe f = path_universe g).
 Proof.
   refine (_ oE equiv_path_arrow f g).
   refine (_ oE equiv_path_equiv f g).
@@ -278,13 +278,13 @@ Proof.
 Defined.
 
 Definition path2_universe
-           {A B : Type} {f g : A <~> B}
-: (f == g) -> (path_universe f = path_universe g)
+  {A B : Type} {f g : A <~> B}
+  : (f == g) -> (path_universe f = path_universe g)
   := equiv_path2_universe f g.
 
 Definition equiv_path2_universe_1
-           {A B : Type} (f : A <~> B)
-: equiv_path2_universe f f (fun x => 1) = 1.
+  {A B : Type} (f : A <~> B)
+  : equiv_path2_universe f f (fun x => 1) = 1.
 Proof.
   simpl.
   rewrite concat_1p, concat_p1, path_forall_1, path_sigma_hprop_1.
@@ -292,8 +292,8 @@ Proof.
 Qed.
 
 Definition path2_universe_1
-           {A B : Type} (f : A <~> B)
-: @path2_universe _ _ f f (fun x => 1) = 1
+  {A B : Type} (f : A <~> B)
+  : @path2_universe _ _ f f (fun x => 1) = 1
   := equiv_path2_universe_1 f.
 
 (** There ought to be a lemma which says something like this:
@@ -331,15 +331,15 @@ Section PathEquivSimplNever.
   Local Arguments equiv_path_equiv : simpl never.
 
   Definition path2_universe_postcompose_idmap
-             {A C : Type} (p : forall a:A, a = a)
-             (g : A <~> C)
-  : equiv_path2_universe g g (fun a => ap g (p a))
-    = (concat_1p _)^
-      @ whiskerR (path_universe_1)^ (path_universe g)
-      @ whiskerR (equiv_path2_universe (equiv_idmap A) (equiv_idmap A) p)
-        (path_universe g)
-      @ whiskerR path_universe_1 (path_universe g)
-      @ concat_1p _.
+    {A C : Type} (p : forall a:A, a = a)
+    (g : A <~> C)
+    : equiv_path2_universe g g (fun a => ap g (p a))
+      = (concat_1p _)^
+        @ whiskerR (path_universe_1)^ (path_universe g)
+        @ whiskerR (equiv_path2_universe (equiv_idmap A) (equiv_idmap A) p)
+          (path_universe g)
+        @ whiskerR path_universe_1 (path_universe g)
+        @ concat_1p _.
   Proof.
     transitivity ((eta_path_universe (path_universe g))^
                   @ equiv_path2_universe
@@ -367,38 +367,38 @@ Section PathEquivSimplNever.
   Defined.
 
   Definition path2_universe_precompose_idmap
-             {A B : Type} (p : forall b:B, b = b)
-             (g : A <~> B)
-  : equiv_path2_universe g g (fun a => (p (g a)))
-    = (concat_p1 _)^
-      @ whiskerL (path_universe g) (path_universe_1)^
-      @ whiskerL (path_universe g)
-          (equiv_path2_universe (equiv_idmap B) (equiv_idmap B) p)
-      @ whiskerL (path_universe g) (path_universe_1)
-      @ concat_p1 _.
+    {A B : Type} (p : forall b:B, b = b)
+    (g : A <~> B)
+    : equiv_path2_universe g g (fun a => (p (g a)))
+      = (concat_p1 _)^
+        @ whiskerL (path_universe g) (path_universe_1)^
+        @ whiskerL (path_universe g)
+            (equiv_path2_universe (equiv_idmap B) (equiv_idmap B) p)
+        @ whiskerL (path_universe g) (path_universe_1)
+        @ concat_p1 _.
   Proof.
-  transitivity ((eta_path_universe (path_universe g))^
-                @ equiv_path2_universe
-                  (equiv_path A B (path_universe g))
-                  (equiv_path A B (path_universe g))
-                  (fun a => p (equiv_path A B (path_universe g) a))
-                @ eta_path_universe (path_universe g)).
-  - refine ((apD (fun g' => equiv_path2_universe g' g'
-                              (fun a => p (g' a)))
-              (eisretr (equiv_path A B) g))^ @ _).
-    refine (transport_paths_FlFr (eisretr (equiv_path A B) g) _ @ _).
-    apply concat2.
-    + apply whiskerR.
-      apply inverse2, symmetry.
-      refine (eisadj (equiv_path A B)^-1 g).
-    + symmetry; refine (eisadj (equiv_path A B)^-1 g).
-  - generalize (path_universe g).
-    intros h. destruct h. cbn.
-    rewrite !concat_p1.
-    refine (_ @ (((concat_1p (whiskerL 1 path_universe_1^))^ @@ 1) @@ 1)).
-    refine (_ @ whiskerR (whiskerL_pp 1 path_universe_1^ _) _).
-    refine (_ @ whiskerL_pp 1 _ path_universe_1).
-    exact ((whiskerL_1p_1 _)^).
+    transitivity ((eta_path_universe (path_universe g))^
+                  @ equiv_path2_universe
+                    (equiv_path A B (path_universe g))
+                    (equiv_path A B (path_universe g))
+                    (fun a => p (equiv_path A B (path_universe g) a))
+                  @ eta_path_universe (path_universe g)).
+    - refine ((apD (fun g' => equiv_path2_universe g' g'
+                                (fun a => p (g' a)))
+                (eisretr (equiv_path A B) g))^ @ _).
+      refine (transport_paths_FlFr (eisretr (equiv_path A B) g) _ @ _).
+      apply concat2.
+      + apply whiskerR.
+        apply inverse2, symmetry.
+        refine (eisadj (equiv_path A B)^-1 g).
+      + symmetry; refine (eisadj (equiv_path A B)^-1 g).
+    - generalize (path_universe g).
+      intros h. destruct h. cbn.
+      rewrite !concat_p1.
+      refine (_ @ (((concat_1p (whiskerL 1 path_universe_1^))^ @@ 1) @@ 1)).
+      refine (_ @ whiskerR (whiskerL_pp 1 path_universe_1^ _) _).
+      refine (_ @ whiskerL_pp 1 _ path_universe_1).
+      exact ((whiskerL_1p_1 _)^).
   Defined.
 
 End PathEquivSimplNever.
@@ -406,8 +406,8 @@ End PathEquivSimplNever.
 (** ** 3-paths *)
 
 Definition equiv_path3_universe
-           {A B : Type} {f g : A <~> B} (p q : f == g)
-: (p == q) <~> (path2_universe p = path2_universe q).
+  {A B : Type} {f g : A <~> B} (p q : f == g)
+  : (p == q) <~> (path2_universe p = path2_universe q).
 Proof.
   refine (_ oE equiv_path_forall p q).
   refine (_ oE equiv_ap (equiv_path_arrow f g) p q).
@@ -417,16 +417,16 @@ Proof.
 Defined.
 
 Definition path3_universe
-           {A B : Type} {f g : A <~> B} {p q : f == g}
-: (p == q) -> (path2_universe p = path2_universe q)
+  {A B : Type} {f g : A <~> B} {p q : f == g}
+  : (p == q) -> (path2_universe p = path2_universe q)
   := equiv_path3_universe p q.
 
 Definition transport_path_universe_pV_uncurried
-           {A B : Type} (f : A <~> B) (z : B)
-: transport_path_universe f (transport idmap (path_universe f)^ z)
-  @ ap f (transport_path_universe_V f z)
-  @ eisretr f z
-  = transport_pV idmap (path_universe f) z.
+  {A B : Type} (f : A <~> B) (z : B)
+  : transport_path_universe f (transport idmap (path_universe f)^ z)
+      @ ap f (transport_path_universe_V f z)
+      @ eisretr f z
+    = transport_pV idmap (path_universe f) z.
 Proof.
   pattern f.
   refine (equiv_ind (equiv_path A B) _ _ _); intros p.
@@ -442,18 +442,18 @@ Proof.
 Defined.
 
 Definition transport_path_universe_pV
-           {A B : Type} (f : A -> B) {feq : IsEquiv f } (z : B)
-: transport_path_universe f (transport idmap (path_universe f)^ z)
-  @ ap f (transport_path_universe_V f z)
-  @ eisretr f z
-  = transport_pV idmap (path_universe f) z
-:= transport_path_universe_pV_uncurried (Build_Equiv A B f feq) z.
+  {A B : Type} (f : A -> B) {feq : IsEquiv f } (z : B)
+  : transport_path_universe f (transport idmap (path_universe f)^ z)
+      @ ap f (transport_path_universe_V f z)
+      @ eisretr f z
+    = transport_pV idmap (path_universe f) z
+  := transport_path_universe_pV_uncurried (Build_Equiv A B f feq) z.
 
 (** ** Equivalence induction *)
 
 (** Paulin-Mohring style *)
-Theorem equiv_induction {U : Type} (P : forall V, U <~> V -> Type) :
-  (P U (equiv_idmap U)) -> (forall V (w : U <~> V), P V w).
+Theorem equiv_induction {U : Type} (P : forall V, U <~> V -> Type)
+  : (P U (equiv_idmap U)) -> (forall V (w : U <~> V), P V w).
 Proof.
   intros H0 V.
   apply (equiv_ind (equiv_path U V)).
@@ -466,8 +466,8 @@ Definition equiv_induction_comp {U : Type} (P : forall V, U <~> V -> Type)
   := (equiv_ind_comp (P U) _ 1).
 
 (** Martin-Lof style *)
-Theorem equiv_induction' (P : forall U V, U <~> V -> Type) :
-  (forall T, P T T (equiv_idmap T)) -> (forall U V (w : U <~> V), P U V w).
+Theorem equiv_induction' (P : forall U V, U <~> V -> Type)
+  : (forall T, P T T (equiv_idmap T)) -> (forall U V (w : U <~> V), P U V w).
 Proof.
   intros H0 U V w.
   apply (equiv_ind (equiv_path U V)).
@@ -479,8 +479,8 @@ Definition equiv_induction'_comp (P : forall U V, U <~> V -> Type)
   : equiv_induction' P didmap U U (equiv_idmap U) = didmap U
   := (equiv_ind_comp (P U U) _ 1).
 
-Theorem equiv_induction_inv {U : Type} (P : forall V, V <~> U -> Type) :
-  (P U (equiv_idmap U)) -> (forall V (w : V <~> U), P V w).
+Theorem equiv_induction_inv {U : Type} (P : forall V, V <~> U -> Type)
+  : (P U (equiv_idmap U)) -> (forall V (w : V <~> U), P V w).
 Proof.
   intros H0 V.
   apply (equiv_ind (equiv_path V U)).
@@ -496,7 +496,7 @@ Definition equiv_induction_inv_comp {U : Type} (P : forall V, V <~> U -> Type)
 (** ** Based equivalence types *)
 
 Global Instance contr_basedequiv@{u +} {X : Type@{u}}
-: Contr {Y : Type@{u} & X <~> Y}.
+  : Contr {Y : Type@{u} & X <~> Y}.
 Proof.
   apply (Build_Contr _ (X; equiv_idmap)).
   intros [Y f]; revert Y f.
@@ -504,7 +504,7 @@ Proof.
 Defined.
 
 Global Instance contr_basedequiv'@{u +} {X : Type@{u}}
-: Contr {Y : Type@{u} & Y <~> X}.
+  : Contr {Y : Type@{u} & Y <~> X}.
 Proof.
   (* The next line is used so that Coq can figure out the type of (X; equiv_idmap). *)
   srapply Build_Contr.
@@ -517,8 +517,8 @@ Defined.
 
 (** Truncatedness of the universe is a subtle question, but with univalence we can conclude things about truncations of certain of its path-spaces. *)
 Global Instance istrunc_paths_Type
-       {n : trunc_index} {A B : Type} `{IsTrunc n.+1 B}
-: IsTrunc n.+1 (A = B).
+  {n : trunc_index} {A B : Type} `{IsTrunc n.+1 B}
+  : IsTrunc n.+1 (A = B).
 Proof.
   refine (istrunc_isequiv_istrunc _ path_universe_uncurried).
 Defined.


### PR DESCRIPTION
This PR cleans up a few files in Basics/ and Types/ that I happened to be looking through.  Many of the changes are simply indentation or other whitespace changes.  Some others move things to a more logical spot.  And a couple actually change things.  I made sure to separate out the non-trivial changes into their own commits, to make it easy to review this.

(There's of course a lot more that could be done, but I'm going over these files with students tomorrow, so I'm just fixing things as I notice them.)
