### PR TITLE
Naturality of coequalizer universal property w.r.t. functor_coeq

### DIFF
--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -64,6 +64,58 @@ Proof.
   rapply path_ishprop.
 Defined.
 
+Definition Coeq_eta_homot {B A f g} {P : @Coeq B A f g -> Type}
+  (h : forall w : Coeq f g, P w)
+  : h == Coeq_ind P (h o coeq) (fun b => apD h (cglue b)).
+Proof.
+  unfold pointwise_paths.
+  nrapply (Coeq_ind _ (fun _ => 1)).
+  intros b.
+  lhs nrapply transport_paths_FlFr_D.
+  lhs nrapply (whiskerL _ (Coeq_ind_beta_cglue _ _ _ _)).
+  lhs nrapply (whiskerR (concat_p1 _)).
+  nrapply concat_Vp.
+Defined.
+
+Definition Coeq_rec_eta_homot {B A f g} {P : Type} (h : @Coeq B A f g -> P)
+  : h == Coeq_rec P (h o coeq) (fun b => ap h (cglue b)).
+Proof.
+  unfold pointwise_paths.
+  nrapply (Coeq_ind _ (fun _ => 1)).
+  intros b.
+  lhs nrapply transport_paths_FlFr.
+  lhs nrapply (whiskerL _ (Coeq_rec_beta_cglue _ _ _ _)).
+  lhs nrapply (whiskerR (concat_p1 _)).
+  nrapply concat_Vp.
+Defined.
+
+Definition Coeq_eta `{Funext}
+  {B A f g} {P : @Coeq B A f g -> Type} (h : forall w : Coeq f g, P w)
+  : h = Coeq_ind P (h o coeq) (fun b => apD h (cglue b))
+  := path_forall _ _ (Coeq_eta_homot h).
+
+Definition Coeq_rec_eta `{Funext}
+  {B A f g} {P : Type} (h : @Coeq B A f g -> P)
+  : h = Coeq_rec P (h o coeq) (fun b => ap h (cglue b))
+  := path_forall _ _ (Coeq_rec_eta_homot h).
+
+Definition Coeq_ind_homotopy {B A f g} (P : @Coeq B A f g -> Type)
+  {m n : forall a, P (coeq a)} (u : m == n)
+  {r : forall b, (cglue b) # (m (f b)) = m (g b)}
+  {s : forall b, (cglue b) # (n (f b)) = n (g b)}
+  (p : forall b, ap (transport P (cglue b)) (u (f b)) @ (s b) = r b @ u (g b))
+  : Coeq_ind P m r == Coeq_ind P n s.
+Proof.
+  unfold pointwise_paths.
+  nrapply Coeq_ind; intros b.
+  lhs nrapply (transport_paths_FlFr_D (f:=Coeq_ind P m r) (g:=Coeq_ind P n s)).
+  lhs nrapply (whiskerL _ (Coeq_ind_beta_cglue P n s b)).
+  lhs nrapply (whiskerR (whiskerR (ap inverse (Coeq_ind_beta_cglue P m r b)) _)).
+  lhs nrapply concat_pp_p; nrapply moveR_Mp.
+  rhs nrapply (whiskerR (inv_V _)).
+  exact (p b).
+Defined.
+
 (** ** Universal property *)
 (** See Colimits/CoeqUnivProp.v for a similar universal property without [Funext]. *)
 

--- a/theories/Cubical/DPath.v
+++ b/theories/Cubical/DPath.v
@@ -134,6 +134,28 @@ Proof.
   by destruct p.
 Defined. 
 
+(** Horizontal composition and whiskering of dependent paths *)
+Definition dp_concat2 {A} {P : A -> Type} {a0 a1 a2}
+  {p : a0 = a1} {q : a1 = a2} {b0 : P a0} {b1 : P a1} {b2 : P a2}
+  {r r' : DPath P p b0 b1} {s s' : DPath P q b1 b2}
+  (h : r = r') (k : s = s')
+  : r @Dp s = r' @Dp s'.
+Proof.
+  by destruct h, k.
+Defined.
+
+Definition dp_whiskerL {A: Type} {P : A -> Type} {a0 a1 a2 : A}
+  {p : a0 = a1} {q : a1 = a2} {b0 : P a0} {b1 : P a1} {b2 : P a2}
+  (r : DPath P p b0 b1) {s s' : DPath P q b1 b2} (h : s = s')
+  : r @Dp s = r @Dp s'
+  := dp_concat2 1 h.
+
+Definition dp_whiskerR {A: Type} {P : A -> Type} {a0 a1 a2 : A}
+  {p : a0 = a1} {q : a1 = a2} {b0 : P a0} {b1 : P a1} {b2 : P a2}
+  {r r' : DPath P p b0 b1} (s : DPath P q b1 b2) (h : r = r')
+  : r @Dp s = r' @Dp s
+  := dp_concat2 h 1.
+
 Section DGroupoid.
 
   Context {A} {P : A -> Type} {a0 a1} {p : a0 = a1}
@@ -300,6 +322,18 @@ Definition dp_apD_compose {A B : Type} (f : A -> B) (P : B -> Type)
            {x y : A} (p : x = y) (g : forall b:B, P b)
   : apD (g o f) p = (dp_compose f P p)^-1 (apD g (ap f p))
   := dp_apD_compose' f P (idpath (ap f p)) g.
+
+Definition dp_apD_compose_inv' {A B : Type} (f : A -> B) (P : B -> Type)
+  {x y : A} {p : x = y} {q : f x = f y} (r : ap f p = q) (g : forall b:B, P b)
+  : apD g q = (dp_compose' f P r) (apD (g o f) p).
+Proof.
+  by destruct r, p.
+Defined.
+
+Definition dp_apD_compose_inv {A B : Type} (f : A -> B) (P : B -> Type)
+  {x y : A} {p : x = y} (g : forall b:B, P b)
+  : apD g (ap f p) = (dp_compose f P p) (apD (g o f) p)
+  := dp_apD_compose_inv' f P (idpath (ap f p)) g.
 
 (** Type constructors *)
 


### PR DESCRIPTION
Addresses step (4) from #1259.

Still TODO:
- Clean up / generalize / rename `Coeq_ind_functor_coeq_beta_cglue`.
- Comments and documentation. It would be nice to also add some documentation explaining what `CoeqUnivProp.v` is doing more generally.