### PR TITLE
more polymorphic terminal unit and initial empty

### DIFF
--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -83,7 +83,7 @@ Defined.
 #[export]
 Hint Immediate catie_isequiv : typeclass_instances.
 
-Global Instance isinitial_zero : IsInitial Empty.
+Global Instance isinitial_zero : IsInitial (A:=Type) Empty.
 Proof.
   intro A.
   exists (Empty_rec _).
@@ -91,7 +91,7 @@ Proof.
   rapply Empty_ind.
 Defined.
 
-Global Instance isterminal_unit : IsTerminal Unit.
+Global Instance isterminal_unit : IsTerminal (A:=Type) Unit.
 Proof.
   intros A.
   exists (fun _ => tt).


### PR DESCRIPTION
The previous version only had instances for `Type0` but now `Empty` and `Unit` are the initial and terminal objects respectively of `Type@{i}` for all universes `i`.