### PR TITLE
cleanup in CayleyDickson and fix #2149

### DIFF
--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -82,12 +82,10 @@ End CayleyDicksonSpheroid_Properties.
 
 (** ** Negation and conjugation on suspensions *)
 
-Global Instance conjugate_susp (A : Type) `(Negate A)
-  : Conjugate (Susp A)
+Global Instance conjugate_susp (A : Type) `(Negate A) : Conjugate (Susp A)
   := functor_susp (-).
 
-Global Instance negate_susp (A : Type) `(Negate A)
-  : Negate (Susp A)
+Global Instance negate_susp (A : Type) `(Negate A) : Negate (Susp A)
   := susp_neg _ o conjugate_susp A (-).
 
 (** [conjugate_susp A] and [negate_susp A] commute. *)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -84,7 +84,7 @@ End CayleyDicksonSpheroid_Properties.
 
 Global Instance conjugate_susp (A : Type) `(Negate A)
   : Conjugate (Susp A)
-  := Susp_rec North South (fun a => merid (-a)).
+  := functor_susp (-).
 
 Global Instance negate_susp (A : Type) `(Negate A)
   : Negate (Susp A)
@@ -117,8 +117,8 @@ Proof.
   lhs nrapply concat_p1.
   rhs nrapply concat_1p.
   lhs nrapply ap.
-  1: nrapply Susp_rec_beta_merid.
-  lhs nrapply Susp_rec_beta_merid.
+  1: nrapply functor_susp_beta_merid.
+  lhs nrapply functor_susp_beta_merid.
   nrapply ap.
   rapply (involutive x).
 Defined.
@@ -132,13 +132,13 @@ Proof.
   lhs nrapply concat_p1.
   rhs nrapply concat_1p.
   rhs nrapply ap.
-  2: nrapply Susp_rec_beta_merid.
+  2: nrapply functor_susp_beta_merid.
   rhs nrapply Susp_rec_beta_merid.
   lhs nrapply ap.
   1: nrapply Susp_rec_beta_merid.
   lhs nrapply (ap_V _ (merid (-x))).
   apply ap.
-  nrapply Susp_rec_beta_merid.
+  nrapply functor_susp_beta_merid.
 Defined.
 
 (** ** Cayley-Dickson imaginaroids *)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -88,57 +88,35 @@ Global Instance conjugate_susp (A : Type) `(Negate A)
 
 Global Instance negate_susp (A : Type) `(Negate A)
   : Negate (Susp A)
-  := Susp_rec South North (fun a => (merid (-a))^).
-
-Global Instance involutive_negate_susp {A} `(Negate A, !Involutive (-))
-  : Involutive (negate_susp A (-)).
-Proof.
-  snrapply Susp_ind_FFlr.
-  1,2: reflexivity.
-  intro x.
-  lhs nrapply concat_p1.
-  rhs nrapply concat_1p.
-  lhs nrapply ap.
-  1: nrapply Susp_rec_beta_merid.
-  lhs nrapply (ap_V (negate_susp A negate) (merid (-x))).
-  lhs nrapply ap.
-  1: nrapply Susp_rec_beta_merid.
-  lhs nrapply inv_V.
-  nrapply ap.
-  rapply (involutive x).
-Defined.
+  := susp_neg _ o conjugate_susp A (-).
 
 Global Instance involutive_conjugate_susp {A} `(Negate A, !Involutive (-))
   : Involutive (conjugate_susp A (-)).
 Proof.
-  snrapply Susp_ind_FFlr.
-  1,2: reflexivity.
-  intro x.
-  lhs nrapply concat_p1.
-  rhs nrapply concat_1p.
-  lhs nrapply ap.
-  1: nrapply functor_susp_beta_merid.
-  lhs nrapply functor_susp_beta_merid.
-  nrapply ap.
-  rapply (involutive x).
+  intros x.
+  lhs_V nrapply functor_susp_compose.
+  rhs_V nrapply functor_susp_idmap.
+  nrapply functor2_susp.
+  rapply involutive.
+Defined.
+
+Global Instance involutive_negate_susp {A} `(Negate A, !Involutive (-))
+  : Involutive (negate_susp A (-)).
+Proof.
+  intros x.
+  unfold negate_susp.
+  lhs_V nrapply ap.
+  1: nrapply susp_neg_natural. 
+  lhs rapply susp_neg_inv.
+  rapply involutive.
 Defined.
 
 Global Instance swapop_conjugate_susp {A} `(Negate A)
   : SwapOp negate (conjugate_susp A (-)).
 Proof.
-  snrapply Susp_ind_FFlFFr.
-  1,2: reflexivity.
   intros x.
-  lhs nrapply concat_p1.
-  rhs nrapply concat_1p.
-  rhs nrapply ap.
-  2: nrapply functor_susp_beta_merid.
-  rhs nrapply Susp_rec_beta_merid.
-  lhs nrapply ap.
-  1: nrapply Susp_rec_beta_merid.
-  lhs nrapply (ap_V _ (merid (-x))).
-  apply ap.
-  nrapply functor_susp_beta_merid.
+  symmetry.
+  nrapply susp_neg_natural.
 Defined.
 
 (** ** Cayley-Dickson imaginaroids *)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -232,9 +232,7 @@ Section ImaginaroidHSpace.
   Arguments f {_ _}.
   Arguments g {_ _}.
 
-  (** Here is the multiplication map in algebraic form:
-      (a,b) * (c,d) = (a * c - d * b*, a* * d + c * b)
-      the following is the spherical form. *)
+  (** Here is the multiplication map in algebraic form: [(a,b) * (c,d) = (a * c - d * b*, a* * d + c * b)] the following is the spherical form. *)
   Global Instance cd_op : SgOp (pjoin (psusp A) (psusp A)).
   Proof.
     snrapply Join_rec2.

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -232,7 +232,7 @@ Section ImaginaroidHSpace.
   Arguments f {_ _}.
   Arguments g {_ _}.
 
-  (** Here is the multiplication map in algebraic form: [(a,b) * (c,d) = (a * c - d * b*, a* * d + c * b)] the following is the spherical form. *)
+  (** Here is the multiplication map in algebraic form: [(a,b) * (c,d) = (a * c - d * b*, a* * d + c * b)].  The following is the spherical form. *)
   Global Instance cd_op : SgOp (pjoin (psusp A) (psusp A)).
   Proof.
     snrapply Join_rec2.

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -9,8 +9,25 @@ Require Import Homotopy.Join.Core.
 Local Open Scope pointed_scope.
 Local Open Scope mc_mult_scope.
 
-(** A Cayley-Dickson Spheroid is a pointed type X which is an H-space, with two operations called negation and conjugation, satisfying the seven following laws.
-  --x=x   x**=x   1*=1    (-x)*=-x*   x(-y)=-(xy)   (xy)* = y* x*    x* x=1    *)
+(** The Cayley-Dickson Construction *)
+
+(** They Cayley-Dickson construction in homotopy type theory due to Buchholtz and Rijke https://arxiv.org/abs/1610.01134 is a method to construct an H-space strucure on the join of two suspensions of a type [A]. As a special case, this gives a way to construct an H-space structure on [S^3] leading to the quarternionic hopf fibration.
+
+The construction works by replicating the classical Cayley-Dickson construction on convolution algebras ([*]-algebras), which can product the complex numbers, quaternions, octonions, etc. starting with the real numbers. We cannot replicate this directly in HoTT since such algebras have a contractible underlying vector space, therefore this construction here attempts to axiomatize the properties of the units of those algebras instead.
+
+This is done by postulating a structure called a "Cayley-Dickson imaginaroid" on a type [A] and showing that [Join (Susp A) (Susp A)] is an H-space. An further open problem is that this space itself is also an imaginaroid given further, yet unspecified, coherences on [A]. *)
+
+(** ** Cayley-Dickson spheroids *)
+
+(** A Cayley-Dickson Spheroid is a pointed type X which is an H-space, with two operations called negation and conjugation, satisfying the seven following laws:
+  1. [--x = x]
+  2. [x** = x]
+  3. [1* = 1]
+  4. [(-x)* = -x*]
+  5. [x(-y) = -(xy)]
+  6. [(xy)* = y* x*]
+  7. [x* x = 1]
+Note that the above laws are written in pseudocode since we cannot define multiplication by juxtaposition in Coq. *)
 Class CayleyDicksonSpheroid (X : pType) := {
   cds_hspace : IsHSpace X;
   cds_negate : Negate X;
@@ -62,6 +79,8 @@ Section CayleyDicksonSpheroid_Properties.
   Defined.
 
 End CayleyDicksonSpheroid_Properties.
+
+(** ** Negation and conjugation on suspensions *)
 
 Global Instance conjugate_susp (A : Type) `(Negate A)
   : Conjugate (Susp A)
@@ -122,6 +141,8 @@ Proof.
   nrapply Susp_rec_beta_merid.
 Defined.
 
+(** ** Cayley-Dickson imaginaroids *)
+
 Class CayleyDicksonImaginaroid (A : Type) := {
   cdi_negate : Negate A;
   cdi_negate_involutive : Involutive cdi_negate;
@@ -174,7 +195,7 @@ Proof.
   srapply cds_factorneg_l.
 Defined.
 
-(** A Cayley-Dickson imaginaroid A whose multiplciation on the suspension is associative gives rise to a H-space structure on the join of the suspension of A with itself. *)
+(** A Cayley-Dickson imaginaroid A whose multiplciation on the suspension is associative gives rise to an H-space structure on the join of the suspension of A with itself. *)
 Section ImaginaroidHSpace.
 
   (* Let A be a Cayley-Dickson imaginaroid with associative H-space multiplication on Susp A *)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -11,15 +11,15 @@ Local Open Scope mc_mult_scope.
 
 (** The Cayley-Dickson Construction *)
 
-(** They Cayley-Dickson construction in homotopy type theory due to Buchholtz and Rijke https://arxiv.org/abs/1610.01134 is a method to construct an H-space strucure on the join of two suspensions of a type [A]. As a special case, this gives a way to construct an H-space structure on [S^3] leading to the quarternionic hopf fibration.
+(** The Cayley-Dickson construction in homotopy type theory due to Buchholtz and Rijke https://arxiv.org/abs/1610.01134 is a method to construct an H-space strucure on the join of two suspensions of a type [A]. As a special case, this gives a way to construct an H-space structure on [S^3] leading to the quarternionic hopf fibration.
 
-The construction works by replicating the classical Cayley-Dickson construction on convolution algebras ([*]-algebras), which can product the complex numbers, quaternions, octonions, etc. starting with the real numbers. We cannot replicate this directly in HoTT since such algebras have a contractible underlying vector space, therefore this construction here attempts to axiomatize the properties of the units of those algebras instead.
+The construction works by replicating the classical Cayley-Dickson construction on convolution algebras ([*]-algebras), which can produce the complex numbers, quaternions, octonions, etc. starting with the real numbers. We cannot replicate this directly in HoTT since such algebras have a contractible underlying vector space, therefore the construction here attempts to axiomatize the properties of the units of those algebras instead.
 
-This is done by postulating a structure called a "Cayley-Dickson imaginaroid" on a type [A] and showing that [Join (Susp A) (Susp A)] is an H-space. An further open problem is that this space itself is also an imaginaroid given further, yet unspecified, coherences on [A]. *)
+This is done by postulating a structure called a "Cayley-Dickson imaginaroid" on a type [A] and showing that [Join (Susp A) (Susp A)] is an H-space. An open problem is to show that this space itself is also an imaginaroid given further, yet unspecified, coherences on [A]. *)
 
 (** ** Cayley-Dickson spheroids *)
 
-(** A Cayley-Dickson Spheroid is a pointed type X which is an H-space, with two operations called negation and conjugation, satisfying the seven following laws:
+(** A Cayley-Dickson Spheroid is a pointed type X which is an H-space, with two operations called negation and conjugation, satisfying the following seven laws:
   1. [--x = x]
   2. [x** = x]
   3. [1* = 1]
@@ -27,7 +27,7 @@ This is done by postulating a structure called a "Cayley-Dickson imaginaroid" on
   5. [x(-y) = -(xy)]
   6. [(xy)* = y* x*]
   7. [x* x = 1]
-Note that the above laws are written in pseudocode since we cannot define multiplication by juxtaposition in Coq. *)
+Note that the above laws are written in pseudocode since we cannot define multiplication by juxtaposition in Coq, and * is used to denote conjugation. *)
 Class CayleyDicksonSpheroid (X : pType) := {
   cds_hspace : IsHSpace X;
   cds_negate : Negate X;
@@ -138,10 +138,8 @@ Class CayleyDicksonImaginaroid (A : Type) := {
   cdi_susp_conjug_distr.
 
 Global Instance isunitpreserving_conjugate_susp {A} `(CayleyDicksonImaginaroid A)
-  : @IsUnitPreserving _ _ pt pt (conjugate_susp A cdi_negate).
-Proof.
-  reflexivity.
-Defined.
+  : @IsUnitPreserving _ _ pt pt (conjugate_susp A cdi_negate)
+  := idpath.
 
 (** Every suspension of a Cayley-Dickson imaginaroid gives a Cayley-Dickson spheroid. *)
 Global Instance cds_susp_cdi {A} `(CayleyDicksonImaginaroid A)
@@ -173,12 +171,11 @@ Proof.
   srapply cds_factorneg_l.
 Defined.
 
-(** A Cayley-Dickson imaginaroid A whose multiplciation on the suspension is associative gives rise to an H-space structure on the join of the suspension of A with itself. *)
+(** A Cayley-Dickson imaginaroid [A] whose multiplciation on the suspension is associative gives rise to an H-space structure on the join of the suspension of [A] with itself. *)
 Section ImaginaroidHSpace.
 
-  (* Let A be a Cayley-Dickson imaginaroid with associative H-space multiplication on Susp A *)
-  Context {A} `(CayleyDicksonImaginaroid A)
-    `(!Associative hspace_op).
+  (** Let [A] be a Cayley-Dickson imaginaroid with associative H-space multiplication on [Susp A]. *)
+  Context {A} `(CayleyDicksonImaginaroid A) `(!Associative hspace_op).
 
   (** Declaring these as local instances so that they can be found *)
   Local Instance hspace_op' : SgOp (Susp A) := hspace_op.

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -90,6 +90,16 @@ Global Instance negate_susp (A : Type) `(Negate A)
   : Negate (Susp A)
   := susp_neg _ o conjugate_susp A (-).
 
+(** [conjugate_susp A] and [negate_susp A] commute. *)
+Global Instance swapop_conjugate_susp {A} `(Negate A)
+  : SwapOp (negate_susp A (-)) (conjugate_susp A (-)).
+Proof.
+  intros x.
+  symmetry.
+  nrapply susp_neg_natural.
+Defined.
+
+(** [conjugate_susp A] is involutive, since any functor applied to an involution gives an involution. *)
 Global Instance involutive_conjugate_susp {A} `(Negate A, !Involutive (-))
   : Involutive (conjugate_susp A (-)).
 Proof.
@@ -100,23 +110,16 @@ Proof.
   rapply involutive.
 Defined.
 
+(** [conjugate_susp A] is involutive as any composite of commuting involutions is an involution. *)
 Global Instance involutive_negate_susp {A} `(Negate A, !Involutive (-))
   : Involutive (negate_susp A (-)).
 Proof.
   intros x.
   unfold negate_susp.
-  lhs_V nrapply ap.
-  1: nrapply susp_neg_natural. 
+  lhs nrapply ap.
+  1: nrapply swapop_conjugate_susp.
   lhs rapply susp_neg_inv.
   rapply involutive.
-Defined.
-
-Global Instance swapop_conjugate_susp {A} `(Negate A)
-  : SwapOp negate (conjugate_susp A (-)).
-Proof.
-  intros x.
-  symmetry.
-  nrapply susp_neg_natural.
 Defined.
 
 (** ** Cayley-Dickson imaginaroids *)

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -58,6 +58,19 @@ Section Join.
       apply Hglue.
   Defined.
 
+  Definition Join_ind_Flr {A B : Type} (f : Join A B -> Join A B)
+    (Hl : forall a, f (joinl a) = joinl a)
+    (Hr : forall b, f (joinr b) = joinr b)
+    (Hglue : forall a b, ap f (jglue a b) @ Hr b = Hl a @ jglue a b)
+    : forall x, f x = x.
+  Proof.
+    snrapply (Join_ind_FlFr _ _ Hl Hr).
+    intros a b.
+    lhs nrapply Hglue.
+    apply ap; symmetry.
+    apply ap_idmap.
+  Defined.
+
   (** And a version for showing that a composite is homotopic to the identity. *)
   Definition Join_ind_FFlr {A B P : Type} (f : Join A B -> P) (g : P -> Join A B)
     (Hl : forall a, g (f (joinl a)) = joinl a)

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -59,12 +59,36 @@ Definition Susp_ind_FlFr {X Y : Type} (f g : Susp X -> Y)
   (Hmerid : forall x, ap f (merid x) @ HS = HN @ ap g (merid x))
   : f == g.
 Proof.
-  snrapply Susp_ind.
-  - exact HN.
-  - exact HS.
-  - intro x.
-    nrapply transport_paths_FlFr'.
-    apply Hmerid.
+  snrapply (Susp_ind _ HN HS).
+  intros x.
+  nrapply transport_paths_FlFr'.
+  exact (Hmerid x).
+Defined.
+
+(** A version of [Susp_ind] specifically for proving that the composition of two functions to and from a suspension are homotopic to the identity map. *)
+Definition Susp_ind_FFlr {X Y : Type} (f : Susp X -> Y) (g : Y -> Susp X)
+  (HN : g (f North) = North)
+  (HS : g (f South) = South)
+  (Hmerid : forall x, ap g (ap f (merid x)) @ HS = HN @ merid x)
+  : g o f == idmap.
+Proof.
+  snrapply (Susp_ind _ HN HS).
+  intros x.
+  snrapply (transport_paths_FFlr' (f:=f) (g:=g)).
+  exact (Hmerid x).
+Defined.
+
+(** A version of [Susp_ind] specifically for proving a composition square from a suspension. *)
+Definition Susp_ind_FFlFFr {X Y Y' Z : Type}
+  (f : Susp X -> Y) (f' : Susp X -> Y') (g : Y -> Z) (g' : Y' -> Z)
+  (HN : g (f North) = g' (f' North)) (HS : g (f South) = g' (f' South))
+  (Hmerid : forall x, ap g (ap f (merid x)) @ HS = HN @ ap g' (ap f' (merid x)))
+  : g o f == g' o f'.
+Proof.
+  snrapply (Susp_ind _ HN HS).
+  intros x.
+  snrapply (transport_paths_FFlFFr' (f:=f) (f':=f') (g:=g) (g':=g')).
+  exact (Hmerid x).
 Defined.
 
 (* ** Non-dependent eliminator. *)


### PR DESCRIPTION
We fix the issue in #2149 which didn't affect much of the later proofs in the file. I don't know why this doesn't affect anything later on. It seems like the H-space construction would have gone through still?

We take this opportunity to clean up the argument in this file. For instance, we have a derived negation and conjugation on the suspension, with further properties given properties of the underlying negation. This all works without needing to assume a Cayley-Dickson imaginaroid structure.

We clean up the argument in `cd_op` making it easier to read, prove and use. We could add beta rules for `Join_rec2` in the future, to make computations easier. We currently don't need to do this yet.