### PR TITLE
cleanups and improvements to lagrange

### DIFF
--- a/theories/Algebra/Groups.v
+++ b/theories/Algebra/Groups.v
@@ -13,7 +13,7 @@ Require Export HoTT.Algebra.Groups.FreeProduct.
 
 Require Export HoTT.Algebra.Groups.Presentation.
 Require Export HoTT.Algebra.Groups.ShortExactSequence.
-Require Export HoTT.Algebra.Groups.Lagrange.
+Require Export HoTT.Algebra.Groups.Finite.
 
 (** Examples *)
 

--- a/theories/Algebra/Groups/Finite.v
+++ b/theories/Algebra/Groups/Finite.v
@@ -6,12 +6,15 @@ Require Import Spaces.Finite.Finite.
 Require Import Spaces.Nat.Core Spaces.Nat.Division.
 Require Import Truncations.Core.
 
-(** ** Lagrange's theorem *)
-
 Local Open Scope mc_mult_scope.
 Local Open Scope nat_scope.
 
-(** TODO: move to file about finite groups *)
+Set Universe Minimization ToSet.
+
+(** * Finite Groups *)
+
+(** ** Basic Properties *)
+
 (** The order of a group is strictly positive. *)
 Global Instance lt_zero_fcard_grp (G : Group) (fin_G : Finite G) : 0 < fcard G.
 Proof.
@@ -22,27 +25,43 @@ Proof.
   - exact _.
 Defined.
 
-(** TODO: move to file about finite groups *)
-Definition subgroup_index {U : Univalence} (G : Group) (H : Subgroup G)
-  (fin_G : Finite G) (fin_H : Finite H)
+(** ** Index of a subgroup *)
+
+Definition subgroup_index@{i j | i < j} {U : Univalence}
+  (G : Group@{i}) (H : Subgroup@{i i} G)
+  {fin_G : Finite@{i i i} G} {fin_H : Finite@{i i i} H}
   : nat.
 Proof.
-  refine (fcard (Quotient (in_cosetL H))).
-  nrapply finite_quotient.
+  refine (fcard@{i i i} (Quotient@{i i i} (in_cosetL@{i i} H))).
+  (* 54 universes! :'( *) 
+  nrapply finite_quotient
+    @{i i i i i i i i i j
+      i i i i i i i i i i
+      i i i i i i i i i i
+      j i i i i i i i i i
+      i i i i i i j i i i
+      i i i i}.
   1-5: exact _.
   intros x y.
-  pose (dec_H := detachable_finite_subset H).
+  (* 33 universes! :'( *) 
+  pose (dec_H := detachable_finite_subset
+    @{i i i i i i i i j i
+      i i i i i i i i i i
+      i i i i i i i i i i
+      i i i} H).
   apply dec_H.
 Defined.
+
+(** ** Lagrange's theorem *)
 
 (** Lagrange's Theorem - Given a finite group [G] and a finite subgroup [H] of [G], the order of [H] divides the order of [G].
 
 Note that constructively, a subgroup of a finite group cannot be shown to be finite without excluded middle. We therefore have to assume it is. This in turn implies that the subgroup is decidable. *)
-Definition divides_fcard_subgroup {U : Univalence} (G : Group) (H : Subgroup G)
-  (fin_G : Finite G) (fin_H : Finite H)
+Definition divides_fcard_subgroup {U : Univalence}
+  (G : Group) (H : Subgroup G) {fin_G : Finite G} {fin_H : Finite H}
   : (fcard H | fcard G).
 Proof.
-  exists (subgroup_index G H _ _).
+  exists (subgroup_index G H).
   symmetry.
   refine (fcard_quotient (in_cosetL H) @ _).
   refine (_ @ finadd_const _ _).
@@ -59,11 +78,20 @@ Proof.
   exact _.
 Defined.
 
-(** As a corollary, we can show that the order of the quotient group [G/H] is the order of [G] divided by the order of [H]. *)
-Definition fcard_grp_quotient {U : Univalence} (G : Group) (H : NormalSubgroup G)
-  (fin_G : Finite G) (fin_H : Finite H)
-  : fcard (QuotientGroup G H) = fcard G / fcard H.
+(** As a corollary, the index of a subgroup is the order of the group divided by the order of the subgroup. *)
+Definition subgroup_index_fcard_div {U : Univalence}
+  (G : Group) (H : Subgroup G) (fin_G : Finite G) (fin_H : Finite H)
+  : subgroup_index G H = fcard G / fcard H.
 Proof.
   rapply nat_div_moveL_nV.
   apply divides_fcard_subgroup.
+Defined.
+
+(** Therefore we can show that the order of the quotient group [G / H] is the order of [G] divided by the order of [H]. *)
+Definition fcard_grp_quotient {U : Univalence}
+  (G : Group) (H : NormalSubgroup G)
+  (fin_G : Finite G) (fin_H : Finite H)
+  : fcard (QuotientGroup G H) = fcard G / fcard H.
+Proof.
+  apply subgroup_index_fcard_div.
 Defined.

--- a/theories/Algebra/Groups/Finite.v
+++ b/theories/Algebra/Groups/Finite.v
@@ -6,8 +6,8 @@ Require Import Spaces.Finite.Finite.
 Require Import Spaces.Nat.Core Spaces.Nat.Division.
 Require Import Truncations.Core.
 
-Local Open Scope mc_mult_scope.
 Local Open Scope nat_scope.
+Local Open Scope mc_mult_scope.
 
 Set Universe Minimization ToSet.
 
@@ -66,15 +66,12 @@ Proof.
   refine (fcard_quotient (in_cosetL H) @ _).
   refine (_ @ finadd_const _ _).
   apply ap, path_forall.
-  srapply Quotient_ind_hprop.
-  simpl. (** simpl is better than cbn here *)
+  srapply Quotient_ind_hprop; simpl.
   intros x.
   apply fcard_equiv'.
-  (** Now we must show that cosets are all equivalent as types. *)
-  simpl.
   snrapply equiv_functor_sigma.
   2: apply (isequiv_group_left_op x^).
-  1: hnf; trivial.
+  1: exact (fun _ => idmap).
   exact _.
 Defined.
 

--- a/theories/Algebra/Groups/Finite.v
+++ b/theories/Algebra/Groups/Finite.v
@@ -27,28 +27,18 @@ Defined.
 
 (** ** Index of a subgroup *)
 
-Definition subgroup_index@{i j | i < j} {U : Univalence}
-  (G : Group@{i}) (H : Subgroup@{i i} G)
-  {fin_G : Finite@{i i i} G} {fin_H : Finite@{i i i} H}
+(** TODO: fix the number of universes appearing here. *)
+(** The index of a subgroup is the number of possible cosets of the subgroup. *) 
+Definition subgroup_index {U : Univalence}
+  (G : Group) (H : Subgroup G)
+  {fin_G : Finite G} {fin_H : Finite H}
   : nat.
 Proof.
-  refine (fcard@{i i i} (Quotient@{i i i} (in_cosetL@{i i} H))).
-  (* 54 universes! :'( *) 
-  nrapply finite_quotient
-    @{i i i i i i i i i j
-      i i i i i i i i i i
-      i i i i i i i i i i
-      j i i i i i i i i i
-      i i i i i i j i i i
-      i i i i}.
+  refine (fcard (Quotient (in_cosetL H))).
+  nrapply finite_quotient.
   1-5: exact _.
   intros x y.
-  (* 33 universes! :'( *) 
-  pose (dec_H := detachable_finite_subset
-    @{i i i i i i i i j i
-      i i i i i i i i i i
-      i i i i i i i i i i
-      i i i} H).
+  pose (dec_H := detachable_finite_subset H).
   apply dec_H.
 Defined.
 

--- a/theories/Algebra/Groups/Finite.v
+++ b/theories/Algebra/Groups/Finite.v
@@ -25,23 +25,6 @@ Proof.
   - exact _.
 Defined.
 
-(** ** Index of a subgroup *)
-
-(** TODO: fix the number of universes appearing here. *)
-(** The index of a subgroup is the number of possible cosets of the subgroup. *) 
-Definition subgroup_index {U : Univalence}
-  (G : Group) (H : Subgroup G)
-  {fin_G : Finite G} {fin_H : Finite H}
-  : nat.
-Proof.
-  refine (fcard (Quotient (in_cosetL H))).
-  nrapply finite_quotient.
-  1-5: exact _.
-  intros x y.
-  pose (dec_H := detachable_finite_subset H).
-  apply dec_H.
-Defined.
-
 (** ** Lagrange's theorem *)
 
 (** Lagrange's Theorem - Given a finite group [G] and a finite subgroup [H] of [G], the order of [H] divides the order of [G].
@@ -59,10 +42,7 @@ Proof.
   srapply Quotient_ind_hprop; simpl.
   intros x.
   apply fcard_equiv'.
-  snrapply equiv_functor_sigma.
-  2: apply (isequiv_group_left_op x^).
-  1: exact (fun _ => idmap).
-  exact _.
+  apply equiv_sigma_in_cosetL_subgroup.
 Defined.
 
 (** As a corollary, the index of a subgroup is the order of the group divided by the order of the subgroup. *)
@@ -80,5 +60,5 @@ Definition fcard_grp_quotient {U : Univalence}
   (fin_G : Finite G) (fin_H : Finite H)
   : fcard (QuotientGroup G H) = fcard G / fcard H.
 Proof.
-  apply subgroup_index_fcard_div.
+  rapply subgroup_index_fcard_div.
 Defined.

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -3,14 +3,26 @@ Require Import Algebra.Groups.Group.
 Require Import Algebra.Groups.Subgroup.
 Require Import Algebra.Groups.QuotientGroup.
 Require Import Spaces.Finite.Finite.
-Require Import Spaces.Nat.Core.
+Require Import Spaces.Nat.Core Spaces.Nat.Division.
+Require Import Truncations.Core.
 
 (** ** Lagrange's theorem *)
 
-Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
 Local Open Scope nat_scope.
 
+(** TODO: move to file about finite groups *)
+(** The order of a group is strictly positive. *)
+Global Instance lt_zero_fcard_grp (G : Group) (fin_G : Finite G) : 0 < fcard G.
+Proof.
+  pose proof (merely_equiv_fin G) as f.
+  strip_truncations.
+  destruct (fcard G).
+  - contradiction (f mon_unit).
+  - exact _.
+Defined.
+
+(** TODO: move to file about finite groups *)
 Definition subgroup_index {U : Univalence} (G : Group) (H : Subgroup G)
   (fin_G : Finite G) (fin_H : Finite H)
   : nat.
@@ -23,10 +35,12 @@ Proof.
   apply dec_H.
 Defined.
 
-(** Given a finite group G and a finite subgroup H of G, the order of H divides the order of G. Note that constructively, a subgroup of a finite group cannot be shown to be finite without exlcluded middle. We therefore have to assume it is. This in turn implies that the subgroup is decidable. *)
-Theorem lagrange {U : Univalence} (G : Group) (H : Subgroup G)
+(** Lagrange's Theorem - Given a finite group [G] and a finite subgroup [H] of [G], the order of [H] divides the order of [G].
+
+Note that constructively, a subgroup of a finite group cannot be shown to be finite without excluded middle. We therefore have to assume it is. This in turn implies that the subgroup is decidable. *)
+Definition divides_fcard_subgroup {U : Univalence} (G : Group) (H : Subgroup G)
   (fin_G : Finite G) (fin_H : Finite H)
-  : exists d, d * (fcard H) = fcard G.
+  : (fcard H | fcard G).
 Proof.
   exists (subgroup_index G H _ _).
   symmetry.
@@ -45,9 +59,11 @@ Proof.
   exact _.
 Defined.
 
-Corollary lagrange_normal {U : Univalence} (G : Group) (H : NormalSubgroup G)
+(** As a corollary, we can show that the order of the quotient group [G/H] is the order of [G] divided by the order of [H]. *)
+Definition fcard_grp_quotient {U : Univalence} (G : Group) (H : NormalSubgroup G)
   (fin_G : Finite G) (fin_H : Finite H)
-  : fcard (QuotientGroup G H) * fcard H = fcard G.
+  : fcard (QuotientGroup G H) = fcard G / fcard H.
 Proof.
-  apply lagrange.
+  rapply nat_div_moveR_nV.
+  apply divides_fcard_subgroup.
 Defined.

--- a/theories/Algebra/Groups/Lagrange.v
+++ b/theories/Algebra/Groups/Lagrange.v
@@ -64,6 +64,6 @@ Definition fcard_grp_quotient {U : Univalence} (G : Group) (H : NormalSubgroup G
   (fin_G : Finite G) (fin_H : Finite H)
   : fcard (QuotientGroup G H) = fcard G / fcard H.
 Proof.
-  rapply nat_div_moveR_nV.
+  rapply nat_div_moveL_nV.
   apply divides_fcard_subgroup.
 Defined.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -17,6 +17,8 @@ Local Open Scope mc_scope.
 Local Open Scope mc_mult_scope.
 Local Open Scope wc_iso_scope.
 
+(** ** Congruence quotients *)
+
 Section GroupCongruenceQuotient.
 
   (** A congruence on a group is a relation satisfying [R x x' -> R y y' -> R (x * y) (x' * y')].  Because we also require that [R] is reflexive, we also know that [R y y' -> R (x * y) (x * y')] for any [x], and similarly for multiplication on the right by [x].  We don't need to assume that [R] is symmetric or transitive. *)
@@ -106,6 +108,55 @@ Section GroupCongruenceQuotient.
 
 End GroupCongruenceQuotient.
 
+(** ** Sets of cosets *)
+
+Section Cosets.
+
+  Context (G : Group) (H : Subgroup G).
+  
+  Definition LeftCoset := G / in_cosetL H.
+
+  (** The set of left cosets of a finite subgroup of a finite group is finite. *)
+  Global Instance finite_leftcoset `{Univalence, Finite G, Finite H}
+    : Finite LeftCoset.
+  Proof.
+    nrapply finite_quotient.
+    1-5: exact _.
+    intros x y.
+    pose (dec_H := detachable_finite_subset H).
+    apply dec_H.
+  Defined.
+
+  (** The index of a subgroup is the number of possible cosets of the subgroup. *) 
+  Definition subgroup_index `{Univalence, Finite G,  Finite H} : nat
+    := fcard LeftCoset.
+
+  Definition RightCoset := G / in_cosetR H.
+  
+  (** The set of left cosets is equivalent to the set of right coset. *)
+  Definition equiv_leftcoset_rightcoset
+    : LeftCoset <~> RightCoset.
+  Proof.
+    snrapply equiv_quotient_functor.
+    - exact inv.
+    - exact _.
+    - intros x y; simpl.
+      by rewrite grp_inv_inv.
+  Defined.
+
+  (** The set of right cosets of a finite subgroup of a finite group is finite since it is equivalent to the set of left cosets. *)
+  Global Instance finite_rightcoset `{Univalence, Finite G, Finite H}
+    : Finite RightCoset.
+  Proof.
+    nrapply finite_equiv'.
+    1: apply equiv_leftcoset_rightcoset.
+    exact _.
+  Defined.
+
+End Cosets.
+
+(** ** Quotient groups *)
+
 (** Now we can define the quotient group by a normal subgroup. *)
 
 Section QuotientGroup.
@@ -126,7 +177,7 @@ Section QuotientGroup.
 
   (** Now we have to make a choice whether to pick the left or right cosets. Due to existing convention we shall pick left cosets but we note that we could equally have picked right. *)
   Definition QuotientGroup : Group
-    := Build_Group (G / (in_cosetL N)) _ _ _ _.
+    := Build_Group (LeftCoset G N) _ _ _ _.
 
   Definition grp_quotient_map : G $-> QuotientGroup.
   Proof.
@@ -343,7 +394,7 @@ Proof.
   simpl in triv.
   apply related_quotient_paths in triv.
   2-5: exact _.
-  apply equiv_subgroup_inverse.
+  apply equiv_subgroup_inv.
   nrapply (subgroup_in_op_l _ _ 1 triv) .
   apply subgroup_in_unit.
 Defined.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -124,11 +124,10 @@ Section Cosets.
     nrapply finite_quotient.
     1-5: exact _.
     intros x y.
-    pose (dec_H := detachable_finite_subset H).
-    apply dec_H.
+    apply (detachable_finite_subset H).
   Defined.
 
-  (** The index of a subgroup is the number of possible cosets of the subgroup. *) 
+  (** The index of a subgroup is the number of cosets of the subgroup. *)
   Definition subgroup_index `{Univalence, Finite G, Finite H} : nat
     := fcard LeftCoset.
 

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -116,6 +116,7 @@ Section Cosets.
   
   Definition LeftCoset := G / in_cosetL H.
 
+  (** TODO: Way too many universes, needs fixing *)
   (** The set of left cosets of a finite subgroup of a finite group is finite. *)
   Global Instance finite_leftcoset `{Univalence, Finite G, Finite H}
     : Finite LeftCoset.
@@ -128,7 +129,7 @@ Section Cosets.
   Defined.
 
   (** The index of a subgroup is the number of possible cosets of the subgroup. *) 
-  Definition subgroup_index `{Univalence, Finite G,  Finite H} : nat
+  Definition subgroup_index `{Univalence, Finite G, Finite H} : nat
     := fcard LeftCoset.
 
   Definition RightCoset := G / in_cosetR H.

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -139,8 +139,15 @@ Proof.
   apply subgroup_in_inv'.
 Defined.
 
-Definition equiv_subgroup_inverse {G : Group} (H : Subgroup G) (x : G)
+Definition equiv_subgroup_inv {G : Group} (H : Subgroup G) (x : G)
   : H x <~> H x^ := Build_Equiv _ _ (subgroup_in_inv H x) _.
+
+Definition equiv_subgroup_op_inv {G : Group} (H : Subgroup G) (x y : G)
+  : H (x * y^) <~> H (y * x^).
+Proof.
+  nrefine (_ oE equiv_subgroup_inv _ _).
+  by rewrite grp_inv_op, grp_inv_inv.
+Defined.
 
 (** The group given by a subgroup *)
 Definition subgroup_group {G : Group} (H : Subgroup G) : Group.
@@ -365,6 +372,27 @@ Proof.
   srapply equiv_iff_hprop.
   all: by intro.
 Defined.
+
+(** The sigma type of a left coset is equivalent to the sigma type of the subgroup. *)
+Definition equiv_sigma_in_cosetL_subgroup (G : Group) (H : Subgroup G) (x : G)
+  : sig (in_cosetL H x) <~> sig H.
+Proof.
+  snrapply equiv_functor_sigma'.
+  - rapply (Build_Equiv _ _ (x^ *.)).
+  - reflexivity.
+Defined.
+
+(** The sigma type of a right coset is equivalent to the sigma type of the subgroup. *)
+Definition equiv_sigma_in_cosetR_subgroup (G : Group) (H : Subgroup G) (x : G)
+  : sig (in_cosetR H x) <~> sig H.
+Proof.
+  snrapply equiv_functor_sigma'.
+  - rapply (Build_Equiv _ _ (.* x ^)).
+  - simpl; intros y.
+    apply equiv_subgroup_op_inv.
+Defined.
+
+(** The sigma type of any two right cosets are equivalent. *)
 
 (** A normal subgroup is a subgroup closed under conjugation. *)
 Class IsNormalSubgroup {G : Group} (N : Subgroup G)

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -392,8 +392,6 @@ Proof.
     apply equiv_subgroup_op_inv.
 Defined.
 
-(** The sigma type of any two right cosets are equivalent. *)
-
 (** A normal subgroup is a subgroup closed under conjugation. *)
 Class IsNormalSubgroup {G : Group} (N : Subgroup G)
   := isnormal : forall {x y}, N (x * y) -> N (y * x).

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -631,6 +631,15 @@ Proof.
   nrapply nat_mod_mul_l.
 Defined.
 
+(** We can move a divisor from the right to become a factor on the left of an equation. *)
+Definition nat_div_moveR_nV n m k : 0 < k -> n * k = m -> n = m / k.
+Proof.
+  intros H p.
+  rewrite <- p.
+  symmetry.
+  rapply nat_div_mul_cancel_r.
+Defined.
+
 (** ** Greatest Common Divisor *)
 
 (** The greatest common divisor of [0] and a number is the number itself. *)

--- a/theories/Spaces/Nat/Division.v
+++ b/theories/Spaces/Nat/Division.v
@@ -632,7 +632,7 @@ Proof.
 Defined.
 
 (** We can move a divisor from the right to become a factor on the left of an equation. *)
-Definition nat_div_moveR_nV n m k : 0 < k -> n * k = m -> n = m / k.
+Definition nat_div_moveL_nV n m k : 0 < k -> n * k = m -> n = m / k.
 Proof.
   intros H p.
   rewrite <- p.


### PR DESCRIPTION
We cleanup `Lagrange.v` by giving the theorem a proper name and making the corollary use division. We didn't have a good theory of division and divisibility of nats at the time of writing, but now we do.

I also improve the comments a bit.