### PR TITLE
Path spaces of graph quotients, coequalizers, and pushouts

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -93,6 +93,33 @@ Section EquivTransport.
 
 End EquivTransport.
 
+(** Doubly dependent transport is an equivalence *)
+Section EquivTransportD.
+
+    Context {A : Type} (P : A -> Type) (Q : forall a : A, P a -> Type) 
+      {x y : A} (p : x = y) {px : P x}.
+
+    Global Instance isequiv_transportD : IsEquiv (transportD P Q p px).
+    Proof.
+      snrapply Build_IsEquiv.
+      { refine (_ o transportD P Q p^ (transport P p px)).
+        exact (transport (Q x) (transport_Vp _ p px)). }
+      all: by destruct p.
+    Defined.
+
+    Definition equiv_transportD : Q x px <~> Q y (transport P p px)
+      := Build_Equiv _ _ (transportD P Q p px) _.
+
+    Context {py : P y} (q : transport P p px = py).
+
+    Global Instance isequiv_transportDD : IsEquiv (transportDD P Q p q)
+     := isequiv_compose.
+
+    Definition equiv_transportDD : Q x px <~> Q y py
+      := Build_Equiv _ _ (transportDD P Q p q) _.
+
+  End EquivTransportD.
+
 (** In all the above cases, we were able to directly construct all the structure of an equivalence.  However, as is evident, sometimes it is quite difficult to prove the adjoint law.
 
    The following adjointification theorem allows us to be lazy about this if we wish.  It says that if we have all the data of an (adjoint) equivalence except the triangle identity, then we can always obtain the triangle identity by modifying the datum [equiv_is_section] (or [equiv_is_retraction]).  The proof is the same as the standard categorical argument that any equivalence can be improved to an adjoint equivalence.

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -84,7 +84,7 @@ Section EquivTransport.
 
   Context {A : Type} (P : A -> Type) {x y : A} (p : x = y).
 
-  (** The inverse and the homotopies of transport is defined explictly. This allows us to reason about the map when the input is not [idpath]. *)
+  (** The inverse and the homotopies of transport are defined explicitly.  This allows us to reason about the inverse when the input is not [idpath]. *)
   Global Instance isequiv_transport : IsEquiv (transport P p) | 0
     := Build_IsEquiv (P x) (P y) (transport P p) (transport P p^)
     (transport_pV P p) (transport_Vp P p) (transport_pVp P p).
@@ -94,13 +94,13 @@ Section EquivTransport.
 
 End EquivTransport.
 
-(** Doubly dependent transport is an equivalence *)
+(** Doubly dependent transport is an equivalence. *)
 Section EquivTransportD.
 
     Context {A : Type} (P : A -> Type) (Q : forall a : A, P a -> Type)
       {x y : A} (p : x = y) {px : P x}.
 
-    (** The inverse of transportD is defined explictly. This allows us to reason about the map when the input is not [idpath]. *)
+    (** The inverse of transportD is defined explicitly.  This allows us to reason about the inverse when the input is not [idpath]. *)
     Global Instance isequiv_transportD : IsEquiv (transportD P Q p px).
     Proof.
       snrapply Build_IsEquiv.

--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -84,6 +84,7 @@ Section EquivTransport.
 
   Context {A : Type} (P : A -> Type) {x y : A} (p : x = y).
 
+  (** The inverse and the homotopies of transport is defined explictly. This allows us to reason about the map when the input is not [idpath]. *)
   Global Instance isequiv_transport : IsEquiv (transport P p) | 0
     := Build_IsEquiv (P x) (P y) (transport P p) (transport P p^)
     (transport_pV P p) (transport_Vp P p) (transport_pVp P p).
@@ -96,9 +97,10 @@ End EquivTransport.
 (** Doubly dependent transport is an equivalence *)
 Section EquivTransportD.
 
-    Context {A : Type} (P : A -> Type) (Q : forall a : A, P a -> Type) 
+    Context {A : Type} (P : A -> Type) (Q : forall a : A, P a -> Type)
       {x y : A} (p : x = y) {px : P x}.
 
+    (** The inverse of transportD is defined explictly. This allows us to reason about the map when the input is not [idpath]. *)
     Global Instance isequiv_transportD : IsEquiv (transportD P Q p px).
     Proof.
       snrapply Build_IsEquiv.
@@ -110,12 +112,8 @@ Section EquivTransportD.
     Definition equiv_transportD : Q x px <~> Q y (transport P p px)
       := Build_Equiv _ _ (transportD P Q p px) _.
 
-    Context {py : P y} (q : transport P p px = py).
-
-    Global Instance isequiv_transportDD : IsEquiv (transportDD P Q p q)
-     := isequiv_compose.
-
-    Definition equiv_transportDD : Q x px <~> Q y py
+    Definition equiv_transportDD {py : P y} (q : transport P p px = py)
+      : Q x px <~> Q y py
       := Build_Equiv _ _ (transportDD P Q p q) _.
 
   End EquivTransportD.
@@ -658,7 +656,7 @@ Goal forall (A : Type) (B : A -> Type) (C : forall a:A, B a -> Type) (D : forall
     intros b; cbn in b.
     intros x; cbn in x.
     elim x; clear x.
-    intros c; cbn in c. 
+    intros c; cbn in c.
     intros d; cbn in d.
     (** Here begins [build_record] *)
     cbn; unshelve econstructor.
@@ -674,7 +672,7 @@ Goal forall (A : Type) (B : A -> Type) (C : forall a:A, B a -> Type) (D : forall
     intros x; cbn in x.
     elim x; clear x.
     intros x; cbn in x.
-    elim x; clear x. 
+    elim x; clear x.
     intros b; cbn in b.
     intros c; cbn in c.
     intros d; cbn in d.
@@ -691,7 +689,7 @@ Goal forall (A : Type) (B : A -> Type) (C : forall a:A, B a -> Type) (D : forall
     intros x; cbn in x.
     elim x; clear x.
     intros x; cbn in x.
-    elim x; clear x. 
+    elim x; clear x.
     intros b; cbn in b.
     intros c; cbn in c.
     intros d; cbn in d.
@@ -704,7 +702,7 @@ Goal forall (A : Type) (B : A -> Type) (C : forall a:A, B a -> Type) (D : forall
     intros b; cbn in b.
     intros x; cbn in x.
     elim x; clear x.
-    intros c; cbn in c. 
+    intros c; cbn in c.
     intros d; cbn in d.
     cbn; exact idpath.
 Defined.
@@ -728,7 +726,7 @@ Goal forall (A:Type) (R:A->A->Type),
     intros a2; cbn in a2.
     intros r; cbn in r.
     cbn; unshelve econstructor.
-    { cbn; unshelve econstructor. 
+    { cbn; unshelve econstructor.
       { (** [build_record] can't guess at this point that it needs to use [a1] instead of [a2], and in fact it tries [a2] first; but later on, [exact r] fails in that case, causing backtracking to this point and a re-try with [a1].  *)
         cbn; exact a1. }
       { cbn; exact a2. } }
@@ -829,7 +827,7 @@ Section Examples.
       intros x; cbn in x.
       elim x; clear x.
       intros a; cbn in a.
-      intros x; cbn in x. 
+      intros x; cbn in x.
       elim x; clear x.
       intros b; cbn in b.
       intros p; cbn in p.
@@ -855,7 +853,7 @@ Section Examples.
     - intros x; cbn in x.
       elim x; clear x.
       intros a; cbn in a.
-      intros x; cbn in x. 
+      intros x; cbn in x.
       elim x; clear x.
       intros b; cbn in b.
       intros p; cbn in p.

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -756,17 +756,26 @@ Defined.
 
 (** Dependent transport in doubly dependent types and more. *)
 
+(** Singly dependent transport over doubly dependent types. *)
 Definition transportD {A : Type} (B : A -> Type) (C : forall a:A, B a -> Type)
   {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C x1 y)
   : C x2 (p # y)
   :=
   match p with idpath => z end.
 
+(** Singly dependent transport over doubly dependent types of 2 variables. *)
 Definition transportD2 {A : Type} (B C : A -> Type) (D : forall a:A, B a -> C a -> Type)
   {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C x1) (w : D x1 y z)
   : D x2 (p # y) (p # z)
   :=
   match p with idpath => w end.
+
+(** Doubly dependent transport over doubly dependent types.  *)
+Definition transportDD {A : Type} (B : A -> Type) (C : forall a : A, B a -> Type)
+  {a1 a2 : A} (pA : a1 = a2)
+  {b1 : B a1} {b2 : B a2} (pB : transport B pA b1 = b2)
+  (c1 : C a1 b1) : C a2 b2
+  := transport (C a2) pB (transportD B C pA b1 c1).
 
 (** *** [ap] for curried two variable functions *)
 

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -774,7 +774,8 @@ Definition transportD2 {A : Type} (B C : A -> Type) (D : forall a:A, B a -> C a 
 Definition transportDD {A : Type} (B : A -> Type) (C : forall a : A, B a -> Type)
   {a1 a2 : A} (pA : a1 = a2)
   {b1 : B a1} {b2 : B a2} (pB : transport B pA b1 = b2)
-  (c1 : C a1 b1) : C a2 b2
+  (c1 : C a1 b1)
+  : C a2 b2
   := transport (C a2) pB (transportD B C pA b1 c1).
 
 (** *** [ap] for curried two variable functions *)
@@ -874,7 +875,7 @@ Defined.
 
 (** Naturality of [transport011]. *)
 Definition ap_transport011{A B} {P Q : A -> B -> Type}
-  {a1 a2 : A} {b1 b2 : B} (p : a1 = a2) (q : b1 = b2)  
+  {a1 a2 : A} {b1 b2 : B} (p : a1 = a2) (q : b1 = b2)
   (f : forall {a b}, P a b -> Q a b) (x : P a1 b1)
   : f (transport011 P p q x) = transport011 Q p q (f x).
 Proof.
@@ -992,6 +993,32 @@ Definition transport2_const {A B : Type} {x1 x2 : A} {p q : x1 = x2}
   (r : p = q) (y : B)
   : transport_const p y = transport2 (fun _ => B) r y @ transport_const q y
   := match r with idpath => (concat_1p _)^ end.
+
+(** We need a better naming scheme for transportD_const, as there are several places where you can have a constant type family. *)
+Definition transportD_const' {A B : Type} (C : A -> B -> Type) {x1 x2 : A}
+  (p : x1 = x2) {y : B} (z : C x1 y)
+  : transportD (fun x => B) C p y z
+    = transport (fun x => C x (transport (fun _ => B) p y)) p
+      (transport (C x1) (transport_const p y)^ z).
+Proof.
+  by destruct p.
+Defined.
+
+Definition transportD_const {A : Type} (B : A -> Type) (C : Type)
+  {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C)
+  : transportD B (fun _ _ => C) p y z = z.
+Proof.
+  by destruct p.
+Defined.
+
+Definition transportDD_const {A : Type} (B : A -> Type) (C : Type)
+  {a1 a2 : A} (pA : a1 = a2)
+  {b1 : B a1} {b2 : B a2} (pB : transport B pA b1 = b2)
+  (c1 : C)
+  : transportDD B (fun _ _ => C) pA pB c1 = c1.
+Proof.
+  by destruct pB, pA.
+Defined.
 
 (** Transporting in a pulled back fibration. *)
 Lemma transport_compose {A B} {x y : A} (P : B -> Type) (f : A -> B)

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -994,19 +994,18 @@ Definition transport2_const {A B : Type} {x1 x2 : A} {p q : x1 = x2}
   : transport_const p y = transport2 (fun _ => B) r y @ transport_const q y
   := match r with idpath => (concat_1p _)^ end.
 
-(** We need a better naming scheme for transportD_const, as there are several places where you can have a constant type family. *)
-Definition transportD_const' {A B : Type} (C : A -> B -> Type) {x1 x2 : A}
-  (p : x1 = x2) {y : B} (z : C x1 y)
-  : transportD (fun x => B) C p y z
-    = transport (fun x => C x (transport (fun _ => B) p y)) p
-      (transport (C x1) (transport_const p y)^ z).
+Definition transportD_const_fiber {A : Type} (B : A -> Type) (C : Type)
+  {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C)
+  : transportD B (fun _ _ => C) p y z = z.
 Proof.
   by destruct p.
 Defined.
 
-Definition transportD_const {A : Type} (B : A -> Type) (C : Type)
-  {x1 x2 : A} (p : x1 = x2) (y : B x1) (z : C)
-  : transportD B (fun _ _ => C) p y z = z.
+Definition transportD_const_base {A B : Type} (C : A -> B -> Type) {x1 x2 : A}
+  (p : x1 = x2) {y : B} (z : C x1 y)
+  : transportD (fun x => B) C p y z
+    = transport (fun x => C x (transport (fun _ => B) p y)) p
+      (transport (C x1) (transport_const p y)^ z).
 Proof.
   by destruct p.
 Defined.

--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -471,14 +471,11 @@ Section Descent.
   Context `{Univalence}.
 
   (** Descent data over [f g : B -> A] is an "equifibrant" or "cartesian" type family [cd_fam : A -> Type].  This means that if [b : B], then the fibers [cd_fam (f b)] and [cd_fam (g b)] are equivalent, witnessed by [cd_e]. *)
-  Record cDescent {A B : Type} (f g : B -> A) := {
-    cd_fam : A -> Type;
+  Record cDescent {A B : Type} {f g : B -> A} := {
+    cd_fam (a : A) : Type;
     cd_e (b : B) : cd_fam (f b) <~> cd_fam (g b)
   }.
-
-  Global Arguments Build_cDescent {A B f g} cd_fam cd_e.
-  Global Arguments cd_fam {A B f g} Pe a : rename.
-  Global Arguments cd_e {A B f g} Pe b : rename.
+  Global Arguments cDescent {A B} f g.
 
   (** Let [A] and [B] be types, with a parallel pair [f g : B -> A]. *)
   Context {A B : Type} {f g : B -> A}.
@@ -511,38 +508,37 @@ Section Descent.
   Defined.
 
   (** A section on the descent data is a fiberwise section that respects the equivalences. *)
-  Record cDescentSection (Pe : cDescent f g) := {
+  Record cDescentSection {Pe : cDescent f g} := {
     cds_sect (a : A) : cd_fam Pe a;
-    cds_e (b : B)
-      : cd_e Pe b (cds_sect (f b)) = cds_sect (g b)
+    cds_e (b : B) : cd_e Pe b (cds_sect (f b)) = cds_sect (g b)
   }.
+
+  Global Arguments cDescentSection Pe : clear implicits.
 
   (** A descent section induces a genuine section of [fam_cdescent Pe]. *)
   Definition cdescent_ind {Pe : cDescent f g}
     (s : cDescentSection Pe)
     : forall (x : Coeq f g), fam_cdescent Pe x.
   Proof.
-    snrapply (Coeq_ind _ (cds_sect _ s)).
+    snrapply (Coeq_ind _ (cds_sect s)).
     intro b.
-    refine (transport_fam_cdescent_cglue Pe b _ @ cds_e _ s b).
+    exact (transport_fam_cdescent_cglue Pe b _ @ cds_e s b).
   Defined.
 
   (** We record its computation rule *)
   Definition cdescent_ind_beta_cglue {Pe : cDescent f g}
     (s : cDescentSection Pe) (b : B)
-    : apD (cdescent_ind s) (cglue b) = transport_fam_cdescent_cglue Pe b _ @ cds_e _ s b
-    := Coeq_ind_beta_cglue _ (cds_sect _ s) _ _.
+    : apD (cdescent_ind s) (cglue b) = transport_fam_cdescent_cglue Pe b _ @ cds_e s b
+    := Coeq_ind_beta_cglue _ (cds_sect s) _ _.
 
   (** Dependent descent data over descent data [Pe : cDescent f g] consists of a type family [cdd_fam : forall a : A, cd_fam Pe a -> Type] together with coherences [cdd_e b pf]. *)
-  Record cDepDescent (Pe : cDescent f g) := {
-    cdd_fam (a : A) : cd_fam Pe a -> Type;
+  Record cDepDescent {Pe : cDescent f g} := {
+    cdd_fam (a : A) (pa : cd_fam Pe a) : Type;
     cdd_e (b : B) (pf : cd_fam Pe (f b))
       : cdd_fam (f b) pf <~> cdd_fam (g b) (cd_e Pe b pf)
   }.
 
-  Global Arguments Build_cDepDescent {Pe} cdd_fam cdd_e.
-  Global Arguments cdd_fam {Pe} Qe a pa : rename.
-  Global Arguments cdd_e {Pe} Qe b pf : rename.
+  Global Arguments cDepDescent Pe : clear implicits.
 
   (** A dependent type family over [fam_cdescent Pe] induces dependent descent data over [Pe]. *)
   Definition cdepdescent_fam {Pe : cDescent f g}
@@ -574,15 +570,13 @@ Section Descent.
   Defined.
 
   (** A section of dependent descent data [Qe : cDepDescent Pe] is a fiberwise section [cdds_sect], together with coherences [cdds_e]. *)
-  Record cDepDescentSection {Pe : cDescent f g} (Qe : cDepDescent Pe) := {
+  Record cDepDescentSection {Pe : cDescent f g} {Qe : cDepDescent Pe} := {
     cdds_sect (a : A) (pa : cd_fam Pe a) : cdd_fam Qe a pa;
     cdds_e (b : B) (pf : cd_fam Pe (f b))
       : cdd_e Qe b pf (cdds_sect (f b) pf) = cdds_sect (g b) (cd_e Pe b pf)
   }.
 
-  Global Arguments Build_cDepDescentSection {Pe Qe} cdds_sect cdds_e.
-  Global Arguments cdds_sect {Pe Qe} s a pa : rename.
-  Global Arguments cdds_e {Pe Qe} s b pf : rename.
+  Global Arguments cDepDescentSection {Pe} Qe.
 
   (** A dependent descent section induces a genuine section over the total space of [fam_cdescent Pe]. *)
   Definition cdepdescent_ind {Pe : cDescent f g}
@@ -600,15 +594,13 @@ Section Descent.
     Defined.
 
   (** The data for a section into a constant type family. *)
-  Record cDepDescentConstSection (Pe : cDescent f g) (Q : Type) := {
-    cddcs_sect (a : A) : cd_fam Pe a -> Q;
+  Record cDepDescentConstSection {Pe : cDescent f g} {Q : Type} := {
+    cddcs_sect (a : A) (pa : cd_fam Pe a) : Q;
     cddcs_e (b : B) (pf : cd_fam Pe (f b))
       : cddcs_sect (f b) pf = cddcs_sect (g b) (cd_e Pe b pf)
   }.
 
-  Global Arguments Build_cDepDescentConstSection {Pe Q} cddcs_sect cddcs_e.
-  Global Arguments cddcs_sect {Pe Q} s a pa : rename.
-  Global Arguments cddcs_e {Pe Q} s b pf : rename.
+  Global Arguments cDepDescentConstSection Pe Q : clear implicits.
 
   (** The data for a section of a constant family induces a section over the total space of [fam_cdescent Pe]. *)
   Definition cdepdescent_rec {Pe : cDescent f g} {Q : Type}

--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -624,7 +624,7 @@ Section Descent.
     exact (cddcs_e s b pf).
   Defined.
 
-  (** In this case, we state a full computation rule. *)
+  (** Here is the computation rule on paths. *)
   Definition cdepdescent_rec_beta_cglue {Pe : cDescent f g} {Q : Type}
     (s : cDepDescentConstSection Pe Q)
     (b : B) {pf : cd_fam Pe (f b)} {pg : cd_fam Pe (g b)} (pb : cd_e Pe b pf = pg)

--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -460,7 +460,7 @@ Defined.
 
 (** ** Descent *)
 
-(** We study "equifibrant" type families over a parallel pair [f, g: B -> A].  By univalence, the descent property tells us that these type families correspond to type families over the coequalizer, and we obtain an induction principle for such type families.  Dependent descent data over some particular descent data are "equifibrant" type families over this descent data.  The "equifibrancy" is only taken over the parallel pair [f g : B -> A], but there is an extra level of dependency coming from the descent data.  In this case, we obtain an induction and recursion principle, but only with a partial computation rule for the induction principle.
+(** We study "equifibrant" type families over a parallel pair [f, g: B -> A].  By univalence, the descent property tells us that these type families correspond to type families over the coequalizer, and we obtain an induction principle for such type families.  Dependent descent data over some particular descent data are "equifibrant" type families over this descent data.  The "equifibrancy" is only taken over the parallel pair [f g : B -> A], but there is an extra level of dependency coming from the descent data.  In this case, we obtain an induction and recursion principle, but only with a computation rule for the recursion principle.
 
 The theory of descent is interesting to consider in itself.  However, we will use it as a means to structure the code, and to obtain induction and recursion principles that are valuable in proving the flattening lemma, and characterizing path spaces.  Thus we will gloss over the bigger picture, and not consider equivalences of descent data, nor homotopies of their sections.  We will also not elaborate on uniqueness of the induced families.
 
@@ -584,35 +584,20 @@ Section Descent.
   Global Arguments cdds_sect {Pe Qe} s a pa : rename.
   Global Arguments cdds_e {Pe Qe} s b pf : rename.
 
-  (** Transporting [cdds_sect s (f b)] over [Q] along [cglue b] is [cdds_sect s (g b)]. *)
-  Definition transport_fam_cglue_cdds_sect {Pe : cDescent f g}
-    {Q : forall (x : Coeq f g), (fam_cdescent Pe) x -> Type}
-    (s : cDepDescentSection (cdepdescent_fam Q))
-    (b : B)
-    : transport (fun (x : Coeq f g) => forall (px : fam_cdescent Pe x), Q x px)
-        (cglue b) (cdds_sect s (f b)) = cdds_sect s (g b).
-  Proof.
-    apply dpath_forall.
-    intro pf.
-    apply (equiv_inj (transport (Q (coeq (g b))) (transport_fam_cdescent_cglue Pe b pf))).
-    rhs nrapply (apD (cdds_sect s (g b)) (transport_fam_cdescent_cglue Pe b pf)).
-    exact (cdds_e s b pf).
-  Defined.
-
-  (** A dependent descent section induces a genuine section of the descended type family [fam_cdescent Pe]. *)
+  (** A dependent descent section induces a genuine section over the total space of [fam_cdescent Pe]. *)
   Definition cdepdescent_ind {Pe : cDescent f g}
     {Q : forall (x : Coeq f g), (fam_cdescent Pe) x -> Type}
     (s : cDepDescentSection (cdepdescent_fam Q))
-    : forall (x : Coeq f g) (px : fam_cdescent Pe x), Q x px
-    := Coeq_ind _ (cdds_sect s) (transport_fam_cglue_cdds_sect s).
-
-  (** This is a partial computation rule, which only handles paths in the base. *)
-  Definition cdepdescent_ind_beta_cglue {Pe : cDescent f g}
-    {Q : forall (x : Coeq f g), fam_cdescent Pe x -> Type}
-    (s : cDepDescentSection (cdepdescent_fam Q))
-    (b : B)
-    : apD (cdepdescent_ind s) (cglue b) = transport_fam_cglue_cdds_sect s b
-    := Coeq_ind_beta_cglue _ (cdds_sect s) (transport_fam_cglue_cdds_sect s) b.
+    : forall (x : Coeq f g) (px : fam_cdescent Pe x), Q x px.
+    Proof.
+      nrapply (Coeq_ind _ (cdds_sect s) _).
+      intro b.
+      apply dpath_forall.
+      intro pf.
+      apply (equiv_inj (transport (Q (coeq (g b))) (transport_fam_cdescent_cglue Pe b pf))).
+      rhs nrapply (apD (cdds_sect s (g b)) (transport_fam_cdescent_cglue Pe b pf)).
+      exact (cdds_e s b pf).
+    Defined.
 
   (** The data for a section into a constant type family. *)
   Record cDepDescentConstSection (Pe : cDescent f g) (Q : Type) := {
@@ -625,28 +610,18 @@ Section Descent.
   Global Arguments cddcs_sect {Pe Q} s a pa : rename.
   Global Arguments cddcs_e {Pe Q} s b pf : rename.
 
-  (** Transporting [cddcs_sect s (f b)] over [Q] along [cglue b] is [cddcs_sect s (g b)]. *)
-  Definition transport_fam_cglue_cddcs_sect {Pe : cDescent f g} {Q : Type}
-    (s : cDepDescentConstSection Pe Q)
-    (b : B)
-    : transport (fun x : Coeq f g => fam_cdescent Pe x -> Q) (cglue b) (cddcs_sect s (f b))
-      = cddcs_sect s (g b).
-  Proof.
-    nrapply dpath_arrow.
-    intro pf.
-    lhs nrapply transport_const.
-    rhs nrapply (ap _ (transport_fam_cdescent_cglue Pe b pf)).
-    exact (cddcs_e s b pf).
-  Defined.
-
   (** The data for a section of a constant family induces a section over the total space of [fam_cdescent Pe]. *)
   Definition cdepdescent_rec {Pe : cDescent f g} {Q : Type}
     (s : cDepDescentConstSection Pe Q)
     : forall (x : Coeq f g), fam_cdescent Pe x -> Q.
   Proof.
-    snrapply Coeq_ind; cbn.
-    - nrapply (cddcs_sect s).
-    - nrapply transport_fam_cglue_cddcs_sect.
+    snrapply (Coeq_ind _ (cddcs_sect s)).
+    intro b.
+    nrapply dpath_arrow.
+    intro pf.
+    lhs nrapply transport_const.
+    rhs nrapply (ap _ (transport_fam_cdescent_cglue Pe b pf)).
+    exact (cddcs_e s b pf).
   Defined.
 
   (** In this case, we state a full computation rule. *)

--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -492,6 +492,15 @@ Section Descent.
     exact (path_universe_uncurried (cd_e Pe b)).
   Defined.
 
+  (** A type family over [Coeq f g] induces descent data. *)
+  Definition cdescent_fam (P : Coeq f g -> Type) : cDescent f g.
+  Proof.
+    snrapply Build_cDescent.
+    - exact (P o coeq).
+    - intro b.
+      exact (equiv_transport P (cglue b)).
+  Defined.
+
   (** Transporting over [fam_cdescent] along [cglue b] is given by [cd_e]. *)
   Definition transport_fam_cdescent_cglue
     (Pe : cDescent f g) (b : B) (pf : cd_fam Pe (f b))
@@ -546,6 +555,22 @@ Section Descent.
     - intros b pf.
       exact (equiv_transportDD (fam_cdescent Pe) Q
                (cglue b) (transport_fam_cdescent_cglue Pe b pf)).
+  Defined.
+
+  (** Dependent descent data over [Pe] induces a dependent type family over [fam_cdescent Pe]. *)
+  Definition fam_cdepdescent {Pe : cDescent f g} (Qe : cDepDescent Pe)
+    : forall (x : Coeq f g), (fam_cdescent Pe x) -> Type.
+  Proof.
+    snrapply Coeq_ind.
+    - exact (cdd_fam Qe).
+    - intro b.
+      nrapply (moveR_transport_p _ (cglue b)).
+      funext pa.
+      rhs nrapply transport_arrow_toconst.
+      rhs nrefine (ap (cdd_fam _ _) _).
+      + exact (path_universe (cdd_e _ _ _)).
+      + lhs nrapply (ap (fun x => (transport _ x _)) (inv_V (cglue _))).
+        nrapply (transport_fam_cdescent_cglue _ _ _).
   Defined.
 
   (** A section of dependent descent data [Qe : cDepDescent Pe] is a fiberwise section [cdds_sect], together with coherences [cdds_e]. *)

--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -1,6 +1,7 @@
 Require Import Basics.
 Require Import Types.Paths Types.Arrow Types.Sigma Types.Forall Types.Universe Types.Prod.
 Require Import Colimits.GraphQuotient.
+Require Import Homotopy.IdentitySystems.
 
 Local Open Scope path_scope.
 
@@ -687,3 +688,36 @@ Section Flattening.
   Defined.
 
 End Flattening.
+
+(** ** Characterization of path spaces *)
+
+(** A pointed type family over a coequalizer has an identity system structure precisely when its associated descent data satisfies Kraus and von Raumer's induction principle, https://arxiv.org/pdf/1901.06022. *)
+
+Section Paths.
+
+  (** Let [f g : B -> A] be a parallel pair, with a distinguished point [a0 : A]. Let [Pe : cDescent f g] be descent data over [f g] with a distinguished point [p0 : cd_fam Pe a0]. Assume that any dependent descent data [Qe : cDepDescent Pe] with a distinguished point [q0 : cdd_fam Qe a0 p0] has a section that respects the distinguished points. This is the Kraus-von Raumer induction principle. *)
+  Context `{Univalence} {A B: Type} {f g : B -> A} (a0 : A)
+    (Pe : cDescent f g) (p0 : cd_fam Pe a0)
+    (based_cdescent_ind : forall (Qe : cDepDescent Pe) (q0 : cdd_fam Qe a0 p0),
+      cDescentSection Qe)
+    (based_cdescent_ind_beta : forall (Qe : cDepDescent Pe) (q0 : cdd_fam Qe a0 p0),
+      cds_sect (based_cdescent_ind Qe q0) a0 p0 = q0).
+
+  (** Under these hypotheses, we get an identity system structure on [Dcd Pe]. *)
+  Local Instance idsys_flatten_cdescent
+    : @IsIdentitySystem _ (coeq a0) (Dcd Pe) p0.
+  Proof.
+    snrapply Build_IsIdentitySystem.
+    - intros Q q0 x p.
+      snrapply cdescent_ind.
+      by apply based_cdescent_ind.
+    - intros Q q0; cbn.
+      nrapply (based_cdescent_ind_beta (cdepdescent_fam Q)).
+  Defined.
+
+  (** It follows that the fibers [Dcd Pe x] are equivalent to path spaces [(coeq a0) = x]. *)
+  Definition Dcd_equiv_path (x : Coeq f g)
+    : (coeq a0) = x <~> Dcd Pe x
+    := @equiv_transport_identitysystem _ (coeq a0) (Dcd Pe) p0 _ x.
+
+End Paths.

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -237,7 +237,7 @@ Section Descent.
     exact (gqddcs_e f r pa).
   Defined.
 
-  (** In this case, we state a full computation rule. *)
+  (** Here is the computation rule on paths. *)
   Definition gqdepdescent_rec_beta_gqglue {Pe : gqDescent R} {Q : Type}
     (f : gqDepDescentConstSection Pe Q)
     {a b : A} {pa : gqd_fam Pe a} {pb : gqd_fam Pe b} (r : R a b) (pr : gqd_e Pe r pa = pb)

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -1,5 +1,6 @@
 Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Equivalences.
 Require Import Types.Universe Types.Paths Types.Forall Types.Arrow Types.Sigma Cubical.DPath.
+Require Import Homotopy.IdentitySystems.
 
 (** * Quotient of a graph *)
 
@@ -299,6 +300,39 @@ Section Flattening.
   Defined.
 
 End Flattening.
+
+(** ** Characterization of path spaces*)
+
+(** A pointed type family over a graph quotient has an identity system structure precisely when its associated descent data satisfies Kraus and von Raumer's induction principle, https://arxiv.org/pdf/1901.06022. *)
+
+Section Paths.
+
+  (** Let [A] and [R] be a graph, with a distinguished point [a0 : A]. Let [Pe : gqDescent R] be descent data over [A] and [R] with a distinguished point [p0 : gqd_fam Pe a0]. Assume that any dependent descent data [Qe : gqDepDescent Pe] with a distinguished point [q0 : gqdd_fam Qe a0 p0] has a section that respects the distinguished points. This is the Kraus-von Raumer induction principle. *)
+  Context `{Univalence} {A : Type} {R : A -> A -> Type} (a0 : A)
+    (Pe : gqDescent R) (p0 : gqd_fam Pe a0)
+    (based_gqdescent_ind : forall (Qe : gqDepDescent Pe) (q0 : gqdd_fam Qe a0 p0),
+      gqDescentSection Qe)
+    (based_gqdescent_ind_beta : forall (Qe : gqDepDescent Pe) (q0 : gqdd_fam Qe a0 p0),
+      gqds_sect (based_gqdescent_ind Qe q0) a0 p0 = q0).
+
+  (** Under these hypotheses, we get an identity system structure on [Dgqd Pe]. *)
+  Local Instance idsys_flatten_gqdescent
+    : @IsIdentitySystem _ (gq a0) (Dgqd Pe) p0.
+  Proof.
+    snrapply Build_IsIdentitySystem.
+    - intros Q q0 x p.
+      snrapply gqdescent_ind.
+      by apply based_gqdescent_ind.
+    - intros Q q0; cbn.
+      nrapply (based_gqdescent_ind_beta (gqdepdescent_fam Q)).
+  Defined.
+
+  (** It follows that the fibers [Dgqd Pe x] are equivalent to path spaces [(gq a0) = x]. *)
+  Definition Dgqd_equiv_path (x : GraphQuotient R)
+    : (gq a0) = x <~> Dgqd Pe x
+    := @equiv_transport_identitysystem _ (gq a0) (Dgqd Pe) p0 _ x.
+
+End Paths.
 
 (** ** Functoriality of graph quotients *)
 

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -105,6 +105,15 @@ Section Descent.
     exact (path_universe_uncurried (gqd_e Pe r)).
   Defined.
 
+  (** A type family over [GraphQuotient R] induces descent data. *)
+  Definition gqdescent_fam (P : GraphQuotient R -> Type) : gqDescent R.
+  Proof.
+    snrapply Build_gqDescent.
+    - exact (P o gq).
+    - intros a b r.
+      exact (equiv_transport P (gqglue r)).
+  Defined.
+
   (** Transporting over [fam_gqdescent] along [gqglue r] is given by [gqd_e]. *)
   Definition transport_fam_gqdescent_gqglue
     (Pe : gqDescent R) {a b : A} (r : R a b) (pa : gqd_fam Pe a)
@@ -159,6 +168,22 @@ Section Descent.
     - intros a b r pa.
       exact (equiv_transportDD (fam_gqdescent Pe) Q
                (gqglue r) (transport_fam_gqdescent_gqglue Pe r pa)).
+  Defined.
+
+  (** Dependent descent data over [Pe] induces a dependent type family over [fam_gqdescent Pe]. *)
+  Definition fam_gqdepdescent {Pe : gqDescent R} (Qe : gqDepDescent Pe)
+    : forall (x : GraphQuotient R), (fam_gqdescent Pe x) -> Type.
+  Proof.
+    snrapply GraphQuotient_ind.
+    - exact (gqdd_fam Qe).
+    - intros a b r.
+      nrapply (moveR_transport_p _ (gqglue r)).
+      funext pa.
+      rhs nrapply transport_arrow_toconst.
+      rhs nrefine (ap (gqdd_fam Qe b) _).
+      + exact (path_universe (gqdd_e Qe r pa)).
+      + lhs nrapply (ap (fun x => (transport _ x _)) (inv_V (gqglue r))).
+        nrapply (transport_fam_gqdescent_gqglue _ _ _).
   Defined.
 
   (** A section of dependent descent data [Qe : gqDepDescent Pe] is a fiberwise section [gqdds_sect], together with coherences [gqdd_e]. *)

--- a/theories/Colimits/GraphQuotient.v
+++ b/theories/Colimits/GraphQuotient.v
@@ -73,7 +73,7 @@ Defined.
 
 (** ** Descent *)
 
-(** We study "equifibrant" type families over a graph [A], with edges indexed by [R].  By univalence, the descent property tells us that these type families correspond to type families over the graph quotient, and we obtain an induction principle for such type families.  Dependent descent data over some particular descent data are "equifibrant" type families over this descent data.  The "equifibrancy" is only taken over the graph [A] and [R], but there is an extra level of dependency coming from the descent data.  In this case, we obtain an induction and recursion principle, but only with a partial computation rule for the induction principle.
+(** We study "equifibrant" type families over a graph [A], with edges indexed by [R].  By univalence, the descent property tells us that these type families correspond to type families over the graph quotient, and we obtain an induction principle for such type families.  Dependent descent data over some particular descent data are "equifibrant" type families over this descent data.  The "equifibrancy" is only taken over the graph [A] and [R], but there is an extra level of dependency coming from the descent data.  In this case, we obtain an induction and recursion principle, but only with a computation rule for the recursion principle.
 
 The theory of descent is interesting to consider in itself.  However, we will use it as a means to structure the code, and to obtain induction and recursion principles that are valuable in proving the flattening lemma, and characterizing path spaces.  Thus we will gloss over the bigger picture, and not consider equivalences of descent data, nor homotopies of their sections.  We will also not elaborate on uniqueness of the induced families.
 
@@ -197,35 +197,20 @@ Section Descent.
   Global Arguments gqdds_sect {Pe Qe} f a pa : rename.
   Global Arguments gqdds_e {Pe Qe} f {a b} r pa : rename.
 
-  (** Transporting [gqdds_sect f a] over [Q] along [gqglue r] is [gqdds_sect f b]. *)
-  Definition transport_fam_gqglue_gqdds_sect {Pe : gqDescent R}
-    {Q : forall x : GraphQuotient R, (fam_gqdescent Pe) x -> Type}
-    (f : gqDepDescentSection (gqdepdescent_fam Q))
-    (a b : A) (r : R a b)
-    : transport (fun x : GraphQuotient R => forall px : fam_gqdescent Pe x, Q x px)
-        (gqglue r) (gqdds_sect f a) = gqdds_sect f b.
-  Proof.
-    apply dpath_forall.
-    intro pa.
-    apply (equiv_inj (transport (Q (gq b)) (transport_fam_gqdescent_gqglue Pe r pa))).
-    rhs nrapply (apD (gqdds_sect f b) (transport_fam_gqdescent_gqglue Pe r pa)).
-    exact (gqdds_e f r pa).
-  Defined.
-
-  (** A dependent descent section induces a genuine section on the total space of [fam_gqdescent Pe]. *)
+  (** A dependent descent section induces a genuine section over the total space of [fam_gqdescent Pe]. *)
   Definition gqdepdescent_ind {Pe : gqDescent R}
     {Q : forall x : GraphQuotient R, (fam_gqdescent Pe) x -> Type}
     (f : gqDepDescentSection (gqdepdescent_fam Q))
-    : forall (x : GraphQuotient R) (px : fam_gqdescent Pe x), Q x px
-    := GraphQuotient_ind _ (gqdds_sect f) (transport_fam_gqglue_gqdds_sect f).
-
-  (** This is a partial computation rule, which only handles paths in the base. *)
-  Definition gqdepdescent_ind_beta_gqglue {Pe : gqDescent R}
-    {Q : forall x, (fam_gqdescent Pe) x -> Type}
-    (f : gqDepDescentSection (gqdepdescent_fam Q))
-    {a b : A} (r : R a b)
-    : apD (gqdepdescent_ind f) (gqglue r) = transport_fam_gqglue_gqdds_sect f a b r
-    := GraphQuotient_ind_beta_gqglue _ (gqdds_sect f) (transport_fam_gqglue_gqdds_sect f) a b r.
+    : forall (x : GraphQuotient R) (px : fam_gqdescent Pe x), Q x px.
+    Proof.
+      nrapply (GraphQuotient_ind _ (gqdds_sect f) _).
+      intros a b r.
+      apply dpath_forall.
+      intro pa.
+      apply (equiv_inj (transport (Q (gq b)) (transport_fam_gqdescent_gqglue Pe r pa))).
+      rhs nrapply (apD (gqdds_sect f b) (transport_fam_gqdescent_gqglue Pe r pa)).
+      exact (gqdds_e f r pa).
+    Defined.
 
   (** The data for a section into a constant type family. *)
   Record gqDepDescentConstSection (Pe : gqDescent R) (Q : Type) := {
@@ -238,28 +223,18 @@ Section Descent.
   Global Arguments gqddcs_sect {Pe Q} f a pa : rename.
   Global Arguments gqddcs_e {Pe Q} f {a b} r pa : rename.
 
-  (** Transporting [gqddcs_sect f a] over [Q] along [gqglue r] is [gddcs_sect f b]. *)
-  Definition transport_fam_gqglue_gqddcs_sect {Pe : gqDescent R} {Q : Type}
-    (f : gqDepDescentConstSection Pe Q)
-    {a b : A} (r : R a b)
-    : transport (fun x : GraphQuotient R => fam_gqdescent Pe x -> Q) (gqglue r) (gqddcs_sect f a)
-      = gqddcs_sect f b.
-  Proof.
-    nrapply dpath_arrow.
-    intro pa.
-    lhs nrapply transport_const.
-    rhs nrapply (ap _ (transport_fam_gqdescent_gqglue Pe r pa)).
-    exact (gqddcs_e f r pa).
-  Defined.
-
   (** The data for a section of a constant family induces a section over the total space of [fam_gqdescent Pe]. *)
   Definition gqdepdescent_rec {Pe : gqDescent R} {Q : Type}
     (f : gqDepDescentConstSection Pe Q)
     : forall (x : GraphQuotient R), fam_gqdescent Pe x -> Q.
   Proof.
-    snrapply GraphQuotient_ind; cbn.
-    - nrapply (gqddcs_sect f).
-    - nrapply transport_fam_gqglue_gqddcs_sect.
+    snrapply (GraphQuotient_ind _ (gqddcs_sect f)).
+    intros a b r.
+    nrapply dpath_arrow.
+    intro pa.
+    lhs nrapply transport_const.
+    rhs nrapply (ap _ (transport_fam_gqdescent_gqglue Pe r pa)).
+    exact (gqddcs_e f r pa).
   Defined.
 
   (** In this case, we state a full computation rule. *)

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -1,6 +1,7 @@
 Require Import Basics.
 Require Import Types.Paths Types.Forall Types.Arrow Types.Sigma Types.Sum Types.Universe.
 Require Export Colimits.Coeq.
+Require Import Homotopy.IdentitySystems.
 
 Local Open Scope path_scope.
 
@@ -785,3 +786,36 @@ Section Flattening.
   Defined.
 
 End Flattening.
+
+(** ** Characterization of path spaces *)
+
+(** A pointed type family over a pushout has an identity system structure precisely when its associated descent data satisfies Kraus and von Raumer's induction principle, https://arxiv.org/pdf/1901.06022. *)
+
+Section Paths.
+
+  (** Let [f : A -> B] and [g : A -> C] be a span, with a distinguished point [b0 : B]. We could let the distinguished point be in [C], but this is symmetric by exchanging the roles of [f] and [g]. Let [Pe : poDescent f g] be descent data over [f g] with a distinguished point [p0 : pod_faml Pe b0]. Assume that any dependent descent data [Qe : poDepDescent Pe] with a distinguished point [q0 : podd_faml Qe b0 p0] has a section that respects the distinguished points. This is the Kraus-von Raumer induction principle. *)
+  Context `{Univalence} {A B C : Type} {f : A -> B} {g : A -> C} (b0 : B)
+    (Pe : poDescent f g) (p0 : pod_faml Pe b0)
+    (based_podescent_ind : forall (Qe : poDepDescent Pe) (q0 : podd_faml Qe b0 p0),
+      poDescentSection Qe)
+    (based_podescent_ind_beta : forall (Qe : poDepDescent Pe) (q0 : podd_faml Qe b0 p0),
+      pods_sectl (based_podescent_ind Qe q0) b0 p0 = q0).
+
+  (** Under these hypotheses, we get an identity system structure on [Dpod Pe]. *)
+  Local Instance idsys_flatten_podescent
+    : @IsIdentitySystem _ (pushl b0) (Dpod Pe) p0.
+  Proof.
+    snrapply Build_IsIdentitySystem.
+    - intros Q q0 x px.
+      snrapply podescent_ind.
+      by apply based_podescent_ind.
+    - intros Q q0; cbn.
+      nrapply (based_podescent_ind_beta (podepdescent_fam Q)).
+  Defined.
+
+  (** It follows that the fibers [Dpod Pe x] are equivalent to path spaces [(pushl a0) = x]. *)
+  Definition Dpod_equiv_path (x : Pushout f g)
+    : (pushl b0) = x <~> Dpod Pe x
+    := @equiv_transport_identitysystem _ (pushl b0) (Dpod Pe) p0 _ x.
+
+End Paths.

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -718,7 +718,7 @@ Section Descent.
     exact (poddcs_e s a pf).
   Defined.
 
-  (** In this case, we state a full computation rule. *)
+  (** Here is the computation rule on paths. *)
   Definition podepdescent_rec_beta_pglue {Pe : poDescent f g} {Q : Type}
     (s : poDepDescentConstSection Pe Q)
     (a : A) {pf : pod_faml Pe (f a)} {pg : pod_famr Pe (g a)} (pa : pod_e Pe a pf = pg)

--- a/theories/Colimits/Pushout.v
+++ b/theories/Colimits/Pushout.v
@@ -575,6 +575,16 @@ Section Descent.
     exact (path_universe_uncurried (pod_e Pe a)).
   Defined.
 
+  (** A type family over [Pushout f g] induces descent data. *)
+  Definition podescent_fam (P : Pushout f g -> Type) : poDescent f g.
+  Proof.
+    snrapply Build_poDescent.
+    - exact (P o pushl).
+    - exact (P o pushr).
+    - intro a.
+      exact (equiv_transport P (pglue a)).
+  Defined.
+
   (** Transporting over [fam_podescent] along [pglue a] is given by [pod_e]. *)
   Definition transport_fam_podescent_pglue
     (Pe : poDescent f g) (a : A) (pf : pod_faml Pe (f a))
@@ -634,6 +644,23 @@ Section Descent.
     - intros a pf.
       exact (equiv_transportDD (fam_podescent Pe) Q
                (pglue a) (transport_fam_podescent_pglue Pe a pf)).
+  Defined.
+
+  (** Dependent descent data over [Pe] induces a dependent type family over [fam_podescent Pe]. *)
+  Definition fam_podepdescent {Pe : poDescent f g} (Qe : poDepDescent Pe)
+    : forall (x : Pushout f g), (fam_podescent Pe x) -> Type.
+  Proof.
+    snrapply Pushout_ind.
+    - exact (podd_faml Qe).
+    - exact (podd_famr Qe).
+    - intro a.
+      nrapply (moveR_transport_p _ (pglue a)).
+      funext pf.
+      rhs nrapply transport_arrow_toconst.
+      rhs nrefine (ap (podd_famr _ _) _).
+      + exact (path_universe (podd_e _ _ _)).
+      + lhs nrapply (ap (fun x => (transport _ x _)) (inv_V (pglue _))).
+        nrapply (transport_fam_podescent_pglue _ _ _).
   Defined.
 
   (** A section of dependent descent data [Qe : poDepDescent Pe] are fiberwise sections [podds_sectl] and [podds_sectr], together with coherences [pods_e]. *)

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -32,9 +32,10 @@ Definition pequiv_hopf_total_join `{Univalence} (X : pType)
   : psigma (hopf_construction X) <~>* pjoin X X.
 Proof.
   snrapply Build_pEquiv'.
-  { refine (_ oE equiv_pushout_flatten (f := const_tt X) (g := const_tt X)
-      (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X))
-      (fun x => Build_Equiv _ _ (x *.) (H1 x))).
+  { refine (_ oE equiv_pod_flatten (f := const_tt X) (g := const_tt X)
+    (@Build_poDescent _ _ _ (const_tt X) (const_tt X)
+    (Unit_ind (pointed_type X)) (Unit_ind (pointed_type X))
+    (fun x => Build_Equiv _ _ (x *.) (H1 x)))).
     snrapply equiv_pushout.
     (* The equivalence [{x : X & X} <~> X * X] that we need sends [(x; y) to (y, x*y)]. *)
     { cbn. refine (equiv_sigma_prod0 _ _ oE _ oE equiv_sigma_symm0 _ _).
@@ -44,7 +45,7 @@ Proof.
     1,2: rapply (equiv_contr_sigma (Unit_ind (pointed_type X))).
     1,2: reflexivity. }
   reflexivity.
-Defined. 
+Defined.
 
 (** ** Miscellaneous lemmas and corollaries about the Hopf construction *)
 

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -265,6 +265,16 @@ Proof.
   destruct p. reflexivity.
 Defined.
 
+(** Doubly dependent transport is the same as transport along a [path_sigma]. *)
+Definition transportDD_is_transport {A : Type} (B : A -> Type) (C : forall a : A, B a -> Type)
+  {a1 a2 : A} (pA : a1 = a2)
+  {b1 : B a1} {b2 : B a2} (pB : transport B pA b1 = b2)
+  (c1 : C a1 b1)
+  : transportDD B C pA pB c1 = transport (fun (ab : sig B) => C ab.1 ab.2) (path_sigma _ (a1; b1) (a2; b2) pA pB) c1.
+Proof.
+  by destruct pB, pA.
+Defined.
+
 (** Applying a two variable function to a [path_sigma]. *)
 Definition ap_path_sigma {A B} (P : A -> Type) (F : forall a : A, P a -> B)
   {x x' : A} {y : P x} {y' : P x'} (p : x = x') (q : p # y = y')

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -270,7 +270,8 @@ Definition transportDD_is_transport {A : Type} (B : A -> Type) (C : forall a : A
   {a1 a2 : A} (pA : a1 = a2)
   {b1 : B a1} {b2 : B a2} (pB : transport B pA b1 = b2)
   (c1 : C a1 b1)
-  : transportDD B C pA pB c1 = transport (fun (ab : sig B) => C ab.1 ab.2) (path_sigma _ (a1; b1) (a2; b2) pA pB) c1.
+  : transportDD B C pA pB c1
+    = transport (fun (ab : sig B) => C ab.1 ab.2) (path_sigma' B pA pB) c1.
 Proof.
   by destruct pB, pA.
 Defined.


### PR DESCRIPTION
Now that we have identity systems, #2143, we can use these to characterize path spaces of certain HITs. In this PR we characterize path spaces of graph quotients, coequalizers and pushouts, using the induction principle given by [Kraus and von Raumer](https://arxiv.org/pdf/1901.06022). These results will be helpful towards characterizing the colimits in Wärn's zigzag-construction.

We first introduce transportDD. This is a doubly dependent transport over doubly dependent type families, defined in PathGroupods.v. In Equivalences.v, we prove that both transportD and transportDD are equivalences. In Sigma.v, we show that transportDD is a curried version of transport over a sigma type.

Next up we prove induction and recursion principles for descent data over graphs, parallel pairs, and spans. We then reprove the flattening lemma using this framework. Finally, we deduce the characterization of path spaces.