### PR TITLE
istrunc_self_implies_istrunc

### DIFF
--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -535,4 +535,13 @@ Proof.
   exact (equiv_iff_hprop_uncurried (iff_contr_hprop A)).
 Defined.
 
+(** If a type [A] implies that it is [n.+1]-truncated, then it is [n.+1]-truncated. **)
+Definition istrunc_self_implies_istrunc {n : trunc_index} {A : Type} (H : A -> IsTrunc n.+1 A)
+  : IsTrunc n.+1 A.
+Proof.
+  apply istrunc_S.
+  intros a b.
+  exact (H a a b).
+Defined.
+
 (** If you are looking for a theorem about truncation, you may want to read the note "Finding Theorems" in "STYLE.md". *)


### PR DESCRIPTION
Added this cute little lemma about truncations that might come in handy. All it says is that a map (A -> istrunc n.+1 A) is sufficient to deduce that A is n+1 truncated.

I wasn't so sure what to name it, so feel free to make it fit into your mold.