### PR TITLE
Defined Bicategory

### DIFF
--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -609,7 +609,7 @@ Defined.
 
 Instance isTruncatedBicat_ptype : IsTruncatedBicat pType.
 Proof.
-  snrapply Build_IsTruncatedBicat.
+  snapply Build_IsTruncatedBicat.
   - exact _.
   - exact _.
   - intros A B C D f g h. apply pmap_compose_assoc.
@@ -647,7 +647,7 @@ Instance is3graph_ptype : Is3Graph pType
 
 Instance is1Bifunctor_ptype_comp (A B C : pType): Is1Bifunctor (cat_comp (a:=A) (b:=B) (c:=C)).
 Proof.
-  snrapply Build_Is1Bifunctor''.
+  snapply Build_Is1Bifunctor''.
   - intro g. apply Build_Is1Functor.
     + intros f f' h h' eq_h. simpl. srapply Build_pHomotopy.
       * intro. apply (ap (ap g)). apply eq_h.
@@ -667,7 +667,7 @@ Proof.
       * reflexivity.
       * destruct f as [f f_eq], g as [g g_eq]. simpl in *.
         destruct f_eq, g_eq; reflexivity.
-    + intros g0 g1 g2 alpha beta. simpl. snrapply Build_pHomotopy.
+    + intros g0 g1 g2 alpha beta. simpl. snapply Build_pHomotopy.
       * reflexivity.
       * by pelim f beta alpha g0 g1 g2.
   - intros g g' beta f f' alpha.
@@ -680,7 +680,7 @@ Defined.
 
 Instance isbicat_ptype : IsBicategory pType.
 Proof.
-  snrapply Build_IsBicategory.
+  snapply Build_IsBicategory.
   1-3: exact _.
   - intros; constructor.
     + unfold bicat_assoc_opp; symmetry.
@@ -692,9 +692,9 @@ Proof.
   - intros; constructor; unfold bicat_idr_opp; symmetry.
     + apply (phomotopy_compose_pV).
     + apply (phomotopy_compose_Vp).
-  - intros a b c d. snrapply Build_Is1Natural.
+  - intros a b c d. snapply Build_Is1Natural.
     intros ((h, g), f) ((h',g'),f') ((tau,sigma),rho). simpl in *.
-    snrapply Build_pHomotopy.
+    snapply Build_pHomotopy.
     + simpl. intro x.
       rewrite concat_1p, concat_p1.
       rewrite ap_compose.
@@ -704,19 +704,19 @@ Proof.
       reflexivity.
     + pelim rho f f' sigma g g' tau.
       by pelim h h'.
-  - intros a b; snrapply Build_Is1Natural.
-    intros f f' h; snrapply Build_pHomotopy.
+  - intros a b; snapply Build_Is1Natural.
+    intros f f' h; snapply Build_pHomotopy.
     + intro; simpl; by autorewrite with paths.
     + by pelim h f f'.
-  - intros a b; snrapply Build_Is1Natural.
-    intros f f' h; snrapply Build_pHomotopy.
+  - intros a b; snapply Build_Is1Natural.
+    intros f f' h; snapply Build_pHomotopy.
     + intro; simpl; by autorewrite with paths.
     + by pelim h f f'.
   - intros a b c d e f g h k.
-    snrapply Build_pHomotopy.
+    snapply Build_pHomotopy.
     + reflexivity.
     + by pelim f g h k.
-  - intros a b c f g. snrapply Build_pHomotopy.
+  - intros a b c f g. snapply Build_pHomotopy.
     + reflexivity.
     + by pelim f g.
 Defined.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -599,6 +599,27 @@ Defined.
 Definition path_zero_morphism_pconst (A B : pType)
   : (@pconst A B) = zero_morphism := idpath.
 
+Instance Is0Bifunctor_ptype_comp (A B C : pType)
+  : Is0Bifunctor (cat_comp (A:= pType)(a:=A)(b:=B)(c:=C)).
+Proof.
+  apply Build_Is0Bifunctor''; constructor; intros.
+  - by apply pmap_postwhisker.
+  - by apply pmap_prewhisker.
+Defined.
+
+Instance isTruncatedBicat_ptype : IsTruncatedBicat pType.
+Proof.
+  snrapply Build_IsTruncatedBicat.
+  - exact _.
+  - exact _.
+  - intros A B C D f g h. apply pmap_compose_assoc.
+  - intros; symmetry; apply pmap_compose_assoc.
+  - intros. apply pmap_postcompose_idmap.
+  - intros. symmetry; apply pmap_postcompose_idmap.
+  - intros. apply pmap_precompose_idmap.
+  - intros; symmetry; apply pmap_precompose_idmap.
+Defined.
+
 (** [pForall] is a 1-category *)
 Instance is1cat_pforall (A : pType) (P : pFam A) : Is1Cat (pForall A P) | 10.
 Proof.
@@ -624,82 +645,85 @@ Defined.
 Instance is3graph_ptype : Is3Graph pType
   := fun f g => is2graph_pforall _ _.
 
-Instance is21cat_ptype : Is21Cat pType.
+Instance is1Bifunctor_ptype_comp (A B C : pType): Is1Bifunctor (cat_comp (a:=A) (b:=B) (c:=C)).
 Proof.
-  unshelve econstructor.
-  - exact _.
-  - intros A B C f; napply Build_Is1Functor.
-    + intros g h p q r.
+  snrapply Build_Is1Bifunctor''.
+  - intro g. apply Build_Is1Functor.
+    + intros f f' h h' eq_h. simpl. srapply Build_pHomotopy.
+      * intro. apply (ap (ap g)). apply eq_h.
+      * by pelim eq_h h h' f f' g.
+    + intro f; srapply Build_pHomotopy.
+      * reflexivity.
+      * by pelim f g.
+    + intros f0 f1 f2 alpha beta. srapply Build_pHomotopy.
+      * intro. cbn; exact (ap_pp _ _ _).
+      * by pelim beta alpha f0 f1 f2 g.
+  - intro f. apply Build_Is1Functor.
+    + intros g g' h h' eqh. simpl.
       srapply Build_pHomotopy.
-      1: exact (fun _ => ap _ (r _)).
-      by pelim r p q g h f.
-    + intros g.
-      srapply Build_pHomotopy.
-      1: reflexivity.
-      by pelim g f.
-    + intros g h i p q.
-      srapply Build_pHomotopy.
-      1: cbn; exact (fun _ => ap_pp _ _ _).
-      by pelim p q g h i f.
-  - intros A B C f; napply Build_Is1Functor.
-    + intros g h p q r.
-      srapply Build_pHomotopy.
-      1: intro; exact (r _).
-      by pelim f r p q g h.
-    + intros g.
-      srapply Build_pHomotopy.
-      1: reflexivity.
-      by pelim f g.
-    + intros g h i p q.
-      srapply Build_pHomotopy.
-      1: reflexivity.
-      by pelim f p q i g h.
-  - intros A B C f g h k p q.
-    snapply Build_pHomotopy.
-    + intros x.
-      exact (concat_Ap q _)^.
-    + by pelim p f g q h k.
-  - intros A B C D f g.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
+      * intro. simpl. apply eqh.
+      * cbn beta zeta. by pelim f eqh h h' g g'.
+    + intro g. srapply Build_pHomotopy.
+      * reflexivity.
+      * destruct f as [f f_eq], g as [g g_eq]. simpl in *.
+        destruct f_eq, g_eq; reflexivity.
+    + intros g0 g1 g2 alpha beta. simpl. snrapply Build_pHomotopy.
+      * reflexivity.
+      * by pelim f beta alpha g0 g1 g2.
+  - intros g g' beta f f' alpha.
+    simpl.
+    unfold pmap_compose, fmap10, fmap01; simpl.
     srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
-    by pelim f g s1 r1 r2.
-  - intros A B C D f g.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
-    by pelim f s1 r1 r2 g.
-  - intros A B C D f g.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: cbn; exact (fun _ => concat_p1 _ @ ap_compose _ _ _ @ (concat_1p _)^).
-    by pelim s1 r1 r2 f g.
-  - intros A B.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ ap_idmap _ @ (concat_1p _)^).
-    by pelim s1 r1 r2.
-  - intros A B.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
-    simpl; by pelim s1 r1 r2.
-  - intros A B C D E f g h j.
-    srapply Build_pHomotopy.
-    1: reflexivity.
-    by pelim f g h j.
-  - intros A B C f g.
-    srapply Build_pHomotopy.
-    1: reflexivity.
-    by pelim f g.
+    * simpl. intro x. symmetry; apply concat_Ap.
+    * by pelim alpha f f' beta g g'.
 Defined.
 
-(** The forgetful map from [pType] to [Type] is a 0-functor *)
+Instance isbicat_ptype : IsBicategory pType.
+Proof.
+  snrapply Build_IsBicategory.
+  1-3: exact _.
+  - intros; constructor.
+    + unfold bicat_assoc_opp; symmetry.
+      apply (phomotopy_compose_pV (pmap_compose_assoc h g f)).
+    + unfold bicat_assoc_opp; symmetry; apply (phomotopy_compose_Vp).
+  - intros; constructor; unfold bicat_idl_opp; symmetry.
+    + apply (phomotopy_compose_pV).
+    + apply (phomotopy_compose_Vp).
+  - intros; constructor; unfold bicat_idr_opp; symmetry.
+    + apply (phomotopy_compose_pV).
+    + apply (phomotopy_compose_Vp).
+  - intros a b c d. snrapply Build_Is1Natural.
+    intros ((h, g), f) ((h',g'),f') ((tau,sigma),rho). simpl in *.
+    snrapply Build_pHomotopy.
+    + simpl. intro x.
+      rewrite concat_1p, concat_p1.
+      rewrite ap_compose.
+      rewrite concat_p_pp.
+      apply (ap (fun z => z @ tau (g' (f' x)))).
+      rewrite <- ap_pp.
+      reflexivity.
+    + pelim rho f f' sigma g g' tau.
+      by pelim h h'.
+  - intros a b; snrapply Build_Is1Natural.
+    intros f f' h; snrapply Build_pHomotopy.
+    + intro; simpl; by autorewrite with paths.
+    + by pelim h f f'.
+  - intros a b; snrapply Build_Is1Natural.
+    intros f f' h; snrapply Build_pHomotopy.
+    + intro; simpl; by autorewrite with paths.
+    + by pelim h f f'.
+  - intros a b c d e f g h k.
+    snrapply Build_pHomotopy.
+    + reflexivity.
+    + by pelim f g h k.
+  - intros a b c f g. snrapply Build_pHomotopy.
+    + reflexivity.
+    + by pelim f g.
+Defined.
+
+Instance is21cat_ptype : Is21Cat pType := {}.
+
+(** The forgetful map from pType to Type is a 0-functor *)
 Instance is0functor_pointed_type : Is0Functor pointed_type.
 Proof.
   apply Build_Is0Functor. intros. exact f.
@@ -742,7 +766,7 @@ Proof.
   intros I x.
   snapply Build_Product.
   - exact (pproduct x).
-  - exact pproduct_proj. 
+  - exact pproduct_proj.
   - exact (pproduct_corec x).
   - intros Z f i.
     snapply Build_pHomotopy.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -607,9 +607,9 @@ Proof.
   - by apply pmap_prewhisker.
 Defined.
 
-Instance isTruncatedBicat_ptype : IsTruncatedBicat pType.
+Instance is1Bicat_ptype : Is1Bicat pType.
 Proof.
-  snapply Build_IsTruncatedBicat.
+  snapply Build_Is1Bicat.
   - exact _.
   - exact _.
   - intros A B C D f g h. apply pmap_compose_assoc.

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -173,6 +173,17 @@ Record RetractionOf {A} `{Is1Cat A} {a b : A} (f : a $-> b) :=
     is_retraction : comp_left_inverse $o f $== Id a
   }.
 
+Record AreInverse {A} `{Is1Cat A} {a b : A} (f : a $->b) (g : b $->a) := {
+  gf_id : Id a $== g $o f;
+  fg_id : Id b $== f $o g
+}.
+
+Definition inverse_op {A} `{Is1Cat A} {a b : A} (f : a $-> b) (g : b $->a) (p : AreInverse f g) : AreInverse g f :=
+{|
+  gf_id := fg_id _ _ p;
+  fg_id := gf_id _ _ p
+|}.
+
 (** Often, the coherences are actually equalities rather than homotopies. *)
 Class Is1Cat_Strong (A : Type)`{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
 {

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -1,5 +1,5 @@
 Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids.
-Require Import WildCat.Core WildCat.TwoOneCat WildCat.NatTrans.
+Require Import WildCat.Core WildCat.TwoOneCat WildCat.NatTrans WildCat.Bifunctor.
 
 (** * Path groupoids as wild categories *)
 
@@ -48,6 +48,11 @@ Proof.
   exact (@ap _ _ (cat_precomp c f)).
 Defined.
 
+(** Composition is a 0-bifunctor when the 2-cells are paths. *)
+Instance is0bifunctor_cat_comp_paths (A :Type) `{Is01Cat A} (a b c :A)
+    : Is0Bifunctor (cat_comp (a:=a) (b:=b) (c:=c))
+    := Build_Is0Bifunctor'' _ .
+
 (** Any type is a 1-category with n-morphisms given by paths. *)
 Instance is1cat_paths {A : Type} : Is1Cat A.
 Proof.
@@ -62,6 +67,20 @@ Proof.
   - exact (@concat_1p A).
 Defined.
 
+Instance IsTruncatedBicat_paths (A: Type) : IsTruncatedBicat A.
+Proof.
+  snrapply Build_IsTruncatedBicat.
+  - exact _.
+  - intros a b c. simpl. change concatR with (cat_comp (a:=a) (b:=b) (c:=c)).
+    rapply is0bifunctor_cat_comp_paths.
+  - intros a b c d; apply concat_p_pp.
+  - intros a b c d; apply concat_pp_p.
+  - intros a b f; apply concat_p1.
+  - intros a b f; symmetry; apply concat_p1.
+  - intros a b f; apply concat_1p.
+  - intros a b f; symmetry; apply concat_1p.
+Defined.
+
 (** Any type is a 1-groupoid with morphisms given by paths. *)
 Instance is1gpd_paths {A : Type} : Is1Gpd A.
 Proof.
@@ -70,55 +89,49 @@ Proof.
   - exact (@concat_Vp A).
 Defined.
 
+Instance Is1Bifunctor_cat_comp_paths (A: Type) (a b c : A)
+  : Is1Bifunctor (cat_comp (a:=a) (b:=b) (c:=c)).
+Proof.
+  apply Build_Is1Bifunctor''.
+  - intro q. snrapply Build_Is1Functor.
+    + intros ? ? ? ?. exact( (ap (fun x => whiskerR x _))).
+    + reflexivity.
+    + intros p0 p1 p2. apply whiskerR_pp.
+  - intro p. snrapply Build_Is1Functor.
+    + intros ? ? ? ?. exact (ap (whiskerL p)).
+    + reflexivity.
+    + intros p0 p1 p2. exact (whiskerL_pp p).
+  - intros q q' beta p p' alpha. exact (concat_whisker _ _ _ _ _ _)^.
+Defined.
+
 (** Any type is a 2-category with higher morphisms given by paths. *)
 Instance is21cat_paths {A : Type} : Is21Cat A.
 Proof.
-  snapply Build_Is21Cat.
-  - exact _.
-  - exact _.
-  - intros x y z p.
-    snapply Build_Is1Functor.
-    + intros a b q r.
-      exact (ap (fun x => whiskerR x _)).
-    + reflexivity.
-    + intros a b c.
-      exact (whiskerR_pp p).
-  - intros x y z p.
-    snapply Build_Is1Functor.
-    + intros a b q r.
-      exact (ap (whiskerL p)).
-    + reflexivity.
-    + intros a b c.
-      exact (whiskerL_pp p).
-  - intros a b c q r s t h g.
-    exact (concat_whisker q r s t h g)^.
-  - intros a b c d q r.
-    snapply Build_Is1Natural.
-    intros s t h.
-    apply concat_p_pp_nat_r.
-  - intros a b c d q r.
-    snapply Build_Is1Natural.
-    intros s t h.
-    apply concat_p_pp_nat_m.
-  - intros a b c d q r.
-    snapply Build_Is1Natural.
-    intros s t h.
-    apply concat_p_pp_nat_l.
-  - intros a b.
-    snapply Build_Is1Natural.
-    intros p q h; cbn.
-    apply moveL_Mp.
-    lhs napply concat_p_pp.
-    exact (whiskerR_p1 h).
-  - intros a b.
-    snapply Build_Is1Natural.
-    intros p q h.
-    apply moveL_Mp.
-    lhs rapply concat_p_pp.
-    exact (whiskerL_1p h).
-  - intros a b c d e p q r s.
-    lhs napply concat_p_pp.
-    exact (pentagon p q r s).
-  - intros a b c p q.
+  snrapply Build_Is21Cat; [snrapply Build_IsBicategory | | ].
+  1-3, 12-13: exact _.
+  - (* assoc and assoc_opp are inverse *)
+    intros a b c d f g h. constructor; simpl; destruct h, g, f; reflexivity.
+  - (* idl and idl_opp are inverse *)
+    intros a b f; constructor; destruct f; reflexivity.
+  - (* idr and idr_opp are inverse *)
+    intros a b f; constructor; destruct f; reflexivity.
+  - (* assoc is natural *)
+    intros a b c d.
+    snrapply Build_Is1Natural.
+    intros ((h, g), f) ((h', g'), f') ((s,r),q). simpl in s, r, q. simpl.
+    destruct q, s, h, r, g, f; reflexivity.
+  - (* idl is natural *)
+    intros a b; snrapply Build_Is1Natural.
+    intros f f' alpha; destruct alpha, f; reflexivity.
+  - (* idr is natural *)
+    intros a b; snrapply Build_Is1Natural.
+    intros f f' alpha; destruct alpha, f; reflexivity.
+  - (* Pentagon *)
+    intros a b c d e p q r s.
+    symmetry.
+    lhs nrapply concat_p_pp.
+    apply pentagon.
+  - (* Triangle *)
+    intros a b c p q.
     exact (triangulator p q).
 Defined.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -67,9 +67,9 @@ Proof.
   - exact (@concat_1p A).
 Defined.
 
-Instance IsTruncatedBicat_paths (A: Type) : IsTruncatedBicat A.
+Instance Is1Bicat_paths (A: Type) : Is1Bicat A.
 Proof.
-  snapply Build_IsTruncatedBicat.
+  snapply Build_Is1Bicat.
   - exact _.
   - intros a b c. simpl. change concatR with (cat_comp (a:=a) (b:=b) (c:=c)).
     rapply (is0bifunctor_cat_comp_paths A a b c).

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -21,7 +21,7 @@ Definition is3graph_paths (A : Type) `{Is2Graph A} : Is3Graph A
 
 (** We assume these as instances for the rest of the file with a low priority. *)
 Local Existing Instances isgraph_paths is2graph_paths is3graph_paths | 10.
-
+Local Canonical isgraph_paths.
 (** Any type has composition and identity morphisms given by path concatenation and reflexivity. *)
 Instance is01cat_paths (A : Type) : Is01Cat A
   := {| Id := @idpath _ ; cat_comp := fun _ _ _ x y => concat y x |}.
@@ -69,10 +69,10 @@ Defined.
 
 Instance IsTruncatedBicat_paths (A: Type) : IsTruncatedBicat A.
 Proof.
-  snrapply Build_IsTruncatedBicat.
+  snapply Build_IsTruncatedBicat.
   - exact _.
   - intros a b c. simpl. change concatR with (cat_comp (a:=a) (b:=b) (c:=c)).
-    rapply is0bifunctor_cat_comp_paths.
+    rapply (is0bifunctor_cat_comp_paths A a b c).
   - intros a b c d; apply concat_p_pp.
   - intros a b c d; apply concat_pp_p.
   - intros a b f; apply concat_p1.
@@ -93,11 +93,11 @@ Instance Is1Bifunctor_cat_comp_paths (A: Type) (a b c : A)
   : Is1Bifunctor (cat_comp (a:=a) (b:=b) (c:=c)).
 Proof.
   apply Build_Is1Bifunctor''.
-  - intro q. snrapply Build_Is1Functor.
+  - intro q. snapply Build_Is1Functor.
     + intros ? ? ? ?. exact( (ap (fun x => whiskerR x _))).
     + reflexivity.
     + intros p0 p1 p2. apply whiskerR_pp.
-  - intro p. snrapply Build_Is1Functor.
+  - intro p. snapply Build_Is1Functor.
     + intros ? ? ? ?. exact (ap (whiskerL p)).
     + reflexivity.
     + intros p0 p1 p2. exact (whiskerL_pp p).
@@ -107,7 +107,7 @@ Defined.
 (** Any type is a 2-category with higher morphisms given by paths. *)
 Instance is21cat_paths {A : Type} : Is21Cat A.
 Proof.
-  snrapply Build_Is21Cat; [snrapply Build_IsBicategory | | ].
+  snapply Build_Is21Cat; [snapply Build_IsBicategory | | ].
   1-3, 12-13: exact _.
   - (* assoc and assoc_opp are inverse *)
     intros a b c d f g h. constructor; simpl; destruct h, g, f; reflexivity.
@@ -117,19 +117,19 @@ Proof.
     intros a b f; constructor; destruct f; reflexivity.
   - (* assoc is natural *)
     intros a b c d.
-    snrapply Build_Is1Natural.
+    snapply Build_Is1Natural.
     intros ((h, g), f) ((h', g'), f') ((s,r),q). simpl in s, r, q. simpl.
     destruct q, s, h, r, g, f; reflexivity.
   - (* idl is natural *)
-    intros a b; snrapply Build_Is1Natural.
+    intros a b; snapply Build_Is1Natural.
     intros f f' alpha; destruct alpha, f; reflexivity.
   - (* idr is natural *)
-    intros a b; snrapply Build_Is1Natural.
+    intros a b; snapply Build_Is1Natural.
     intros f f' alpha; destruct alpha, f; reflexivity.
   - (* Pentagon *)
     intros a b c d e p q r s.
     symmetry.
-    lhs nrapply concat_p_pp.
+    lhs snapply concat_p_pp.
     apply pentagon.
   - (* Triangle *)
     intros a b c p q.

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -1,93 +1,126 @@
 Require Import Basics.Overture Basics.Tactics.
+Require Import Types.Forall.
 Require Import WildCat.Core.
+Require Import WildCat.Prod.
+Require Import WildCat.Bifunctor.
 Require Import WildCat.NatTrans.
 
-(** * Wild (2,1)-categories *)
-
-Class Is21Cat (A : Type) `{Is1Cat A, !Is3Graph A} :=
-{
-  is1cat_hom : forall (a b : A), Is1Cat (a $-> b) ;
-  is1gpd_hom : forall (a b : A), Is1Gpd (a $-> b) ;
-  is1functor_postcomp : forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) ;
-  is1functor_precomp : forall (a b c : A) (f : a $-> b), Is1Functor (cat_precomp c f) ;
-  bifunctor_coh_comp : forall {a b c : A} {f f' : a $-> b}  {g g' : b $-> c}
-    (p : f $== f') (p' : g $== g'),
-    (p' $@R f) $@ (g' $@L p) $== (g $@L p) $@ (p' $@R f') ;
-
-  (** Naturality of the associator in each variable separately *)
-  is1natural_cat_assoc_l : forall (a b c d : A) (f : a $-> b) (g : b $-> c),
-      Is1Natural (cat_precomp d f o cat_precomp d g) (cat_precomp d (g $o f))
-                 (cat_assoc f g);
-  is1natural_cat_assoc_m : forall (a b c d : A) (f : a $-> b) (h : c $-> d),
-      Is1Natural (cat_precomp d f o cat_postcomp b h) (cat_postcomp a h o cat_precomp c f)
-                 (fun g => cat_assoc f g h);
-  is1natural_cat_assoc_r : forall (a b c d : A) (g : b $-> c) (h : c $-> d),
-      Is1Natural (cat_postcomp a (h $o g)) (cat_postcomp a h o cat_postcomp a g)
-                 (fun f => cat_assoc f g h);
-
-  (** Naturality of the unitors *)
-  is1natural_cat_idl : forall (a b : A),
-      Is1Natural (cat_postcomp a (Id b)) idmap
-                 cat_idl ;
-
-  is1natural_cat_idr : forall (a b : A),
-      Is1Natural (cat_precomp b (Id a)) idmap
-                 cat_idr;
-
-  (** Coherence *)
-  cat_pentagon : forall (a b c d e : A)
-                        (f : a $-> b) (g : b $-> c) (h : c $-> d) (k : d $-> e),
-      (k $@L cat_assoc f g h) $o (cat_assoc f (h $o g) k) $o (cat_assoc g h k $@R f)
-      $== (cat_assoc (g $o f) h k) $o (cat_assoc f g (k $o h)) ;
-
-  cat_tril : forall (a b c : A) (f : a $-> b) (g : b $-> c),
-      (g $@L cat_idl f) $o (cat_assoc f (Id b) g) $== (cat_idr g $@R f)
+(** * A truncated bicategory has the same generating 2-cells as a bicategory but no relations between them.
+      A truncated bicategory where all 2-cells are invertible is the same as a 1-category. *)
+Class IsTruncatedBicat (A: Type) `{Is01Cat A} `{!Is2Graph A} := {
+  is01cat_bicat_hom :: forall (a b : A), Is01Cat (a $-> b);
+  is0bifunctor_bicat_comp :: forall (a b c : A),
+    Is0Bifunctor (cat_comp (a:=a) (b:=b) (c:=c));
+  bicat_assoc : forall {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    (h $o g) $o f $-> h $o (g $o f);
+  bicat_assoc_opp : forall {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    h $o (g $o f) $-> (h $o g) $o f;
+  bicat_idl : forall {a b : A} (f : a $-> b), Id b $o f $-> f;
+  bicat_idl_opp : forall {a b : A} (f : a $-> b), f $-> Id b $o f ;
+  bicat_idr : forall {a b : A} (f : a $-> b), f $o Id a $-> f;
+  bicat_idr_opp : forall {a b : A} (f : a $-> b), f $-> f $o Id a;
 }.
 
-Existing Instance is1cat_hom.
-Existing Instance is1gpd_hom.
-Existing Instance is1functor_precomp.
-Existing Instance is1functor_postcomp.
-Existing Instance is1natural_cat_assoc_l.
-Existing Instance is1natural_cat_assoc_m.
-Existing Instance is1natural_cat_assoc_r.
-Existing Instance is1natural_cat_idl.
-Existing Instance is1natural_cat_idr.
+Instance Is0Functor_bicat_postcomp `{A: Type} `{IsTruncatedBicat A} (a b c : A) (g : b $->c):
+  Is0Functor (cat_postcomp a g).
+Proof.
+  unfold cat_postcomp.
+  exact _.
+Defined.
 
+Instance Is0Functor_bicat_precomp `{A: Type} `{IsTruncatedBicat A} (a b c : A) (f : a $->b):
+  Is0Functor (cat_precomp c f).
+Proof.
+  unfold cat_precomp.
+  exact _.
+Defined.
+
+Declare Scope twocat_scope.
+Notation "A $=> B" := (Hom (A:= Hom _ _) A B) : twocat_scope.
+(* Vertical composition of 2-cells*)
+Notation "g * f" := (cat_comp (A:=Hom _ _) g f) : twocat_scope.
+
+Notation "h $@L p" := (fmap (cat_postcomp _ h) p) : twocat_scope.
+Notation "p $@R h" := (fmap (cat_precomp _ h) p) : twocat_scope.
+Notation "beta $@@ alpha" := (fmap11 (cat_comp) beta alpha) : twocat_scope.
+
+Open Scope twocat_scope.
+
+(*
+  The elaborator has trouble checking this definition, so we tell it to
+  resolve typeclasses in the order of their dependencies: first solving
+  IsGraph, then solving Is01Cat and Is2Cat, and so on.
+  The default typeclass search behavior is apparently
+  more complex than that.
+*)
+Set Typeclasses Dependency Order.
+
+Class IsBicategory (A : Type) `{Is01Cat A} `{!Is2Graph A} `{!Is3Graph A} := {
+  is_truncated_bicat:: IsTruncatedBicat A;
+  is1cat_2cells:: forall (a b : A), Is1Cat (Hom a b);
+  is1bifunctor_bicat_comp :: forall (a b c : A), Is1Bifunctor (cat_comp (a:=a) (b:=b) (c:=c));
+  is1functor_bicat_postcomp :: forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) := _;
+  is1functor_bicat_precomp :: forall (a b c : A) (f : a $-> b), Is1Functor (cat_precomp c f) := _;
+  bicat_assoc_inv: forall {a b c d} (f : a $->b) (g : b $-> c) (h : c $->d),
+    AreInverse (bicat_assoc f g h) (bicat_assoc_opp f g h);
+  bicat_idl_inv : forall {a b} (f : a $-> b), AreInverse (bicat_idl f) (bicat_idl_opp f);
+  bicat_idr_inv : forall {a b} (f : a $-> b), AreInverse (bicat_idr f) (bicat_idr_opp f);
+  bicat_assoc_nat :: forall {a b c d: A},
+    Is1Natural
+    (fun '(h, g, f) => h $o g $o f)
+    (fun '(h, g, f) => h $o (g $o f))
+    (fun '(h, g, f)  => bicat_assoc (a:=a)(b:=b)(c:=c)(d:=d) f g h);
+  bicat_idl_nat :: forall {a b : A}, Is1Natural
+    (fun f : a $->b => (Id b) $o f)
+    (fun f : a $->b => f)
+    (fun f : a $->b => bicat_idl f);
+  bicat_idr_nat :: forall {a b : A}, Is1Natural
+    (fun f : a $->b => f $o (Id a))
+    (fun f : a $->b => f)
+    (fun f : a $->b => bicat_idr f);
+  bicat_pentagon : forall {a b c d e:A}
+    (f : a $-> b) (g : b $->c) (h : c $-> d) (k: d $->e),
+    (bicat_assoc (g $o f) h k) $o (bicat_assoc f g (k $o h)) $==
+      (fmap (cat_postcomp a k) (bicat_assoc f g h)) $o
+      (bicat_assoc f (h $o g) k) $o
+      (fmap (cat_precomp e f) (bicat_assoc g h k));
+  bicat_triangle:  forall {a b c:A} (f : a $-> b) (g : b $->c),
+    (fmap (cat_postcomp a g) (bicat_idl f)) $o (bicat_assoc f (Id b) g)
+    $== (fmap (cat_precomp c f) (bicat_idr g))
+}.
+
+Unset Typeclasses Dependency Order.
+
+Definition bifunctor_coh_comp (A: Type) `{IsBicategory A} :
+  forall {a b c : A} {f f' : a $-> b}  {g g' : b $-> c}
+    (p : f $=> f') (p' : g $=> g'),
+    (g' $@L p) * (p' $@R f) $== (p' $@R f') * (g $@L p).
+Proof.
+    intros a b c f f' g g' p q.
+    apply (bifunctor_coh cat_comp).
+Defined.
 (** *** Whiskering functoriality *)
 
-Definition cat_postwhisker_pp {A} `{Is21Cat A} {a b c : A}
-  {f g h : a $-> b} (k : b $-> c) (p : f $== g) (q : g $== h)
-  : k $@L (p $@ q) $== (k $@L p) $@ (k $@L q).
-Proof.
-  rapply fmap_comp.
-Defined.
+Definition cat_postwhisker_pp {A} `{IsBicategory A} {a b c : A}
+  {f g h : a $-> b} (k : b $-> c) (p : f $=> g) (q : g $=> h)
+  : k $@L (q * p) $== (k $@L q) * (k $@L p) := fmap_comp _ _ _.
 
-Definition cat_prewhisker_pp {A} `{Is21Cat A} {a b c : A}
-  {f g h : b $-> c} (k : a $-> b) (p : f $== g) (q : g $== h)
-  : (p $@ q) $@R k $== (p $@R k) $@ (q $@R k).
-Proof.
-  rapply fmap_comp.
-Defined.
+Definition cat_prewhisker_pp {A} `{IsBicategory A} {a b c : A}
+  {f g h : b $-> c} (k : a $-> b) (p : f $=> g) (q : g $=> h)
+  : (q * p) $@R k $== (q $@R k) * (p $@R k) := fmap_comp _ _ _.
 
-(** *** Exchange law *)
-
-Definition cat_exchange {A : Type} `{Is21Cat A} {a b c : A}
+Definition cat_exchange {A : Type} `{IsBicategory A} {a b c : A}
   {f f' f'' : a $-> b} {g g' g'' : b $-> c}
-  (p : f $== f') (q : f' $== f'') (r : g $== g') (s : g' $== g'')
-  : (p $@ q) $@@ (r $@ s) $== (p $@@ r) $@ (q $@@ s).
-Proof.
-  unfold "$@@".
-  (** We use the distributivity of [$@R] and [$@L] in a (2,1)-category (since they are functors) to see that we have the same data on both sides of the 3-morphism. *)
-  nrefine ((_ $@L cat_prewhisker_pp _ _ _ ) $@ _).
-  nrefine ((cat_postwhisker_pp _ _ _ $@R _) $@ _).
-  (** Now we reassociate and whisker on the left and right. *)
-  nrefine (cat_assoc _ _ _ $@ _).
-  refine (_ $@ (cat_assoc _ _ _)^$).
-  nrefine (_ $@L _).
-  refine (_ $@ cat_assoc _ _ _).
-  refine ((cat_assoc _ _ _)^$ $@ _).
-  nrefine (_ $@R _).
-  (** Finally we are left with the bifunctoriality condition for left and right whiskering which is part of the data of the (2,1)-cat. *)
-  apply bifunctor_coh_comp.
-Defined.
+  (p : f $=> f') (q : f' $=> f'') (r : g $=> g') (s : g' $=> g'')
+  : (s * r) $@@ (q * p) $== (s $@@ q) * (r $@@ p)
+  := fmap11_comp _ _ _ _ _.
+
+  (** * Wild (2,1)-categories *)
+Class Is21Cat (A : Type) `{Is01Cat A,!Is2Graph A,!Is3Graph A} :=
+{
+  isbicat : IsBicategory A;
+  is0gpd_hom : forall (a b : A), Is0Gpd (a $-> b) ;
+  is1gpd_hom : forall (a b : A), Is1Gpd (a $-> b) ;
+}.
+
+Close Scope twocat_scope.

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -5,9 +5,8 @@ Require Import WildCat.Prod.
 Require Import WildCat.Bifunctor.
 Require Import WildCat.NatTrans.
 
-(** * A truncated bicategory has the same generating 2-cells as a bicategory but no relations between them.
-      A truncated bicategory where all 2-cells are invertible is the same as a 1-category. *)
-Class IsTruncatedBicat (A: Type) `{Is01Cat A} `{!Is2Graph A} := {
+(** * A 1-truncated bicategory, or 1-bicategory, has the same generating 2-cells as a bicategory but no relations between them. A 1-truncated bicategory where all 2-cells are invertible is the same as a 1-category. *)
+Class Is1Bicat (A: Type) `{Is01Cat A} `{!Is2Graph A} := {
   is01cat_bicat_hom :: forall (a b : A), Is01Cat (a $-> b);
   is0bifunctor_bicat_comp :: forall (a b c : A),
     Is0Bifunctor (cat_comp (a:=a) (b:=b) (c:=c));
@@ -21,14 +20,14 @@ Class IsTruncatedBicat (A: Type) `{Is01Cat A} `{!Is2Graph A} := {
   bicat_idr_opp : forall {a b : A} (f : a $-> b), f $-> f $o Id a;
 }.
 
-Instance Is0Functor_bicat_postcomp `{A: Type} `{IsTruncatedBicat A} (a b c : A) (g : b $->c):
+Instance Is0Functor_bicat_postcomp `{A: Type} `{Is1Bicat A} (a b c : A) (g : b $->c):
   Is0Functor (cat_postcomp a g).
 Proof.
   unfold cat_postcomp.
   exact _.
 Defined.
 
-Instance Is0Functor_bicat_precomp `{A: Type} `{IsTruncatedBicat A} (a b c : A) (f : a $->b):
+Instance Is0Functor_bicat_precomp `{A: Type} `{Is1Bicat A} (a b c : A) (f : a $->b):
   Is0Functor (cat_precomp c f).
 Proof.
   unfold cat_precomp.
@@ -56,7 +55,7 @@ Open Scope twocat_scope.
 Set Typeclasses Dependency Order.
 
 Class IsBicategory (A : Type) `{Is01Cat A} `{!Is2Graph A} `{!Is3Graph A} := {
-  is_truncated_bicat:: IsTruncatedBicat A;
+  is_truncated_bicat:: Is1Bicat A;
   is1cat_2cells:: forall (a b : A), Is1Cat (Hom a b);
   is1bifunctor_bicat_comp :: forall (a b c : A), Is1Bifunctor (cat_comp (a:=a) (b:=b) (c:=c));
   is1functor_bicat_postcomp :: forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) := _;

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -160,9 +160,9 @@ Proof.
   symmetry; apply concat_Ap.
 Defined.
 
-Instance isTruncatedBicat_Type : IsTruncatedBicat Type.
+Instance is1Bicat_Type : Is1Bicat Type.
 Proof.
-  snapply Build_IsTruncatedBicat; intros; cbn.
+  snapply Build_Is1Bicat; intros; cbn.
   1-2: exact _.
   all: reflexivity.
 Defined.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics Basics.Equivalences Basics.PathGroupoids.
 Require Import Types.Equiv.
-Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat.
+Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.Bifunctor WildCat.TwoOneCat.
 
 (** ** The (1-)category of types *)
 
@@ -43,6 +43,10 @@ Proof.
   apply Build_Is0Functor.
   intros f g p a; exact (p (h a)).
 Defined.
+
+Instance is0bifunctor_type_comp {A B C : Type} :
+  Is0Bifunctor (cat_comp (a:=A) (b:=B) (c:=C))
+  := Build_Is0Bifunctor'' _.
 
 Instance is1cat_strong_type : Is1Cat_Strong Type.
 Proof.
@@ -147,25 +151,44 @@ Proof.
   intros ? ? ? ? p ?; exact (p _).
 Defined.
 
+Instance is1bifunctor_cat_comp {A B C :Type}:
+  Is1Bifunctor (cat_comp (A:=Type) (a:=A) (b:=B) (c:=C)).
+Proof.
+  apply Build_Is1Bifunctor''.
+  1-2: exact _.
+  intros g g' h_g f f' h_f a; cbn.
+  symmetry; apply concat_Ap.
+Defined.
+
+Instance isTruncatedBicat_Type : IsTruncatedBicat Type.
+Proof.
+  snrapply Build_IsTruncatedBicat; intros; cbn.
+  1-2: exact _.
+  all: reflexivity.
+Defined.
+
 Instance is21cat_type : Is21Cat Type.
 Proof.
-  snapply Build_Is21Cat.
-  1-4, 6-7: exact _.
-  - intros a b c f g h k p q x; cbn.
-    symmetry.
-    apply concat_Ap.
-  - intros a b c d f g.
-    snapply Build_Is1Natural.
-    intros h i p x; cbn.
-    exact (concat_p1 _ @ ap_compose _ _ _ @ (concat_1p _)^).
-  - intros a b.
-    snapply Build_Is1Natural.
-    intros f g p x; cbn.
-    exact (concat_p1 _ @ ap_idmap _ @ (concat_1p _)^).
-  - intros a b.
-    snapply Build_Is1Natural.
-    intros f g p x; cbn.
-    exact (concat_p1 _ @ (concat_1p _)^).
+  snrapply Build_Is21Cat; [snrapply Build_IsBicategory | | ].
+  1-3, 12-13: exact _.
+  1-3: intros; constructor; reflexivity.
+  - intros A B C D. snrapply Build_Is1Natural.
+    intros ((h,g),f) ((h',g'),f').
+    intros ((gamma,beta),alpha) a; simpl.
+    unfold fmap11; simpl.
+    rewrite concat_1p.
+    rewrite concat_p1.
+    rewrite concat_p_pp.
+    apply (ap (fun z => z @ gamma (g' (f' a)))).
+    rewrite ap_compose.
+    rewrite ap_pp.
+    reflexivity.
+  - intros A B; snrapply Build_Is1Natural.
+    intros f f' h a; simpl.
+    rewrite ap_idmap.
+    exact (concat_p1_1p _).
+  - intros A B; snrapply Build_Is1Natural.
+    intros f f' h a. exact (concat_p1_1p _).
   - reflexivity.
   - reflexivity.
 Defined.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -162,17 +162,17 @@ Defined.
 
 Instance isTruncatedBicat_Type : IsTruncatedBicat Type.
 Proof.
-  snrapply Build_IsTruncatedBicat; intros; cbn.
+  snapply Build_IsTruncatedBicat; intros; cbn.
   1-2: exact _.
   all: reflexivity.
 Defined.
 
 Instance is21cat_type : Is21Cat Type.
 Proof.
-  snrapply Build_Is21Cat; [snrapply Build_IsBicategory | | ].
+  snapply Build_Is21Cat; [snapply Build_IsBicategory | | ].
   1-3, 12-13: exact _.
   1-3: intros; constructor; reflexivity.
-  - intros A B C D. snrapply Build_Is1Natural.
+  - intros A B C D. snapply Build_Is1Natural.
     intros ((h,g),f) ((h',g'),f').
     intros ((gamma,beta),alpha) a; simpl.
     unfold fmap11; simpl.
@@ -183,11 +183,11 @@ Proof.
     rewrite ap_compose.
     rewrite ap_pp.
     reflexivity.
-  - intros A B; snrapply Build_Is1Natural.
+  - intros A B; snapply Build_Is1Natural.
     intros f f' h a; simpl.
     rewrite ap_idmap.
     exact (concat_p1_1p _).
-  - intros A B; snrapply Build_Is1Natural.
+  - intros A B; snapply Build_Is1Natural.
     intros f f' h a. exact (concat_p1_1p _).
   - reflexivity.
   - reflexivity.


### PR DESCRIPTION
This defines a bicategory, mimicking the definition in Monoidal.v. 

There is no sharing between the bicategory definition and the monoidal category definition. If you think this could be refactored to remove redundancy between files, let me know.

In the spirit of the typeclass-based approach to the Wildcat library, where you only assume what is necessary at each step, it would be interesting to introduce the concept of a "2-truncated bicategory" which is a weakening of a 1-category such that Hom(a, b) is a 0-category rather than a 0-groupoid, and define a 1-category to be a 2-truncated bicategory such that all Hom-0-cats are 0-groupoids. It seems likely that a good share of category theory can be carried out for these 2-truncated bicategories, so this would eliminate some duplication in theorems about bicategories and 1-categories. However this is a more substantial project.