### PR TITLE
Variants of decidable_exists_nat

### DIFF
--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -71,6 +71,17 @@ Section bounded_search.
              rewrite eqlSn; assumption.
   Defined.
 
+  (** Should we include [minimal l] in the condition as well? *)
+  Definition decidable_search (n : nat) : Decidable { l : nat & (l <= n) * P l }.
+  Proof.
+    destruct (bounded_search n) as [s | no_l].
+    - destruct s as [l [[Pl min] l_leq_n]].
+      exact (inl (l; (l_leq_n, Pl))).
+    - right.
+      intros [l [l_leq_n Pl]].
+      exact (no_l l l_leq_n Pl).
+  Defined.
+
   Local Definition n_to_min_n (n : nat) (Pn : P n) : min_n_Type.
   Proof.
     assert (smaller n + forall l, (l <= n) -> not (P l)) as X by apply bounded_search.

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -76,17 +76,6 @@ Section bounded_search.
              rewrite eqlSn; assumption.
   Defined.
 
-  (** Should we include [minimal l] in the condition as well? *)
-  Definition decidable_search (n : nat) : Decidable { l : nat & (l <= n) * P l }.
-  Proof.
-    destruct (bounded_search n) as [s | no_l].
-    - destruct s as [l [[Pl min] l_leq_n]].
-      exact (inl (l; (l_leq_n, Pl))).
-    - right.
-      intros [l [l_leq_n Pl]].
-      exact (no_l l l_leq_n Pl).
-  Defined.
-
   Local Definition n_to_min_n (n : nat) (Pn : P n) : min_n_Type.
   Proof.
     assert (smaller n + forall l, (l <= n) -> not (P l)) as X by apply bounded_search.
@@ -107,6 +96,17 @@ Section bounded_search.
   Proof.
     destruct (prop_n_to_min_n P_inhab) as [n pl]. destruct pl as [p _].
     exact (n; fst merely_inhabited_iff_inhabited_stable p).
+  Defined.
+
+  (** As a consequence of [bounded_search] we deduce that bounded existence is decidable.  See also [decidable_exists_bounded_nat] in Spaces/Lists/Theory.v for a similar result with different dependencies. *)
+  Definition decidable_search (n : nat) : Decidable { l : nat & (l <= n) * P l }.
+  Proof.
+    destruct (bounded_search n) as [s | no_l].
+    - destruct s as [l [[Pl min] l_leq_n]].
+      exact (inl (l; (l_leq_n, Pl))).
+    - right.
+      intros [l [l_leq_n Pl]].
+      exact (no_l l l_leq_n Pl).
   Defined.
 
 End bounded_search.

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -1,3 +1,7 @@
+(** * Bounded Search *)
+
+(** The main result of this file is [minimal_n], which say that if [P : nat -> Type] is a family such that each [P n] is decidable and [{n & P n}] is merely inhabited, then [{n & P n}] is inhabited.  Since [P n] is decidable, it is sufficient to prove [{n & merely (P n)}], and to do this, we prove the stronger claim that there is a *minimal* [n] satisfying [merely (P n)].  This stronger claim is a proposition, which is what makes the argument work.  Along the way, we also prove that [{ l : nat & (l <= n) * P l }] is decidable for each [n]. *)
+
 Require Import Basics.Overture Basics.Decidable Basics.Trunc Basics.Tactics.
 Require Import Types.Sigma Types.Prod.
 Require Import Truncations.Core.

--- a/theories/BoundedSearch.v
+++ b/theories/BoundedSearch.v
@@ -1,6 +1,7 @@
-Require Import HoTT.Basics HoTT.Types.
-Require Import HoTT.Truncations.Core.
-Require Import HoTT.Spaces.Nat.Core.
+Require Import Basics.Overture Basics.Decidable Basics.Trunc Basics.Tactics.
+Require Import Types.Sigma Types.Prod.
+Require Import Truncations.Core.
+Require Import Spaces.Nat.Core.
 
 Section bounded_search.
 

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -1249,3 +1249,8 @@ Proof.
   1: exact H1.
   exact _.
 Defined.
+
+Definition decidable_exists_bounded_nat (n : nat) (P : nat -> Type)
+  (H2 : forall k, Decidable (P k))
+  : Decidable { k : nat & prod (k < n) (P k) }
+  := decidable_exists_nat n _ (fun k => fst) _.

--- a/theories/Spaces/List/Theory.v
+++ b/theories/Spaces/List/Theory.v
@@ -1250,6 +1250,7 @@ Proof.
   exact _.
 Defined.
 
+(** A common special case.  See also [decidable_search] in BoundedSearch.v for a similar result with different dependencies. *)
 Definition decidable_exists_bounded_nat (n : nat) (P : nat -> Type)
   (H2 : forall k, Decidable (P k))
   : Decidable { k : nat & prod (k < n) (P k) }

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -417,6 +417,18 @@ Definition nat_mul_one_r@{} n : n * 1 = n
 (** [<=] is reflexive by definition. *)
 Global Instance reflexive_leq : Reflexive leq := leq_refl.
 
+(** The default induction principle for [leq] applies to a type family depending on the second variable.  Here is a version involving a type family depending on the first variable.  A more general form would involve [Q : forall (m : nat) (l : m <= n.+1), Type], but that seems trickier to prove. *)
+Definition leq_ind_l {n : nat} (Q : forall (m : nat), Type)
+  (H_Sn : Q n.+1)
+  (H_m : forall (m : nat) (l : m <= n), Q m)
+  : forall (m : nat) (l : m <= n.+1), Q m.
+Proof.
+  intros m leq_m_Sn.
+  inversion leq_m_Sn.
+  1: assumption.
+  apply H_m, H.
+Defined.
+
 (** Being less than or equal to is a transitive relation. *)
 Definition leq_trans {x y z} : x <= y -> y <= z -> x <= z.
 Proof.
@@ -434,12 +446,15 @@ Proof.
 Defined.
 Global Existing Instance leq_zero_l | 10.
 
+Global Instance pred_leq {m} : nat_pred m <= m.
+Proof.
+  destruct m; exact _.
+Defined.
+
 (** A predecessor is less than or equal to a predecessor if the original number is less than or equal. *)
 Global Instance leq_pred {n m} : n <= m -> nat_pred n <= nat_pred m.
 Proof.
-  intros H; induction H.
-  1: exact _.
-  destruct m; exact _.
+  intros H; induction H; exact _.
 Defined.
 
 (** A successor is less than or equal to a successor if the original numbers are less than or equal. *)
@@ -993,6 +1008,14 @@ Proof.
   destruct (IHm n).
   1: left; exact _.
   1: right; exact _.
+Defined.
+
+(** A variant. *)
+Definition leq_succ_dichotomy {n m : nat} (l : m <= n.+1) : (m = n.+1) + (m <= n).
+Proof.
+  inversion l.
+  - left; reflexivity.
+  - right; assumption.
 Defined.
 
 (** *** Trichotomy *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -504,6 +504,12 @@ Proof.
   exact _.
 Defined.
 
+(** [n.+1 <= m] implies [n <= m]. *)
+Definition leq_succ_l {n m} : n.+1 <= m -> n <= m.
+Proof.
+  intro l; apply leq_pred'; exact _.
+Defined.
+
 (** A general form for injectivity of this constructor *)
 Definition leq_refl_inj_gen n k (p : n <= k) (r : n = k) : p = r # leq_refl n.
 Proof.
@@ -581,12 +587,6 @@ Proof.
   inversion leq_m_Sn as [p | k H p]; destruct p^; clear p.
   - exact (path_ishprop _ _ # H_Sn).
   - exact (path_ishprop _ _ # H_m _ _).
-Defined.
-
-(** [n.+1 <= m] implies [n <= m]. *)
-Definition leq_succ_l {n m} : n.+1 <= m -> n <= m.
-Proof.
-  intro l; apply leq_pred'; exact _.
 Defined.
 
 (** *** Basic properties of [<] *)

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -417,18 +417,6 @@ Definition nat_mul_one_r@{} n : n * 1 = n
 (** [<=] is reflexive by definition. *)
 Global Instance reflexive_leq : Reflexive leq := leq_refl.
 
-(** The default induction principle for [leq] applies to a type family depending on the second variable.  Here is a version involving a type family depending on the first variable.  A more general form would involve [Q : forall (m : nat) (l : m <= n.+1), Type], but that seems trickier to prove. *)
-Definition leq_ind_l {n : nat} (Q : forall (m : nat), Type)
-  (H_Sn : Q n.+1)
-  (H_m : forall (m : nat) (l : m <= n), Q m)
-  : forall (m : nat) (l : m <= n.+1), Q m.
-Proof.
-  intros m leq_m_Sn.
-  inversion leq_m_Sn.
-  1: assumption.
-  apply H_m, H.
-Defined.
-
 (** Being less than or equal to is a transitive relation. *)
 Definition leq_trans {x y z} : x <= y -> y <= z -> x <= z.
 Proof.
@@ -581,6 +569,18 @@ Proof.
     + rapply decidable_equiv'.
       symmetry.
       apply equiv_leq_succ.
+Defined.
+
+(** The default induction principle for [leq] applies to a type family depending on the second variable.  Here is a version involving a type family depending on the first variable. *)
+Definition leq_ind_l {n : nat} (Q : forall (m : nat) (l : m <= n.+1), Type)
+  (H_Sn : Q n.+1 (leq_refl n.+1))
+  (H_m : forall (m : nat) (l : m <= n), Q m (leq_succ_r l))
+  : forall (m : nat) (l : m <= n.+1), Q m l.
+Proof.
+  intros m leq_m_Sn.
+  inversion leq_m_Sn as [p | k H p]; destruct p^; clear p.
+  - exact (path_ishprop _ _ # H_Sn).
+  - exact (path_ishprop _ _ # H_m _ _).
 Defined.
 
 (** [n.+1 <= m] implies [n <= m]. *)


### PR DESCRIPTION
I noticed that there are two ways to prove that it's decidable whether a bounded natural satisfies a decidable predicate.  One is already in List/Theory, which I extended with `decidable_exists_bounded_nat`.  But BoundedSearch essentially proves this as well, as I illustrate with `decidable_search`.

On the one hand, it's nice that BoundedSearch avoids needing to use lists.  On the other hand, BoundedSearch requires `merely`, which currently requires Modalities (although I suspect this dependency can easily be removed with some reorganization).

Maybe it's worth having both?  If so, I'll add comments pointing each one to the other.  Or, we could just keep one.

Incidentally, the one in List/Theory is hard to find.  Since the statement of the lemma doesn't involve lists, it's not an obvious place to look.  Is there somewhere else that would make sense to put it?  (The reason I proved the version using bounded search is because I didn't remember that there was a version already in List/Theory.)