### PR TITLE
Strong_cat into own submodule

### DIFF
--- a/theories/Algebra/AbSES/Pullback.v
+++ b/theories/Algebra/AbSES/Pullback.v
@@ -444,7 +444,7 @@ Proof.
   nrefine (_ @ (ap (fun x => x $@ _)) _).
   2: { refine (_ @ ap _ equiv_path_absesV_1^).
        exact (fmap_id_strong _ _)^. }
-  exact (cat_idr_strong _)^.
+  exact (Strong.cat_idr_strong _)^.
 Defined.
 
 Definition equiv_hfiber_abses_pullback `{Univalence} {A B B' : AbGroup} {f : B' $-> B}

--- a/theories/Algebra/AbSES/Pullback.v
+++ b/theories/Algebra/AbSES/Pullback.v
@@ -1,6 +1,7 @@
 Require Import Basics Types.
 Require Import HSet Limits.Pullback.
 Require Import WildCat Pointed.Core Homotopy.ExactSequence.
+Import WildCat.Core.Strong.
 Require Import Modalities.ReflectiveSubuniverse.
 Require Import AbGroups.AbelianGroup AbGroups.AbPullback AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.DirectSum.

--- a/theories/Algebra/AbSES/PullbackFiberSequence.v
+++ b/theories/Algebra/AbSES/PullbackFiberSequence.v
@@ -1,5 +1,6 @@
 Require Import Basics Types HSet HFiber Limits.Pullback.
 Require Import WildCat Pointed.Core Homotopy.ExactSequence.
+Import WildCat.Core.Strong.
 Require Import Groups.QuotientGroup.
 Require Import AbGroups.AbelianGroup AbGroups.AbPullback AbGroups.Biproduct.
 Require Import AbSES.Core AbSES.Pullback. 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -839,9 +839,9 @@ Proof.
     exact (isequiv_adjointify f g p q).
 Defined.
 
-Global Instance is1cat_strong `{Funext} : Is1Cat_Strong Group.
+Global Instance is1cat_strong `{Funext} : Strong.Is1Cat_Strong Group.
 Proof.
-  rapply Build_Is1Cat_Strong.
+  rapply Strong.Build_Is1Cat_Strong.
   all: intros; apply equiv_path_grouphomomorphism; intro; reflexivity.
 Defined.
 

--- a/theories/Algebra/Rings/Matrix.v
+++ b/theories/Algebra/Rings/Matrix.v
@@ -1013,7 +1013,8 @@ Defined.
 
 (** Skew-symmetric matrices degenerate to symmetric matrices in rings with characteristic 2. In odd characteristic the module of matrices can be decomposed into the direct sum of symmetric and skew-symmetric matrices. *)
 
-Section MatrixCat.
+Module MatrixCat.
+  Import WildCat.Core.Strong.
 
   (** The wild category [MatrixCat R] of [R]-valued matrices. This category has natural numbers as objects and m x n matrices as the arrows between [m] and [n]. *)
   Definition MatrixCat (R : Ring) := nat.
@@ -1047,3 +1048,4 @@ Section MatrixCat.
 (** TODO: Define HasEquivs for MatrixCat.  *)
 
 End MatrixCat.
+Export MatrixCat.

--- a/theories/Algebra/Universal/Homomorphism.v
+++ b/theories/Algebra/Universal/Homomorphism.v
@@ -9,6 +9,8 @@ Require Export
 Require Import
   HoTT.Types.
 
+Import HoTT.WildCat.Core.Strong.
+
 Local Open Scope Algebra_scope.
 
 Section is_homomorphism.

--- a/theories/Homotopy/Bouquet.v
+++ b/theories/Homotopy/Bouquet.v
@@ -1,5 +1,6 @@
 Require Import Basics Types.
 Require Import Pointed WildCat.
+Import WildCat.Core.Strong.
 Require Import Algebra.Groups.
 Require Import Modalities.ReflectiveSubuniverse Truncations.Core.
 Require Import Homotopy.Suspension.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -288,13 +288,15 @@ Proof.
   exact (fmap_comp psusp g f).
 Defined.
 
-Global Instance is1natural_loop_susp_adjoint_r `{Funext} (A : pType)
+Module Strong.
+Import WildCat.Core.Strong.
+Instance is1natural_loop_susp_adjoint_r `{Funext} (A : pType)
   : Is1Natural (opyon (psusp A)) (opyon A o loops)
       (loop_susp_adjoint A).
 Proof.
   snrapply Build_Is1Natural.
   intros B B' g f.
-  refine ( _ @ cat_assoc_strong _ _ _).
+  refine ( _ @ Strong.cat_assoc_strong _ _ _).
   refine (ap (fun x => x o* loop_susp_unit A) _).
   apply path_pforall.
   rapply (fmap_comp loops).
@@ -305,4 +307,5 @@ Lemma natequiv_loop_susp_adjoint_r `{Funext} (A : pType)
 Proof.
   rapply Build_NatEquiv.
 Defined.
-
+End Strong.
+Export Strong.

--- a/theories/WildCat/Adjoint.v
+++ b/theories/WildCat/Adjoint.v
@@ -1,5 +1,6 @@
 Require Import Basics.Utf8 Basics.Overture Basics.Tactics Basics.Equivalences.
 Require Import WildCat.Core.
+Import WildCat.Core.Strong.
 Require Import WildCat.NatTrans.
 Require Import WildCat.Equiv.
 Require Import WildCat.Prod.
@@ -161,7 +162,7 @@ Section AdjunctionData.
     : equiv_adjunction adj x y f = fmap G f $o adjunction_counit x.
   Proof.
     refine (_ @ is1natural_equiv_adjunction_r adj _ _ _ _ _).
-    by cbv; rewrite (cat_idr_strong f).
+    by cbv; rewrite (Strong.cat_idr_strong f).
   Qed.
 
   Lemma triangle_helper2 x y g

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -173,6 +173,19 @@ Record RetractionOf {A} `{Is1Cat A} {a b : A} (f : a $-> b) :=
     is_retraction : comp_left_inverse $o f $== Id a
   }.
 
+(** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
+Class HasMorExt (A : Type) `{Is1Cat A} := {
+  isequiv_Htpy_path : forall a b f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
+}.
+
+Global Existing Instance isequiv_Htpy_path.
+
+Definition path_hom {A} `{HasMorExt A} {a b : A} {f g : a $-> b} (p : f $== g)
+  : f = g
+  := GpdHom_path^-1 p.
+
+Module Strong.
+
 (** Often, the coherences are actually equalities rather than homotopies. *)
 Class Is1Cat_Strong (A : Type)`{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
 {
@@ -197,7 +210,7 @@ Arguments cat_assoc_opp_strong {_ _ _ _ _ _ _ _ _} f g h.
 Arguments cat_idl_strong {_ _ _ _ _ _ _} f.
 Arguments cat_idr_strong {_ _ _ _ _ _ _} f.
 
-Global Instance is1cat_is1cat_strong (A : Type) `{Is1Cat_Strong A}
+Instance is1cat_is1cat_strong (A : Type) `{Is1Cat_Strong A}
   : Is1Cat A | 1000.
 Proof.
   srapply Build_Is1Cat.
@@ -211,6 +224,19 @@ Proof.
   - intros; apply GpdHom_path, cat_idl_strong.
   - intros; apply GpdHom_path, cat_idr_strong.
 Defined.
+
+(** A 1-category with morphism extensionality induces a strong 1-category *)
+Instance is1cat_strong_hasmorext {A : Type} `{HasMorExt A}
+  : Is1Cat_Strong A.
+Proof.
+  rapply Build_Is1Cat_Strong; hnf; intros; apply path_hom.
+  + apply cat_assoc.
+  + apply cat_assoc_opp.
+  + apply cat_idl.
+  + apply cat_idr.
+Defined.
+
+End Strong.
 
 (** Initial objects *)
 Definition IsInitial {A : Type} `{Is1Cat A} (x : A)
@@ -239,28 +265,6 @@ Definition mor_terminal_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal 
   (f : x $-> y)
   : mor_terminal x y $== f
   := (h x).2 f.
-
-(** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
-Class HasMorExt (A : Type) `{Is1Cat A} := {
-  isequiv_Htpy_path : forall a b f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
-}.
-
-Global Existing Instance isequiv_Htpy_path.
-
-Definition path_hom {A} `{HasMorExt A} {a b : A} {f g : a $-> b} (p : f $== g)
-  : f = g
-  := GpdHom_path^-1 p.
-
-(** A 1-category with morphism extensionality induces a strong 1-category *)
-Global Instance is1cat_strong_hasmorext {A : Type} `{HasMorExt A}
-  : Is1Cat_Strong A.
-Proof.
-  rapply Build_Is1Cat_Strong; hnf; intros; apply path_hom.
-  + apply cat_assoc.
-  + apply cat_assoc_opp.
-  + apply cat_idl.
-  + apply cat_idr.
-Defined.
 
 (** A 1-functor acts on 2-cells (satisfying no axioms) and also preserves composition and identities up to a 2-cell. *)
   (* The [!] tells Coq to use typeclass search to find the [IsGraph] parameters of [Is0Functor] instead of assuming additional copies of them. *)

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -3,6 +3,7 @@ Require Import Basics.PathGroupoids.
 Require Import Basics.Tactics.
 Require Import Types.Sigma.
 Require Import WildCat.Core.
+Import WildCat.Core.Strong.
 Require Import WildCat.Prod.
 
 Class IsDGraph {A : Type} `{IsGraph A} (D : A -> Type)

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -1,6 +1,6 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
-
+Import WildCat.Core.Strong.
 (** ** Opposite categories *)
 
 Definition op (A : Type) := A.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,7 +1,7 @@
 Require Import Basics.Overture Basics.Tactics Basics.Equivalences Basics.PathGroupoids.
 Require Import Types.Equiv.
 Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat.
-
+Import WildCat.Core.Strong.
 (** ** The (1-)category of types *)
 
 Global Instance isgraph_type@{u v} : IsGraph@{v u} Type@{u}
@@ -57,6 +57,8 @@ Proof.
   intros p.
   destruct p; reflexivity.
 Defined.
+
+Global Instance is1cat_type : Is1Cat Type := _.
 
 Global Instance hasequivs_type : HasEquivs Type.
 Proof.

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -1,5 +1,6 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
+Import Strong.
 Require Import WildCat.Equiv.
 Require Import WildCat.Universe.
 Require Import WildCat.Opposite.


### PR DESCRIPTION
Currently in the codebase there is a known typeclass loop caused by two hints, `Is1Cat_Strong -> Is1Cat` and `Is1Cat + HasMorExt -> Is1Cat_Strong`. 

The typeclass loop is currently ameliorated by setting one of the hints to a low priority, so that the loop is never activated if there are other valid solutions.

Not all of the development environments for Coq seem able to easily interrupt such a loop. For VsCoq I have resorted to keeping a terminal window open so I can send the `kill` command when this happens. Typeclass resolution failures are very common so this really impedes my workflow.

In this PR I move all the Strong 1Cat functionality into its own submodule `Strong` within `Core`. In order for the associated typeclass hints to be used in a file, one must write `Import WildCat.Core.Strong`. If one only wants to use a lemma or a definition in the file, one can write `Strong.lemma_name` rather than importing it globally and writing `lemma_name`.

In some cases where there is a file `A.v` downstream which only has one or two lemmas involving `Strong`, I have put those lemmas into a subsection or submodule and imported the `Strong` module only within that submodule so that the loop is not imported globally into the file.

