### PR TITLE
mathclasses improvements (`^` for group inverses)

### DIFF
--- a/test/Algebra/Groups/Expressions.v
+++ b/test/Algebra/Groups/Expressions.v
@@ -1,0 +1,112 @@
+From HoTT Require Import Basics.Overture Groups.Group AbGroups.AbelianGroup.
+
+Set Universe Minimization ToSet.
+
+(** In this file, we test various aspects of writing group expressions. These kinds of expressions appear throughout the library, but since mathclasses is quite sensitive to subtle changes, we keep this file to document and enforce certain behaviours.
+
+We use the [Type] vernacular command which is like [Check] but doesn't allow for evars. *)
+
+Section Groups.
+
+  (** We used a fixed universe of groups since the [Type] command doesn't work with polymorphic universes. *)
+  Context {G : Group@{Set}} (x y : G).
+
+  (** Without opening any scopes, the notation [x * y] will default to the one in [type_scope] which is the product type. In this case it will fail since Coq is expecting a type argument rather than [x : G]. *)
+  Fail Type (x * y : G).
+  
+  (** [x^] will be interpreted as path inversion, therefore Coq will complain about its type. *)
+  Fail Type (x^ : G).
+
+  (** In [mc_scope], [_ * _] denotes an instance of [Mult], which groups do not have. It is useful for rings, see below. *)
+  Local Open Scope mc_scope.
+
+  (** We fail saying that no [Mult] instance was found for [G] as expected. *)
+  Fail Type (x * y : G).
+  (** Here [^] is still interpreted as path inversion. *)
+  Fail Type (x^ : G).
+
+  Local Close Scope mc_scope.
+
+  (** The correct scope for a general group is [mc_mult_scope], where [x * y] is [sg_op x y] and [^] is [inv]. *)
+  Local Open Scope mc_mult_scope.
+
+  (** This gets correctly interpreted as the group operation. *)
+  Succeed Type (x * y : G).
+  (** So does the group inverse. *)
+  Succeed Type (x^ * y : G).
+
+End Groups.
+
+Section AbGroups.
+
+  Context {A : AbGroup@{Set}} (x y : A).
+
+  (** Working with abelian groups can be confusing if the correct scopes are not open. We document the correct usage here. *)
+  
+  (** Similar to [*], without any scopes open, the following expression fails since Coq interprets it as the sum type. *)
+  Fail Type (x + y : A).
+
+  (** The [- _] notation doesn't have any meaning when the correct scope is not open. *)
+  Fail Type (-x : A).
+
+  (** Nor does the subtraction notation. *)
+  Fail Type (x - y : A).
+
+  (** Opening [mc_scope] will mean that:
+    - [+] becomes the operation of a [Plus].
+    - [- x] becomes a [Negate] operation.
+    - [x - y] is interpreted as [x + (- y)] for a [Negate] and [Plus]. *)
+  Local Open Scope mc_scope.
+
+  (** Notably, even though these instances exist for [Ring]s, they do not in general for abelian groups as we treat those as groups with a commutative [sg_op] rather than a [plus] operation. This allows us to use group lemmas without deforming abelian group expressions. *)
+  
+  (** These fail due to a lack of [Plus]. *)
+  Fail Type (x + y : A).
+  Fail Type (x - y : A).
+  (** This fails due to a lack of [Negate]. *)
+  Fail Type (-x : A).
+
+  Local Close Scope mc_scope.
+
+  (** Opening [mc_add_scope] will make writing expressions of abelian groups possible. *)
+  Local Open Scope mc_add_scope.
+
+  Succeed Type (x + y : A).
+  Succeed Type (-x : A).
+  Succeed Type (-x + y : A).
+  Succeed Type (x - y : A).
+  
+  Local Close Scope mc_add_scope.
+  
+  (** We can also work with the abelian group with a multiplicative notation, as we would for any group. *)
+  Local Open Scope mc_mult_scope.
+  
+  Succeed Type (x * y : A).
+  Succeed Type (x^ : A).
+  Succeed Type (x^ * y : A).
+  
+  (** This can get confusing if we further allow for additive notations to also be shown, so only one of [mc_add_scope] and [mc_mult_scope] should be used. *)
+  
+  Local Open Scope mc_add_scope.
+
+  Succeed Type (-x * y + x^).
+  Succeed Type (-x^ + --x^).
+
+  Local Close Scope mc_add_scope.
+  Local Close Scope mc_mult_scope.
+
+  (** Sometimes, as when working with rings, we want [+] to denote [plus] rather than [sg_op]. In this case, we include a module with hints which can be imported. *)
+  
+  Import AbelianGroup.AdditiveInstances.
+  
+  Local Open Scope mc_scope.
+
+  (** This allows us to write additive notations even though we don't have [mc_add_scope] or [mc_mult_scope] open. The disadvantage of working like this however, is that any group lemmas applied to abelian groups will have their [plus], [zero] and [negate] unfolded to the underlying group operations. *)
+  Succeed Type (x + y : A).
+  Succeed Type (-x : A).
+  Succeed Type (-x + y : A).
+  Succeed Type (x - y : A).
+
+  Local Close Scope mc_scope.
+
+End AbGroups.

--- a/test/Algebra/Groups/Presentation.v
+++ b/test/Algebra/Groups/Presentation.v
@@ -4,7 +4,6 @@ From HoTT.Algebra.Groups Require Import Group Presentation FreeGroup.
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
 
-Check ⟨ x | x * x * x , -x ⟩.
-Check ⟨ x , y | x * y ,  x * y * x , x * (-y) * x * x * x⟩.
-Check ⟨ x , y , z | x * y * z , x * -z , x * y⟩.
- 
+Check ⟨ x | x * x * x , x^ ⟩.
+Check ⟨ x , y | x * y ,  x * y * x , x * y^ * x * x * x⟩.
+Check ⟨ x , y , z | x * y * z , x * z^ , x * y⟩.

--- a/test/Algebra/Rings/Expressions.v
+++ b/test/Algebra/Rings/Expressions.v
@@ -1,0 +1,24 @@
+From HoTT Require Import Basics.Overture Algebra.Rings.Ring.
+
+Set Universe Minimization ToSet.
+
+(** In this file, we test various aspects of writing group expressions. These kinds of expressions appear throughout the library, but since mathclasses is quite sensitive to subtle changes, we keep this file to document and enforce certain behaviours.
+
+We use the [Type] vernacular command which is like [Check] but doesn't allow for evars. *)
+
+Section Rings.
+
+  Context {R : Ring@{Set}} (x y : R).
+
+  (** [mc_scope] is appropriate for rings. *)
+
+  Local Open Scope mc_scope.
+
+  Succeed Type (x + y : R).
+  Succeed Type (x - y : R).
+  Succeed Type (x * y * x - x * y : R).
+  Succeed Type (x - y : R).
+  Succeed Type (x - y : R).
+
+  Local Close Scope mc_scope.
+End Rings.

--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -21,16 +21,12 @@ Global Instance inverse_hom {A : Group} {B : AbGroup}
 (** For [A] and [B] groups, with [B] abelian, homomorphisms [A $-> B] form an abelian group. *)
 Definition grp_hom `{Funext} (A : Group) (B : AbGroup) : Group.
 Proof.
-  nrefine (Build_Group (GroupHomomorphism A B)
-             sgop_hom grp_homo_const inverse_hom _).
-  repeat split.
+  snrapply (Build_Group' (GroupHomomorphism A B) sgop_hom grp_homo_const inverse_hom).
   1: exact _.
   all: hnf; intros; apply equiv_path_grouphomomorphism; intro; cbn.
-  + apply associativity.
-  + apply left_identity.
-  + apply right_identity.
-  + apply left_inverse.
-  + apply right_inverse.
+  - apply associativity.
+  - apply left_identity.
+  - apply left_inverse.
 Defined.
 
 Definition ab_hom `{Funext} (A : Group) (B : AbGroup) : AbGroup.

--- a/theories/Algebra/AbGroups/AbPullback.v
+++ b/theories/Algebra/AbGroups/AbPullback.v
@@ -4,6 +4,8 @@ Require Export Algebra.Groups.GrpPullback.
 Require Import Algebra.AbGroups.AbelianGroup.
 Require Import WildCat.Core.
 
+Local Open Scope mc_add_scope.
+
 (** * Pullbacks of abelian groups *)
 
 Section AbPullback.
@@ -21,11 +23,7 @@ Section AbPullback.
     apply path_ishprop.
   Defined.
 
-  Global Instance isabgroup_ab_pullback
-    : IsAbGroup (grp_pullback f g) := {}.
-
-  Definition ab_pullback
-    : AbGroup := Build_AbGroup (grp_pullback f g) _.
+  Definition ab_pullback : AbGroup := Build_AbGroup (grp_pullback f g) _.
 
   (** The corecursion principle is inherited from Groups; use grp_pullback_corec and friends from Groups/GrpPullback.v. *)
 

--- a/theories/Algebra/AbGroups/AbPushout.v
+++ b/theories/Algebra/AbGroups/AbPushout.v
@@ -27,10 +27,9 @@ Proof.
   - exact (ab_biprod_rec b c).
   - intros [x y] q; strip_truncations; simpl.
     destruct q as [a q]. cbn in q.
-    refine (ap (uncurry (fun x y => b x + c y)) q^ @ _).
-    cbn.
-    refine (ap011 sg_op (preserves_negate _) (p a)^ @ _).
-    exact (left_inverse _).
+    lhs_V nrapply (ap (fun '(x, y) => b x + c y) q); cbn.
+    lhs rapply (ap011 (+) (preserves_inverse _) (p a)^).
+    apply left_inverse.
 Defined.
 
 Corollary ab_pushout_rec_uncurried {A B C : AbGroup}
@@ -50,13 +49,11 @@ Definition ab_pushout_inr {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
 Proposition ab_pushout_commsq {A B C : AbGroup} {f : A $-> B} {g : A $-> C}
   : (@ab_pushout_inl A B C f g) $o f == ab_pushout_inr $o g.
 Proof.
-  intro a.
-  apply qglue; cbn.
-  apply tr.
-  exists a.
+  intro a; simpl.
+  apply qglue, tr; exists a.
   apply path_prod; simpl.
   - exact (right_identity _)^.
-  - rewrite negate_mon_unit.
+  - rewrite grp_inv_unit.
     exact (left_identity _)^.
 Defined.
 
@@ -145,7 +142,7 @@ Proof.
     exact (left_inverse mon_unit @ (grp_homo_unit g)^).
   - apply (grp_moveR_M1).
     refine (_ @ ap fst p); cbn; symmetry.
-    refine (_ @ negate_mon_unit).
+    refine (_ @ grp_inv_unit).
     refine (ap _ _).
     exact (ap f z @ grp_homo_unit f).
 Defined.

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -52,15 +52,7 @@ Definition Build_AbGroup' (G : Type)
   : AbGroup.
 Proof.
   snrapply Build_AbGroup.
-  - (* TODO: introduce smart constructor for [Build_Group] *)
-    rapply (Build_Group G).
-    repeat split; only 1-3, 5: exact _.
-    + intros x.
-      lhs nrapply comm.
-      exact (unit_l x).
-    + intros x.
-      lhs nrapply comm.
-      exact (inv_l x).
+  - rapply (Build_Group' G).
   - exact comm.
 Defined.
 

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -131,8 +131,7 @@ Section Abel.
   Defined.
 
   (** We also have a recursion princple. *)
-  Definition Abel_rec (P : Type) `{IsHSet P}
-    (a : G -> P)
+  Definition Abel_rec (P : Type) `{IsHSet P} (a : G -> P)
     (c : forall x y z, a (x * (y * z)) = a (x * (z * y)))
     : Abel -> P.
   Proof.
@@ -314,8 +313,7 @@ Defined.
 Arguments abel G : simpl never.
 
 (** The unit of this map is the map [abel_in] which typeclasses can pick up to be a homomorphism. We write it out explicitly here. *)
-Definition abel_unit {G : Group}
-  : G $-> (abel G)
+Definition abel_unit {G : Group} : G $-> abel G
   := @Build_GroupHomomorphism G (abel G) abel_in _.
 
 Definition grp_homo_abel_rec {G : Group} {A : AbGroup} (f : G $-> A)

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -196,7 +196,7 @@ Section AbelGroup.
     Abel_ind_hprop z; revert y.
     Abel_ind_hprop y; revert x.
     Abel_ind_hprop x; simpl.
-    apply (ap abel_in), associativity.
+    nrapply (ap abel_in); apply associativity.
   Defined.
 
   (** From this we know that [Abel G] is a semigroup. *)
@@ -208,14 +208,14 @@ Section AbelGroup.
   (** By using Abel_ind_hprop we can prove the left and right identity laws. *)
   Global Instance leftidentity_abel : LeftIdentity (.*.) 1.
   Proof.
-    Abel_ind_hprop x.
-    simpl; apply (ap abel_in), left_identity.
+    Abel_ind_hprop x; cbn beta.
+    nrapply (ap abel_in); apply left_identity.
   Defined.
 
   Global Instance rightidentity_abel : RightIdentity (.*.) 1.
   Proof.
-    Abel_ind_hprop x.
-    simpl; apply (ap abel_in), right_identity.
+    Abel_ind_hprop x; cbn beta.
+    nrapply (ap abel_in); apply right_identity.
   Defined.
 
   (** Hence [Abel G] is a monoid *)
@@ -259,13 +259,13 @@ Section AbelGroup.
   Global Instance leftinverse_abel : LeftInverse (.*.) (^) 1.
   Proof.
     Abel_ind_hprop x; simpl.
-    apply (ap abel_in); apply left_inverse.
+    nrapply (ap abel_in); apply left_inverse.
   Defined.
 
   Instance rightinverse_abel : RightInverse (.*.) (^) 1.
   Proof.
     Abel_ind_hprop x; simpl.
-    apply (ap abel_in); apply right_inverse.
+    nrapply (ap abel_in); apply right_inverse.
   Defined.
 
   (** Thus [Abel G] is a group *)

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -4,13 +4,15 @@ Require Import Colimits.Coeq.
 Require Import Algebra.AbGroups.AbelianGroup.
 Require Import Modalities.ReflectiveSubuniverse.
 
-(** In this file we define what it means for a group homomorphism G -> H into an abelian group H to be an abelianization. We then construct an example of an abelianization. *)
+(** * Abelianization *)
+
+(** In this file we define what it means for a group homomorphism [G -> H] into an abelian group [H] to be an abelianization. We then construct an example of an abelianization. *)
 
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
 Local Open Scope wc_iso_scope.
 
-(** Definition of Abelianization.
+(** ** Definition of abelianization.
 
   A "unit" homomorphism [eta : G -> G_ab], with [G_ab] abelian, is considered an abelianization if and only if for all homomorphisms [G -> A], where [A] is abelian, there exists a unique [g : G_ab -> A] such that [h == g o eta X].   We express this in funext-free form by saying that precomposition with [eta] in the wild 1-category [Group] induces an equivalence of hom 0-groupoids, in the sense of WildCat/EquivGpd.
 
@@ -45,27 +47,28 @@ Definition equiv_group_precomp_isabelianization `{Funext}
   : (G_ab $-> A) <~> (G $-> A)
   := Build_Equiv _ _ _ (isequiv_group_precomp_isabelianization eta A).
 
-(** Here we define abelianization as a HIT. Specifically as a set-coequalizer of the following two maps: (a, b, c) |-> a (b c) and (a, b, c) |-> a (c b).
+(** Here we define abelianization as a HIT. Specifically as a set-coequalizer of the following two maps [fun '(a, b, c) => a * (b * c)] and [fun '(a, b, c) => a * (c * b)].
 
 From this we can show that Abel G is an abelian group.
 
 In fact this models the following HIT:
 
+<<<
 HIT Abel (G : Group) := 
  | abel_in : G -> Abel G
  | abel_in_comm : forall x y z, abel_in (x * (y * z)) = abel_in (x * (z * y)).
+>>>
 
 We also derive [abel_in] and [abel_in_comm] from our coequalizer definition, and even prove the induction and computation rules for this HIT.
 
-This HIT was suggested by Dan Christensen.
-*)
+This HIT was suggested by Dan Christensen. *)
 
 Section Abel.
 
   (** Let G be a group. *)
   Context (G : Group).
 
-  (** We locally define a map uncurry2 that lets us uncurry A * B * C -> D twice. *)
+  (** We locally define a map uncurry2 that lets us uncurry [A * B * C -> D] twice. *)
   Local Definition uncurry2 {A B C D : Type}
     : (A -> B -> C -> D) -> A * B * C -> D.
   Proof.
@@ -73,7 +76,7 @@ Section Abel.
     by apply f.
   Defined.
 
-  (** The type Abel is defined to be the set coequalizer of the following maps G^3 -> G. *)
+  (** The type [Abel] is defined to be the set coequalizer of the following maps [G^3 -> G]. *)
   Definition Abel
     := Tr 0 (Coeq
       (uncurry2 (fun a b c : G => a * (b * c)))
@@ -86,7 +89,7 @@ Section Abel.
     apply tr, coeq, g.
   Defined.
 
-  (** This map satisfies the condition ab_comm. *)
+  (** This map satisfies the condition [ab_comm]. It's a form of commutativity in a right factor. *)
   Definition abel_in_comm a b c
     : abel_in (a * (b * c)) = abel_in (a * (c * b)).
   Proof.
@@ -180,7 +183,7 @@ Section AbelGroup.
       { intro a.
         exact (abel_in (a * b)). }
       intros a c d; hnf.
-      (* The pattern seems to be to alternate associativity and ab_comm. *)
+      (* The pattern seems to be to alternate [associativity] and [ab_comm]. *)
       refine (ap _ (associativity _ _ _)^ @ _).
       refine (abel_in_comm _ _ _ @ _).
       refine (ap _ (associativity _ _ _) @ _).
@@ -244,7 +247,7 @@ Section AbelGroup.
 <<
         - (abel_in g) := abel_in (- g)
 >>
-      However when checking that it respects ab_comm we have to show the following:
+      However when checking that it respects [ab_comm] we have to show the following:
 <<
         abel_in (- z * - y * - x) = abel_in (- y * - z * - x)
 >>
@@ -274,10 +277,10 @@ Section AbelGroup.
     apply ap; apply right_inverse.
   Defined.
 
-  (** Thus Abel G is a group *)
+  (** Thus [Abel G] is a group *)
   Global Instance isgroup_abel : IsGroup (Abel G) := {}.
 
-  (** And since the operation is commutative, an abelian group. *)
+  (** And furthermore, since the operation is commutative, it is an abelian group. *)
   Global Instance isabgroup_abel : IsAbGroup (Abel G) := {}.
 
   (** By definition, the map [abel_in] is also a group homomorphism. *)
@@ -301,7 +304,7 @@ Defined.
 
 (** Now we finally check that our definition of abelianization satisfies the universal property of being an abelianization. *)
 
-(** We define abel to be the abelianization of a group. This is a map from Group to AbGroup. *)
+(** We define [abel] to be the abelianization of a group. This is a map from [Group] to [AbGroup]. *)
 Definition abel : Group -> AbGroup.
 Proof.
   intro G.
@@ -310,6 +313,7 @@ Proof.
   - exact _.
 Defined.
 
+(** We don't wish for [abel G] to be unfolded when using [simpl] or [cbn]. *)
 Arguments abel G : simpl never.
 
 (** The unit of this map is the map [abel_in] which typeclasses can pick up to be a homomorphism. We write it out explicitly here. *)

--- a/theories/Algebra/AbGroups/Centralizer.v
+++ b/theories/Algebra/AbGroups/Centralizer.v
@@ -29,16 +29,16 @@ Defined.
 
 Definition centralizer_inverse {G : Group} (g h : G)
            (p : centralizer g h)
-  : centralizer g (-h).
+  : centralizer g h^.
 Proof.
   unfold centralizer in *.
   symmetry.
   refine ((grp_unit_r _)^ @ _ @ grp_unit_l _).
-  refine (ap (fun x => (-h * g * x)) (grp_inv_r h)^ @ _ @ ap (fun x => x * (g * -h)) (grp_inv_l h)).
+  refine (ap ((_ * g) *.) (grp_inv_r h)^ @ _ @ ap (.* (g * _)) (grp_inv_l h)).
   refine (grp_assoc _ _ _ @ _ @ (grp_assoc _ _ _)^).
-  refine (ap (fun x => x * (-h)) _).
+  refine (ap (.* h^) _).
   refine ((grp_assoc _ _ _)^ @ _ @ grp_assoc _ _ _).
-  exact (ap (fun x => (-h) * x) p).
+  exact (ap (h^ *.) p).
 Defined.
 
 Global Instance issubgroup_centralizer {G : Group} (g : G)

--- a/theories/Algebra/AbGroups/FiniteSum.v
+++ b/theories/Algebra/AbGroups/FiniteSum.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import Spaces.Nat.Core Spaces.Int.
-Require Export Classes.interfaces.canonical_names (Zero, zero, Plus).
+Require Export Classes.interfaces.canonical_names (Commutative).
 Require Export Classes.interfaces.abstract_algebra (IsAbGroup(..), abgroup_group, abgroup_commutative).
 Require Import AbelianGroup.
 
@@ -13,7 +13,7 @@ Local Open Scope mc_add_scope.
 Definition ab_sum {A : AbGroup} (n : nat) (f : forall k, (k < n)%nat -> A) : A.
 Proof.
   induction n as [|n IHn].
-  - exact zero.
+  - exact 0.
   - refine (f n _ + IHn _).
     intros k Hk.
     exact (f k _).
@@ -51,8 +51,8 @@ Proof.
   1: by rewrite grp_unit_l.
   simpl.
   rewrite <- !grp_assoc; f_ap.
-  rewrite IHn, ab_comm, <- grp_assoc; f_ap.
-  by rewrite ab_comm.
+  rewrite IHn, abgroup_commutative, <- grp_assoc; f_ap.
+  by rewrite abgroup_commutative.
 Defined.
 
 (** Double finite sums commute. *)

--- a/theories/Algebra/AbGroups/TensorProduct.v
+++ b/theories/Algebra/AbGroups/TensorProduct.v
@@ -214,7 +214,9 @@ Proof.
     + change (P (tensor_in (freegroup_in (a, b)) + tensor_in (freegroup_eta w))).
       apply Hop; trivial.
       apply Hin.
-    + change (P (-tensor_in (freegroup_in (a, b)) + tensor_in (freegroup_eta w))).
+    + change (P (tensor_in (- freegroup_in (a, b)) + tensor_in (freegroup_eta w))).
+      (* This [rewrite] is reflexivity, but using [change] to achieve this is slow and slows down the Defined line. *)
+      rewrite grp_homo_inv.
       apply Hop; trivial.
       rewrite <- tensor_neg_l.
       apply Hin.

--- a/theories/Algebra/AbGroups/TensorProduct.v
+++ b/theories/Algebra/AbGroups/TensorProduct.v
@@ -11,7 +11,6 @@ Require Import Spaces.List.Core Spaces.Int.
 Require Import AbGroups.Z.
 Require Import Truncations.
 
-Local Open Scope mc_scope.
 Local Open Scope mc_add_scope.
 
 (** * The Tensor Product of Abelian Groups *)
@@ -215,9 +214,7 @@ Proof.
     + change (P (tensor_in (freegroup_in (a, b)) + tensor_in (freegroup_eta w))).
       apply Hop; trivial.
       apply Hin.
-    + change (P (tensor_in (- freegroup_in (a, b)) + tensor_in (freegroup_eta w))).
-      (* This [rewrite] is also reflexivity. *)
-      rewrite grp_homo_inv.
+    + change (P (-tensor_in (freegroup_in (a, b)) + tensor_in (freegroup_eta w))).
       apply Hop; trivial.
       rewrite <- tensor_neg_l.
       apply Hin.
@@ -240,7 +237,7 @@ Definition ab_tensor_prod_ind_homotopy_plus {A B G : AbGroup}
   {f f' f'' : ab_tensor_prod A B $-> G}
   (H : forall a b, f (tensor a b) = f' (tensor a b) + f'' (tensor a b))
   : forall x, f x = f' x + f'' x
-  := ab_tensor_prod_ind_homotopy (f':=ab_homo_add f' f'') H.
+  := ab_tensor_prod_ind_homotopy (f':=f' + f'') H.
 
 (** Here we give an induction principle for a triple tensor, a.k.a a dependent trilinear function. *)
 Definition ab_tensor_prod_ind_hprop_triple {A B C : AbGroup}
@@ -617,9 +614,8 @@ Proof.
   - snrapply Build_Is1Natural.
     intros A A' f.
     snrapply ab_tensor_prod_ind_homotopy.
-    intros a z.
-    change (grp_pow (f a) z = f (grp_pow a z)).
-    exact (grp_pow_natural _ _ _)^.
+    intros a z; symmetry.
+    exact (grp_pow_natural _ _ _).
 Defined.
 
 (** Since we have symmetry of the tensor product, we get left unitality for free. *)
@@ -647,8 +643,8 @@ Proof.
   snrapply triangle_twist.
   intros A B.
   snrapply ab_tensor_prod_ind_homotopy_triple.
-  intros a b z.
-  exact (tensor_ab_mul z a b)^.
+  intros a b z; symmetry.
+  exact (tensor_ab_mul z a b).
 Defined.
 
 (** The hexagon identity is also straighforward to prove. We simply have to reduce all the involved functions on the simple tensors using our custom triple tensor induction principle. *)
@@ -774,7 +770,7 @@ Proof.
       snrapply grp_homo_op.
     + intros x x'.
       rapply Abel_ind_hprop.
-      snrapply (FreeGroup_ind_homotopy _ (f' := ab_homo_add _ _)).
+      snrapply (FreeGroup_ind_homotopy _ (f' := sgop_hom _ _)).
       intros y.
       lhs nrapply FreeGroup_rec_beta.
       lhs nrapply grp_homo_op.

--- a/theories/Algebra/AbGroups/Z.v
+++ b/theories/Algebra/AbGroups/Z.v
@@ -4,17 +4,18 @@ Require Import Algebra.AbGroups.AbelianGroup.
 
 Local Set Universe Minimization ToSet.
 
+Local Open Scope int_scope.
+Local Open Scope mc_add_scope.
+
 (** * The group of integers *)
 
 (** See also Cyclic.v for a definition of the integers as the free group on one generator. *)
-
-Local Open Scope int_scope.
 
 Definition abgroup_Z@{} : AbGroup@{Set}.
 Proof.
   snrapply Build_AbGroup'.
   - exact Int.
-  - exact 0.
+  - exact 0%int.
   - exact int_neg.
   - exact int_add.
   - exact _.
@@ -32,8 +33,6 @@ Proof.
   1: exact (grp_pow g).
   intros m n; apply grp_pow_add.
 Defined.
-
-Local Open Scope mc_add_scope.
 
 (** [ab_mul] (and [grp_pow]) give multiplication in [abgroup_Z]. *)
 Definition abgroup_Z_ab_mul (z z' : Int)

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -6,7 +6,7 @@ Require Import Homotopy.ExactSequence Pointed.
 Require Import Modalities.ReflectiveSubuniverse.
 
 Local Open Scope pointed_scope.
-Local Open Scope mc_scope.
+Local Open Scope path_scope.
 Local Open Scope type_scope.
 Local Open Scope mc_add_scope.
 
@@ -159,7 +159,7 @@ Proof.
     1: apply center, issurjection_projection.
     strip_truncations.
     (** The difference [f - (phi e0.1)] is sent to [0] by [projection F], hence lies in [A]. *)
-    assert (a : Tr (-1) (hfiber (inclusion F) (f + (- phi e0.1)))).
+    assert (a : Tr (-1) (hfiber (inclusion F) (f - phi e0.1))).
     1: { refine (isexact_preimage (Tr (-1)) (inclusion F) (projection F) _ _).
          refine (grp_homo_op _ _ _ @ _).
          refine (ap _ (grp_homo_inv _ _) @ _).
@@ -491,7 +491,7 @@ Definition hom_loops_data_abses {A B : AbGroup} (E : AbSES B A)
 Proof.
   intro phi.
   srefine (_; (_, _)).
-  - exact (ab_homo_add grp_homo_id (inclusion E $o phi $o projection E)).
+  - exact (grp_homo_id + (inclusion E $o phi $o projection E)).
   - intro a; cbn.
     refine (ap (fun x => _ + inclusion E (phi x)) _ @ _).
     1: apply iscomplex_abses.
@@ -558,12 +558,11 @@ Definition projection_split_to_kernel {B A : AbGroup} (E : AbSES B A)
   : (middle E) $-> (@ab_kernel E B (projection _)).
 Proof.
   snrapply (grp_kernel_corec (G:=E) (A:=E)).
-  - refine (ab_homo_add grp_homo_id
-              (grp_homo_compose ab_homo_negation (s $o (projection _)))).
+  - refine (grp_homo_id - (s $o projection _)).
   - intro x; simpl.
     refine (grp_homo_op (projection _) x _ @ _).
     refine (ap (fun y => (projection _) x + y) _ @ right_inverse ((projection _) x)).
-    refine (grp_homo_inv _ _ @ ap negate _ ).
+    refine (grp_homo_inv _ _ @ ap (-) _).
     apply h.
 Defined.
 
@@ -577,7 +576,7 @@ Proof.
   apply grp_cancelL1.
   refine (ap (fun x => - s x) _ @ _).
   1: rapply cx_isexact.
-  exact (ap _ (grp_homo_unit _) @ negate_mon_unit).
+  exact (ap _ (grp_homo_unit _) @ grp_inv_unit).
 Defined.
 
 (** The induced map [E -> ab_kernel (projection E) + B] is an isomorphism. We suffix it with 1 since it is the first composite in the desired isomorphism [E -> A + B]. *)

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -48,7 +48,7 @@ Proof.
     strip_truncations.
     exact (tr (abses_baer_sum E F)).
   - exact (point (Ext B A)).
-  - unfold Negate.
+  - unfold Inverse.
     exact (Trunc_functor _ (abses_pullback (- grp_homo_id))).
   - repeat split.
     1: apply istrunc_truncation.

--- a/theories/Algebra/AbSES/PullbackFiberSequence.v
+++ b/theories/Algebra/AbSES/PullbackFiberSequence.v
@@ -6,7 +6,6 @@ Require Import AbSES.Core AbSES.Pullback.
 Require Import Modalities.Identity Modalities.Modality Truncations.Core.
 
 Local Open Scope pointed_scope.
-Local Open Scope mc_scope.
 Local Open Scope mc_add_scope.
 
 (** * The fiber sequence induced by pulling back along a short exact sequence *)
@@ -86,8 +85,8 @@ Proof.
            refine (ap (grp_pullback_pr1 _ _) (fst p^$.2 (-a)) @ _).
            exact (grp_homo_inv _ _). }
     (* Using [q2], we conclude. *)
-    pose proof (q3 := ap negate (fst ((equiv_path_prod _ _)^-1 q2))); cbn in q3.
-    exact ((negate_involutive _)^ @ q3^ @ negate_mon_unit).
+    pose proof (q3 := ap (-) (fst ((equiv_path_prod _ _)^-1 q2))); cbn in q3.
+    exact ((inverse_involutive _)^ @ q3^ @ grp_inv_unit).
   - apply (cancelR_conn_map (Tr (-1)) grp_quotient_map).
     1: exact _.
     simpl.
@@ -129,7 +128,7 @@ Proof.
       apply qglue.
       exists b.
       refine (_ @ (grp_unit_r _)^).
-      exact (negate_involutive _)^.
+      exact (inverse_involutive _)^.
 Defined.
 
 (** That [abses_pullback_trivial_preimage E F p] pulls back to [F] is immediate from [abses_pullback_component1_id] and the following map. As such, we've shown that sequences which become trivial after pulling back along [inclusion E] are in the image of pullback along [projection E]. *)

--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -6,7 +6,7 @@ Require Import AbSES.Core AbSES.DirectSum.
 
 Local Open Scope pointed_scope.
 Local Open Scope type_scope.
-Local Open Scope mc_scope.
+Local Open Scope path_scope.
 Local Open Scope mc_add_scope.
 
 (** * Pushouts of short exact sequences *)
@@ -53,8 +53,8 @@ Proof.
       refine (tr (-a; _)).
       apply path_prod; cbn.
       * apply grp_moveL_Mg.
-        by rewrite negate_involutive.
-      * exact ((preserves_negate a) @ ap _ s @ (right_identity _)^).
+        by rewrite involutive.
+      * exact ((preserves_inverse a) @ ap _ s @ (right_identity _)^).
 Defined.
 
 (** ** The universal property of [abses_pushout_morphism] *)
@@ -206,7 +206,7 @@ Proof.
   refine (tr (0; _)).
   apply path_prod'; cbn.
   - refine (ap _ (grp_homo_unit _) @ _).
-    refine (negate_mon_unit @ _).
+    refine (grp_inv_unit @ _).
     apply grp_moveL_Vg.
     exact (right_identity _ @ right_identity _).
   - refine (grp_homo_unit _ @ _).

--- a/theories/Algebra/Groups/FreeGroup.v
+++ b/theories/Algebra/Groups/FreeGroup.v
@@ -24,10 +24,10 @@ Section Reduction.
   Local Definition change_sign : A + A -> A + A := equiv_sum_symm A A.
 
   (** We introduce a local notation for [change_sign]. It is only defined in this section however. *)
-  Local Notation "a ^" := (change_sign a).
+  Local Notation "a ^'" := (change_sign a) (at level 1).
 
   (** Changing sign is an involution *)
-  Local Definition change_sign_inv a : a^^ = a.
+  Local Definition change_sign_inv a : a^'^' = a.
   Proof.
     by destruct a.
   Defined.
@@ -44,7 +44,7 @@ Section Reduction.
   Local Definition map1 : Words * (A + A) * Words -> Words.
   Proof.
     intros [[x a] y].
-    exact (x ++ [a] ++ [a^] ++ y).
+    exact (x ++ [a] ++ [a^'] ++ y).
   Defined.
   
   Arguments map1 _ /.
@@ -65,7 +65,7 @@ Section Reduction.
 
   (** This is the path constructor *)
   Definition freegroup_tau (x : Words) (a : A + A) (y : Words)
-    : freegroup_eta (x ++ [a] ++ [a^] ++ y) = freegroup_eta (x ++ y).
+    : freegroup_eta (x ++ [a] ++ [a^'] ++ y) = freegroup_eta (x ++ y).
   Proof.
     apply path_Tr, tr.
     exact ((cglue (x, a, y))).
@@ -82,7 +82,7 @@ Section Reduction.
       { intros y.
         exact (freegroup_eta (x ++ y)). }
       intros [[y a] z]; simpl.
-      change (freegroup_eta (x ++ y ++ ([a] ++ [a^] ++ z))
+      change (freegroup_eta (x ++ y ++ ([a] ++ [a^'] ++ z))
         = freegroup_eta (x ++ y ++ z)).
       rhs nrapply ap.
       2: nrapply app_assoc.
@@ -93,7 +93,7 @@ Section Reduction.
     revert y.
     srapply Coeq_ind_hprop.
     intro a.
-    change (freegroup_eta ((c ++ [b] ++ [b^] ++ d) ++ a)
+    change (freegroup_eta ((c ++ [b] ++ [b^'] ++ d) ++ a)
       = freegroup_eta ((c ++ d) ++ a)).
     lhs_V nrapply ap.
     1: nrapply app_assoc.
@@ -144,11 +144,11 @@ Section Reduction.
     1: reflexivity.
     lhs nrapply (ap (fun x => freegroup_eta (x ++ _))).
     1: nrapply reverse_cons.
-    change (freegroup_eta ((word_change_sign x ++ [a^]) ++ [a] ++ x)
+    change (freegroup_eta ((word_change_sign x ++ [a^']) ++ [a] ++ x)
       = mon_unit). 
     lhs_V nrapply ap.
     1: nrapply app_assoc.
-    set (a' := a^).
+    set (a' := a^').
     rewrite <- (change_sign_inv a).
     lhs nrapply freegroup_tau.
     apply IHx.
@@ -163,8 +163,8 @@ Section Reduction.
     apply word_concat_Vw.
   Defined.
 
-  (** Negation is defined by changing the order of a word that appears in eta. Most of the work here is checking that it is agreeable with the path constructor. *)
-  Global Instance negate_freegroup_type : Negate freegroup_type.
+  (** Inverses are defined by changing the order of a word that appears in eta. Most of the work here is checking that it is agreeable with the path constructor. *)
+  Global Instance inverse_freegroup_type : Inverse freegroup_type.
   Proof.
     intro x.
     strip_truncations.
@@ -222,7 +222,7 @@ Section Reduction.
   Defined.
 
   (** Left inverse *)
-  Global Instance leftinverse_freegroup_type : LeftInverse sg_op negate mon_unit.
+  Global Instance leftinverse_freegroup_type : LeftInverse (.*.) (^) mon_unit.
   Proof.
     rapply Trunc_ind.
     srapply Coeq_ind_hprop; intro x.
@@ -230,7 +230,7 @@ Section Reduction.
   Defined.
 
   (** Right inverse *)
-  Global Instance rightinverse_freegroup_type : RightInverse sg_op negate mon_unit.
+  Global Instance rightinverse_freegroup_type : RightInverse (.*.) (^) mon_unit.
   Proof.
     rapply Trunc_ind.
     srapply Coeq_ind_hprop; intro x.
@@ -247,7 +247,7 @@ Section Reduction.
   Proof.
     intros [x|x].
     - exact (s x).
-    - exact (- s x).
+    - exact (s x)^.
   Defined.
 
   (** When we have a list of words we can recursively define a group element. The obvious choice would be to map [nil] to the identity and [x :: xs] to [x * words_rec xs]. This has the disadvantage that a single generating element gets mapped to [x * 1] instead of [x]. To fix this issue, we map [nil] to the identity, the singleton to the element we want, and do the rest recursively. *)
@@ -341,7 +341,7 @@ Section Reduction.
     `{forall x, IsHProp (P x)}
     (H1 : P mon_unit)
     (Hin : forall x, P (freegroup_in x))
-    (Hop : forall x y, P x -> P y -> P (- x * y))
+    (Hop : forall x y, P x -> P y -> P (x^ * y))
     : forall x, P x.
   Proof.
     rapply FreeGroup_ind_hprop'.
@@ -355,7 +355,7 @@ Section Reduction.
         * rewrite <- grp_unit_r.
           by apply Hop.
         * assumption.
-      + change (P (-(freegroup_in a) * freegroup_eta w)).
+      + change (P ((freegroup_in a)^ * freegroup_eta w)).
         by apply Hop.
   Defined.
   

--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -708,8 +708,8 @@ Proof.
     intros w.
     induction w as [|gh].
     1: exact (grp_homo_unit _ @ (grp_homo_unit _)^).
-    change (f (amal_eta [gh] * amal_eta w) = g (amal_eta [gh] * amal_eta w)).
-    nrapply grp_homo_op_agree.
+    (* The goal is definitionally the same as [f (amal_eta [gh] * amal_eta w) = g (amal_eta [gh] * amal_eta w)], but using [change] to put it in that form slows down the next line for some reason. *)
+    nrapply (@grp_homo_op_agree _ _ _ f g (amal_eta [gh]) (amal_eta w) (amal_eta [gh]) (amal_eta w)).
     2: apply IHw.
     destruct gh as [g' | h].
     + exact (p g').

--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -43,8 +43,8 @@ Section FreeProduct.
     destruct x as [|x xs].
     1: exact nil.
     destruct x as [h|k].
-    + exact ((word_inverse xs) ++ [inl (- h)]).
-    + exact ((word_inverse xs) ++ [inr (- k)]).
+    + exact ((word_inverse xs) ++ [inl h^]).
+    + exact ((word_inverse xs) ++ [inr k^]).
   Defined.
 
   (** Inversion changes order of concatenation. *)
@@ -355,7 +355,7 @@ Section FreeProduct.
     exact (amal_eta nil).
   Defined.
 
-  Global Instance negate_amal_type : Negate amal_type.
+  Global Instance inverse_amal_type : Inverse amal_type.
   Proof.
     srapply amal_type_rec.
     { intros w.
@@ -368,7 +368,7 @@ Section FreeProduct.
         apply ap; simpl.
         rapply (ap (fun s => [s])).
         apply ap.
-        apply negate_sg_op. }
+        apply inverse_sg_op. }
       simpl.
       refine (ap amal_eta _^ @ _ @ ap amal_eta _).
       1,3: apply app_assoc.
@@ -381,7 +381,7 @@ Section FreeProduct.
         apply ap; simpl.
         rapply (ap (fun s => [s])).
         apply ap.
-        apply negate_sg_op. }
+        apply inverse_sg_op. }
       simpl.
       refine (ap amal_eta _^ @ _ @ ap amal_eta _).
       1,3: apply app_assoc.
@@ -405,7 +405,7 @@ Section FreeProduct.
       refine (ap amal_eta _^ @ _).
       1: apply app_assoc.
       simpl.
-      rewrite negate_mon_unit.
+      rewrite inverse_mon_unit.
       apply amal_omega_H. }
     { hnf; intros x z.
       refine (ap amal_eta _ @ _ @ ap amal_eta _^).
@@ -416,7 +416,7 @@ Section FreeProduct.
       refine (ap amal_eta _^ @ _).
       1: apply app_assoc.
       simpl.
-      rewrite negate_mon_unit.
+      rewrite inverse_mon_unit.
       apply amal_omega_K. }
   Defined.
 
@@ -471,13 +471,13 @@ Section FreeProduct.
     destruct x as [h|k].
     + cbn.
       rewrite app_assoc.
-      change (amal_eta ([inl h]) * amal_eta ((xs ++ word_inverse xs)) * amal_eta ([inl (- h)]) = mon_unit).
+      change (amal_eta ([inl h]) * amal_eta ((xs ++ word_inverse xs)) * amal_eta ([inl h^]) = mon_unit).
       rewrite IHxs.
       rewrite rightidentity_sgop_amal_type.
       rewrite <- (app_nil (cons _ _)).
-      change (amal_eta (([inl h] ++ [inl (- h)]) ++ nil) = mon_unit).
+      change (amal_eta (([inl h] ++ [inl h^]) ++ nil) = mon_unit).
       rewrite <- app_assoc.
-      change (amal_eta (nil ++ [inl h] ++ [inl (- h)] ++ nil) = mon_unit).
+      change (amal_eta (nil ++ [inl h] ++ [inl h^] ++ nil) = mon_unit).
       refine (amal_mu_H _ _ _ _ @ _).
       refine (_ @ _).
       { apply ap, ap.
@@ -488,13 +488,13 @@ Section FreeProduct.
       apply amal_omega_H.
     +  cbn.
       rewrite app_assoc.
-      change (amal_eta ([inr k]) * amal_eta ((xs ++ word_inverse xs)) * amal_eta ([inr (-k)]) = mon_unit).
+      change (amal_eta ([inr k]) * amal_eta ((xs ++ word_inverse xs)) * amal_eta ([inr k^]) = mon_unit).
       rewrite IHxs.
       rewrite rightidentity_sgop_amal_type.
       rewrite <- (app_nil (cons _ _)).
-      change (amal_eta (([inr k] ++ [inr (- k)]) ++ nil) = mon_unit).
+      change (amal_eta (([inr k] ++ [inr k^]) ++ nil) = mon_unit).
       rewrite <- app_assoc.
-      change (amal_eta (nil ++ [inr k] ++ [inr (- k)] ++ nil) = mon_unit).
+      change (amal_eta (nil ++ [inr k] ++ [inr k^] ++ nil) = mon_unit).
       refine (amal_mu_K _ _ _ _ @ _).
       refine (_ @ _).
       { apply ap, ap.
@@ -505,13 +505,13 @@ Section FreeProduct.
       apply amal_omega_K.
   Defined.
 
-  Global Instance leftinverse_sgop_amal_type : LeftInverse sg_op negate mon_unit.
+  Global Instance leftinverse_sgop_amal_type : LeftInverse (.*.) (^) mon_unit.
   Proof.
     rapply amal_type_ind_hprop; intro x.
     apply amal_eta_word_concat_Vw.
   Defined.
 
-  Global Instance rightinverse_sgop_amal_type : RightInverse sg_op negate mon_unit.
+  Global Instance rightinverse_sgop_amal_type : RightInverse (.*.) (^) mon_unit.
   Proof.
     rapply amal_type_ind_hprop; intro x.
     apply amal_eta_word_concat_wV.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -167,8 +167,8 @@ Definition Build_Group' (G : Type) `{IsHSet G}
 Proof.
   rapply (Build_Group G).
   repeat split.
-  4: rapply right_identity_left_identity.
-  5: rapply right_inverse_left_inverse.
+  4: nrapply right_identity_left_identity; exact _.
+  5: nrapply right_inverse_left_inverse; exact _.
   all: exact _.
 Defined.
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -118,6 +118,60 @@ Proof.
   apply left_identity.
 Defined.
 
+(** With other assumptions, the right inverse law follows from the left inverse law. *)
+Definition right_inverse_left_inverse (G : Type) `{IsHSet G}
+  `(SgOp G, MonUnit G, Inverse G, !Associative (.*.),
+    !LeftIdentity (.*.) mon_unit,
+    !LeftInverse (.*.) (^) mon_unit)
+  : RightInverse (.*.) (^) mon_unit.
+Proof.
+  intros x.
+  lhs_V rapply left_identity.
+  apply (transport (fun x => x * _ = x) (left_inverse x^)).
+  lhs_V rapply simple_associativity.
+  nrapply ap.
+  lhs rapply simple_associativity.
+  lhs nrapply (ap (.* x^)).
+  1: apply left_inverse.
+  apply left_identity.
+Defined.
+Global Opaque right_inverse_left_inverse.
+  
+(** With other assumptions, the right identity law follows from the left identity law. *)
+Definition right_identity_left_identity (G : Type) `{IsHSet G}
+  `(SgOp G, MonUnit G, Inverse G, !Associative (.*.),
+    !LeftIdentity (.*.) mon_unit,
+    !LeftInverse (.*.) (^) mon_unit)
+  : RightIdentity (.*.) mon_unit.
+Proof.
+  intros x.
+  lhs_V rapply left_identity.
+  rhs_V rapply left_identity.
+  apply (transport (fun x => x * _ = x * _) (left_inverse x^)).
+  lhs_V rapply simple_associativity.
+  rhs_V rapply simple_associativity.
+  nrapply ap.
+  lhs rapply simple_associativity.
+  lhs apply (ap (.* mon_unit) (left_inverse x)).
+  lhs apply left_identity.
+  symmetry; apply left_inverse.
+Defined.
+Global Opaque right_identity_left_identity.
+
+(** When building a group we can choose to omit the right inverse law and right identity law, since they follow from the left ones. *)
+Definition Build_Group' (G : Type) `{IsHSet G}
+  `(SgOp G, MonUnit G, Inverse G, !Associative (.*.),
+    !LeftIdentity (.*.) mon_unit,
+    !LeftInverse (.*.) (^) mon_unit)
+  : Group.
+Proof.
+  rapply (Build_Group G).
+  repeat split.
+  4: rapply right_identity_left_identity.
+  5: rapply right_inverse_left_inverse.
+  all: exact _.
+Defined.
+
 (** ** Group homomorphisms *)
 
 (** Group homomorphisms are maps between groups that preserve the group operation. They allow us to compare groups and map their structure to one another. This is useful for determining if two groups are really the same, in which case we say they are "isomorphic". *)

--- a/theories/Algebra/Groups/GroupCoeq.v
+++ b/theories/Algebra/Groups/GroupCoeq.v
@@ -5,9 +5,6 @@ Require Import Algebra.Groups.Group.
 Require Import Colimits.Coeq.
 Require Import Algebra.Groups.FreeProduct.
 
-Local Open Scope mc_scope.
-Local Open Scope mc_mult_scope.
-
 (** Coequalizers of group homomorphisms *)
 
 Definition GroupCoeq {A B : Group} (f g : A $-> B) : Group.

--- a/theories/Algebra/Groups/GrpPullback.v
+++ b/theories/Algebra/Groups/GrpPullback.v
@@ -56,15 +56,14 @@ Section GrpPullback.
 
   Local Instance ismonoid_grp_pullback : IsMonoid (Pullback f g) := {}.
 
-  Local Instance grp_pullback_negate : Negate (Pullback f g).
+  Local Instance grp_pullback_inverse : Inverse (Pullback f g).
   Proof.
     intros [b [c p]].
-    refine (-b; -c; grp_homo_inv f b @ _ @ (grp_homo_inv g c)^).
-    exact (ap (fun a => -a) p).
+    refine (b^; c^; grp_homo_inv f b @ _ @ (grp_homo_inv g c)^).
+    exact (ap (^) p).
   Defined.
 
-  Local Instance grp_pullback_leftinverse
-    : LeftInverse grp_pullback_sgop grp_pullback_negate grp_pullback_mon_unit.
+  Local Instance grp_pullback_leftinverse : LeftInverse (.*.) (^) mon_unit.
   Proof.
     unfold LeftInverse.
     intros [b [c p]].
@@ -75,8 +74,7 @@ Section GrpPullback.
     apply path_ishprop.
   Defined.
 
-  Local Instance grp_pullback_rightinverse
-    : RightInverse grp_pullback_sgop grp_pullback_negate grp_pullback_mon_unit.
+  Local Instance grp_pullback_rightinverse : RightInverse (.*.) (^) mon_unit.
   Proof.
     intros [b [c p]].
     unfold grp_pullback_sgop; simpl.
@@ -201,7 +199,7 @@ Proof.
       2: reflexivity.
       srapply equiv_path_pullback_hset; split; cbn.
       1: reflexivity.
-      exact z1^.
+      symmetry; exact z1.
 Defined.
 
 Section IsEquivGrpPullbackCorec.

--- a/theories/Algebra/Groups/Image.v
+++ b/theories/Algebra/Groups/Image.v
@@ -20,7 +20,7 @@ Proof.
     apply grp_homo_unit.
   - intros x y p q; strip_truncations; apply tr.
     destruct p as [a p], q as [b q].
-    exists (a * -b).
+    exists (a * b^).
     lhs nrapply grp_homo_op; f_ap.
     lhs nrapply grp_homo_inv; f_ap.
 Defined.
@@ -47,7 +47,7 @@ Proof.
     exists (a * b).
     apply grp_homo_op.
   - intros b [a []].
-    exists (-a).
+    exists a^.
     apply grp_homo_inv.
 Defined.
 

--- a/theories/Algebra/Groups/Kernel.v
+++ b/theories/Algebra/Groups/Kernel.v
@@ -7,6 +7,7 @@ Require Import WildCat.Core.
 
 Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
+Local Open Scope path_scope.
 
 Definition grp_kernel {A B : Group} (f : GroupHomomorphism A B) : NormalSubgroup A.
 Proof.
@@ -20,7 +21,7 @@ Proof.
     apply (grp_homo_moveL_1V _ _ _)^-1.
     lhs_V nrapply grp_inv_inv.
     apply (ap (-)).
-    exact ((grp_homo_moveL_1V f x y) p)^.
+    exact (grp_homo_moveL_1V f x y p)^.
 Defined.
 
 (** ** Corecursion principle for group kernels *)

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -8,6 +8,7 @@ Require Import Spaces.Nat.Core.
 (** ** Lagrange's theorem *)
 
 Local Open Scope mc_scope.
+Local Open Scope mc_mult_scope.
 Local Open Scope nat_scope.
 
 Definition subgroup_index {U : Univalence} (G : Group) (H : Subgroup G)
@@ -39,7 +40,7 @@ Proof.
   (** Now we must show that cosets are all equivalent as types. *)
   simpl.
   snrapply equiv_functor_sigma.
-  2: apply (isequiv_group_left_op (-x)).
+  2: apply (isequiv_group_left_op x^).
   1: hnf; trivial.
   exact _.
 Defined.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -39,62 +39,68 @@ Section GroupCongruenceQuotient.
     apply class_of, mon_unit.
   Defined.
 
-  Global Instance congquot_negate : Negate CongruenceQuotient.
+  Global Instance congquot_inverse : Inverse CongruenceQuotient.
   Proof.
     srapply Quotient_rec.
-    1: exact (class_of R o negate).
-    intros x y p; cbn.
-    symmetry.
-    rewrite <- (left_identity (-x)).
-    destruct (left_inverse y).
-    set (-y * y * -x).
-    rewrite <- (right_identity (-y)).
-    destruct (right_inverse x).
-    unfold g; clear g.
-    rewrite <- simple_associativity.
-    apply qglue.
-    apply iscong; try reflexivity.
-    apply iscong; try reflexivity.
-    exact p.
+    1: exact (class_of R o (^)).
+    intros x y p; cbn beta.
+    transitivity (class_of R (y^ * (y * x^))).
+    - rewrite grp_assoc.
+      rewrite grp_inv_l.
+      rewrite grp_unit_l.
+      reflexivity.
+    - transitivity (class_of R (y^ * (x * x^))).
+      + symmetry; apply qglue; repeat apply iscong.
+        1,3: reflexivity.
+        exact p.
+      + rewrite grp_inv_r.
+        rewrite grp_unit_r.
+        reflexivity.
   Defined.
 
   Global Instance congquot_sgop_associative : Associative congquot_sgop.
   Proof.
     srapply Quotient_ind3_hprop; intros x y z.
-    simpl; by rewrite associativity.
-  Qed.
+    snrapply (ap (class_of R)).
+    rapply associativity.
+  Defined.
+  Global Opaque congquot_sgop_associative.
 
   Global Instance issemigroup_congquot : IsSemiGroup CongruenceQuotient := {}.
 
-  Global Instance congquot_leftidentity
-    : LeftIdentity congquot_sgop congquot_mon_unit.
+  Global Instance congquot_leftidentity : LeftIdentity (.*.) mon_unit.
   Proof.
     srapply Quotient_ind_hprop; intro x.
-    by simpl; rewrite left_identity.
-  Qed.
+    snrapply (ap (class_of R)).
+    rapply left_identity.
+  Defined.
+  Global Opaque congquot_leftidentity.
 
-  Global Instance congquot_rightidentity
-    : RightIdentity congquot_sgop congquot_mon_unit.
+  Global Instance congquot_rightidentity : RightIdentity (.*.) mon_unit.
   Proof.
     srapply Quotient_ind_hprop; intro x.
-    by simpl; rewrite right_identity.
-  Qed.
+    snrapply (ap (class_of R)).
+    rapply right_identity.
+  Defined.
+  Global Opaque congquot_rightidentity.
 
   Global Instance ismonoid_quotientgroup : IsMonoid CongruenceQuotient := {}.
 
-  Global Instance quotientgroup_leftinverse
-    : LeftInverse congquot_sgop congquot_negate congquot_mon_unit.
+  Global Instance quotientgroup_leftinverse : LeftInverse (.*.) (^) mon_unit.
   Proof.
-    srapply Quotient_ind_hprop; intro x.
-    by simpl; rewrite left_inverse.
-  Qed.
+    srapply Quotient_ind_hprop; intro x; cbn beta.
+    snrapply (ap (class_of R)).
+    rapply left_inverse.
+  Defined.
+  Global Opaque quotientgroup_leftinverse.
 
-  Global Instance quotientgroup_rightinverse
-    : RightInverse congquot_sgop congquot_negate congquot_mon_unit.
+  Global Instance quotientgroup_rightinverse : RightInverse (.*.) (^) mon_unit.
   Proof.
-    srapply Quotient_ind_hprop; intro x.
-    by simpl; rewrite right_inverse.
-  Qed.
+    srapply Quotient_ind_hprop; intro x; cbn beta.
+    snrapply (ap (class_of R)).
+    rapply right_inverse.
+  Defined.
+  Global Opaque quotientgroup_rightinverse.
 
   Global Instance isgroup_quotientgroup : IsGroup CongruenceQuotient := {}.
 
@@ -253,7 +259,7 @@ Section FirstIso.
     apply qglue; cbn.
     apply (equiv_path_sigma_hprop _ _)^-1%equiv in h; cbn in h.
     cbn. rewrite grp_homo_op, grp_homo_inv, h.
-    srapply negate_l.
+    apply grp_inv_l.
   Defined.
 
   (** First isomorphism theorem for groups *)
@@ -292,9 +298,9 @@ Proof.
     intros [g p].
     rapply contr_inhabited_hprop.
     srefine (tr ((g; _); _)).
-    + rewrite <- grp_unit_l, <- negate_mon_unit.
-      apply (related_quotient_paths (fun x y => N (-x * y))).
-      exact p^.
+    + rewrite <- grp_unit_l, <- inverse_mon_unit.
+      apply (related_quotient_paths (fun x y => N (x^ * y))).
+      exact p^%path.
     + srapply path_sigma_hprop.
       reflexivity.
 Defined.

--- a/theories/Algebra/Groups/ShortExactSequence.v
+++ b/theories/Algebra/Groups/ShortExactSequence.v
@@ -4,10 +4,6 @@ Require Import WildCat.Core Pointed.
 Require Import Groups.Group Groups.Subgroup Groups.Kernel.
 Require Import Homotopy.ExactSequence Modalities.Identity.
 
-Local Open Scope mc_scope.
-Local Open Scope mc_add_scope.
-Local Open Scope path_scope.
-
 (** * Complexes of groups *)
 
 Definition grp_cxfib {A B C : Group} {i : A $-> B} {f : B $-> C} (cx : IsComplex i f)

--- a/theories/Algebra/Monoids/Monoid.v
+++ b/theories/Algebra/Monoids/Monoid.v
@@ -5,9 +5,9 @@ Require Import WildCat.Core WildCat.Induced WildCat.Equiv WildCat.Universe
 Require Import (notations) Classes.interfaces.canonical_names.
 Require Export (hints) Classes.interfaces.abstract_algebra.
 Require Export (hints) Classes.interfaces.canonical_names.
-Require Export Classes.interfaces.canonical_names (SgOp, sg_op, One, one,
+Require Export Classes.interfaces.canonical_names (SgOp, sg_op,
     MonUnit, mon_unit, LeftIdentity, left_identity, RightIdentity, right_identity,
-    Negate, negate, Associative, simple_associativity, associativity,
+    Associative, simple_associativity, associativity,
     LeftInverse, left_inverse, RightInverse, right_inverse, Commutative, commutativity).
 Export canonical_names.BinOpNotations.
 Require Export Classes.interfaces.abstract_algebra (IsSemiGroup(..), sg_set, sg_ass,

--- a/theories/Algebra/Rings/Ideal.v
+++ b/theories/Algebra/Rings/Ideal.v
@@ -2,11 +2,9 @@ Require Import Basics Types.
 Require Import Spaces.Finite.Fin.
 Require Import Classes.interfaces.canonical_names.
 Require Import Algebra.Rings.Ring.
-Require Import Algebra.Groups.Subgroup.
-Require Import Algebra.AbGroups.
+Require Import Algebra.Groups.Subgroup Algebra.Groups.Kernel.
+Require Import Algebra.AbGroups.AbelianGroup.
 Require Import WildCat.Core.
-
-Local Open Scope mc_scope.
 
 Declare Scope ideal_scope.
 Delimit Scope ideal_scope with ideal.
@@ -749,13 +747,15 @@ Proof.
       * exact (y - z).
       * by apply ideal_in_plus_negate.
       * cbn.
-        refine (_ @ ap011 (fun x y => x - y) p q).
-        rewrite <- 2 rng_plus_assoc.
+        rhs_V nrapply (ap011 (fun x y => x - y) p q).
+        lhs_V nrapply rng_plus_assoc.
+        rhs_V nrapply rng_plus_assoc.
         f_ap.
-        rewrite negate_sg_op.
-        rewrite rng_plus_comm.
-        rewrite rng_plus_assoc.
-        reflexivity.
+        rewrite rng_negate_plus.
+        rhs_V nrapply rng_plus_comm.
+        rhs_V nrapply rng_plus_assoc.
+        f_ap.
+        apply commutativity.
   - intro x.
     strip_truncations.
     intros r.

--- a/theories/Algebra/Rings/Localization.v
+++ b/theories/Algebra/Rings/Localization.v
@@ -476,7 +476,7 @@ Section Localization.
     snrapply isinvertible_cring.
     - exact (class_of _ (Build_Fraction 1 x Sx)).
     - apply qglue, fraction_eq_simple.
-      exact (rng_mult_assoc _ _ _)^.
+      exact (ring_mult_assoc_opp _ _ _ _).
   Defined.
   
   (** As a special case, any denominator of a fraction must necessarily be invertible. *)

--- a/theories/Algebra/Rings/Localization.v
+++ b/theories/Algebra/Rings/Localization.v
@@ -355,7 +355,12 @@ Section Localization.
   Definition rng_localization : CRing.
   Proof.
     snrapply Build_CRing'.
-    1: rapply (Build_AbGroup' (Quotient fraction_eq)).
+    (* All of the laws can be found by typeclass search, but it's slightly faster if we fill them in: *)
+    1: exact (Build_AbGroup' (Quotient fraction_eq)
+                commutative_plus_rng_localization
+                associative_plus_rng_localization
+                leftidentity_plus_rng_localization
+                leftinverse_plus_rng_localization).
     all: exact _.
   Defined.
 
@@ -510,7 +515,8 @@ Section Localization.
     (Hmul : forall x y, P x -> P y -> P (x * y))
     : forall x, P x.
   Proof.
-    srapply Quotient_ind.
+    snrapply Quotient_ind.
+    - exact _.
     - intros f.
       refine (transport P (fraction_decompose f)^ _).
       apply Hmul.

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -737,7 +737,7 @@ Global Instance lower_triangular_negate {R : Ring@{i}} {n : nat}
 Proof.
   unfold IsLowerTriangular.
   rewrite matrix_transpose_negate.
-  exact _.
+  by apply upper_triangular_negate.
 Defined.
 
 (** The product of two upper triangular matrices is upper triangular. *)

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -9,8 +9,6 @@ Require Import Modalities.ReflectiveSubuniverse.
 
 Set Universe Minimization ToSet.
 
-Local Open Scope mc_scope.
-
 (** * Matrices *)
 
 (** ** Definition *)
@@ -591,7 +589,7 @@ Proof.
   unfold skip in p.
   destruct (dec (x < n)%nat) as [H|H], (dec (y < n)%nat) as [H'|H'].
   - exact p.
-  - destruct p^.
+  - symmetry in p; destruct p.
     contradiction (H' (leq_trans _ H)).
   - destruct p.
     contradiction (H (leq_trans _ H')).
@@ -1009,7 +1007,7 @@ Proof.
   unfold IsSkewSymmetric.
   rewrite matrix_transpose_plus.
   rhs nrapply (grp_inv_op (G:=abgroup_matrix R n n)).
-  rhs_V nrapply (AbelianGroup.ab_comm (A:=abgroup_matrix R n n)).
+  rhs_V rapply AbelianGroup.abgroup_commutative.
   f_ap.
 Defined.
 

--- a/theories/Algebra/Rings/QuotientRing.v
+++ b/theories/Algebra/Rings/QuotientRing.v
@@ -56,12 +56,12 @@ Section QuotientRing.
     1: exact _.
     (** Associativity follows from the underlying operation *)
     { srapply Quotient_ind3_hprop; intros x y z.
-      unfold sg_op, mult_is_sg_op, mult_quotient_group; simpl.
+      unfold mult, sg_op; simpl.
       apply ap.
       apply associativity. }
     (* Left and right identity follow from the underlying structure *)
     1,2: snrapply Quotient_ind_hprop; [exact _ | intro x].
-    1-2: unfold sg_op, mult_is_sg_op, mult_quotient_group; simpl.
+    1,2: unfold mult, sg_op; simpl.
     1-2: apply ap.
     1: apply left_identity.
     1: apply right_identity.
@@ -69,12 +69,12 @@ Section QuotientRing.
     { srapply Quotient_ind3_hprop; intros x y z.
       unfold sg_op, mult_is_sg_op, mult_quotient_group,
         plus, mult, plus_quotient_group; simpl.
-      apply ap.
+      nrapply ap.
       apply simple_distribute_l. }
     { srapply Quotient_ind3_hprop; intros x y z.
       unfold sg_op, mult_is_sg_op, mult_quotient_group,
         plus, mult, plus_quotient_group; simpl.
-      apply ap.
+      nrapply ap.
       apply simple_distribute_r. }
   Defined.
 

--- a/theories/Algebra/Rings/Ring.v
+++ b/theories/Algebra/Rings/Ring.v
@@ -2,10 +2,14 @@ Require Import WildCat.
 Require Import Spaces.Nat.Core Spaces.Nat.Arithmetic.
 (* Some of the material in abstract_algebra and canonical names could be selectively exported to the user, as is done in Groups/Group.v. *)
 Require Import Classes.interfaces.abstract_algebra.
-Require Import Algebra.Groups.Group Algebra.Groups.Subgroup.
-Require Export Algebra.AbGroups.
+Require Import Algebra.Groups.Group Algebra.Groups.Subgroup Algebra.Groups.Image.
+Require Export Algebra.AbGroups.AbelianGroup Algebra.AbGroups.Biproduct Algebra.AbGroups.FiniteSum.
+
 Require Export Classes.theory.rings.
 Require Import Modalities.ReflectiveSubuniverse.
+
+(** We make sure to treat [AbGroup] as if it has a [Plus], [Zero], and [Negate] operation from now on. *)
+Export AbelianGroup.AdditiveInstances.
 
 (** * Rings *)
 
@@ -91,8 +95,8 @@ Section RingLaws.
   Definition rng_plus_assoc : x + (y + z) = (x + y) + z := simple_associativity x y z.
   Definition rng_mult_assoc : x * (y * z) = (x * y) * z := simple_associativity x y z.
 
-  Definition rng_negate_negate : - (- x) = x := groups.negate_involutive _.
-  Definition rng_negate_zero : - (0 : A) = 0 := groups.negate_mon_unit.
+  Definition rng_negate_negate : - (- x) = x := groups.inverse_involutive _.
+  Definition rng_negate_zero : - (0 : A) = 0 := groups.inverse_mon_unit.
   Definition rng_negate_plus : - (x + y) = - x - y := negate_plus_distr _ _.
 
   Definition rng_mult_one_l : 1 * x = x := left_identity _.
@@ -133,7 +137,7 @@ Section RingHomoLaws.
   Definition rng_homo_negate : f (-x) = -(f x) := preserves_negate x.
 
   Definition rng_homo_minus_one : f (-1) = -1
-    := preserves_negate 1%mc @ ap negate preserves_1.
+    := preserves_negate _ @ ap negate preserves_1.
 
 End RingHomoLaws.
 

--- a/theories/Algebra/Rings/Z.v
+++ b/theories/Algebra/Rings/Z.v
@@ -80,8 +80,8 @@ Proof.
   - rewrite grp_pow_pred.
     rewrite IHx.
     clear IHx.
-    rewrite <- (rng_homo_one g).
-    rewrite <- (rng_homo_negate g).
+    change (-1 + g (-x)%int = g (-x).-1%int).
+    rewrite <- (rng_homo_minus_one g).
     lhs_V nrapply (rng_homo_plus g).
     f_ap.
 Defined.

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -6,9 +6,6 @@ Require Import
   HoTT.Classes.orders.semirings
   HoTT.Classes.theory.apartness.
 
-Local Open Scope nat_scope.
-Local Open Scope mc_scope.
-
 Local Set Universe Minimization ToSet.
 
 (* This should go away one Coq has universe cumulativity through inductives. *)
@@ -18,6 +15,7 @@ Universe N.
 (* It's important that the universe [N] be free.  Occasionally, Coq will choose universe variables in proofs that force [N] to be [Set].  To pinpoint where this happens, you can add the line [Constraint Set < N.] here, and see what fails below. *)
 
 Let natpaths := @paths@{N} nat.
+Arguments natpaths (_ _)%_nat_scope.
 Infix "=N=" := natpaths.
 
 Definition natpaths_symm : Symmetric@{N N} natpaths.
@@ -408,7 +406,7 @@ repeat split.
   destruct E1 as [k1 E1], E2 as [k2 E2].
   assert (k1 + k2 = 0) as E.
   + apply (left_cancellation (+) a).
-    rewrite plus_0_r.
+    rhs rapply plus_0_r.
     path_via (k2 + b).
     rewrite E1.
     rewrite (plus_comm a), (plus_assoc k2), (plus_comm k2).

--- a/theories/Classes/implementations/peano_naturals.v
+++ b/theories/Classes/implementations/peano_naturals.v
@@ -203,8 +203,6 @@ Qed.
 
 (* Add Ring nat: (rings.stdlib_semiring_theory nat). *)
 
-(* Close Scope nat_scope. *)
-
 Lemma O_nat_0 : O =N= 0.
 Proof. reflexivity. Qed.
 

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -7,8 +7,8 @@ Local Set Polymorphic Inductive Cumulativity.
 
 Generalizable Variables A B C f g x y.
 
-(* 
-For various structures we omit declaration of substructures. For example, if we 
+(*
+For various structures we omit declaration of substructures. For example, if we
 say:
 
 Class Setoid_Morphism :=
@@ -21,12 +21,12 @@ then each time a Setoid instance is required, Coq will try to prove that a
 Setoid_Morphism exists. This obviously results in an enormous blow-up of the
 search space. Moreover, one should be careful to declare a Setoid_Morphisms
 as a substructure. Consider [f t1 t2], now if we want to perform setoid rewriting
-in [t2] Coq will first attempt to prove that [f t1] is Proper, for which it will 
+in [t2] Coq will first attempt to prove that [f t1] is Proper, for which it will
 attempt to prove [Setoid_Morphism (f t1)]. If many structures declare
 Setoid_Morphism as a substructure, setoid rewriting will become horribly slow.
 *)
 
-(* An unbundled variant of the former CoRN CSetoid. We do not 
+(* An unbundled variant of the former CoRN CSetoid. We do not
   include a proof that A is a Setoid because it can be derived. *)
 Class IsApart A {Aap : Apart A} : Type :=
   { apart_set : IsHSet A
@@ -61,7 +61,7 @@ End setoid_morphisms.
 Hint Extern 4 (?f _ = ?f _) => eapply (ap f) : core.
 
 Section setoid_binary_morphisms.
-  Context {A B C} {Aap: Apart A} 
+  Context {A B C} {Aap: Apart A}
     {Bap : Apart B} {Cap : Apart C} (f : A -> B -> C).
 
   Class StrongBinaryExtensionality := strong_binary_extensionality
@@ -69,7 +69,7 @@ Section setoid_binary_morphisms.
 End setoid_binary_morphisms.
 
 (*
-Since apartness usually only becomes relevant when considering fields (e.g. the 
+Since apartness usually only becomes relevant when considering fields (e.g. the
 real numbers), we do not include it in the lower part of the algebraic hierarchy
 (as opposed to CoRN).
 *)
@@ -167,7 +167,7 @@ Section upper_classes.
     lhs rapply distribute_l.
     f_ap; apply commutativity.
   Defined.
-  
+
   Class IsIntegralDomain :=
     { intdom_ring : IsCRing
     ; intdom_nontrivial : PropHolds (not (1 = 0))
@@ -190,7 +190,7 @@ Section upper_classes.
     field_mult_ext.
 
   (* We let /0 = 0 so properties as Injective (/),
-    f (/x) = / (f x), / /x = x, /x * /y = /(x * y) 
+    f (/x) = / (f x), / /x = x, /x * /y = /(x * y)
     hold without any additional assumptions *)
   Class IsDecField {Adec_recip : DecRecip A} :=
     { decfield_ring : IsCRing
@@ -219,11 +219,11 @@ Hint Extern 5 (PropHolds (1 ≶ 0)) =>
 Hint Extern 5 (PropHolds (1 <> 0)) =>
   eapply @decfield_nontrivial : typeclass_instances.
 
-(* 
+(*
 For a strange reason IsCRing instances of Integers are sometimes obtained by
 Integers -> IntegralDomain -> Ring and sometimes directly. Making this an
 instance with a low priority instead of using intdom_ring:> IsCRing forces Coq to
-take the right way 
+take the right way
 *)
 #[export]
 Hint Extern 10 (IsCRing _) => apply @intdom_ring : typeclass_instances.
@@ -236,10 +236,10 @@ Arguments dec_recip_0 {A Aplus Amult Azero Aone Anegate Adec_recip IsDecField}.
 Section lattice.
   Context A {Ajoin: Join A} {Ameet: Meet A} {Abottom : Bottom A} {Atop : Top A}.
 
-  Class IsJoinSemiLattice := 
+  Class IsJoinSemiLattice :=
     join_semilattice : @IsSemiLattice A join_is_sg_op.
   #[export] Existing Instance join_semilattice.
-  Class IsBoundedJoinSemiLattice := 
+  Class IsBoundedJoinSemiLattice :=
     bounded_join_semilattice : @IsBoundedSemiLattice A
       join_is_sg_op bottom_is_mon_unit.
   #[export] Existing Instance bounded_join_semilattice.
@@ -252,15 +252,15 @@ Section lattice.
   #[export] Existing Instance bounded_meet_semilattice.
 
 
-  Class IsLattice := 
+  Class IsLattice :=
     { lattice_join : IsJoinSemiLattice
     ; lattice_meet : IsMeetSemiLattice
-    ; join_meet_absorption : Absorption (⊔) (⊓) 
+    ; join_meet_absorption : Absorption (⊔) (⊓)
     ; meet_join_absorption : Absorption (⊓) (⊔) }.
   #[export] Existing Instances
     lattice_join
     lattice_meet
-    join_meet_absorption 
+    join_meet_absorption
     meet_join_absorption.
 
   Class IsBoundedLattice :=
@@ -273,9 +273,9 @@ Section lattice.
     boundedlattice_meet
     boundedjoin_meet_absorption
     boundedmeet_join_absorption.
-  
 
-  Class IsDistributiveLattice := 
+
+  Class IsDistributiveLattice :=
     { distr_lattice_lattice : IsLattice
     ; join_meet_distr_l : LeftDistribute (⊔) (⊓) }.
   #[export] Existing Instances distr_lattice_lattice join_meet_distr_l.
@@ -452,7 +452,7 @@ Hint Extern 4 (IsMonoidPreserving (_^-1)) =>
 Instance isinjective_mapinO_tr {A B : Type} (f : A -> B)
   {p : MapIn (Tr (-1)) f} : IsInjective f
   := fun x y pfeq => ap pr1 (@center _ (p (f y) (x; pfeq) (y; idpath))).
-  
+
 Section strong_injective.
   Context {A B} {Aap : Apart A} {Bap : Apart B} (f : A -> B) .
   Class IsStrongInjective :=

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -116,6 +116,8 @@ Hint Extern 4 (Apart (NonNeg _)) => apply @sig_apart : typeclass_instances.
 #[export]
 Hint Extern 4 (Apart (Pos _)) => apply @sig_apart : typeclass_instances.
 
+(** For more information on using [mc_add_scope] and [mc_mult_scope], see the files test/Algebra/Groups/Expressions.v and test/Algebra/Rings/Expressions.v. *)
+
 Module AdditiveNotations.
 
   (** [mc_add_scope] is generally used when working with abelian groups. *)

--- a/theories/Classes/interfaces/naturals.v
+++ b/theories/Classes/interfaces/naturals.v
@@ -19,8 +19,8 @@ Class Naturals A {Aap:Apart A} {Aplus Amult Azero Aone Ale Alt}
 
 (* Specializable operations: *)
 Class NatDistance N `{Plus N}
-  := nat_distance_sig : forall x y : N, { z : N | (x + z = y)%mc } |_|
-                                   { z : N | (y + z = x)%mc }.
+  := nat_distance_sig : forall x y : N, { z : N | x + z = y } |_|
+                                   { z : N | y + z = x }.
 Definition nat_distance {N} `{nd : NatDistance N} (x y : N) :=
   match nat_distance_sig x y with
   | inl (n;_) => n

--- a/theories/Classes/orders/integers.v
+++ b/theories/Classes/orders/integers.v
@@ -36,7 +36,7 @@ destruct (int_abs_sig Z nat n) as [[a A]|[a A]].
     apply Psuc1.
     * apply to_semiring_nonneg.
     * trivial.
-- rewrite <-(groups.negate_involutive n), <-A.
+- rewrite <-(negate_involutive n), <-A.
   clear A. revert a. apply naturals.induction.
   + rewrite rings.preserves_0, rings.negate_0. trivial.
   + intros m E.

--- a/theories/Classes/orders/nat_int.v
+++ b/theories/Classes/orders/nat_int.v
@@ -41,8 +41,8 @@ Context `{Naturals N} `{Apart N} `{Le N} `{Lt N} `{!FullPseudoSemiRingOrder le l
 
 (* Add Ring R : (stdlib_semiring_theory R). *)
 
-Lemma nat_int_to_semiring : forall x : R, exists z, x = naturals_to_semiring N R z |_|
-  (x + naturals_to_semiring N R z)%mc = 0.
+Lemma nat_int_to_semiring : forall x : R, exists z,
+  x = naturals_to_semiring N R z |_| x + naturals_to_semiring N R z = 0.
 Proof.
 apply biinduction.
 - exists 0.

--- a/theories/Classes/theory/groups.v
+++ b/theories/Classes/theory/groups.v
@@ -8,31 +8,31 @@ Section group_props.
   Context `{IsGroup G}.
 
   (** Group inverses are involutive *)
-  Global Instance negate_involutive : Involutive (-).
+  Global Instance inverse_involutive : Involutive (^).
   Proof.
     intros x.
     transitivity (mon_unit * x).
     2: apply left_identity.
-    transitivity ((- - x * - x) * x).
+    transitivity ((x^^ *  x^) * x).
     2: apply (@ap _ _ (fun y => y * x)),
           left_inverse.
-    transitivity (- - x * (- x * x)).
+    transitivity (x^^ * (x^ * x)).
     2: apply associativity.
-    transitivity (- - x * mon_unit).
+    transitivity (x^^ * mon_unit).
     2: apply ap, symmetry, left_inverse.
     apply symmetry, right_identity.
   Qed.
 
-  Global Instance isinj_group_negate : IsInjective (-).
+  Global Instance isinj_group_inverse : IsInjective (^).
   Proof.
     intros x y E.
     refine ((involutive x)^ @ _ @ involutive y).
     apply ap, E.
   Qed.
 
-  Lemma negate_mon_unit : - mon_unit = mon_unit.
+  Lemma inverse_mon_unit : mon_unit^ = mon_unit.
   Proof.
-    change ((fun x => - mon_unit = x) mon_unit).
+    change ((fun x => mon_unit^ = x) mon_unit).
     apply (transport _ (left_inverse mon_unit)).
     apply symmetry, right_identity.
   Qed.
@@ -61,7 +61,7 @@ Section group_props.
     reflexivity.
   Qed.
 
-  Lemma negate_sg_op x y : - (x * y) = -y * -x.
+  Lemma inverse_sg_op x y : (x * y)^ = y^ * x^.
   Proof.
     rewrite <- (left_identity (-y * -x)).
     rewrite <- (left_inverse (unit:=mon_unit) (x * y)).
@@ -77,21 +77,23 @@ Section group_props.
 End group_props.
 
 Section abgroup_props.
+  Local Open Scope mc_add_scope.
 
-  Lemma negate_sg_op_distr `{IsAbGroup G} x y : -(x * y) = -x * -y.
+  Lemma negate_sg_op_distr `{IsAbGroup G} x y : -(x + y) = -x + -y.
   Proof.
-    path_via (-y * -x).
-    - apply negate_sg_op.
+    path_via (-y + -x).
+    - rapply inverse_sg_op.
     - apply commutativity.
   Qed.
 
+  Local Close Scope mc_add_scope.
 End abgroup_props.
 
 Section groupmor_props.
 
   Context `{IsGroup A} `{IsGroup B} {f : A -> B} `{!IsMonoidPreserving f}.
 
-  Lemma preserves_negate x : f (-x) = -f x.
+  Lemma preserves_inverse x : f x^ = (f x)^.
   Proof.
     apply (left_cancellation (.*.) (f x)).
     rewrite <-preserves_sg_op.
@@ -189,41 +191,43 @@ End from_another_com_monoid.
 Section from_another_group.
 
   Context
-    `{IsGroup A} `{IsHSet B}
-    `{Bop : SgOp B} `{Bunit : MonUnit B} `{Bnegate : Negate B}
+    `{isg : IsGroup A} `{IsHSet B}
+    `{Bop : SgOp B} `{Bunit : MonUnit B} `{Binv : Inverse B}
     (f : B -> A) `{!IsInjective f}
     (op_correct : forall x y, f (x * y) = f x * f y)
     (unit_correct : f mon_unit = mon_unit)
-    (negate_correct : forall x, f (-x) = -f x).
+    (inverse_correct : forall x, f x^ = (f x)^).
 
   Lemma projected_group : IsGroup B.
   Proof.
     split.
     - apply (projected_monoid f);assumption.
     - repeat intro; apply (injective f).
-      rewrite op_correct, negate_correct, unit_correct, left_inverse.
+      rewrite op_correct, inverse_correct, unit_correct, left_inverse.
       apply reflexivity.
     - repeat intro; apply (injective f).
-      rewrite op_correct, negate_correct, unit_correct, right_inverse.
+      rewrite op_correct, inverse_correct, unit_correct, right_inverse.
       reflexivity.
   Qed.
 
 End from_another_group.
 
 Section from_another_ab_group.
+  Local Open Scope mc_add_scope.
 
   Context `{IsAbGroup A} `{IsHSet B}
    `{Bop : SgOp B} `{Bunit : MonUnit B} `{Bnegate : Negate B}
    (f : B -> A) `{!IsInjective f}
-   (op_correct : forall x y, f (x * y) = f x * f y)
-   (unit_correct : f mon_unit = mon_unit)
+   (op_correct : forall x y, f (x + y) = f x + f y)
+   (unit_correct : f 0 = 0)
    (negate_correct : forall x, f (-x) = -f x).
 
   Lemma projected_ab_group : IsAbGroup B.
   Proof.
     split.
-    - apply (projected_group f);assumption.
-    - apply (projected_comm f);assumption.
+    - apply (projected_group f (isg:=abgroup_group _)); assumption.
+    - apply (projected_comm f); assumption.
   Qed.
 
+  Local Close Scope mc_add_scope.
 End from_another_ab_group.

--- a/theories/Classes/theory/integers.v
+++ b/theories/Classes/theory/integers.v
@@ -153,7 +153,7 @@ as [[n E]|[n E]];[left|right];exists n.
 - apply (injective (integers_to_ring Z (NatPair.Z N))).
   rewrite <-E. apply (naturals.to_semiring_twice _ _ _).
 - apply (injective (integers_to_ring Z (NatPair.Z N))).
-  rewrite rings.preserves_negate, <-E.
+  rewrite preserves_negate, <-E.
   apply (naturals.to_semiring_twice _ _ _).
 Qed.
 

--- a/theories/Classes/theory/naturals.v
+++ b/theories/Classes/theory/naturals.v
@@ -137,10 +137,10 @@ Section borrowed_from_nat.
   exact nat_induction.
   Qed.
 
-  Lemma case : forall x : N, x = 0 |_| exists y : N, (x = 1 + y)%mc.
+  Lemma case : forall x : N, x = 0 |_| exists y : N, (x = 1 + y).
   Proof.
   refine (from_nat_stmt nat
-    (fun s => forall x : s, x = 0 |_| exists y : s, (x = 1 + y)%mc) _).
+    (fun s => forall x : s, x = 0 |_| exists y : s, x = 1 + y) _).
   simpl. intros [|x];eauto.
   Qed.
 

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -225,7 +225,7 @@ Proof.
 split.
 - apply _.
 - intros e f;apply tr; exists (e/2), (e/2);split.
-  + apply pos_split2.
+  + apply (pos_split2 e).
   + intros x;reflexivity.
 - intros e f g;apply (Trunc_ind _);intros [d [d' [E1 E2]]].
   apply tr;exists d, d';split;trivial.

--- a/theories/Classes/theory/rings.v
+++ b/theories/Classes/theory/rings.v
@@ -47,7 +47,7 @@ End cancellation.
 Section strong_cancellation.
   Context `{IsApart A} (op : A -> A -> A).
 
-  Lemma strong_right_cancel_from_left `{!Commutative op} 
+  Lemma strong_right_cancel_from_left `{!Commutative op}
     `{!StrongLeftCancellation op z}
     : StrongRightCancellation op z.
   Proof.
@@ -191,7 +191,7 @@ Qed.
 *)
 Section cring_props.
   Context `{IsCRing R}.
-  
+
   Instance: LeftAbsorb (.*.) 0.
   Proof.
   intro.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -9,9 +9,8 @@ Require Import Homotopy.HomotopyGroup.
 Require Import Homotopy.WhiteheadsPrinciple.
 
 Local Open Scope pointed_scope.
-Local Open Scope mc_scope.
-Local Open Scope trunc_scope.
 Local Open Scope mc_mult_scope.
+Local Open Scope path_scope.
 
 (** * We define the Classifying space of a group to be the following HIT:
 
@@ -42,6 +41,8 @@ Module Export ClassifyingSpace.
     Proof. Admitted.
 
   End ClassifyingSpace.
+  
+  Arguments bloop {G} _%_mc_mult_scope.
 
   (** Now we can state the expected dependent elimination principle, and derive other versions of the elimination principle from it. *)
   Section ClassifyingSpace_ind.
@@ -121,7 +122,7 @@ Section Eliminators.
   Proof.
     refine (ClassifyingSpace_ind P bbase' bloop' _).
     intros.
-    apply ds_G1. 
+    apply ds_G1.
     apply path_ishprop.
   Defined.
 
@@ -176,9 +177,8 @@ Proof.
 Defined.
 
 (** [bloop] "preserves inverses" by taking inverses in [G] to inverses of paths in [BG]. *)
-Definition bloop_inv {G : Group} : forall x : G, bloop (-x) = (bloop x)^.
+Definition bloop_inv {G : Group} (x : G) : bloop x^ = (bloop x)^.
 Proof.
-  intro x.
   refine (_ @ concat_p1 _).
   apply moveL_Vp.
   refine (_ @ bloop_id).
@@ -421,7 +421,7 @@ Proof.
   nrapply pClassifyingSpace_rec_beta_bloop.
 Defined.
 
-Lemma pbloop_natural (G K : Group) (f : G $-> K) 
+Lemma pbloop_natural (G K : Group) (f : G $-> K)
   : fmap loops (fmap B f) o* pbloop ==* pbloop o* f.
 Proof.
   srapply phomotopy_homotopy_hset.

--- a/theories/Homotopy/HSpace/Core.v
+++ b/theories/Homotopy/HSpace/Core.v
@@ -9,6 +9,7 @@ Require Import Truncations.Core Truncations.Connectedness.
 Local Open Scope pointed_scope.
 Local Open Scope trunc_scope.
 Local Open Scope mc_mult_scope.
+Local Open Scope path_scope.
 
 (** * H-spaces *)
 

--- a/theories/Homotopy/HSpace/Moduli.v
+++ b/theories/Homotopy/HSpace/Moduli.v
@@ -3,6 +3,7 @@ Require Import Basics Types HSpace.Core HSpace.Coherent HSpace.Pointwise
 
 Local Open Scope pointed_scope.
 Local Open Scope mc_mult_scope.
+Local Open Scope path_scope.
 
 (** * The moduli type of coherent H-space structures *)
 

--- a/theories/Homotopy/HSpace/Pointwise.v
+++ b/theories/Homotopy/HSpace/Pointwise.v
@@ -2,6 +2,7 @@ Require Import Basics Types Pointed HSpace.Core HSpace.Coherent.
 
 Local Open Scope pointed_scope.
 Local Open Scope mc_mult_scope.
+Local Open Scope path_scope.
 
 (** * Pointwise H-space structures *)
 

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -107,11 +107,9 @@ Global Instance ishset_pi {n : nat} {X : pType}
   := ltac:(destruct n; exact _).
 
 (** When n >= 2 we have that the nth homotopy group is an abelian group. Note that we don't actually define it as an abelian group but merely show that it is one. This would cause lots of complications with the typechecker. *)
-Global Instance isabgroup_pi (n : nat) (X : pType)
-  : IsAbGroup (Pi n.+2 X).
+Global Instance commutative_pi (n : nat) (X : pType)
+  : Commutative (A:=Pi n.+2 X) sg_op.
 Proof.
-  nrapply Build_IsAbGroup.
-  1: exact _.
   intros x y.
   strip_truncations.
   cbn; apply (ap tr).


### PR DESCRIPTION
We introduce a set of improvements to the mathclasses library. The main one being that `^` is now the notation of group inverses. Doing so required lots of tweaking of hints throughout the library and I took the time to fix some obviously wrong things as I encountered them, including rewriting various proofs.

Generally the new `x^` notation works well around `p^` for a path, but sometimes Coq has difficulty guessing which is which. Luckily you can disambiguate with scopes such as `%mc` or `%path`.

The reason why I chose `^-1` over `^` is because the former is quite verbosee, especially in algebraic expressions. Compare `x^-1 * y^-1` with `x^ * y^`. Unfortunately we cannot overload the juxtaposition "notation" for function application, so this is probably the most compact we will be able to do.

The entire typeclasses library has a large "butterfly effect" where you make a small tweak to something early on, and everything following it breaks in strange ways. It took a while to be able to patch all of these issues, but the end result is that we have a nice notation for multiplicative inverses.

Unfortunately, I don't think it will be easy to share the `^` notation literally with paths, since paths are a type family. It would have also been nice to adapt the notation to work for invertible ring elements, but the invertability proof gets in the way. The group of units of a ring should have no such issue however.

This issue was brought up a while back in:
- fixes #1156