### PR TITLE
abgroup_group is a functor

### DIFF
--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -179,6 +179,13 @@ Proof.
   all: intro A; apply ispointedcat_group.
 Defined.
 
+(** [abgroup_group] is a functor *)
+Global Instance is0functor_abgroup_group : Is0Functor abgroup_group
+  := is0functor_induced _.
+
+Global Instance is1functor_abgroup_group : Is1Functor abgroup_group
+  := is1functor_induced _.
+
 (** Image of group homomorphisms between abelian groups *)
 Definition abgroup_image {A B : AbGroup} (f : A $-> B) : AbGroup
   := Build_AbGroup (grp_image f) _.


### PR DESCRIPTION
This makes working with equivalences of abelian groups easier when working with groups since you can do `emap abgroup_group`. Even though they are the same thing under the hood, the terms get difficult to work with without explicit casting.