### PR TITLE
chore: update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726042813,
-        "narHash": "sha256-LnNKCCxnwgF+575y0pxUdlGZBO/ru1CtGHIqQVfvjlA=",
+        "lastModified": 1728336163,
+        "narHash": "sha256-rISnMC117SHUI19jwOyoBpeH1lg0JkNUwDS2khhEXzc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "159be5db480d1df880a0135ca0bfed84c2f88353",
+        "rev": "df8a060c473cf49d3d3b0480f892ffcbea7bba41",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A Coq library for Homotopy Type Theory";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
 
     flake-utils.url = "github:numtide/flake-utils";
   };
@@ -16,25 +16,36 @@
             coqPackages = pkgs.mkCoqPackages coq // {
               __attrsFailEvaluation = true;
             };
-          in { extraPackages ? [ coqPackages.coq-lsp ] }:
+          in
+          { extraPackages ? [ coqPackages.coq-lsp ] }:
           pkgs.mkShell {
-            buildInputs = with coqPackages;
+            buildInputs =
               [ pkgs.dune_3 pkgs.ocaml ] ++ extraPackages ++ [ coq ];
           };
-      in {
+      in
+      {
         packages.default = pkgs.coqPackages.mkCoqDerivation {
           pname = "hott";
-          version = "8.19";
+          version = "8.20";
           src = self;
           useDune = true;
         };
 
-        devShells.default = makeDevShell { coq = pkgs.coq_8_20; } { };
-        devShells.coq_8_19 = makeDevShell { coq = pkgs.coq_8_19; } { };
+        devShells.default =
+          makeDevShell
+            { coq = pkgs.coq_8_20; }
+            { };
+
+        devShells.coq_8_19 =
+          makeDevShell
+            { coq = pkgs.coq_8_19; }
+            { };
 
         # To use, pass --impure to nix develop
         devShells.coq_master =
-          makeDevShell { coq = pkgs.coq.override { version = "master"; }; } { };
+          makeDevShell
+            { coq = pkgs.coq.override { version = "master"; }; }
+            { extraPackages = [ ]; };
 
         formatter = pkgs.nixpkgs-fmt;
       });


### PR DESCRIPTION
Update the nix flake to a newer version of `nixpkgs` giving us `coq-lsp` `0.2.2`. Also fix the dev shell and format the flake.