### PR TITLE
Defining properties of maxima and minima, lemmas for the take operation in lists, lists from sequences.

### DIFF
--- a/theories/Algebra/Rings/Vector.v
+++ b/theories/Algebra/Rings/Vector.v
@@ -23,29 +23,21 @@ Definition Vector@{i|} (A : Type@{i}) (n : nat) : Type@{i}
 
 Definition Build_Vector (A : Type) (n : nat)
   (f : forall (i : nat), (i < n)%nat -> A)
-  : Vector A n. 
-Proof.
-  exists (list_map (fun '(i; Hi) => f i Hi) (seq' n)).
-  lhs nrapply length_list_map.
-  apply length_seq'.
-Defined.
+  : Vector A n
+  := (Build_list n f; length_Build_list n f).
 
 (** *** Projections *)
 
 Definition entry {A : Type} {n : nat} (v : Vector A n) i {Hi : (i < n)%nat} : A
   := nth' (pr1 v) i ((pr2 v)^ # Hi).
 
-(** *** Basic properties *) 
+(** *** Basic properties *)
 
 Definition entry_Build_Vector {A : Type} {n}
   (f : forall (i : nat), (i < n)%nat -> A) i {Hi : (i < n)%nat}
   : entry (Build_Vector A n f) i = f i Hi.
 Proof.
-  snrefine (nth'_list_map _ _ _ (_^ # Hi) _ @ _).
-  1: nrapply length_seq'.
-  snrapply ap011D.
-  1: nrapply nth'_seq'.
-  rapply path_ishprop. 
+  snrapply nth'_Build_list.
 Defined.
 
 Global Instance istrunc_vector@{i} (A : Type@{i}) (n : nat) k `{IsTrunc k.+2 A}

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -542,32 +542,22 @@ Defined.
 
 (** [drop n l] removes the first [n] elements of [l]. *)
 Fixpoint drop {A : Type} (n : nat) (l : list A) : list A :=
-  match l, n with
-  | _ :: l, n.+1 => drop n l
-  | _, _ => l
+  match n with
+  | 0 => l
+  | n.+1 => drop n (tail l)
   end.
 
-(** A [drop] of zero elements is the identity. *)
-Definition drop_0 {A : Type} (l : list A)
-  : drop 0 l = l.
-Proof.
-  by destruct l.
-Defined.
+(** A [drop] of zero elements is the identity, by definition. *)
+Definition drop_0 {A : Type} (l : list A) : drop 0 l = l := idpath.
 
-(** A [drop] of one element is the tail of the list. *)
-Definition drop_1 {A : Type} (l : list A)
-  : drop 1 l = tail l.
-Proof.
-  induction l.
-  1: reflexivity.
-  by destruct l.
-Defined.
+(** A [drop] of one element is the tail of the list, by definition. *)
+Definition drop_1 {A : Type} (l : list A) : drop 1 l = tail l := idpath.
 
 (** A [drop] of the empty list is the empty list. *)
 Definition drop_nil {A : Type} (n : nat)
   : drop n (@nil A) = nil.
 Proof.
-  by destruct n.
+  by induction n.
 Defined.
 
 (** A [drop] of [n] elements with [length l <= n] is the empty list. *)
@@ -603,7 +593,7 @@ Proof.
   induction l as [|a l IHl] in n, H, x |- * using list_ind@{i i}.
   1: rewrite drop_nil in H; contradiction.
   destruct n.
-  1: rewrite drop_0 in H; assumption.
+  1: exact H.
   right; nrapply (IHl _ _ H).
 Defined.
 
@@ -708,11 +698,7 @@ Definition remove {A : Type} (n : nat) (l : list A) : list A
   := take n l ++ drop n.+1 l.
 
 (** Removing the first element of a list is the tail of the list. *)
-Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l.
-Proof.
-  unfold remove.
-  by rewrite drop_1.
-Defined.
+Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l := idpath.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)
 Definition remove_length_leq {A : Type} (n : nat) (l : list A)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -665,8 +665,10 @@ Defined.
 Definition take_take_min {A : Type} {m n : nat} (l : list A)
   : take n (take m l) = take (nat_min n m) l.
 Proof.
-  revert n m l; induction n, m; intro l.
-  1-3: reflexivity.
+  induction n in m, l |- *.
+  1: reflexivity.
+  destruct m.
+  1: reflexivity.
   destruct l as [|a l'].
   1: by rewrite !take_nil.
   cbn. apply ap, IHn.
@@ -685,10 +687,10 @@ Definition take_app {A : Type} {n : nat} (l1 l2 : list A) (hn : n <= length l1)
 Proof.
   induction n in l1, l2, hn |- *.
   - reflexivity.
-  - induction l1 as [|a l1 IHl1].
+  - destruct l1 as [|a l1].
     + contradiction (not_lt_zero_r _ hn).
     + cbn.
-      apply ap, IHn, (_ hn).
+      apply ap, IHn, leq_pred', hn.
 Defined.
 
 (** *** Remove *)
@@ -980,9 +982,9 @@ Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
   {i : nat} (Hi : i < n)
   : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
 Proof.
-  lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  - nrapply length_seq'.
   - exact (ap s (nth'_seq' _ _ _)).
-  Unshelve. nrapply length_seq'.
 Defined.
 
 (** ** Repeat *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -288,7 +288,7 @@ Proof.
   apply IHl.
 Defined.
 
-(** The [reverse] of a [cons] is the concatenation of the [reverse] with the head. *) 
+(** The [reverse] of a [cons] is the concatenation of the [reverse] with the head. *)
 Definition reverse_cons {A : Type} (a : A) (l : list A)
   : reverse (a :: l) = reverse l ++ [a].
 Proof.
@@ -388,7 +388,7 @@ Definition nth'_cons {A : Type} (l : list A) (n : nat) (x : A)
   : nth' (x :: l) n.+1 H' = nth' l n H.
 Proof.
   apply isinj_some.
-  nrefine (_^ @ _ @ _).  
+  nrefine (_^ @ _ @ _).
   1,3: rapply nth_nth'.
   reflexivity.
 Defined.
@@ -513,7 +513,7 @@ Defined.
 
 (** The [nth i] element where [pred (length l) = i] is the last element of the list. *)
 Definition nth_last {A : Type} (l : list A) (i : nat) (p : nat_pred (length l) = i)
-  : nth l i = last l. 
+  : nth l i = last l.
 Proof.
   destruct p.
   induction l as [|a l IHl].
@@ -731,7 +731,7 @@ Proof.
   lhs nrapply nat_sub_succ_r.
   apply ap.
   apply nat_add_sub_cancel_l.
-Defined. 
+Defined.
 
 (** An element of a [remove] is an element of the original list. *)
 Definition remove_inlist {A : Type} (n : nat) (l : list A) (x : A)
@@ -853,7 +853,7 @@ Defined.
 Definition seq'@{} (n : nat) : list {k : nat & k < n}
   := reverse (seq_rev' n).
 
-(** The length of [seq_rev' n] is [n]. *) 
+(** The length of [seq_rev' n] is [n]. *)
 Definition length_seq_rev'@{} (n : nat)
   : length (seq_rev' n) = n.
 Proof.
@@ -955,7 +955,7 @@ Proof.
   rapply equiv_iff_hprop.
 Defined.
 
-(** Turning a finite sequence into a list. This is taken from [Build_Vector]. *)
+(** Turning a finite sequence into a list. *)
 Definition Build_list {A : Type} (n : nat)
   (f : forall (i : nat), (i < n) -> A)
   : list A
@@ -969,18 +969,30 @@ Proof.
   apply length_seq'.
 Defined.
 
+Definition nth'_Build_list {A : Type} {n : nat}
+  (f : forall (i : nat), (i < n) -> A) {i : nat} (Hi : i < n)
+  (Hi' : i < length (Build_list n f))
+  : nth' (Build_list n f) i Hi' = f i Hi.
+Proof.
+  unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  1: nrapply length_seq'.
+  snrapply ap011D.
+  1: nrapply nth'_seq'.
+  rapply path_ishprop.
+Defined.
+
 (** Restriction of an infinite sequence to a list of specified length. *)
 Definition list_restrict {A : Type} (s : nat -> A) (n : nat) : list A
   := Build_list n (fun m _ => s m).
 
-Definition list_restrict_length {A : Type} (s : nat -> A) (n : nat)
+Definition length_list_restrict {A : Type} (s : nat -> A) (n : nat)
   : length (list_restrict s n) = n
   := length_Build_list _ _.
 
 (** [nth'] of the restriction of a sequence is the corresponding term of the sequence.  *)
-Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
+Definition nth'_list_restrict {A : Type} (s : nat -> A) (n : nat)
   {i : nat} (Hi : i < n)
-  : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
+  : nth' (list_restrict s n) i ((length_list_restrict s n)^ # Hi) = s i.
 Proof.
   unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
   - nrapply length_seq'.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -991,8 +991,8 @@ Definition length_list_restrict {A : Type} (s : nat -> A) (n : nat)
 
 (** [nth'] of the restriction of a sequence is the corresponding term of the sequence.  *)
 Definition nth'_list_restrict {A : Type} (s : nat -> A) (n : nat)
-  {i : nat} (Hi : i < n)
-  : nth' (list_restrict s n) i ((length_list_restrict s n)^ # Hi) = s i.
+  {i : nat} (Hi : i < n) (Hi' : i < length (list_restrict s n))
+  : nth' (list_restrict s n) i Hi' = s i.
 Proof.
   unshelve lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
   - nrapply length_seq'.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -612,16 +612,13 @@ Defined.
 
 (** [take n l] keeps the first [n] elements of [l] and returns [l] if [n >= length l]. *)
 Fixpoint take {A : Type} (n : nat) (l : list A) : list A :=
-  match l, n with
-  | x :: l, n.+1%nat => x :: take n l
+  match n, l with
+  | n.+1, x :: l => x :: take n l
   | _, _ => nil
   end.
 
-(** A [take] of zero elements is the empty list. *)
-Definition take_0 {A : Type} (l : list A) : take 0 l = nil.
-Proof.
-  by destruct l.
-Defined.
+(** A [take] of zero elements is the empty list, by definition. *)
+Definition take_0 {A : Type} (l : list A) : take 0 l = nil := idpath.
 
 (** A [take] of the empty list is the empty list. *)
 Definition take_nil {A : Type} (n : nat) : take n (@nil A) = nil.
@@ -669,7 +666,7 @@ Proof.
   induction l as [|a l IHl] in n, H, x |- * using list_ind@{i i}.
   1: rewrite take_nil in H; contradiction.
   destruct n.
-  1: rewrite take_0 in H; contradiction.
+  { cbn in H. contradiction. }
   destruct H as [-> | H].
   - left; reflexivity.
   - right; exact (IHl _ _ H).
@@ -679,8 +676,8 @@ Defined.
 Definition take_take_min {A : Type} {m n : nat} (l : list A)
   : take n (take m l) = take (nat_min n m) l.
 Proof.
-  revert n m l; induction n, m.
-  1-3: intro l; by rewrite !take_0.
+  revert n m l; induction n, m; intro l.
+  1-3: reflexivity.
   destruct l as [|a l'].
   1: by rewrite !take_nil.
   cbn. apply ap, IHn.
@@ -698,7 +695,7 @@ Definition take_app {A : Type} {n : nat} (l1 l2 : list A) (hn : n <= length l1)
   : take n l1 = take n (l1++l2).
 Proof.
   induction n in l1, l2, hn |- *.
-  - by rewrite !take_0.
+  - reflexivity.
   - induction l1 as [|a l1 IHl1].
     + contradiction (not_lt_zero_r _ hn).
     + cbn.
@@ -715,7 +712,7 @@ Definition remove {A : Type} (n : nat) (l : list A) : list A
 Definition remove_0 {A : Type} (l : list A) : remove 0 l = tail l.
 Proof.
   unfold remove.
-  by rewrite take_0, drop_1.
+  by rewrite drop_1.
 Defined.
 
 (** Removing the [n]-th element of a list with [length l <= n] is the original list. *)

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -617,7 +617,7 @@ Defined.
 
 (** A [take] of [n] elements with [length l <= n] is the original list. *)
 Definition take_length_leq@{i|} {A : Type@{i}} (n : nat) (l : list A)
-  (H : (length l <= n))
+  (H : length l <= n)
   : take n l = l.
 Proof.
   induction l as [|a l IHl] in H, n |- * using list_ind@{i i}.
@@ -1223,7 +1223,7 @@ Proof.
 Defined.
 
 Definition list_exists_seq {n : nat} (P : nat -> Type)
-  (H : forall k, P k -> (k < n))
+  (H : forall k, P k -> k < n)
   : (exists k, P k) <-> list_exists P (seq n).
 Proof.
   split.
@@ -1240,7 +1240,7 @@ Defined.
 
 (** An upper bound on witnesses of a decidable predicate makes the sigma type decidable. *)
 Definition decidable_exists_nat (n : nat) (P : nat -> Type)
-  (H1 : forall k, P k -> (k < n))
+  (H1 : forall k, P k -> k < n)
   (H2 : forall k, Decidable (P k))
   : Decidable (exists k, P k).
 Proof.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -645,7 +645,7 @@ Defined.
 (** The length of a [take] is less than or equal to the length of the list. *)
 Definition length_take_leq {A : Type} {n : nat} (l : list A)
   : length (take n l) <= length l
-  := transport (fun x => x <= length l) (length_take n l)^ (nat_min_leq_r _ _).
+  := transport (fun x => x <= length l) (length_take n l)^ (leq_nat_min_r _ _).
 
 (** An element of a [take] is an element of the original list. *)
 Definition take_inlist@{i|} {A : Type@{i}} (n : nat) (l : list A) (x : A)
@@ -683,7 +683,7 @@ Defined.
 
 (** A [take n] does not change under concatenation if [n] is less than or equal to the length of the first list. *)
 Definition take_app {A : Type} {n : nat} (l1 l2 : list A) (hn : n <= length l1)
-  : take n l1 = take n (l1++l2).
+  : take n l1 = take n (l1 ++ l2).
 Proof.
   induction n in l1, l2, hn |- *.
   - reflexivity.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -971,6 +971,38 @@ Proof.
   rapply equiv_iff_hprop.
 Defined.
 
+(** Turning a finite sequence into a list. This is taken from [Build_Vector]. *)
+Definition Build_list {A : Type} (n : nat)
+  (f : forall (i : nat), (i < n) -> A)
+  : list A
+  := list_map (fun '(i; Hi) => f i Hi) (seq' n).
+
+Definition length_Build_list {A : Type} (n : nat)
+  (f : forall (i : nat), (i < n) -> A)
+  : length (Build_list n f) = n.
+Proof.
+  lhs nrapply length_list_map.
+  apply length_seq'.
+Defined.
+
+(** Restriction of an infinite sequence to a list of specified length. *)
+Definition list_restrict {A : Type} (s : nat -> A) (n : nat) : list A
+  := Build_list n (fun m _ => s m).
+
+Definition list_restrict_length {A : Type} (s : nat -> A) (n : nat)
+  : length (list_restrict s n) = n
+  := length_Build_list _ _.
+
+(** [nth'] of the restriction of a sequence is the corresponding term of the sequence.  *)
+Definition entry_list_restrict {A : Type} (s : nat -> A) (n : nat)
+  {i : nat} (Hi : i < n)
+  : nth' (list_restrict s n) i ((list_restrict_length s n)^ # Hi) = s i.
+Proof.
+  lhs snrefine (nth'_list_map _ _ _ (_^ # Hi) _).
+  - exact (ap s (nth'_seq' _ _ _)).
+  Unshelve. nrapply length_seq'.
+Defined.
+
 (** ** Repeat *)
 
 (** The length of a repeated list is the number of repetitions. *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -832,7 +832,7 @@ Proof.
 Defined.
 
 (** The defining properties of [nat_min]: [nat_min n m] is less than or equal to [m] and [n] and any number less than or equal to [m] and [n] is less than or equal to [nat_min n m]. *)
-Definition nat_min_leq_l@{} n m : nat_min n m <= n.
+Definition leq_nat_min_l@{} n m : nat_min n m <= n.
 Proof.
   induction n as [|n IHn] in m |- *.
   1: cbn; reflexivity.
@@ -841,7 +841,7 @@ Proof.
   exact (leq_succ (IHn m)).
 Defined.
 
-Definition nat_min_leq_r@{} n m : nat_min n m <= m.
+Definition leq_nat_min_r@{} n m : nat_min n m <= m.
 Proof.
   induction n as [|n IHn] in m |- *.
   1: exact (leq_zero_l _).
@@ -850,7 +850,7 @@ Proof.
   exact (leq_succ (IHn m)).
 Defined.
 
-Definition leq_nat_min@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
+Definition nat_min_leq@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
   : k <= nat_min n m.
 Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -740,6 +740,34 @@ Proof.
   exact (ap S IH).
 Defined.
 
+(** The defining properties of [nat_max]: [m] and [n] are less than or equal to [nat_max n m] and [nat_max n m] is less than or equal to any number greater than or equal to [m] and [n]. *)
+Definition leq_nat_max_l@{} n m : n <= nat_max n m.
+Proof.
+  induction n as [|n IHn] in m |- *.
+  1: exact (leq_zero_l _).
+  destruct m; cbn.
+  1: cbn; reflexivity.
+  exact (leq_succ (IHn m)).
+Defined.
+
+Definition leq_nat_max_r@{} n m : m <= nat_max n m.
+Proof.
+  induction n as [|n IHn] in m |- *.
+  1: cbn; reflexivity.
+  destruct m; cbn.
+  1: exact (leq_zero_l _).
+  exact (leq_succ (IHn m)).
+Defined.
+
+Definition nat_max_leq@{} {n m k : nat} (Hn : n <= k) (Hm : m <= k)
+  : nat_max n m <= k.
+Proof.
+  induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
+  1-3, 5-7: exact _.
+  - contradiction (not_lt_zero_r _ _).
+  - exact (leq_succ (IHk n m _ _)).
+Defined.
+
 (** [nat_max] is commutative. *)
 Definition nat_max_comm@{} n m : nat_max n m = nat_max m n.
 Proof.
@@ -801,6 +829,33 @@ Proof.
   simple_induction' n; cbn.
   1: reflexivity.
   exact (ap S IH).
+Defined.
+
+(** The defining properties of [nat_min]: [nat_min n m] is less than or equal to [m] and [n] and any number less than or equal to [m] and [n] is less than or equal to [nat_min n m]. *)
+Definition nat_min_leq_l@{} n m : nat_min n m <= n.
+Proof.
+  induction n as [|n IHn] in m |- *.
+  1: cbn; reflexivity.
+  destruct m; cbn.
+  1: exact (leq_zero_l _).
+  exact (leq_succ (IHn m)).
+Defined.
+
+Definition nat_min_leq_r@{} n m : nat_min n m <= m.
+Proof.
+  induction n as [|n IHn] in m |- *.
+  1: exact (leq_zero_l _).
+  destruct m; cbn.
+  1: cbn; reflexivity.
+  exact (leq_succ (IHn m)).
+Defined.
+
+Definition leq_nat_min@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
+  : k <= nat_min n m.
+Proof.
+  induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
+  1-7: exact _.
+  exact (leq_succ (IHk n m _ _)).
 Defined.
 
 (** [nat_min] is commutative. *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -759,7 +759,7 @@ Proof.
   exact (leq_succ (IHn m)).
 Defined.
 
-Definition nat_max_leq@{} {n m k : nat} (Hn : n <= k) (Hm : m <= k)
+Definition leq_nat_max@{} {n m k : nat} (Hn : n <= k) (Hm : m <= k)
   : nat_max n m <= k.
 Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.
@@ -850,7 +850,7 @@ Proof.
   exact (leq_succ (IHn m)).
 Defined.
 
-Definition nat_min_leq@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
+Definition leq_nat_min@{} {n m k : nat} (Hn : k <= n) (Hm : k <= m)
   : k <= nat_min n m.
 Proof.
   induction k in m, n, Hn, Hm |- *; destruct m, n; cbn.


### PR DESCRIPTION
Added various small results and improvements that will be used in future PRs.

**Nat.Core:**

- Properties of `nat_max` and `nat_min`.

**List.Theory:**

-  Results for `take` (two takes are the same as a take with the minimum, commutativity, invariance of `take n` with respect to concatenation if n is less than or equal to the length of the first list).
- Adapted the `Build_Vector` constructor to get a `Build_list`  constructor for a list given a function from `nat`, changed the results for Vectors so that they are based on this.
- Simplification of definitions by @jdchristensen
