### PR TITLE
Isolating loop in strong_cat

### DIFF
--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -197,7 +197,8 @@ Arguments cat_assoc_opp_strong {_ _ _ _ _ _ _ _ _} f g h.
 Arguments cat_idl_strong {_ _ _ _ _ _ _} f.
 Arguments cat_idr_strong {_ _ _ _ _ _ _} f.
 
-Global Instance is1cat_is1cat_strong (A : Type) `{Is1Cat_Strong A}
+Module Strong.
+Instance is1cat_is1cat_strong (A : Type) `{Is1Cat_Strong A}
   : Is1Cat A | 1000.
 Proof.
   srapply Build_Is1Cat.
@@ -211,7 +212,7 @@ Proof.
   - intros; apply GpdHom_path, cat_idl_strong.
   - intros; apply GpdHom_path, cat_idr_strong.
 Defined.
-
+End Strong.
 (** Initial objects *)
 Definition IsInitial {A : Type} `{Is1Cat A} (x : A)
   := forall (y : A), {f : x $-> y & forall g, f $== g}.

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -3,6 +3,7 @@ Require Import Basics.PathGroupoids.
 Require Import Basics.Tactics.
 Require Import Types.Sigma.
 Require Import WildCat.Core.
+Import WildCat.Core.Strong.
 Require Import WildCat.Prod.
 
 Class IsDGraph {A : Type} `{IsGraph A} (D : A -> Type)

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -1,5 +1,6 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
+Import WildCat.Core.Strong.
 
 (** ** Opposite categories *)
 

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -1,7 +1,7 @@
 Require Import Basics.Overture Basics.Tactics Basics.Equivalences Basics.PathGroupoids.
 Require Import Types.Equiv.
 Require Import WildCat.Core WildCat.Equiv WildCat.NatTrans WildCat.TwoOneCat.
-
+Import WildCat.Core.Strong.
 (** ** The (1-)category of types *)
 
 Global Instance isgraph_type@{u v} : IsGraph@{v u} Type@{u}
@@ -48,6 +48,8 @@ Global Instance is1cat_strong_type : Is1Cat_Strong Type.
 Proof.
   srapply Build_Is1Cat_Strong; cbn; intros; reflexivity.
 Defined.
+
+Global Instance is1cat_type : Is1Cat Type := _.
 
 Global Instance hasmorext_type `{Funext} : HasMorExt Type.
 Proof.

--- a/theories/WildCat/Yoneda.v
+++ b/theories/WildCat/Yoneda.v
@@ -1,5 +1,6 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
+Import WildCat.Core.Strong.
 Require Import WildCat.Equiv.
 Require Import WildCat.Universe.
 Require Import WildCat.Opposite.


### PR DESCRIPTION
This is a near duplicate of #2225 offered as a potential alternative. It is less obtrusive as a change, because it only moves one hint into a submodule, to break the loop, rather than all the Strong functionality. However, for the sake of organization and readability of the code base, it might be better to put all the Strong functionality together into one module.

My vote is #2225 rather than this PR but I'll leave it open to feedback.