### PR TITLE
cleanup: make into aliases: easy -> done, now -> by

### DIFF
--- a/contrib/SetoidRewrite.v
+++ b/contrib/SetoidRewrite.v
@@ -55,7 +55,7 @@ Defined.
          CRelationClasses.arrow) (GpdHom a).
 Proof.
   intros x y eq_xy eq_ax.
-  now transitivity x.
+  by transitivity x.
 Defined.
 
 (* forall a : A, x $== y -> a $== y -> a $== x *)

--- a/theories/Algebra/Universal/Algebra.v
+++ b/theories/Algebra/Universal/Algebra.v
@@ -128,7 +128,7 @@ Proof.
   destruct p, q.
   unfold path_algebra, path_sigma_hprop, path_sigma_uncurried.
   cbn -[center].
-  now destruct (center (ha = hb)).
+  by destruct (center (ha = hb)).
 Defined.
 
 Arguments path_ap_carriers_path_algebra {_} {_} (A B)%_Algebra_scope (p q)%_path_scope.

--- a/theories/Algebra/Universal/Operation.v
+++ b/theories/Algebra/Universal/Operation.v
@@ -199,7 +199,7 @@ Proof.
   rewrite compute_fin_ind_fin_zero.
   refine (ap (operation_uncurry A (fstail ss) t (a x)) _).
   funext i'.
-  now rewrite compute_fin_ind_fsucc.
+  by rewrite compute_fin_ind_fsucc.
 Qed.
 
 Global Instance isequiv_operation_curry `{Funext} {σ} (A : Carriers σ)

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -466,26 +466,9 @@ Ltac done :=
 Tactic Notation "by" tactic(tac) :=
   tac; done.
 
-Ltac easy :=
-  let rec use_hyp H :=
-    match type of H with
-    | _ => try solve [inversion H]
-    end
-  with do_intro := let H := fresh in intro H; use_hyp H
-  with destruct_hyp H := case H; clear H; do_intro; do_intro in
-  let rec use_hyps :=
-    match goal with
-    | H : _ |- _ => solve [inversion H]
-    | _ => idtac
-    end in
-  let rec do_atom :=
-    solve [reflexivity | symmetry; trivial] ||
-    contradiction ||
-    (split; do_atom)
-  with do_ccl := trivial; repeat do_intro; do_atom in
-  (use_hyps; do_ccl) || fail "Cannot solve this goal".
+Ltac easy := done.
 
-Tactic Notation "now" tactic(t) := t; easy.
+Tactic Notation "now" tactic(t) := by t.
 
 (** Apply using the same opacity information as typeclass proof search. *)
 Ltac class_apply c := autoapply c with typeclass_instances.

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -466,8 +466,6 @@ Ltac done :=
 Tactic Notation "by" tactic(tac) :=
   tac; done.
 
-Ltac easy := done.
-
 Tactic Notation "now" tactic(t) := by t.
 
 (** Apply using the same opacity information as typeclass proof search. *)

--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -466,8 +466,6 @@ Ltac done :=
 Tactic Notation "by" tactic(tac) :=
   tac; done.
 
-Tactic Notation "now" tactic(t) := by t.
-
 (** Apply using the same opacity information as typeclass proof search. *)
 Ltac class_apply c := autoapply c with typeclass_instances.
 

--- a/theories/Classes/theory/dec_fields.v
+++ b/theories/Classes/theory/dec_fields.v
@@ -218,7 +218,7 @@ Proof with auto.
     apply (is_ne_0 1).
    reflexivity.
   intros.
-  rewrite commutativity. now apply dec_recip_inverse.
+  rewrite commutativity. by apply dec_recip_inverse.
 Qed. *)
 
 (* Section from_stdlib_field_theory.

--- a/theories/Classes/theory/ua_first_isomorphism.v
+++ b/theories/Classes/theory/ua_first_isomorphism.v
@@ -121,7 +121,7 @@ Section first_isomorphism.
   Proof.
     refine (Quotient_rec (cong_ker f s) _ (λ x, (f s x; tr (x; idpath))) _).
     intros x y p.
-    now apply path_sigma_hprop.
+    by apply path_sigma_hprop.
   Defined.
 
   Lemma oppreserving_first_isomorphism {w : SymbolType σ}
@@ -179,7 +179,7 @@ Section first_isomorphism.
     refine (Trunc_rec _ M). intros [y Y].
     apply tr.
     exists (class_of _ y).
-    now apply path_sigma_hprop.
+    by apply path_sigma_hprop.
   Qed.
 
   Global Instance is_isomorphism_first_isomorphism

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -201,7 +201,7 @@ Section hom_id.
   Proof.
     intro u. generalize u.#A. intro w. induction (σ u).
     - reflexivity.
-    - now intro x.
+    - by intro x.
   Defined.
 
   Global Instance is_isomorphism_id
@@ -262,7 +262,7 @@ Section hom_compose.
   Proof.
     induction w; simpl in *.
     - by path_induction.
-    - intro x. now apply (IHw _ (β (f _ x))).
+    - intro x. by apply (IHw _ (β (f _ x))).
   Defined.
 
   Global Instance is_homomorphism_compose

--- a/theories/HIT/unique_choice.v
+++ b/theories/HIT/unique_choice.v
@@ -11,7 +11,7 @@ intros H H0 [x p] [y q].
 specialize (H0 x y p q).
 induction H0.
 assert (H0: (p =q)) by apply path_ishprop.
-now induction H0.
+by induction H0.
 Qed.
 
 Lemma iota {X} (P:X-> Type):

--- a/theories/Sets/AC.v
+++ b/theories/Sets/AC.v
@@ -33,7 +33,7 @@ Proof.
     + pose proof (HAR := ordinal_has_minimal_hsolutions A (fun a => Build_HProp (merely (exists y, f y = a /\ R x y)))).
       eapply merely_destruct; try apply HAR.
       * eapply merely_destruct; try apply (HR x). intros [y Hy].
-        apply tr. exists (f y). apply tr. exists y. now split.
+        apply tr. exists (f y). apply tr. exists y. by split.
       * intros [a [H1 H2]]. eapply merely_destruct; try apply H1.
         intros [y [<- Hy]]. apply tr. exists y. apply tr. split; trivial.
         intros y' Hy'. apply H2. apply tr. exists y'. split; trivial.
@@ -45,5 +45,5 @@ Proof.
       eapply merely_destruct; try apply (H4 y); trivial. intros [H6| -> ]; trivial.
       apply Empty_rec. apply (irreflexive_ordinal_relation _ _ _ (f y)).
       apply (ordinal_transitivity _ (f y')); trivial.
-  - intros x. cbn. destruct iota as [y Hy]. eapply merely_destruct; try apply Hy. now intros [].
+  - intros x. cbn. destruct iota as [y Hy]. eapply merely_destruct; try apply Hy. by intros [].
 Qed.

--- a/theories/Sets/GCH.v
+++ b/theories/Sets/GCH.v
@@ -22,7 +22,7 @@ Lemma Cantor_inj {PR : PropResizing} {FE : Funext} X :
 Proof.
   intros [i HI]. pose (p n := Build_HProp (smalltype (forall q, i q = n -> ~ q n))).
   enough (Hp : p (i p) <-> ~ p (i p)).
-  { apply Hp; apply Hp; intros H; now apply Hp. }
+  { apply Hp; apply Hp; intros H; by apply Hp. }
   unfold p at 1. split.
   - intros H. apply equiv_smalltype in H. apply H. reflexivity.
   - intros H. apply equiv_smalltype. intros q -> % HI. apply H.
@@ -36,8 +36,8 @@ Proof.
   repeat (nrapply istrunc_forall; intros).
   apply hprop_allpath. intros [H|H] [H'|H'].
   - enough (H = H') as ->; trivial. apply path_ishprop.
-  - apply Empty_rec. eapply merely_destruct; try eapply (Cantor_inj a); trivial. now apply InjectsInto_trans with a0.
-  - apply Empty_rec. eapply merely_destruct; try eapply (Cantor_inj a); trivial. now apply InjectsInto_trans with a0.
+  - apply Empty_rec. eapply merely_destruct; try eapply (Cantor_inj a); trivial. by apply InjectsInto_trans with a0.
+  - apply Empty_rec. eapply merely_destruct; try eapply (Cantor_inj a); trivial. by apply InjectsInto_trans with a0.
   - enough (H = H') as ->; trivial. apply path_ishprop.
 Qed.
 
@@ -71,10 +71,10 @@ Section LEM.
   Proof.
     intros HI. pose (p n := Build_HProp (smalltype (forall q, i q = hpaths n -> ~ q n))).
     exists p. intros [n HN]. enough (Hp : p n <-> ~ p n).
-    { apply Hp; apply Hp; intros H; now apply Hp. }
+    { apply Hp; apply Hp; intros H; by apply Hp. }
     unfold p at 1. split.
     - intros H. apply equiv_smalltype in H. apply H, HN.
-    - intros H. apply equiv_smalltype. intros q HQ. rewrite <- HN in HQ. now apply HI in HQ as ->.
+    - intros H. apply equiv_smalltype. intros q HQ. rewrite <- HN in HQ. by apply HI in HQ as ->.
   Qed.
 
   Lemma injective_proj1 {Z} (r : Z -> HProp) :
@@ -90,7 +90,7 @@ Section LEM.
     (P + ~ P) -> Injection (X -> HProp) sings.
   Proof.
     intros HP. unshelve eexists.
-    - intros p. exists p. apply tr. now right.
+    - intros p. exists p. apply tr. by right.
     - intros p q. intros H. change p with ((exist (fun r => sing r \/ (P + ~ P)) p (tr (inr HP))).1).
       rewrite H. cbn. reflexivity.
   Qed.
@@ -102,17 +102,17 @@ Section LEM.
     intros ch. eapply merely_destruct; try apply ch.
     - unshelve eexists.
       + intros x. exists (hpaths x). apply tr. left. exists x. reflexivity.
-      + intros x y. intros H % pr1_path. cbn in H. change (hpaths x y). now rewrite H.
-    - exists (@proj1 _ _). now apply injective_proj1.
+      + intros x y. intros H % pr1_path. cbn in H. change (hpaths x y). by rewrite H.
+    - exists (@proj1 _ _). by apply injective_proj1.
     - intros H. assert (HP' : ~ ~ (P + ~ P)).
-      { intros HP. apply HP. right. intros p. apply HP. now left. }
+      { intros HP. apply HP. right. intros p. apply HP. by left. }
       apply HP'. intros HP % inject_sings. clear HP'.
-      apply Cantor_inj with X. now eapply (Injection_trans _ _ _ HP).
+      apply Cantor_inj with X. by eapply (Injection_trans _ _ _ HP).
     - intros [i Hi]. destruct (Cantor_sing (fun p => @proj1 _ _ (i p))) as [p HP].
-      + intros x y H % injective_proj1. now apply Hi.
+      + intros x y H % injective_proj1. by apply Hi.
       + destruct (i p) as [q Hq]; cbn in *.
         eapply merely_destruct; try apply Hq.
-        intros [H|H]; [destruct (HP H)|now apply tr].
+        intros [H|H]; [destruct (HP H)|by apply tr].
   Qed.
 
 End LEM.

--- a/theories/Sets/GCHtoAC.v
+++ b/theories/Sets/GCHtoAC.v
@@ -51,8 +51,8 @@ Proof.
   apply path_universe_uncurried. srapply equiv_adjointify.
   - exact (fun x => match x with inl _ => O | inr n => S n end).
   - exact (fun n => match n with O => inl tt | S n => inr n end).
-  - now intros [].
-  - now intros [[]|n]. 
+  - by intros [].
+  - by intros [[]|n]. 
 Qed.
 
 Lemma path_unit_fun X :
@@ -90,12 +90,12 @@ Lemma path_pred_sum X (p : X -> HProp) :
   X = sig p + sig (fun x => ~ p x).
 Proof.
   apply path_universe_uncurried. srapply equiv_adjointify.
-  - intros x. destruct (LEM (p x) _) as [H|H]; [left | right]; now exists x.
+  - intros x. destruct (LEM (p x) _) as [H|H]; [left | right]; by exists x.
   - intros [[x _]|[x _]]; exact x.
   - cbn. intros [[x Hx]|[x Hx]]; destruct LEM as [H|H]; try contradiction.
     + enough (H = Hx) as -> by reflexivity. apply path_ishprop.
-    + enough (H = Hx) as -> by reflexivity. apply path_forall. now intros HP.
-  - cbn. intros x. now destruct LEM.
+    + enough (H = Hx) as -> by reflexivity. apply path_forall. by intros HP.
+  - cbn. intros x. by destruct LEM.
 Qed.
 
 Definition ran {X Y : Type} (f : X -> Y) :=
@@ -106,9 +106,9 @@ Lemma path_ran {X} {Y : HSet} (f : X -> Y) :
 Proof.
   intros Hf. apply path_universe_uncurried. srapply equiv_adjointify.
   - intros [y H]. destruct (iota (fun x => f x = y) _) as [x Hx]; try exact x.
-    split; try apply H. intros x x'. cbn. intros Hy Hy'. rewrite <- Hy' in Hy. now apply Hf.
+    split; try apply H. intros x x'. cbn. intros Hy Hy'. rewrite <- Hy' in Hy. by apply Hf.
   - intros x. exists (f x). apply tr. exists x. reflexivity.
-  - cbn. intros x. destruct iota as [x' H]. now apply Hf.
+  - cbn. intros x. destruct iota as [x' H]. by apply Hf.
   - cbn. intros [y x]. apply path_sigma_hprop. cbn.
     destruct iota as [x' Hx]. apply Hx.
 Qed.
@@ -128,7 +128,7 @@ Fact path_infinite_power (X : HSet) :
   infinite X -> (X -> HProp) + (X -> HProp) = (X -> HProp).
 Proof.
   intros H. rewrite path_sum_bool. rewrite <- path_bool_subsingleton.
-  rewrite path_sum_prod. now rewrite path_infinite_unit.
+  rewrite path_sum_prod. by rewrite path_infinite_unit.
 Qed.
 
 
@@ -143,7 +143,7 @@ Lemma Cantor X (f : X -> X -> Type) :
 Proof.
   exists (fun x => ~ f x x). intros x H.
   enough (Hx : f x x <-> ~ f x x).
-  - apply Hx; apply Hx; intros H'; now apply Hx.
+  - apply Hx; apply Hx; intros H'; by apply Hx.
   - pattern (f x) at 1. rewrite H. reflexivity.
 Qed.
 
@@ -152,7 +152,7 @@ Lemma hCantor {X} (f : X -> X -> HProp) :
 Proof.
   exists (fun x => Build_HProp (f x x -> Empty)). intros x H.
   enough (Hx : f x x <-> ~ f x x).
-  - apply Hx; apply Hx; intros H'; now apply Hx.
+  - apply Hx; apply Hx; intros H'; by apply Hx.
   - pattern (f x) at 1. rewrite H. reflexivity.
 Qed.
 
@@ -160,25 +160,25 @@ Definition clean_sum {X Y Z} (f : X -> Y + Z) :
   (forall x y, f x <> inl y) -> forall x, { z | inr z = f x }.
 Proof.
   intros Hf. enough (H : forall x a, a = f x -> {z : Z & inr z = f x}).
-  - intros x. now apply (H x (f x)).
+  - intros x. by apply (H x (f x)).
   - intros x a Hxa. specialize (Hf x). destruct (f x) as [y|z].
-    + apply Empty_rect. now apply (Hf y).
-    + now exists z.
+    + apply Empty_rect. by apply (Hf y).
+    + by exists z.
 Qed.
 
 Fact Cantor_path_injection {X Y} :
   (X -> HProp) = (X + Y) -> (X + X) = X -> Injection (X -> HProp) Y.
 Proof.
   intros H1 H2. assert (H : X + Y = (X -> HProp) * (X -> HProp)).
-  - now rewrite <- H1, path_sum_prod, H2. 
+  - by rewrite <- H1, path_sum_prod, H2. 
   - apply equiv_path in H as [f [g Hfg Hgf _]].
     pose (f' x := fst (f (inl x))). destruct (hCantor f') as [p Hp].
     pose (g' q := g (p, q)). assert (H' : forall q x, g' q <> inl x).
-    + intros q x H. apply (Hp x). unfold f'. rewrite <- H. unfold g'. now rewrite Hfg.
+    + intros q x H. apply (Hp x). unfold f'. rewrite <- H. unfold g'. by rewrite Hfg.
     + exists (fun x => proj1 (clean_sum _ H' x)). intros q q' H. assert (Hqq' : g' q = g' q').
-      * destruct clean_sum as [z <-]. destruct clean_sum as [z' <-]. cbn in H. now rewrite H.
+      * destruct clean_sum as [z <-]. destruct clean_sum as [z' <-]. cbn in H. by rewrite H.
       * unfold g' in Hqq'. change (snd (p, q) = snd (p, q')).
-        rewrite <- (Hfg (p, q)), <- (Hfg (p, q')). now rewrite Hqq'.
+        rewrite <- (Hfg (p, q)), <- (Hfg (p, q')). by rewrite Hqq'.
 Qed.
 
 (* Version just requiring propositional injections *)
@@ -188,10 +188,10 @@ Lemma Cantor_rel X (R : X -> (X -> HProp) -> HProp) :
 Proof.
   intros HR. pose (pc x := Build_HProp (smalltype (forall p : X -> HProp, R x p -> ~ p x))).
   exists pc. intros x H. enough (Hpc : pc x <-> ~ pc x). 2: split.
-  { apply Hpc; apply Hpc; intros H'; now apply Hpc. }
-  - intros Hx. apply equiv_smalltype in Hx. now apply Hx.
+  { apply Hpc; apply Hpc; intros H'; by apply Hpc. }
+  - intros Hx. apply equiv_smalltype in Hx. by apply Hx.
   - intros Hx. apply equiv_smalltype. intros p Hp.
-    eapply merely_destruct; try apply (HR _ _ _ Hp H). now intros ->.
+    eapply merely_destruct; try apply (HR _ _ _ Hp H). by intros ->.
 Qed.
 
 Lemma InjectsInto_power_morph X Y :
@@ -201,9 +201,9 @@ Proof.
   apply tr. exists (fun p => fun y => hexists (fun x => p x /\ y = f x)).
   intros p q H. apply path_forall. intros x. apply equiv_path_iff_hprop. split; intros Hx.
   - assert (Hp : (fun y : Y => hexists (fun x : X => p x * (y = f x))) (f x)). { apply tr. exists x. split; trivial. }
-    pattern (f x) in Hp. rewrite H in Hp. eapply merely_destruct; try apply Hp. now intros [x'[Hq <- % Hf]].
+    pattern (f x) in Hp. rewrite H in Hp. eapply merely_destruct; try apply Hp. by intros [x'[Hq <- % Hf]].
   - assert (Hq : (fun y : Y => hexists (fun x : X => q x * (y = f x))) (f x)). { apply tr. exists x. split; trivial. }
-    pattern (f x) in Hq. rewrite <- H in Hq. eapply merely_destruct; try apply Hq. now intros [x'[Hp <- % Hf]].
+    pattern (f x) in Hq. rewrite <- H in Hq. eapply merely_destruct; try apply Hq. by intros [x'[Hp <- % Hf]].
 Qed.
 
 Fact Cantor_injects_injects {X Y : HSet} :
@@ -217,12 +217,12 @@ Proof.
     pose (R x p := hexists (fun q => f (p, q) = inl x)). destruct (@Cantor_rel _ R) as [p Hp].
     { intros x p p' H3 H4. eapply merely_destruct; try apply H3. intros [q Hq].
       eapply merely_destruct; try apply H4. intros [q' Hq']. apply tr.
-      change p with (fst (p, q)). rewrite (Hf (p, q) (p', q')); trivial. now rewrite Hq, Hq'. }
+      change p with (fst (p, q)). rewrite (Hf (p, q) (p', q')); trivial. by rewrite Hq, Hq'. }
     pose (f' q := f (p, q)). assert (H' : forall q x, f' q <> inl x).
     + intros q x H. apply (Hp x). apply tr. exists q. apply H.
     + apply tr. exists (fun x => proj1 (clean_sum _ H' x)). intros q q' H. assert (Hqq' : f' q = f' q').
-      * destruct clean_sum as [z <-]. destruct clean_sum as [z' <-]. cbn in H. now rewrite H.
-      * apply Hf in Hqq'. change q with (snd (p, q)). now rewrite Hqq'.
+      * destruct clean_sum as [z <-]. destruct clean_sum as [z' <-]. cbn in H. by rewrite H.
+      * apply Hf in Hqq'. change q with (snd (p, q)). by rewrite Hqq'.
 Qed.
 
 End Preparation.
@@ -257,8 +257,8 @@ Proof.
   apply tr. exists (fun z => match z with inl x => inl (f x) | inr y => inr (g y) end).
   intros [x|y] [x'|y'] H.
   - apply ap. apply Hf. apply path_sum_inl with Y'. apply H.
-  - now apply inl_ne_inr in H.
-  - now apply inr_ne_inl in H.
+  - by apply inl_ne_inr in H.
+  - by apply inr_ne_inl in H.
   - apply ap. apply Hg. apply path_sum_inr with X'. apply H.
 Qed.
 
@@ -268,9 +268,9 @@ Lemma Sierpinski_step (X : HSet) n :
   GCH -> infinite X -> powfix X -> InjectsInto (HN X) (power_iterated X n) -> InjectsInto X (HN X).
 Proof.
   intros gch H1 H2 Hi. induction n.
-  - now apply HN_ninject in Hi.
+  - by apply HN_ninject in Hi.
   - destruct (gch (Build_HSet (power_iterated X n)) (Build_HSet (power_iterated X n + HN X))) as [H|H].
-    + now apply infinite_power_iterated.
+    + by apply infinite_power_iterated.
     + apply tr. exists inl. intros x x'. apply path_sum_inl.
     + eapply InjectsInto_trans.
       * apply InjectsInto_sum; try apply Hi. apply tr, Injection_power. exact _.
@@ -286,7 +286,7 @@ Proof.
   intros gch HX. eapply InjectsInto_trans; try apply tr, Injection_power; try apply X.
   apply (@Sierpinski_step (Build_HSet (X -> HProp)) HN_bound gch).
   - apply infinite_inject with X; trivial. apply Injection_power. apply X.
-  - intros n. cbn. rewrite !power_iterated_shift. eapply path_infinite_power. cbn. now apply infinite_power_iterated.
+  - intros n. cbn. rewrite !power_iterated_shift. eapply path_infinite_power. cbn. by apply infinite_power_iterated.
   - apply HN_inject.
 Qed.
 

--- a/theories/Sets/GCHtoAC.v
+++ b/theories/Sets/GCHtoAC.v
@@ -74,10 +74,10 @@ Proof.
   - exact (fun b : Bool => if b then merely Unit else merely Empty).
   - intros []; destruct LEM as [H|H]; auto.
     + destruct (H (tr tt)).
-    + apply (@merely_destruct Empty); try easy. exact _.
+    + apply (@merely_destruct Empty); try done. exact _.
   - intros P. destruct LEM as [H|H]; apply equiv_path_iff_hprop.
     + split; auto. intros _. apply tr. exact tt.
-    + split; try easy. intros HE. apply (@merely_destruct Empty); try easy. exact _.
+    + split; try done. intros HE. apply (@merely_destruct Empty); try done. exact _.
 Qed.
 
 Lemma path_bool_subsingleton :

--- a/theories/Sets/Hartogs.v
+++ b/theories/Sets/Hartogs.v
@@ -228,13 +228,13 @@ Section Hartogs_Number.
         * intros [a <-]. cbn. apply tr. exists a. cbn. apply ap. apply path_ishprop.
       + apply isembedding_isinj_hset. intros a b. intros H % pr1_path. cbn in H.
         specialize (injective_uni_fix (hartogs_number'_injection.1 a) (hartogs_number'_injection.1 b)).
-        intros H'. apply H' in H. now apply hartogs_number'_injection.2.
+        intros H'. apply H' in H. by apply hartogs_number'_injection.2.
   Qed.
 
   Definition hartogs_number : Ordinal@{A _}
     := resize_ordinal hartogs_number' hartogs_number_carrier hartogs_equiv.
 
-  (* This final definition now satisfies the expected cardinality properties. *)
+  (* This final definition by satisfies the expected cardinality properties. *)
 
   Lemma hartogs_number_injection
     : exists f : hartogs_number -> 𝒫 (𝒫 (𝒫 A)), IsInjective f.
@@ -247,7 +247,7 @@ Section Hartogs_Number.
     : ~ (exists f : hartogs_number -> A, IsInjective f).
   Proof.
     cbn. intros [f Hf]. cbn in f.
-    assert (HN : card hartogs_number <= card A). { apply tr. now exists f. }
+    assert (HN : card hartogs_number <= card A). { apply tr. by exists f. }
     transparent assert (HNO : hartogs_number'). { exists hartogs_number. apply HN. }
     apply (ordinal_initial hartogs_number' HNO).
     eapply (transitive_Isomorphism hartogs_number' hartogs_number).

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -235,10 +235,10 @@ Proof.
   - apply tr. exists a. split; try apply Ha. intros b Hb.
     specialize (trichotomy_ordinal a b). intros H1.
     eapply merely_destruct; try apply H1.
-    intros [H2|H2]. { apply tr. now left. }
+    intros [H2|H2]. { apply tr. by left. }
     eapply merely_destruct; try apply H2.
-    intros [H3|H3]. { apply tr. now right. }
-    apply Empty_rec, H, tr. exists b. now split.
+    intros [H3|H3]. { apply tr. by right. }
+    apply Empty_rec, H, tr. exists b. by split.
 Qed.
 
 (** * Simulations *)

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -162,7 +162,7 @@ Lemma Injection_trans X Y Z :
   Injection X Y -> Injection Y Z -> Injection X Z.
 Proof.
   intros [f Hf] [g Hg]. exists (fun x => g (f x)).
-  intros x x' H. now apply Hf, Hg.
+  intros x x' H. by apply Hf, Hg.
 Qed.
 
 Definition InjectsInto X Y :=
@@ -181,7 +181,7 @@ Proof.
   eapply merely_destruct; try apply H1. intros [f Hf].
   eapply merely_destruct; try apply H2. intros [g Hg].
   apply tr. exists (fun x => g (f x)).
-  intros x x' H. now apply Hf, Hg.
+  intros x x' H. by apply Hf, Hg.
 Qed.
 
 

--- a/theories/Spaces/Card.v
+++ b/theories/Spaces/Card.v
@@ -145,7 +145,6 @@ Section contents.
 End contents.
 
 
-
 (** * Cardinality comparisons *)
 
 (* We also work with cardinality comparisons directly to avoid unnecessary type truncations via cardinals. *)
@@ -156,7 +155,7 @@ Definition Injection X Y :=
 Global Instance Injection_refl :
   Reflexive Injection.
 Proof.
-  intros X. exists (fun x => x). intros x x'. easy.
+  intros X. exists (fun x => x). intros x x'. done.
 Qed.
 
 Lemma Injection_trans X Y Z :

--- a/theories/Spaces/FreeInt.v
+++ b/theories/Spaces/FreeInt.v
@@ -44,7 +44,7 @@ Lemma Z1_mul_nat_beta {A : AbGroup} (a : A) (n : nat)
   : Z1_rec a (nat_to_Z1 n) = ab_mul n a.
 Proof.
   induction n as [|n H].
-  1: easy.
+  1: done.
   exact (grp_pow_natural _ _ _).
 Defined.
 

--- a/theories/Spaces/Nat/Arithmetic.v
+++ b/theories/Spaces/Nat/Arithmetic.v
@@ -29,7 +29,7 @@ Proof.
   - destruct (nat_add_succ_r n k)^.
     refine (leq_trans (nataddsub_comm_ineq_lemma (n+k) m) _).
     destruct (nat_add_succ_r (n - m) k)^.
-    now apply leq_succ.
+    by apply leq_succ.
 Defined.
 
 (** TODO: move, rename *)
@@ -114,7 +114,7 @@ Proof.
   intros l ineq.
   destruct j.
   - contradiction (not_lt_zero_r i).
-  - now simpl; apply leq_pred'.
+  - by simpl; apply leq_pred'.
 Defined.
 
 (** TODO: move, rename *)
@@ -191,7 +191,7 @@ Proof.
   intro a.
   induction a.
   - constructor.
-  - now constructor.
+  - by constructor.
 Defined.
 
 Proposition increasing_geq_n_0 (n : nat) : increasing_geq n 0.
@@ -199,8 +199,8 @@ Proof.
   simple_induction n n IHn.
   - constructor.
   - induction IHn.
-    + constructor; now constructor.
-    + constructor; now assumption.
+    + constructor; by constructor.
+    + constructor; by assumption.
 Defined.
 
 Lemma increasing_geq_minus (n k : nat)
@@ -218,7 +218,7 @@ Proof.
       apply increasing_geq_S.
       unfold ">", "<" in *.
       apply equiv_lt_lt_sub in g. 
-      now (destruct (symmetric_paths _ _ (nat_succ_pred (n - k) _))).
+      by (destruct (symmetric_paths _ _ (nat_succ_pred (n - k) _))).
 Defined.
 
 Lemma ineq_sub' (n k : nat) : k < n -> n - k = (n - k.+1).+1.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -901,7 +901,7 @@ Proof.
     intros H1 p; destruct p.
     contradiction (lt_irrefl _ _).
   - intro l; induction l.
-    + now right.
+    + by right.
     + left; exact (leq_succ l).
   - intros [l|p].
     + exact (leq_succ_l l).
@@ -981,7 +981,7 @@ Definition neq_iff_lt_or_gt {n m} : n <> m <-> (n < m) + (n > m).
 Proof.
   split.
   - intros diseq.
-    destruct (dec (n < m)) as [| a]; [ now left |].
+    destruct (dec (n < m)) as [| a]; [ by left |].
     apply geq_iff_not_lt in a.
     apply equiv_leq_lt_or_eq in a.
     destruct a as [lt | eq].


### PR DESCRIPTION
These tactics have been around and pretty much do the same thing. We therefore define them in terms of the more commonly used variant. We could consider removing them completely, but the diff will be a bit larger.
