### PR TITLE
make maximal_subgroup a printed coercion

### DIFF
--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -211,6 +211,10 @@ Proof.
   split; auto; exact _.
 Defined.
 
+(** We wish to coerce a group to its maximal subgroup. However, if we don't explicitly print [maximal_subgroup] things can get confusing, so we mark it as a coercion to be printed. *)
+Coercion maximal_subgroup : Group >-> Subgroup.
+Add Printing Coercion maximal_subgroup.
+
 (** Paths between subgroups correspond to homotopies between the underlying predicates. *) 
 Proposition equiv_path_subgroup `{F : Funext} {G : Group} (H K : Subgroup G)
   : (H == K) <~> (H = K).


### PR DESCRIPTION
This lets us coerce groups to their subgroups. The coercion is always printed as to not introduce sneaky terms.