### PR TITLE
Functoriality results for Colimits

### DIFF
--- a/theories/Colimits/Coeq.v
+++ b/theories/Colimits/Coeq.v
@@ -212,18 +212,20 @@ Definition functor_coeq_homotopy {B A f g B' A' f' g'}
 : functor_coeq h k p q == functor_coeq h' k' p' q'.
 Proof.
   refine (Coeq_ind _ (fun a => ap coeq (s a)) _); cbn; intros b.
-  refine (transport_paths_FlFr (cglue b) _ @ _).
-  rewrite concat_pp_p; apply moveR_Vp.
+  apply transport_paths_FlFr'.
   rewrite !functor_coeq_beta_cglue.
   Open Scope long_path_scope.
+  rewrite 2 ap_V.
   rewrite !concat_p_pp.
+  apply moveL_pV.
   rewrite <- (ap_pp (@coeq _ _ f' g') (s (f b)) (p' b)).
-  rewrite u, ap_pp, !concat_pp_p; apply whiskerL; rewrite !concat_p_pp.
-  rewrite ap_V; apply moveR_pV.
-  rewrite !concat_pp_p, <- (ap_pp (@coeq _ _ f' g') (s (g b)) (q' b)).
-  rewrite v, ap_pp, ap_V, concat_V_pp.
-  rewrite <- !ap_compose.
-  exact (concat_Ap (@cglue _ _ f' g') (r b)).
+  rewrite u, ap_pp.
+  rewrite !concat_pp_p; apply whiskerL.
+  rewrite <- (ap_pp (@coeq _ _ f' g') (s (g b)) (q' b)).
+  rewrite v, ap_pp.
+  rewrite concat_V_pp.
+  rewrite <- 2 ap_compose.
+  exact (concat_Ap (@cglue _ _ f' g') (r b))^.
   Close Scope long_path_scope.
 Qed.
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -69,24 +69,14 @@ Definition colimp {G : Graph} {D : Diagram G} (i j : G) (f : G i j) (x : D i)
   : colim j (D _f f x) = colim i x
   := (cglue ((i; x); j; f))^.
 
-(** Naturality of [ap] applied to [colim]. *)
-Definition concat_ap_colim {G : Graph} {D : Diagram G} {i j : G} (f : G i j) {x y : D i} (p : x = y)
-  : ap (colim j) (ap (D _f f) p) @ colimp i j f y
-    = colimp i j f x @ ap (colim i) p.
-Proof.
-  lhs_V nrapply (ap_compose _ _ _ @@ 1).
-  exact (concat_Ap (colimp i j f) p).
-Defined.
-
 (** To obtain a path [colim j (D _f f x) = colim j (D _f f y)] from a path [x = y], one can either use [ap (D _f f)] followed by [ap (colim j)], or conjugate [ap (colim i)] by [colimp i j f]. These paths are equivalent. *)
 Definition ap_colim_homotopic {G : Graph} {D : Diagram G} {i j : G} (f : G i j) {x y : D i} (p : x = y)
   : ap (colim j) (ap (D _f f) p)
     = colimp i j f x @ ap (colim i) p @ (colimp i j f y)^.
 Proof.
-  nrapply moveL_pV.
-  nrapply concat_ap_colim.
+  lhs_V nrapply ap_compose.
+  exact (ap_homotopic (colimp _ _ _) p).
 Defined.
-
 
 Definition Colimit_ind {G : Graph} {D : Diagram G} (P : Colimit D -> Type)
 (q : forall i x, P (colim i x))
@@ -299,6 +289,7 @@ Section FunctorialityColimit.
   Context `{Funext} {G : Graph}.
 
   (** Colimits are preserved by composition with a (diagram) equivalence. *)
+
   Definition iscolimit_precompose_equiv {D1 D2 : Diagram G}
     (m : D1 ~d~ D2) {Q : Type}
     : IsColimit D2 Q -> IsColimit D1 Q.
@@ -369,6 +360,7 @@ Section FunctorialityColimit.
   (** ** Colimits of equivalent diagrams *)
 
   (** Now we have that two equivalent diagrams have equivalent colimits. *)
+
   Context {D1 D2 : Diagram G} (m : D1 ~d~ D2) {Q1 Q2}
     (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2).
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -3,6 +3,7 @@ Require Import Diagrams.Diagram.
 Require Import Diagrams.Graph.
 Require Import Diagrams.Cocone.
 Require Import Diagrams.ConstantDiagram.
+Require Import Diagrams.CommutativeSquares.
 Require Import Colimits.Coeq.
 
 Local Open Scope path_scope.
@@ -11,6 +12,8 @@ Generalizable All Variables.
 (** This file contains the definition of colimits, and functoriality results on colimits. *)
 
 (** * Colimits *)
+
+(** ** Abstract definition *)
 
 (** A colimit is the extremity of a cocone. *)
 
@@ -33,21 +36,16 @@ Definition cocone_postcompose_inv `{D: Diagram G} {Q X}
   (H : IsColimit D Q) (C' : Cocone D X) : Q -> X
   := @equiv_inv _ _ _ (iscolimit_unicocone H X) C'.
 
-(** * Existence of colimits *)
+(** ** Existence of colimits *)
 
-(** Whatever the diagram considered, there exists a colimit of it. The existence is given by the HIT [colimit]. *)
-
-(** ** Definition of the HIT 
+(** Every diagram has a colimit.  It could be described as the following HIT
 <<
   HIT Colimit {G : Graph} (D : Diagram G) : Type :=
   | colim : forall i, D i -> Colimit D
   | colimp : forall i j (f : G i j) (x : D i) : colim j (D _f f x) = colim i x
   .
 >>
-*)
-
-(** A colimit is just the coequalizer of the source and target maps of the diagram. *)
-(** The source type in the coequalizer ought to be:
+but we instead describe it as the coequalizer of the source and target maps of the diagram.  The source type in the coequalizer ought to be:
 <<
 {x : sig D & {y : sig D & {f : G x.1 y.1 & D _f f x.2 = y.2}}}
 >>
@@ -70,6 +68,26 @@ Definition colim {G : Graph} {D : Diagram G} (i : G) (x : D i) : Colimit D :=
 Definition colimp {G : Graph} {D : Diagram G} (i j : G) (f : G i j) (x : D i)
   : colim j (D _f f x) = colim i x
   := (cglue ((i; x); j; f))^.
+
+(** The two ways of getting a path [colim j (D _f f x) = colim j (D _f f y)] from an path [x = y] are equivalent. *)
+Definition ap_colim {G : Graph} {D : Diagram G} {i j : G} (f : G i j) {x y : D i} (p : x = y) 
+  : colimp i j f x @ ap (colim i) p @ (colimp i j f y)^
+    = ap (colim j) (ap (D _f f) p).
+Proof.
+  rhs_V nrapply ap_compose.
+  exact (ap_homotopic (colimp i j f) p)^.
+Defined.
+
+(** The two ways of getting a path [colim i x = colim i y] from a path [x = y] are equivalent. *)
+Definition ap_colim' {G : Graph} {D : Diagram G} {i j : G} (f : G i j) {x y : D i} (p : x = y)
+  : (colimp i j f x)^ @ ap (colim j) (ap (D _f f) p) @ colimp i j f y = ap (colim i) p.
+Proof.
+  apply moveR_pM.
+  apply moveR_Vp.
+  symmetry.
+  lhs nrapply concat_p_pp.
+  apply ap_colim.
+Defined.
 
 Definition Colimit_ind {G : Graph} {D : Diagram G} (P : Colimit D -> Type)
 (q : forall i x, P (colim i x))
@@ -123,66 +141,159 @@ Defined.
 Arguments colim : simpl never.
 Arguments colimp : simpl never.
 
-(** Colimit_rec is an equivalence *)
+(** The natural cocone to the colimit. *)
+Definition cocone_colimit {G : Graph} (D : Diagram G) : Cocone D (Colimit D)
+  := Build_Cocone colim colimp.
 
+(** Given a cocone [C] and [f : Colimit D -> P] inducing a "homotopic" cocone, [Colimit_rec P C] is homotopic to [f]. *)
+Definition Colimit_rec_homotopy {G : Graph} {D : Diagram G} (P : Type) (C : Cocone D P)
+  (f : Colimit D -> P)
+  (h_obj : forall i, legs C i == f o colim i)
+  (h_comm : forall i j (g : G i j) x,
+      legs_comm C i j g x @ h_obj i x = h_obj j ((D _f g) x) @ ap f (colimp i j g x))
+  : Colimit_rec P C == f.
+Proof.
+  snrapply Colimit_ind.
+  - simpl. exact h_obj.
+  - cbn beta; intros i j g x.
+    nrapply (transport_paths_FlFr' (colimp i j g x)).
+    lhs nrapply (Colimit_rec_beta_colimp _ _ _ _ _ _ @@ 1).
+    apply h_comm.
+Defined.
+
+(** "Homotopic" cocones induces homotopic maps. *)
+Definition Colimit_rec_homotopy' {G : Graph} {D : Diagram G} (P : Type) (C1 C2 : Cocone D P)
+  (h_obj : forall i, legs C1 i == legs C2 i)
+  (h_comm : forall i j (g : G i j) x,
+      legs_comm C1 i j g x @ h_obj i x = h_obj j (D _f g x) @ legs_comm C2 i j g x)
+  : Colimit_rec P C1 == Colimit_rec P C2.
+Proof.
+  snrapply Colimit_rec_homotopy.
+  - apply h_obj.
+  - intros i j g x.
+    rhs nrapply (1 @@ Colimit_rec_beta_colimp _ _ _ _ _ _).
+    apply h_comm.
+Defined.
+
+(** [Colimit_rec] is an equivalence. *)
 Global Instance isequiv_colimit_rec `{Funext} {G : Graph}
-  {D : Diagram G} (P : Type) : IsEquiv (Colimit_rec (D:=D) P).
+  {D : Diagram G} (P : Type)
+  : IsEquiv (Colimit_rec (D:=D) P).
 Proof.
   srapply isequiv_adjointify.
-  { intro f.
-    srapply Build_Cocone.
-    1: intros i g; apply f, (colim i g).
-    intros i j g x.
-    apply ap, colimp. }
-  { intro.
+  - exact (cocone_postcompose (cocone_colimit D)).
+  - intro f.
     apply path_forall.
-    srapply Colimit_ind.
+    snrapply Colimit_rec_homotopy.
     1: reflexivity.
-    intros ????; cbn.
-    nrapply transport_paths_FlFr'.
-    apply equiv_p1_1q.
-    apply Colimit_rec_beta_colimp. }
-  { intros [].
+    intros; cbn.
+    apply concat_p1_1p.
+  - intros [].
     srapply path_cocone.
     1: reflexivity.
-    intros ????; cbn.
-    rewrite Colimit_rec_beta_colimp.
-    hott_simpl. }
+    intros; cbn.
+    apply equiv_p1_1q.
+    apply Colimit_rec_beta_colimp.
 Defined.
 
 Definition equiv_colimit_rec `{Funext} {G : Graph} {D : Diagram G} (P : Type)
   : Cocone D P <~> (Colimit D -> P) := Build_Equiv _ _ _ (isequiv_colimit_rec P).
 
-(** And we can now show that the HIT is actually a colimit. *)
-
-Definition cocone_colimit {G : Graph} (D : Diagram G) : Cocone D (Colimit D)
-  := Build_Cocone colim colimp.
-
+(** It follows that the HIT Colimit is an abstract colimit. *)
 Global Instance unicocone_colimit `{Funext} {G : Graph} (D : Diagram G)
   : UniversalCocone (cocone_colimit D).
 Proof.
   srapply Build_UniversalCocone; intro Y.
-  srapply (isequiv_adjointify _ (Colimit_rec Y) _ _).
-  - intros C.
-    srapply path_cocone.
-    1: reflexivity.
-    intros i j f x; simpl.
-    apply equiv_p1_1q.
-    apply Colimit_rec_beta_colimp.
-  - intro f.
-    apply path_forall.
-    srapply Colimit_ind.
-    1: reflexivity.
-    intros i j g x; simpl.
-    nrapply (transport_paths_FlFr' (g:=f)).
-    apply equiv_p1_1q.
-    apply Colimit_rec_beta_colimp.
+  (* The goal is to show that [cocone_postcompose (cocone_colimit D)] is an equivalence, but that's the inverse to the equivalence we just defined. *)
+  exact (isequiv_inverse (equiv_colimit_rec Y)).
 Defined.
 
 Global Instance iscolimit_colimit `{Funext} {G : Graph} (D : Diagram G)
-  : IsColimit D (Colimit D) := Build_IsColimit _ (unicocone_colimit D).
+  : IsColimit D (Colimit D)
+  := Build_IsColimit _ (unicocone_colimit D).
 
-(** * Functoriality of colimits *)
+(** ** Functoriality of concrete colimits *)
+
+(** We will capitalize [Colimit] in the identifiers to indicate that these definitions relate to the concrete colimit defined above.  Below, we will also get functoriality for abstract colimits, without the capital C.  However, to apply those results to the concrete colimit uses [iscolimit_colimit], which requires [Funext], so it is also useful to give direct proofs of some facts. *)
+
+(** We first work in a more general situation.  Any diagram map [m : D1 => D2] induces a map between the canonical colimit of [D1] and any cocone over [D2].  We use "half" to indicate this situation. *)
+Definition functor_Colimit_half {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2) {Q} (HQ : Cocone D2 Q)
+  : Colimit D1 -> Q.
+Proof.
+  apply Colimit_rec.
+  refine (cocone_precompose m HQ).
+Defined.
+
+Definition functor_Colimit_half_beta_colimp {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2) {Q} (HQ : Cocone D2 Q) (i j : G) (g : G i j) (x : D1 i)
+  : ap (functor_Colimit_half m HQ) (colimp i j g x) = legs_comm (cocone_precompose m HQ) i j g x
+  := Colimit_rec_beta_colimp _ _ _ _ _ _.
+
+(** Homotopic diagram maps induce homotopic maps. *)
+Definition functor_Colimit_half_homotopy {G : Graph} {D1 D2 : Diagram G}
+  {m1 m2 : DiagramMap D1 D2} (h : DiagramMap_homotopy m1 m2) 
+  {Q} (HQ : Cocone D2 Q)
+  : functor_Colimit_half m1 HQ == functor_Colimit_half m2 HQ.
+Proof.
+  destruct h as [h_obj h_comm].
+  snrapply Colimit_rec_homotopy'.
+  - intros i x; cbn. apply ap, h_obj.
+  - intros i j g x; simpl.
+    Open Scope long_path_scope.
+    (* TODO: Most of the work here comes from a mismatch between the direction of the path in [DiagramMap_comm] and [legs_comm] in the [Cocone] record, causing a reversal in [cocone_precompose].  There is no reversal in [cocone_postcompose], so I think [Cocone] should change. If that is done, then this result wouldn't be needed at all, and one could directly use [Colimit_rec_homotopy']. *)
+    rewrite ap_V.
+    lhs nrapply concat_pp_p.
+    apply moveR_Vp.
+    rewrite ! concat_p_pp.
+    rewrite <- 2 ap_pp.
+    rewrite h_comm.
+    rewrite concat_pp_V.
+    rewrite <- ap_compose.
+    exact (concat_Ap (legs_comm HQ i j g) (h_obj i x))^.
+    Close Scope long_path_scope.
+Defined.
+
+(** Now we specialize to the case where the second cone is a colimiting cone. *)
+Definition functor_Colimit {G : Graph} {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
+  : Colimit D1 -> Colimit D2
+  := functor_Colimit_half m (cocone_colimit D2).
+
+(** A homotopy between diagram maps [m1, m2 : D1 => D2] gives a homotopy between the induced maps. *)
+Definition functor_Colimit_homotopy {G : Graph} {D1 D2 : Diagram G}
+  {m1 m2 : DiagramMap D1 D2} (h : DiagramMap_homotopy m1 m2)
+  : functor_Colimit m1 == functor_Colimit m2
+  := functor_Colimit_half_homotopy h _.
+
+(** Composition of diagram maps commutes with [functor_Colimit_half], provided the first map uses [functor_Colimit]. *)
+Definition functor_Colimit_half_compose {G : Graph} {A B C : Diagram G} (f : DiagramMap A B) (g : DiagramMap B C) {Q} (HQ : Cocone C Q)
+  : functor_Colimit_half (diagram_comp g f) HQ == functor_Colimit_half g HQ o functor_Colimit f.
+Proof.
+  snrapply Colimit_rec_homotopy.
+  - reflexivity.
+  - intros i j k x; cbn.
+    apply equiv_p1_1q.
+    unfold comm_square_comp.
+    Open Scope long_path_scope.
+    lhs nrapply (ap_V _ _ @@ 1).
+    lhs nrapply (inverse2 (ap_pp (HQ j) _ _) @@ 1).
+    lhs nrapply (inv_pp _ _ @@ 1).
+    symmetry.
+    lhs nrapply (ap_compose (functor_Colimit f)).
+    lhs nrapply (ap _ (Colimit_rec_beta_colimp _ _ _ _ _ _)).
+    (* [legs_comm] unfolds to a composite of paths, but the next line works best without unfolding it. *)
+    lhs nrapply ap_pp.
+    lhs nrefine (1 @@ _). 1: nrapply functor_Colimit_half_beta_colimp.
+    simpl.
+    lhs nrapply concat_p_pp.
+    nrefine (_ @@ 1).
+    apply ap011.
+    2: nrapply ap_V.
+    lhs_V nrapply (ap_compose (colim j)); simpl.
+    lhs nrapply (ap_V (HQ j o g j) _).
+    apply ap, ap_compose.
+    Close Scope long_path_scope.
+Defined.
+
+(** ** Functoriality of abstract colimits *)
 
 Section FunctorialityColimit.
 
@@ -207,14 +318,12 @@ Section FunctorialityColimit.
     apply cocone_postcompose_equiv_universality, HQ.
   Defined.
 
-  (** A diagram map [m] : [D1] => [D2] induces a map between any two colimits of [D1] and [D2]. *)
-
+  (** A diagram map [m : D1 => D2] induces a map between any two colimits of [D1] and [D2]. *)
   Definition functor_colimit {D1 D2 : Diagram G} (m : DiagramMap D1 D2)
     {Q1 Q2} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
     : Q1 -> Q2 := cocone_postcompose_inv HQ1 (cocone_precompose m HQ2).
 
   (** And this map commutes with diagram map. *)
-
   Definition functor_colimit_commute {D1 D2 : Diagram G}
     (m : DiagramMap D1 D2) {Q1 Q2}
     (HQ1 : IsColimit D1 Q1) (HQ2: IsColimit D2 Q2)
@@ -222,9 +331,46 @@ Section FunctorialityColimit.
       = cocone_postcompose HQ1 (functor_colimit m HQ1 HQ2)
     := (eisretr (cocone_postcompose HQ1) _)^.
 
+  (** Additional coherence with postcompose and precompose. *)
+  Definition cocone_precompose_postcompose_comp {D1 D2 : Diagram G}
+    (m : DiagramMap D1 D2) {Q1 Q2 : Type} (HQ1 : IsColimit D1 Q1)
+    (HQ2 : IsColimit D2 Q2) {T : Type} (t : Q2 -> T)
+    : cocone_postcompose HQ1 (t o functor_colimit m HQ1 HQ2)
+      = cocone_precompose m (cocone_postcompose HQ2 t).
+    Proof.
+      lhs nrapply cocone_postcompose_comp.
+      lhs_V exact (ap (fun x => cocone_postcompose x t) 
+        (functor_colimit_commute m HQ1 HQ2)).
+      nrapply cocone_precompose_postcompose.
+    Defined.
+
+  (** In order to show that colimits are functorial, we show that this is true after precomposing with the cocone. *)
+  Definition postcompose_functor_colimit_compose {D1 D2 D3 : Diagram G} 
+    (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
+    {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
+    (HQ3 : IsColimit D3 Q3)
+    : cocone_postcompose HQ1 (functor_colimit n HQ2 HQ3 o functor_colimit m HQ1 HQ2)
+      = cocone_postcompose HQ1 (functor_colimit (diagram_comp n m) HQ1 HQ3).
+  Proof.
+    lhs nrapply cocone_precompose_postcompose_comp.
+    lhs_V nrapply (ap _ (functor_colimit_commute n HQ2 HQ3)).
+    lhs nrapply cocone_precompose_comp.
+    nrapply functor_colimit_commute.
+  Defined.
+
+  Definition functor_colimit_compose {D1 D2 D3 : Diagram G} 
+    (m : DiagramMap D1 D2) (n : DiagramMap D2 D3) 
+    {Q1 Q2 Q3} (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2)
+    (HQ3 : IsColimit D3 Q3)
+    : functor_colimit n HQ2 HQ3 o functor_colimit m HQ1 HQ2
+      = functor_colimit (diagram_comp n m) HQ1 HQ3
+    := @equiv_inj _ _ 
+      (cocone_postcompose HQ1) (iscolimit_unicocone HQ1 Q3) _ _ 
+      (postcompose_functor_colimit_compose m n HQ1 HQ2 HQ3).
+
   (** ** Colimits of equivalent diagrams *)
 
-  (** Now we have than two equivalent diagrams have equivalent colimits. *)
+  (** Now we have that two equivalent diagrams have equivalent colimits. *)
 
   Context {D1 D2 : Diagram G} (m : D1 ~d~ D2) {Q1 Q2}
     (HQ1 : IsColimit D1 Q1) (HQ2 : IsColimit D2 Q2).
@@ -271,7 +417,7 @@ Section FunctorialityColimit.
 
 End FunctorialityColimit.
 
-(** * Unicity of colimits *)
+(** ** Unicity of colimits *)
 
 (** A particuliar case of the functoriality result is that all colimits of a diagram are equivalent (and hence equal in presence of univalence). *)
 
@@ -283,7 +429,7 @@ Proof.
   srapply (Build_diagram_equiv (diagram_idmap D)).
 Defined.
 
-(** * Colimits are left adjoint to constant diagram *)
+(** ** Colimits are left adjoint to constant diagram *)
 
 Theorem colimit_adjoint `{Funext} {G : Graph} {D : Diagram G} {C : Type}
   : (Colimit D -> C) <~> DiagramMap D (diagram_const C).
@@ -292,4 +438,3 @@ Proof.
   refine (equiv_colimit_rec C oE _).
   apply equiv_diagram_const_cocone.
 Defined.
-

--- a/theories/Diagrams/ConstantDiagram.v
+++ b/theories/Diagrams/ConstantDiagram.v
@@ -1,4 +1,4 @@
-Require Import Basics.
+Require Import Basics Types.Paths.
 Require Import Cone.
 Require Import Cocone.
 Require Import Diagram.
@@ -29,29 +29,30 @@ Section ConstantDiagram.
   Definition diagram_const_functor_comp {A B C : Type}
     (f : A -> B) (g : B -> C)
     : diagram_const_functor (g o f)
-    = diagram_comp (diagram_const_functor g) (diagram_const_functor f).
-  Proof.
-    reflexivity.
-  Defined.
+      = diagram_comp (diagram_const_functor g) (diagram_const_functor f)
+    := idpath.
 
   Definition diagram_const_functor_idmap {A : Type}
-    : diagram_const_functor (idmap : A -> A) = diagram_idmap (diagram_const A).
-  Proof.
-    reflexivity.
-  Defined.
+    : diagram_const_functor (idmap : A -> A) = diagram_idmap (diagram_const A)
+    := idpath.
 
   Definition equiv_diagram_const_cocone `{Funext} (D : Diagram G) (X : Type)
     : DiagramMap D (diagram_const X) <~> Cocone D X.
   Proof.
     srapply equiv_adjointify.
+    (* The two functions are defined in parallel: *)
     1,2: intros [? w]; econstructor.
+    (* This reversal is a defect in the definition of [Cocone]. *)
     1,2: intros x y z z'; symmetry; revert x y z z'.
     1,2: exact w.
-    1,2: intros[].
-    1: srapply path_cocone.
-    3: srapply path_DiagramMap.
+    (* The two homotopies are proved in parallel: *)
+    1,2: intros [].
+    1: srapply path_cocone; cbn.
+    3: srapply path_DiagramMap; snrefine (_; _); cbn.
     1,3: reflexivity.
-    all: cbn; intros; hott_simpl.
+    1,2: intros; cbn.
+    1,2: apply equiv_p1_1q.
+    1,2: apply inv_V.
   Defined.
 
   Definition equiv_diagram_const_cone `{Funext} (X : Type) (D : Diagram G)
@@ -68,6 +69,3 @@ Section ConstantDiagram.
   Defined.
 
 End ConstantDiagram.
-
-
-

--- a/theories/Diagrams/Diagram.v
+++ b/theories/Diagrams/Diagram.v
@@ -78,18 +78,31 @@ Section Diagram.
   Global Arguments DiagramMap_comm  [D1 D2] m [i j] f x : rename.
   Global Arguments Build_DiagramMap [D1 D2] _ _.
 
+  Definition DiagramMap_homotopy {D1 D2 : Diagram G}
+    (m1 m2 : DiagramMap D1 D2) : Type
+    := {h_obj : (forall i, m1 i == m2 i) & (forall i j (g : G i j) x,
+      DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
+      = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)}.
+
+  Global Instance reflexive_DiagramMap_homotopy {D1 D2 : Diagram G} : Reflexive (@DiagramMap_homotopy D1 D2).
+  Proof.
+    intros m.
+    snrapply exist.
+    - intro i; reflexivity.
+    - intros i j g x; cbn.
+      apply concat_p1_1p.
+  Defined.
+
   (** [path_DiagramMap] says when two maps are equals (up to funext). *)
 
   Definition path_DiagramMap {D1 D2 : Diagram G}
-    {m1 m2 : DiagramMap D1 D2} (h_obj : forall i, m1 i == m2 i)
-    (h_comm : forall i j (g : G i j) x,
-      DiagramMap_comm m1 g x @ h_obj j (D1 _f g x)
-      = ap (D2 _f g) (h_obj i x) @ DiagramMap_comm m2 g x)
+    {m1 m2 : DiagramMap D1 D2} (h : DiagramMap_homotopy m1 m2)
     : m1 = m2.
   Proof.
     destruct m1 as [m1_obj m1_comm].
     destruct m2 as [m2_obj m2_comm].
     simpl in *.
+    destruct h as [h_obj h_comm].
     revert h_obj h_comm.
     set (E := (@equiv_functor_forall _
        G (fun i => m1_obj i = m2_obj i)
@@ -156,11 +169,12 @@ Section Diagram.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
     set (we i := Build_Equiv _ _ _ (is_eq_w i)).
-    simple refine (path_DiagramMap _ _).
-    - exact (fun i => eisretr (we i)).
-    - simpl.
-      intros i j f x. apply (concatR (concat_p1 _)^).
-      apply (comm_square_inverse_is_retr (we i) (we j) _ x).
+    apply path_DiagramMap.
+    exists (fun i => eisretr (we i)).
+    simpl.
+    intros i j f x.
+    rhs nrapply concat_p1.
+    apply (comm_square_inverse_is_retr (we i) (we j) _ x).
   Defined.
 
   Lemma diagram_inv_is_retraction {D1 D2 : Diagram G}
@@ -169,11 +183,12 @@ Section Diagram.
   Proof.
     destruct w as [[w_obj w_comm] is_eq_w]. simpl in *.
     set (we i := Build_Equiv _ _ _ (is_eq_w i)).
-    simple refine (path_DiagramMap _ _).
-    - exact (fun i => eissect (we i)).
-    - simpl.
-      intros i j f x. apply (concatR (concat_p1 _)^).
-      apply (comm_square_inverse_is_sect (we i) (we j) _ x).
+    apply path_DiagramMap.
+    exists (fun i => eissect (we i)).
+    simpl.
+    intros i j f x.
+    rhs nrapply concat_p1.
+    apply (comm_square_inverse_is_sect (we i) (we j) _ x).
   Defined.
 
   (** The equivalence of diagram is an equivalence relation. *)
@@ -186,9 +201,11 @@ Section Diagram.
 
   Global Instance transitive_diagram_equiv : Transitive diagram_equiv | 1.
   Proof.
-  simple refine (fun D1 D2 D3 m1 m2 =>
-                   Build_diagram_equiv (diagram_comp m2 m1) _).
-  simpl. intros i; apply isequiv_compose';[apply m1 | apply m2].
+    intros D1 D2 D3 m1 m2.
+    nrapply (Build_diagram_equiv (diagram_comp m2 m1)).
+    intros i.
+    simpl.
+    apply isequiv_compose'; [apply m1 | apply m2].
   Defined.
 End Diagram.
 


### PR DESCRIPTION
In this PR we add more results pertaining to `functor_colimit`. The library currently supports two approaches to use colimits. One either considers *concrete colimits* that are the HITs defined from the data of the diagrams, or *abstract colimits* that are arbitrary types with the correct universal property. As per the implementation of today, a concrete colimit is an abstract colimit once function extensionality is assumed. 

This PR adds a sort of third approach, where we allow ourselves to use both concrete and abstract colimits at the same time. The map `functor_colimit` has a diagram map `m : D1 => D2` as input, and outputs a map `Colimit D1 -> Colimit D2`. We add `functor_Colimit_half` that acts like the above function, but you can choose an arbitrary cocone `Q` over the target diagram to obtain a map `Colimit D1 -> Q`. Hopefully, this will let us leverage the computational properties of concrete colimits, while keeping some of the flexibility and freedom with abstract colimits.

The main contribution from this PR consists of studying how the recursor for concrete colimits interact with homotopic cocones. This lets us study `functor_Colimit_half`, and prove verious results pertaining to it. We also record naturality for `ap` at the function `colim`, prove some functoriality results for abstract colimits, and perform some cleanup of the existing code.

Hopefully this code will find its use in the zigzag construction for path spaces of pushouts. With some additional luck, we can also simplify some of the contents found in Sequential.v.