### PR TITLE
Equivalence cleanups

### DIFF
--- a/theories/Equiv/BiInv.v
+++ b/theories/Equiv/BiInv.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics Types.Prod Types.Equiv.
 
 Local Open Scope path_scope.
 Generalizable Variables A B f.

--- a/theories/Equiv/BiInv.v
+++ b/theories/Equiv/BiInv.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics Types.Prod Types.Equiv.
+Require Import Basics Types.Prod Types.Equiv.
 
 Local Open Scope path_scope.
 Generalizable Variables A B f.

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -381,6 +381,7 @@ Defined.
 
 (** ** Equivalences *)
 
+(** The converse to [isequiv_functor_sigma] when [f] is [idmap] is [isequiv_from_functor_sigma] in Types/Equiv.v, which also contains Theorem 4.7.7 *)
 Global Instance isequiv_functor_sigma `{P : A -> Type} `{Q : B -> Type}
   `{IsEquiv A B f} `{forall a, @IsEquiv (P a) (Q (f a)) (g a)}
   : IsEquiv (functor_sigma f g) | 1000.
@@ -730,7 +731,6 @@ Proof.
            (fun (w:hfiber idmap b) => hfiber (g w.1) (transport Q (w.2)^ v))).
 Defined.
 
-(** The converse and Theorem 4.7.7 can be found in Types/Equiv.v *)
 Definition istruncmap_from_functor_sigma n {A P Q}
   (g : forall a : A, P a -> Q a)
   `{!IsTruncMap n (functor_sigma idmap g)}


### PR DESCRIPTION
Mainly changes Types/Equiv.v:

- Removed rewrites from one proof.
- Moved most things that don't depend on Funext out of the Funext section.  I think the new order also makes the structure more clear.
- Fix formatting of some comments and indentation.

In Equiv/BiInv.v, I just reduced the imports.