### PR TITLE
demote priority of cocartesian monoidal structure

### DIFF
--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -381,7 +381,7 @@ Definition cat_bincoprod_swap_rec {A : Type} `{Is1Cat A}
 
 Global Instance ismonoidal_cat_bincoprod {A : Type} `{HasEquivs A}
   `{!HasBinaryCoproducts A} (zero : A) `{!IsInitial zero}
-  : IsMonoidal A (fun x y => cat_bincoprod x y) zero.
+  : IsMonoidal A (fun x y => cat_bincoprod x y) zero | 10.
 Proof.
   nrapply ismonoidal_op'.
   nrapply (ismonoidal_cat_binprod (A:=A^op) zero).
@@ -390,7 +390,7 @@ Defined.
 
 Global Instance issymmetricmonoidal_cat_bincoprod {A : Type} `{HasEquivs A}
   `{!HasBinaryCoproducts A} (zero : A) `{!IsInitial zero}
-  : IsSymmetricMonoidal A (fun x y => cat_bincoprod x y) zero.
+  : IsSymmetricMonoidal A (fun x y => cat_bincoprod x y) zero | 10.
 Proof.
   nrapply issymmetricmonoidal_op'.
   nrapply (issymmetricmonoidal_cat_binprod (A:=A^op) zero).


### PR DESCRIPTION
The cocartesian monoidal structure for any wild category with coproducts had the same priority with the cartesian monoidal structure for any wild category with products. This meant that in practice, inferring a monoidal structure on say `Type` chose the cocartesian monoidal structure. This is due to the second instance appearing at the same priority but later.

This PR demotes the priority of the cocartesian monoidal structure so that the cartesian monoidal structure is generally preferred. The cocartesian monoidal structure is not used nearly as much in practice anyway.