### PR TITLE
forall y, Decidable (x = y) is an hprop

### DIFF
--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -96,6 +96,22 @@ Proof.
   - exact not_not_unit.
 Defined.
 
+Definition stable_iff {A B} (f : A <-> B)
+  : Stable A -> Stable B.
+Proof.
+  intros stableA nnb.
+  destruct f as [f finv].
+  exact (f (stableA (fun na => nnb (fun b => na (finv b))))).
+Defined.
+
+Definition stable_equiv' {A B} (f : A <~> B)
+  : Stable A -> Stable B
+  := stable_iff f.
+
+Definition stable_equiv {A B} (f : A -> B) `{!IsEquiv f}
+  : Stable A -> Stable B
+  := stable_equiv' (Build_Equiv _ _ f _).
+
 (**
   Because [vm_compute] evaluates terms in [PROP] eagerly
   and does not remove dead code we

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -72,6 +72,10 @@ Global Existing Instance dec_paths.
 
 Class Stable P := stable : ~~P -> P.
 
+(** We always have a map in the other direction. *)
+Definition not_not_unit {P : Type} : P -> ~~P
+  := fun x np => np x.
+
 Global Instance stable_decidable P `{!Decidable P} : Stable P.
 Proof.
   intros dn;destruct (dec P) as [p|n].
@@ -82,14 +86,14 @@ Qed.
 Global Instance stable_negation P : Stable (~ P).
 Proof.
   intros nnnp p.
-  exact (nnnp (fun np => np p)).
+  exact (nnnp (not_not_unit p)).
 Defined.
 
 Definition iff_stable P `(Stable P) : ~~P <-> P.
 Proof.
   split.
   - apply stable.
-  - exact (fun x f => f x).
+  - exact not_not_unit.
 Defined.
 
 (**

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -76,12 +76,15 @@ Class Stable P := stable : ~~P -> P.
 Definition not_not_unit {P : Type} : P -> ~~P
   := fun x np => np x.
 
-Global Instance stable_decidable P `{!Decidable P} : Stable P.
+Global Instance ishprop_stable_hprop `{Funext} P `{IsHProp P} : IsHProp (Stable P)
+  := istrunc_forall.
+
+Global Instance stable_decidable P `{Decidable P} : Stable P.
 Proof.
-  intros dn;destruct (dec P) as [p|n].
-  - assumption.
-  - apply Empty_rect,dn,n.
-Qed.
+  intros dn.
+  (* [dec P] either solves the goal or contradicts [dn]. *)
+  by destruct (dec P).
+Defined.
 
 Global Instance stable_negation P : Stable (~ P).
 Proof.

--- a/theories/Metatheory/TruncImpliesFunext.v
+++ b/theories/Metatheory/TruncImpliesFunext.v
@@ -3,7 +3,7 @@
 Require Import HoTT.Basics HoTT.Truncations HoTT.Types.Bool.
 Require Import Metatheory.Core Metatheory.FunextVarieties Metatheory.ImpredicativeTruncation.
 
-(** ** An approach using the truncations defined as HITs *)
+(** Assuming that we have a propositional truncation operation with a definitional computation rule, we can prove function extensionality.  Since we can't assume we have a definitional computation rule, we work with the propositional truncation defined as a HIT, which does have a definitional computation rule. *)
 
 (** We can construct an interval type as [Trunc -1 Bool]. *)
 Local Definition interval := Trunc (-1) Bool.
@@ -11,7 +11,7 @@ Local Definition interval := Trunc (-1) Bool.
 Local Definition interval_rec (P : Type) (a b : P) (p : a = b)
   : interval -> P.
 Proof.
-  (** We define this map by factoring it through the type [{ x : P & x = b}], which is a proposition since it is contractible. *)
+  (* We define this map by factoring it through the type [{ x : P & x = b}], which is a proposition since it is contractible. *)
   refine ((pr1 : { x : P & x = b } -> P) o _).
   apply Trunc_rec.
   intros [].
@@ -22,7 +22,7 @@ Defined.
 Local Definition seg : tr true = tr false :> interval
   := path_ishprop _ _.
 
-(** From an interval type, and thus from truncations, we can prove function extensionality. *)
+(** From an interval type, and thus from truncations, we can prove function extensionality. See IntervalImpliesFunext.v for an approach that works with an interval defined as a HIT. *)
 Definition funext_type_from_trunc : Funext_type
   := WeakFunext_implies_Funext (NaiveFunext_implies_WeakFunext
     (fun A P f g p =>
@@ -30,7 +30,7 @@ Definition funext_type_from_trunc : Funext_type
         interval_rec _ (f a) (g a) (p a) x
         in ap h seg)).
 
-(** ** An approach without using HITs *)
+(** ** Function extensionality implies an interval type *)
 
 (** Assuming [Funext] (and not propositional resizing), the construction [Trm] in ImpredicativeTruncation.v applied to [Bool] gives an interval type with definitional computation on the end points.  So we see that function extensionality is equivalent to the existence of an interval type. *)
 

--- a/theories/Modalities/Notnot.v
+++ b/theories/Modalities/Notnot.v
@@ -3,24 +3,22 @@ Require Import Modality.
 
 Local Open Scope path_scope.
 
-
 (** * The double negation modality *)
 
-(** This is Exercise 7.12 in the book.  Note that it is (apparently) *not* accessible unless we assume propositional resizing. *)
-
+(** The operation sending [X] to [~~X] is a modality.  This is Exercise 7.12 in the book.  Note that it is (apparently) *not* accessible unless we assume propositional resizing. *)
 Definition NotNot `{Funext} : Modality.
 Proof.
   snrapply easy_modality.
-  - intros X; exact (~ (~ X)).
-  - intros T x nx; exact (nx x).
-  - intros A B f z nBz.
+  - intros X; exact (~~X).
+  - exact @not_not_unit.
+  - cbn beta; intros A B f z nBz.
     apply z; intros a.
     exact (f a (transport (fun x => ~ (B x))
                           (path_ishprop _ _)
                           nBz)).
-  - intros A B f a.
+  - cbn beta; intros A B f a.
     apply path_ishprop.
-  - intros A z z'.
+  - cbn beta; intros A z z'.
     refine (isequiv_iff_hprop _ _).
     intros; apply path_ishprop.
 Defined.

--- a/theories/Modalities/Notnot.v
+++ b/theories/Modalities/Notnot.v
@@ -25,5 +25,5 @@ Defined.
 
 (** By definition, the local types for this modality are the types such that [not_not_unit : P -> ~~P] is an equivalence.  These are exactly the stable propositions, i.e. those propositions [P] such that [~~P -> P]. *)
 Definition inO_notnot `{Funext} (P : Type)
-  : In NotNot P <-> (Stable P * IsHProp P)
-  := stable_hprop_iff_isequiv_not_not_unit P.
+  : In NotNot P <~> (Stable P * IsHProp P)
+  := equiv_isequiv_not_not_unit_stable_hprop P.

--- a/theories/Modalities/Notnot.v
+++ b/theories/Modalities/Notnot.v
@@ -1,4 +1,4 @@
-Require Import HoTT.Basics HoTT.Types.
+Require Import HoTT.Basics HoTT.Types Universes.HProp.
 Require Import Modality.
 
 Local Open Scope path_scope.
@@ -22,3 +22,8 @@ Proof.
     refine (isequiv_iff_hprop _ _).
     intros; apply path_ishprop.
 Defined.
+
+(** By definition, the local types for this modality are the types such that [not_not_unit : P -> ~~P] is an equivalence.  These are exactly the stable propositions, i.e. those propositions [P] such that [~~P -> P]. *)
+Definition inO_notnot `{Funext} (P : Type)
+  : In NotNot P <-> (Stable P * IsHProp P)
+  := stable_hprop_iff_isequiv_not_not_unit P.

--- a/theories/Universes/HProp.v
+++ b/theories/Universes/HProp.v
@@ -145,7 +145,18 @@ Proof.
   - exact (inr (if_not_hprop_then_equiv_Empty hprop nx)).
 Defined.
 
-(** Recall that a type [A] is "stable" if [~~A -> A].  Under function extensionality, if [A] is stable, then [~~A] is the propositional truncation of [A]. Here, for dependency reasons, we don't give the equivalence to [Tr (-1) A], but just show that the recursion principle holds. See Metatheory/ImpredicativeTruncation.v for a generalization to all types, and Modalities/Notnot.v for a description of the universal property of [~~A] when [A] is not assumed to be stable. *)
+(** ** Stable types and stable hprops *)
+
+(** Recall that a type [A] is "stable" if [~~A -> A]. *)
+
+(** When [A] is an hprop, so is [Stable A] (by [ishprop_stable_hprop]), so [Stable A * IsHProp A] is an hprop for any [A]. *)
+Global Instance ishprop_stable_ishprop `{Funext} (A : Type) : IsHProp (Stable A * IsHProp A).
+Proof.
+  apply hprop_allpath; intros [st1 hp1] [st2 hp2].
+  apply path_ishprop.
+Defined.
+
+(** Under function extensionality, if [A] is a stable type, then [~~A] is the propositional truncation of [A]. Here, for dependency reasons, we don't give the equivalence to [Tr (-1) A], but just show that the recursion principle holds. See Metatheory/ImpredicativeTruncation.v for a generalization to all types, and Modalities/Notnot.v for a description of the universal property of [~~A] when [A] is not assumed to be stable. *)
 
 (** Any negation is an hprop, by [istrunc_Empty] and [istrunc_arrow]. In particular, double-negation is an hprop. *)
 Definition ishprop_not_not `{Funext} {A : Type} : IsHProp (~~A) := _.
@@ -164,7 +175,7 @@ Definition not_not_rec_beta {A : Type} `{Stable A} (P : HProp) (f : A -> P) (a :
   := path_ishprop _ _.
 
 (** The map [A -> ~~A] is an equivalence if and only if [A] is a stable hprop.  This characterizes the local types for the double-negation modality.  See Modality/Notnot.v. *)
-Definition stable_hprop_iff_isequiv_not_not_unit `{Funext} A
+Definition isequiv_not_not_unit_iff_stable_hprop `{Funext} A
   : IsEquiv (@not_not_unit A) <-> (Stable A * IsHProp A).
 Proof.
   split.
@@ -175,6 +186,13 @@ Proof.
     rapply isequiv_iff_hprop.
     apply stable.
 Defined.
+
+(** We can upgrade the previous "iff" result to an equivalence. *)
+Definition equiv_isequiv_not_not_unit_stable_hprop `{Funext} (P : Type)
+  : IsEquiv (@not_not_unit P) <~> (Stable P * IsHProp P)
+  := equiv_iff_hprop_uncurried (isequiv_not_not_unit_iff_stable_hprop P).
+
+(** ** A generalization of [ishprop_decpaths] *)
 
 (** Under [Funext], [ishprop_decpaths] shows that [DecidablePaths A] is an hprop.  More generally, it's also an hprop with the first argument fixed. *)
 Global Instance ishprop_decpaths' `{Funext} {A : Type} (x : A)

--- a/theories/Universes/HProp.v
+++ b/theories/Universes/HProp.v
@@ -145,23 +145,21 @@ Proof.
   - exact (inr (if_not_hprop_then_equiv_Empty hprop nx)).
 Defined.
 
-(** Under function extensionality, if [A] is decidable, then [~~A] is the propositional truncation of [A]. Here, for dependency reasons, we don't give the equivalence to [Tr (-1) A], but just show that the recursion principle holds. See ../Metatheory/ImpredicativeTruncation.v for a generalization to all types. *)
+(** Recall that a type [A] is "stable" if [~~A -> A].  Under function extensionality, if [A] is stable, then [~~A] is the propositional truncation of [A]. Here, for dependency reasons, we don't give the equivalence to [Tr (-1) A], but just show that the recursion principle holds. See Metatheory/ImpredicativeTruncation.v for a generalization to all types, and Modalities/Notnot.v for a description of the universal property of [~~A] when [A] is not assumed to be stable. *)
 
 (** Any negation is an hprop, by [istrunc_Empty] and [istrunc_arrow]. In particular, double-negation is an hprop. *)
 Definition ishprop_not_not `{Funext} {A : Type} : IsHProp (~~A) := _.
 
-(** The recursion principle for [~~A]. *)
-Definition not_not_rec {A : Type} `{Decidable A} (P : HProp) (f : A -> P)
+(** The recursion principle for [~~A] when [A] is stable. *)
+Definition not_not_rec {A : Type} `{stable : Stable A} (P : HProp) (f : A -> P)
   : ~~A -> P.
 Proof.
   intro nna.
-  destruct (dec A) as [a | na].
-  - exact (f a).
-  - elim (nna na).
+  exact (f (stable nna)).
 Defined.
 
-(** The computation rule only holds propositionally. *)
-Definition not_not_rec_beta {A : Type} `{Decidable A} (P : HProp) (f : A -> P) (a : A)
+(** The unit is [not_not_unit : A -> ~~A], and the computation rule only holds propositionally. *)
+Definition not_not_rec_beta {A : Type} `{Stable A} (P : HProp) (f : A -> P) (a : A)
   : not_not_rec P f (not_not_unit a) = f a
   := path_ishprop _ _.
 
@@ -170,7 +168,7 @@ Global Instance ishprop_decpaths' `{Funext} {A : Type} (x : A)
   : IsHProp (forall (y : A), Decidable (x = y)).
 Proof.
   apply hprop_allpath; intros d d'.
-  (* Define [C] to be the component of [A] containing [x]. Since [x = y] is decidable, we can use [~~(x = y)] as an elementary form of propositional truncation. It also works to use [merely] here, but that brings in further dependencies and requires HITs. *)
+  (* Define [C] to be the component of [A] containing [x]. Since [x = y] is decidable, it is stable, so we can use [~~(x = y)] as an elementary form of propositional truncation. It also works to use [merely] here, but that brings in further dependencies and requires HITs. *)
   pose (C := {y : A & ~~(x = y)}).
   assert (cC : Contr C).
   { snrapply (Build_Contr C (x; not_not_unit idpath)).

--- a/theories/Universes/HProp.v
+++ b/theories/Universes/HProp.v
@@ -143,3 +143,26 @@ Proof.
   - exact (inl (if_hprop_then_equiv_Unit hprop x)).
   - exact (inr (if_not_hprop_then_equiv_Empty hprop nx)).
 Defined.
+
+(** Under function extensionality, if [A] is decidable, then [~~A] is the propositional truncation of [A]. Here, for dependency reasons, we don't give the equivalence to [Tr (-1) A], but just show that the recursion principle holds. See ../Metatheory/ImpredicativeTruncation.v for a generalization to all types. *)
+
+(** Any negation is an hprop, by [istrunc_Empty] and [istrunc_arrow]. In particular, double-negation is an hprop. *)
+Definition ishprop_not_not `{Funext} {A : Type} : IsHProp (~~A) := _.
+
+Definition not_not_unit {A : Type} : A -> ~~A
+  := fun a na => na a.
+
+(** The recursion principle for [~~A]. *)
+Definition not_not_rec {A : Type} `{Decidable A} (P : HProp) (f : A -> P)
+  : ~~A -> P.
+Proof.
+  intro nna.
+  destruct (dec A) as [a | na].
+  - exact (f a).
+  - elim (nna na).
+Defined.
+
+(** The computation rule only holds propositionally. *)
+Definition not_not_rec_beta {A : Type} `{Decidable A} (P : HProp) (f : A -> P) (a : A)
+  : not_not_rec P f (not_not_unit a) = f a
+  := path_ishprop _ _.

--- a/theories/Universes/HProp.v
+++ b/theories/Universes/HProp.v
@@ -1,6 +1,7 @@
 (** * HPropositions *)
 
-Require Import HoTT.Basics HoTT.Types.
+Require Import Basics.
+Require Import Types.Empty Types.Unit Types.Prod Types.Paths Types.Sigma Types.Equiv.
 
 Local Open Scope path_scope.
 

--- a/theories/Universes/HProp.v
+++ b/theories/Universes/HProp.v
@@ -163,6 +163,19 @@ Definition not_not_rec_beta {A : Type} `{Stable A} (P : HProp) (f : A -> P) (a :
   : not_not_rec P f (not_not_unit a) = f a
   := path_ishprop _ _.
 
+(** The map [A -> ~~A] is an equivalence if and only if [A] is a stable hprop.  This characterizes the local types for the double-negation modality.  See Modality/Notnot.v. *)
+Definition stable_hprop_iff_isequiv_not_not_unit `{Funext} A
+  : IsEquiv (@not_not_unit A) <-> (Stable A * IsHProp A).
+Proof.
+  split.
+  - intros iseq.
+    pose proof (eq := (Build_Equiv _ _ _ iseq)^-1%equiv); clear iseq.
+    exact (stable_equiv eq _, istrunc_equiv_istrunc _ eq).
+  - intros [stable ishprop].
+    rapply isequiv_iff_hprop.
+    apply stable.
+Defined.
+
 (** Under [Funext], [ishprop_decpaths] shows that [DecidablePaths A] is an hprop.  More generally, it's also an hprop with the first argument fixed. *)
 Global Instance ishprop_decpaths' `{Funext} {A : Type} (x : A)
   : IsHProp (forall (y : A), Decidable (x = y)).

--- a/theories/Universes/HProp.v
+++ b/theories/Universes/HProp.v
@@ -150,9 +150,6 @@ Defined.
 (** Any negation is an hprop, by [istrunc_Empty] and [istrunc_arrow]. In particular, double-negation is an hprop. *)
 Definition ishprop_not_not `{Funext} {A : Type} : IsHProp (~~A) := _.
 
-Definition not_not_unit {A : Type} : A -> ~~A
-  := fun a na => na a.
-
 (** The recursion principle for [~~A]. *)
 Definition not_not_rec {A : Type} `{Decidable A} (P : HProp) (f : A -> P)
   : ~~A -> P.


### PR DESCRIPTION
I noticed that one can strengthen
```coq
IsHProp(forall x y, Decidable (x = y))
```
to
```coq
forall x, IsHProp(forall y, Decidable (x = y))
```
using a cute argument involving restricting to a component.  Not sure if this is useful, but since it's slightly non-trivial, I'm pushing it.

The weaker result is `ishprop_decpaths` in Basics/Decidable.v, but because of dependencies, the new result can't go there.  I originally used `merely A` in the proof, but realized that it can be avoided by using `not (not A)` in this case, which reduces the dependencies.  I put this in `HProp.v`, since that file had similar dependencies and already had one result involving decidable types and being an h-proposition.

I also added in the fact that for decidable `A`, `~~A` has the universal property of propositional truncation.  This isn't needed to prove `ishprop_decpaths'` (the stronger result).  The only thing used in that proof is `not_not_unit : A -> ~~A`, which could be inlined instead.  But having this recorded is probably worthwhile, and makes the proof of `ishprop_decpaths'` more conceptually clear.

While thinking about this, I noticed that some of the comments in `TruncImpliesFunext.v` could be improved.