### PR TITLE
fix: change Warnings Append -> Warnings

### DIFF
--- a/test/bugs/github754.v
+++ b/test/bugs/github754.v
@@ -18,9 +18,9 @@ Fixpoint code_nat (m n : nat) {struct m} : DProp.DHProp :=
               end
   end.
 
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Notation "x =n y" := (code_nat x y) : nat_scope.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Bind Scope nat_scope with nat.
 Axiom equiv_path_nat :
   forall n m : nat,

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -10,7 +10,7 @@ Reserved Notation "'exists' x .. y , p"
 
 
 (** Work around bug 5569, https://coq.inria.fr/bugs/show_bug.cgi?id=5569, Warning skip-spaces-curly,parsing seems bogus *)
-Local Set Warnings Append "-skip-spaces-curly".
+Local Set Warnings "-skip-spaces-curly".
 
 (** These are the notations whose level and associativity are imposed by Coq *)
 

--- a/theories/Categories.v
+++ b/theories/Categories.v
@@ -74,7 +74,7 @@ Require HoTT.Categories.FundamentalPreGroupoidCategory.
 Require HoTT.Categories.HomotopyPreCategory.
 
 (* We bind the record structures for [PreCategory], [IsCategory], [IsStrictCategory], [Functor], and eventually [NaturalTransformation] at top level. *)
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Include HoTT.Categories.Category.Core.
 Include HoTT.Categories.Category.Strict.
 Include HoTT.Categories.Category.Univalent.

--- a/theories/Categories/Adjoint/UniversalMorphisms/Core.v
+++ b/theories/Categories/Adjoint/UniversalMorphisms/Core.v
@@ -4,9 +4,9 @@ Require Import Functor.Identity Functor.Composition.Core.
 Require Import Functor.Dual Category.Dual.
 Require Import Adjoint.Core Adjoint.UnitCounit Adjoint.UnitCounitCoercions Adjoint.Dual.
 Require Comma.Core.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Require Import UniversalProperties Comma.Dual InitialTerminalCategory.Core InitialTerminalCategory.Functors.
 
 Set Universe Polymorphism.

--- a/theories/Categories/Category.v
+++ b/theories/Categories/Category.v
@@ -26,7 +26,7 @@ Require Category.Sum.
 (** ** Categories (univalent or saturated) *)
 Require Category.Univalent.
 
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Include Category.Core.
 Include Category.Dual.
 Include Category.Morphisms.

--- a/theories/Categories/Category/Pi.v
+++ b/theories/Categories/Category/Pi.v
@@ -45,7 +45,7 @@ Proof.
   typeclasses eauto.
 Qed.
 
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Module Export CategoryPiNotations.
   Notation "'forall'  x .. y , P" := (forall x, .. (forall y, P) ..)%type : type_scope.
   Notation "'forall'  x .. y , P" := (pi (fun x => .. (pi (fun y => P)) .. )) : category_scope.

--- a/theories/Categories/Category/Utf8.v
+++ b/theories/Categories/Category/Utf8.v
@@ -1,8 +1,8 @@
 (** * Unicode notations for categories *)
 Require Import Category.Morphisms Category.Dual Category.Sum Category.Pi.
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Export Category.Notations.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Require Import Basics.Utf8.
 
 Infix "∘" := compose : morphism_scope.

--- a/theories/Categories/Comma.v
+++ b/theories/Categories/Comma.v
@@ -1,6 +1,6 @@
 (** * Comma Categories *)
 (** Since there are only notations in [Comma.Notations], we can just export those. *)
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Import Basics.Notations.
 Require Export Comma.Notations.
 

--- a/theories/Categories/Comma/Core.v
+++ b/theories/Categories/Comma/Core.v
@@ -339,7 +339,7 @@ Global Arguments CC_Functor' / .
 Global Arguments cc_functor_from_terminal' / .
 Global Arguments cc_identity_functor' / .
 
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Module Export CommaCoreNotations.
   (** We really want to use infix [↓] for comma categories, but that's unicode.  Infix [,] might also be reasonable, but I can't seem to get it to work without destroying the [(_, _)] notation for ordered pairs.  So I settle for the ugly ASCII rendition [/] of [↓]. *)
   (** Set some notations for printing *)

--- a/theories/Categories/Comma/Dual.v
+++ b/theories/Categories/Comma/Dual.v
@@ -3,9 +3,9 @@ Require Import Category.Core Functor.Core.
 Require Import Category.Dual Functor.Dual.
 Require Import Functor.Composition.Core Functor.Identity.
 Require Comma.Core.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Comma/Functorial.v
+++ b/theories/Categories/Comma/Functorial.v
@@ -5,9 +5,9 @@ Require Import NaturalTransformation.Composition.Laws.
 Require Import Functor.Paths.
 Require Import Category.Strict.
 Require Comma.Core.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Import Functor.Identity.FunctorIdentityNotations NaturalTransformation.Identity.NaturalTransformationIdentityNotations.
 Require Import HoTT.Tactics PathGroupoids Types.Forall.
 

--- a/theories/Categories/Comma/InducedFunctors.v
+++ b/theories/Categories/Comma/InducedFunctors.v
@@ -6,9 +6,9 @@ Require Import NaturalTransformation.Identity.
 Require Import FunctorCategory.Core Cat.Core.
 Require Import InitialTerminalCategory.Core InitialTerminalCategory.Functors.
 Require Comma.Core.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Require Import HoTT.Tactics.
 Require Import Basics.Tactics.
 

--- a/theories/Categories/Comma/Notations.v
+++ b/theories/Categories/Comma/Notations.v
@@ -2,5 +2,5 @@
 Require Import Basics.Notations.
 Require Comma.Core.
 
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Include Comma.Core.CommaCoreNotations.

--- a/theories/Categories/Comma/Projection.v
+++ b/theories/Categories/Comma/Projection.v
@@ -5,9 +5,9 @@ Require Import Functor.Composition.Core Functor.Identity.
 Require Import InitialTerminalCategory.Functors.
 Require Comma.Core.
 Require Import Types.Prod.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Comma/ProjectionFunctors.v
+++ b/theories/Categories/Comma/ProjectionFunctors.v
@@ -8,9 +8,9 @@ Require Import FunctorCategory.Core.
 Require Import Cat.Core.
 Require Import Functor.Paths.
 Require Comma.Core.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Require Import Comma.InducedFunctors Comma.Projection.
 Require ProductLaws ExponentialLaws.Law1.Functors ExponentialLaws.Law4.Functors.
 Require Import Types.Forall PathGroupoids HoTT.Tactics.

--- a/theories/Categories/Comma/Utf8.v
+++ b/theories/Categories/Comma/Utf8.v
@@ -1,5 +1,5 @@
 (** * Unicode notations for comma categories *)
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Import Basics.Notations.
 Require Import Comma.Core.
 Require Export Comma.Notations.

--- a/theories/Categories/Functor/Prod/Core.v
+++ b/theories/Categories/Functor/Prod/Core.v
@@ -103,7 +103,7 @@ Section induced.
   Defined.
 End induced.
 
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Module Export FunctorProdCoreNotations.
   Infix "*" := prod : functor_scope.
   Notation "( x , y , .. , z )" := (pair .. (pair x y) .. z) : functor_scope.

--- a/theories/Categories/LaxComma.v
+++ b/theories/Categories/LaxComma.v
@@ -1,6 +1,6 @@
 (** * Lax Comma Categories *)
 (** Since there are only notations in [LaxComma.Notations], we can just export those. *)
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Export LaxComma.Notations.
 
 (** ** Definitions *)

--- a/theories/Categories/LaxComma/Core.v
+++ b/theories/Categories/LaxComma/Core.v
@@ -170,7 +170,7 @@ End lax_arrow_category.
 Arguments lax_arrow_category {_} P {_}.
 Arguments oplax_arrow_category {_} P {_}.
 
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Module Export LaxCommaCoreNotations.
   (** We play some games to get nice notations for lax comma categories. *)
   Section tc_notation_boiler_plate.

--- a/theories/Categories/LaxComma/Notations.v
+++ b/theories/Categories/LaxComma/Notations.v
@@ -1,5 +1,5 @@
 (** * Notations for lax comma categories *)
 Require LaxComma.Core.
 
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Include LaxComma.Core.LaxCommaCoreNotations.

--- a/theories/Categories/LaxComma/Utf8.v
+++ b/theories/Categories/LaxComma/Utf8.v
@@ -1,5 +1,5 @@
 (** * Unicode notations for comma categories *)
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Import LaxComma.Core.
 Require Export LaxComma.Notations.
 Require Import Basics.Utf8.

--- a/theories/Categories/Limits/Core.v
+++ b/theories/Categories/Limits/Core.v
@@ -4,9 +4,9 @@ Require Import Functor.Composition.Core.
 Require Import ExponentialLaws.Law1.Functors FunctorCategory.Core.
 Require Import KanExtensions.Core InitialTerminalCategory.Core NatCategory.
 Require Import Functor.Paths.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 
 Set Universe Polymorphism.
 Set Implicit Arguments.

--- a/theories/Categories/Notations.v
+++ b/theories/Categories/Notations.v
@@ -8,7 +8,7 @@ Require NatCategory.
 Export NatCategory.Notations.
 Require Export InitialTerminalCategory.Notations.
 Require Export Profunctor.Notations.
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Export Comma.Notations.
 Require Export Adjoint.Notations.
 Require Export Structure.Notations.

--- a/theories/Categories/UniversalProperties.v
+++ b/theories/Categories/UniversalProperties.v
@@ -4,9 +4,9 @@ Require Import Category.Dual Functor.Dual.
 Require Import Category.Objects.
 Require Import InitialTerminalCategory.Core InitialTerminalCategory.Functors.
 Require Comma.Core.
-Local Set Warnings Append "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
+Local Set Warnings "-notation-overridden". (* work around bug #5567, https://coq.inria.fr/bugs/show_bug.cgi?id=5567, notation-overridden,parsing should not trigger for only printing notations *)
 Import Comma.Core.
-Local Set Warnings Append "notation-overridden".
+Local Set Warnings "notation-overridden".
 Require Import Trunc Types.Sigma HoTT.Tactics.
 Require Import Basics.Tactics.
 

--- a/theories/Categories/Utf8.v
+++ b/theories/Categories/Utf8.v
@@ -1,5 +1,5 @@
 (** * Unicode notations for categories *)
-Local Set Warnings Append "-notation-overridden".
+Local Set Warnings "-notation-overridden".
 Require Export HoTT.Categories.Notations.
 Require Export Category.Utf8 Functor.Utf8 NaturalTransformation.Utf8.
 Require Export Comma.Utf8.


### PR DESCRIPTION
This should fix some of the recent warnings we have been seeing.

If I've understood correctly, there should be no change in semantics.