### PR TITLE
double recursion for join

### DIFF
--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -883,3 +883,36 @@ Section JoinPower.
   Defined.
 
 End JoinPower.
+
+(** ** Doulbe recursion for Join *)
+
+Section Rec2.
+  Context {A B C D : Type} (P : Type)
+    (P_AC : A -> C -> P) (P_AD : A -> D -> P) (P_BC : B -> C -> P) (P_BD : B -> D -> P)
+    (P_gAx : forall a c d, P_AC a c = P_AD a d)
+    (P_gBx : forall b c d, P_BC b c = P_BD b d)
+    (P_gxC : forall c a b, P_AC a c = P_BC b c)
+    (P_gxD : forall d a b, P_AD a d = P_BD b d)
+    (P_g : forall a b c d, P_gAx a c d @ P_gxD d a b = P_gxC c a b @ P_gBx b c d).
+
+  Definition Join_rec2 : Join A B -> Join C D -> P.
+  Proof.
+    intros x y; revert x.
+    snrapply Join_rec.
+    1: intros a; exact (Join_rec (P_AC a) (P_AD a) (P_gAx a) y).
+    1: intros b; exact (Join_rec (P_BC b) (P_BD b) (P_gBx b) y).
+    intros a b.
+    revert y.
+    snrapply Join_ind_FlFr.
+    1: intros c; exact (P_gxC c a b).
+    1: intros d; exact (P_gxD d a b).
+    intros c d.
+    simpl.
+    lhs nrapply whiskerR.
+    1: apply Join_rec_beta_jglue.
+    rhs nrapply whiskerL.
+    2: apply Join_rec_beta_jglue.
+    exact (P_g a b c d).
+  Defined.
+
+End Rec2.


### PR DESCRIPTION
Here is a double recursion principle for `Join`. It is slightly more general than a typical double recursion principle since we allow for the types in each join to be different. This generalisation makes the overall lemma clearer to state and prove.

One place this will be used is in CayleyDickson.v where we define a H-space multiplication operation on `Join (Susp A) (Susp A)` for a Cayley-Dickson imaginaroid `A`. This lemma makes the construction there much clearer.

Presumably there ought to be a dependent variant of this, but I haven't yet thought about how to state or prove it.