### PR TITLE
Adapt to rocq#19987

### DIFF
--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -131,7 +131,7 @@ Section Join.
     (P_B : B -> P) (P_g : forall a b, P_A a = P_B b) a b
     : ap (Join_rec P_A P_B P_g) (jglue a b) = P_g a b.
   Proof.
-    snrapply Pushout_rec_beta_pglue.
+    exact (Pushout_rec_beta_pglue _ _ _ (fun ab => P_g (fst ab) (snd ab)) _).
   Defined.
 
   (** If [A] is ipointed, so is [Join A B]. *)

--- a/theories/WildCat/Products.v
+++ b/theories/WildCat/Products.v
@@ -483,13 +483,12 @@ Global Instance is0functor_cat_binprod_l {A : Type} `{HasBinaryProducts A}
   (y : A)
   : Is0Functor (fun x => cat_binprod x y).
 Proof.
-  exact (is0functor10_bifunctor _ y).
+  exact (is0functor10_bifunctor (fun x y => @cat_binprod _ _ _ _ _ _ _ (@has_binary_products _ _ _ _ _ H0 x y)) y).
 Defined.
 
 Global Instance is1functor_cat_binprod_l {A : Type} `{HasBinaryProducts A}
   (y : A)
   : Is1Functor (fun x => cat_binprod x y).
-Proof.
   exact (is1functor10_bifunctor _ y).
 Defined.
 
@@ -497,7 +496,7 @@ Global Instance is0functor_cat_binprod_r {A : Type} `{HasBinaryProducts A}
   (x : A)
   : Is0Functor (fun y => cat_binprod x y).
 Proof.
-  exact (is0functor01_bifunctor _ x).
+  exact (is0functor10_bifunctor (fun x y => @cat_binprod _ _ _ _ _ _ _ (@has_binary_products _ _ _ _ _ H0 y x)) x).
 Defined.
 
 Global Instance is1functor_cat_binprod_r {A : Type} `{HasBinaryProducts A}


### PR DESCRIPTION
https://github.com/coq/coq/pull/19987 refolds terms before using them to instantiate evars. In `WildCat/Products.v`, this causes (twice) the solution to a typeclass to change, but since the term has a visible type which is not the typeclass and the unification flags forbid to unfold the typeclass and see that the term has a compatible type, it fails. In `Homotopy/Join/Core.v`, there is a second order (and hence very fragile) unification problem which gets solved differently, and in an incompatible way to what was done before.