### PR TITLE
Prove Yoneda-like result for paths, and required lemmas

### DIFF
--- a/theories/HFiber.v
+++ b/theories/HFiber.v
@@ -262,6 +262,13 @@ Proof.
   exact (equiv_iff_hprop (@isequiv_ap_isembedding _ _ f) (@isembedding_isequiv_ap _ _ f)).
 Defined.
 
+(** It follows from [isembedding_isequiv_ap] and [isequiv_ap_equiv_fun] that [equiv_fun] is an embedding. *)
+Global Instance isembedding_equiv_fun `{Funext} {A B : Type}
+  : IsEmbedding (@equiv_fun A B).
+Proof.
+  rapply isembedding_isequiv_ap.
+Defined.
+
 Lemma ap_isinj_embedding_beta {X Y : Type} (f : X -> Y) {I : IsEmbedding f} {x0 x1 : X}
   : forall (p : f x0 = f x1), ap f (isinj_embedding f I x0 x1 p) = p.
 Proof.

--- a/theories/HFiber.v
+++ b/theories/HFiber.v
@@ -200,6 +200,17 @@ Section UnstableOctahedral.
 
 End UnstableOctahedral.
 
+(** We characterize the fibers of [functor_forall], but only in the special case where the base map is [idmap]. This doesn't dependn on anything else in this file, but can't be put in Types/Forall.v, because it requires results from Types/Sigma.v. *)
+Definition hfiber_functor_forall_id `{Funext} {A : Type} {P Q : A -> Type}
+  (h : forall a, P a -> Q a) (g : forall a, Q a)
+  : hfiber (functor_forall_id h) g <~> (forall a, hfiber (h a) (g a)).
+Proof.
+  unfold hfiber, functor_forall_id, functor_forall.
+  nrefine (equiv_sig_coind _ _ oE _).
+  apply equiv_functor_sigma_id; intro f.
+  apply equiv_apD10.
+Defined.
+
 (** ** Fibers of constant functions *)
 Definition hfiber_const A {B} (y y' : B)
   : hfiber (fun _ : A => y) y' <~> A * (y = y')

--- a/theories/HFiber.v
+++ b/theories/HFiber.v
@@ -200,7 +200,7 @@ Section UnstableOctahedral.
 
 End UnstableOctahedral.
 
-(** We characterize the fibers of [functor_forall], but only in the special case where the base map is [idmap]. This doesn't dependn on anything else in this file, but can't be put in Types/Forall.v, because it requires results from Types/Sigma.v. *)
+(** We characterize the fibers of [functor_forall], but only in the special case where the base map is [idmap]. This doesn't depend on anything else in this file, but can't be put in Types/Forall.v, because it requires results from Types/Sigma.v. *)
 Definition hfiber_functor_forall_id `{Funext} {A : Type} {P Q : A -> Type}
   (h : forall a, P a -> Q a) (g : forall a, Q a)
   : hfiber (functor_forall_id h) g <~> (forall a, hfiber (h a) (g a)).

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1585,6 +1585,15 @@ Section ModalMaps.
     refine (inO_equiv_inO _ (hfiber_unfunctor_sum_r h Ha Hb b)^-1).
   Defined.
 
+  (** Given a family of maps [f : forall a, P a -> Q a] which are in [O], the induced map on Pi types is also in [O]. *)
+  Definition mapinO_functor_forall_id `{Funext}
+    {A : Type} {P Q : A -> Type} (f : forall a, P a -> Q a) `{forall a, MapIn O (f a)}
+    : MapIn O (functor_forall_id f).
+  Proof.
+    intro g.
+    rapply (inO_equiv_inO _ (hfiber_functor_forall_id f g)^-1%equiv).
+  Defined.
+
 End ModalMaps.
 
 (** ** Modally connected maps *)

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -1,4 +1,4 @@
-Require Import Basics Types WildCat.Core WildCat.Universe.
+Require Import Basics Types WildCat.Core WildCat.Universe HFiber.
 Require Import Modalities.Modality.
 (* Users of this file almost always want to be able to write [Tr n] for both a [Modality] and a [ReflectiveSubuniverse], so they want the coercion [modality_to_reflective_subuniverse]: *)
 Require Export (coercions) Modalities.Modality.
@@ -209,6 +209,8 @@ Proof.
   revert ma; rapply Trunc_ind; exact na.
 Defined.
 
+(** ** Surjections *)
+
 (** Surjections are the (-1)-connected maps, but they can be characterized more simply since an inhabited hprop is automatically contractible. *)
 Notation IsSurjection := (IsConnMap (Tr (-1))).
 
@@ -256,12 +258,25 @@ Proof.
   exact (tr (s y; h y)).
 Defined.
 
+(** ** Embeddings *)
+
 (** Since embeddings are the (-1)-truncated maps, a map that is both a surjection and an embedding is an equivalence. *)
 Definition isequiv_surj_emb {A B} (f : A -> B)
   `{IsSurjection f} `{IsEmbedding f}
   : IsEquiv f.
 Proof.
   apply (@isequiv_conn_ino_map (Tr (-1))); assumption.
+Defined.
+
+(** As a corollary, it follows that if [i o f] is an equivalence and [i] is an embedding, then [f] is an equivalence. *)
+Definition isequiv_isequiv_compose_embedding {X Y Z : Type}
+  {f : X -> Y} (i : Y -> Z) `{IsEmbedding i}
+  `{!IsEquiv (i o f)}
+  : IsEquiv f.
+Proof.
+  rapply (cancelL_isequiv i).
+  refine (isequiv_surj_emb i).
+  rapply (cancelR_issurjection f).
 Defined.
 
 (** If [X] is a set and [f : Y -> Z] is a surjection, then [- o f] is an embedding. *)
@@ -275,6 +290,43 @@ Proof.
   apply path_sigma_hprop, equiv_path_arrow.
   rapply conn_map_elim; intro y.
   exact (ap10 (g0.2 @ g1.2^) y).
+Defined.
+
+(** We next prove that [paths : X -> (X -> Type)] is an embedding. This was proved by Escardo as Lemma 15 in "Injective types in univalent mathematics", but we give an argument similar to the proof of Thm 2.25 of CORS. *)
+
+(** This will be an inverse to [ap paths].  We'll want to show that it is an embedding, so we'll construct it out of pieces that are clearly equivalences, except for one step, [equiv_fun]. *)
+Definition ap_paths_inverse `{Univalence} {X : Type} (x1 x2 : X)
+  : paths x1 = paths x2 -> x1 = x2.
+Proof.
+  refine (_ o @equiv_ap10 _ X Type (paths x1) (paths x2)).
+  refine (_ o equiv_functor_forall_id (fun y => equiv_equiv_path (x1 = y) (x2 = y))).
+  refine (_ o functor_forall_id (fun y => @equiv_fun (x1 = y) (x2 = y))).
+  refine (_ o (equiv_paths_ind x1 (fun y p => x2 = y))^-1%equiv).
+  exact (equiv_path_inverse x2 x1).
+Defined.
+
+(** A Yoneda-like embedding for path types: [paths : X -> (X -> Type)] is an embedding. *)
+Definition isembedding_paths `{Univalence} {X : Type@{u}} : IsEmbedding (@paths X).
+Proof.
+  (* To show that [paths] is an embedding, it suffices to show that [ap paths : x1 = x2 -> (paths x1) = (paths x2)] is an equivalence. *)
+  snrapply isembedding_isequiv_ap.
+  intros x1 x2.
+  (* And for that, it suffices to show that [i o (ap paths)] is an equivalence for a well-chosen embedding [i]. *)
+  snrapply (isequiv_isequiv_compose_embedding (ap_paths_inverse x1 x2)).
+  - (* [ap_paths_inverse x1 x2] is an embedding since it is a composite of four equivalences and one embedding.  We can group these into three parts. *)
+    unfold ap_paths_inverse.
+    nrefine (mapinO_compose (O:=Tr (-1)) _ (equiv_path_inverse x2 x1 oE _)).
+    2: exact _. (* The second part is an equivalence, so it's an embedding. *)
+    nrefine (mapinO_compose _ (functor_forall_id _)).
+    1: exact _. (* The first part is an equivalence, so it's an embedding. *)
+    rapply mapinO_functor_forall_id.
+    intro y.
+    apply isembedding_equiv_fun.
+  - (* The composite is an equivalence because it is homotopic to the identity. *)
+    simpl.
+    srapply (isequiv_homotopic idmap).
+    intros [].
+    reflexivity.
 Defined.
 
 (** ** Tactic to remove truncations in hypotheses if possible


### PR DESCRIPTION
The third commit proves that `paths : X -> (X -> Type)` is an embedding.  For this we needed that `functor_forall_id` sends families of O-modal maps to an O-modal map, which is in commit 1.  And that `equiv_fun` is an embedding, which is in commit 2.