### PR TITLE
HoTT.v: add (some) missing Exports

### DIFF
--- a/theories/HoTT.v
+++ b/theories/HoTT.v
@@ -104,12 +104,17 @@ Require Export HoTT.Modalities.Meet.
 Require Export HoTT.Modalities.CoreflectiveSubuniverse.
 
 Require Export HoTT.Spaces.Nat.
-Require Export HoTT.Spaces.BinInt.
+Require Export HoTT.Spaces.Int.
+Require Export HoTT.Spaces.FreeInt.
 Require Export HoTT.Spaces.Pos.
+Require Export HoTT.Spaces.BinInt.
 
 Require Export HoTT.Spaces.List.Core.
 Require Export HoTT.Spaces.List.Theory.
 Require Export HoTT.Spaces.List.Paths.
+
+Require Export HoTT.Spaces.NatSeq.Core.
+Require Export HoTT.Spaces.NatSeq.UStructure.
 
 Require Export HoTT.Spaces.Cantor.
 
@@ -181,6 +186,8 @@ Require Export HoTT.Sets.GCHtoAC.
 Require Export HoTT.Sets.Hartogs.
 Require Export HoTT.Sets.Ordinals.
 Require Export HoTT.Sets.Powers.
+
+Require Export HoTT.Misc.UStructures.
 
 (** We do _not_ export [UnivalenceAxiom], [FunextAxiom], or any of the files in [Metatheory] from this file.  Thus, importing this file does not prevent you from tracking usage of [Univalence] and [Funext] theorem-by-theorem in the same way that the library does.  If you want any of those files, you should import them separately. *)
 


### PR DESCRIPTION
I noticed a few missing Exports in HoTT.v.  I didn't systematically check for others.