### PR TITLE
Hint mode

### DIFF
--- a/contrib/SetoidRewrite.v
+++ b/contrib/SetoidRewrite.v
@@ -121,7 +121,7 @@ Defined.
 
 #[export] Instance gpd_hom_is_proper1 {A : Type} `{Is0Gpd A}
  : CMorphisms.Proper
-     (Hom (A:=A)==> Hom ==> CRelationClasses.arrow) Hom.
+     (Hom (A:=A) ==> Hom ==> CRelationClasses.arrow) Hom.
 Proof.
   intros x y eq_xy a b eq_ab f.
   refine (transitivity _ eq_ab).

--- a/contrib/SetoidRewrite.v
+++ b/contrib/SetoidRewrite.v
@@ -121,7 +121,7 @@ Defined.
 
 #[export] Instance gpd_hom_is_proper1 {A : Type} `{Is0Gpd A}
  : CMorphisms.Proper
-     (Hom ==> Hom ==> CRelationClasses.arrow) Hom.
+     (Hom (A:=A)==> Hom ==> CRelationClasses.arrow) Hom.
 Proof.
   intros x y eq_xy a b eq_ab f.
   refine (transitivity _ eq_ab).

--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -40,10 +40,10 @@ Defined.
 (** ** Coequalizers *)
 
 (** Using the cokernel and addition and negation for the homs of abelian groups, we can define the coequalizer of two group homomorphisms as the cokernel of their difference. *)
-Definition ab_coeq {A B : AbGroup} (f g : GroupHomomorphism A B)
+Definition ab_coeq {A B : AbGroup} (f g : Hom A B)
   := ab_cokernel ((-f) + g).
 
-Definition ab_coeq_in {A B} {f g : A $-> B} : B $-> ab_coeq f g.
+Definition ab_coeq_in {A B : AbGroup} {f g : A $-> B} : B $-> ab_coeq f g.
 Proof.
   snrapply grp_quotient_map.
 Defined.
@@ -97,7 +97,7 @@ Proof.
   exact p.
 Defined.
 
-Definition functor_ab_coeq {A B} {f g : A $-> B} {A' B'} {f' g' : A' $-> B'}
+Definition functor_ab_coeq {A B : AbGroup} {f g : A $-> B} {A' B'} {f' g' : A' $-> B'}
   (a : A $-> A') (b : B $-> B') (p : f' $o a $== b $o f) (q : g' $o a $== b $o g)
   : ab_coeq f g $-> ab_coeq f' g'.
 Proof.
@@ -109,7 +109,7 @@ Proof.
   nrapply ab_coeq_glue.
 Defined.
 
-Definition functor2_ab_coeq {A B} {f g : A $-> B} {A' B'} {f' g' : A' $-> B'}
+Definition functor2_ab_coeq {A B : AbGroup} {f g : A $-> B} {A' B'} {f' g' : A' $-> B'}
   {a a' : A $-> A'} {b b' : B $-> B'}
   (p : f' $o a $== b $o f) (q : g' $o a $== b $o g)
   (p' : f' $o a' $== b' $o f) (q' : g' $o a' $== b' $o g)
@@ -121,7 +121,7 @@ Proof.
   exact (ap ab_coeq_in (s x)).
 Defined.
 
-Definition functor_ab_coeq_compose {A B} {f g : A $-> B}
+Definition functor_ab_coeq_compose {A B : AbGroup} {f g : A $-> B}
   {A' B'} {f' g' : A' $-> B'} 
   (a : A $-> A') (b : B $-> B') (p : f' $o a $== b $o f) (q : g' $o a $== b $o g)
   {A'' B''} {f'' g'' : A'' $-> B''}
@@ -206,10 +206,7 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_ab_hom `{Funext}
-  : Is0Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup) := Build_Is0Bifunctor'' _.
 
 Global Instance is1bifunctor_ab_hom `{Funext}
   : Is1Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).

--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -40,7 +40,7 @@ Defined.
 (** ** Coequalizers *)
 
 (** Using the cokernel and addition and negation for the homs of abelian groups, we can define the coequalizer of two group homomorphisms as the cokernel of their difference. *)
-Definition ab_coeq {A B : AbGroup} (f g : Hom A B)
+Definition ab_coeq {A B : AbGroup} (f g : A $-> B)
   := ab_cokernel ((-f) + g).
 
 Definition ab_coeq_in {A B : AbGroup} {f g : A $-> B} : B $-> ab_coeq f g.

--- a/theories/Algebra/AbSES/BaerSum.v
+++ b/theories/Algebra/AbSES/BaerSum.v
@@ -52,10 +52,7 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_abses' `{Univalence}
-  : Is0Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type).
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type) := Build_Is0Bifunctor'' _.
 
 Global Instance is1bifunctor_abses' `{Univalence}
   : Is1Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type).
@@ -230,10 +227,7 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_abses `{Univalence}
-  : Is0Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType).
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType) := Build_Is0Bifunctor'' _.
 
 Global Instance is1bifunctor_abses `{Univalence}
   : Is1Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType).

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -147,7 +147,7 @@ Definition path_abses_iso `{Univalence} {B A : AbGroup@{u}}
 
 (** A special case of the "short 5-lemma" where the two outer maps are (definitionally) identities. *)
 Lemma short_five_lemma {B A : AbGroup@{u}}
-  {E F : AbSES B A} (phi : GroupHomomorphism E F)
+  {E F : AbSES B A} (phi : Hom (A:=Group) E F)
   (p0 : phi $o inclusion E == inclusion F) (p1 : projection E == projection F $o phi)
   : IsEquiv phi.
 Proof.
@@ -185,7 +185,7 @@ Defined.
 
 (** Below we prove that homomorphisms respecting [projection] and [inclusion] correspond to paths in [AbSES B A]. We refer to such homomorphisms simply as path data in [AbSES B A]. *)
 Definition abses_path_data {B A : AbGroup@{u}} (E F : AbSES B A)
-  := {phi : GroupHomomorphism E F
+  := {phi : Hom (A:=Group) E F
             & (phi $o inclusion _ == inclusion _)
               * (projection _ == projection _ $o phi)}.
 

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -147,7 +147,7 @@ Definition path_abses_iso `{Univalence} {B A : AbGroup@{u}}
 
 (** A special case of the "short 5-lemma" where the two outer maps are (definitionally) identities. *)
 Lemma short_five_lemma {B A : AbGroup@{u}}
-  {E F : AbSES B A} (phi : Hom (A:=Group) E F)
+  {E F : AbSES B A} (phi : Hom (A:=AbGroup) E F)
   (p0 : phi $o inclusion E == inclusion F) (p1 : projection E == projection F $o phi)
   : IsEquiv phi.
 Proof.
@@ -185,7 +185,7 @@ Defined.
 
 (** Below we prove that homomorphisms respecting [projection] and [inclusion] correspond to paths in [AbSES B A]. We refer to such homomorphisms simply as path data in [AbSES B A]. *)
 Definition abses_path_data {B A : AbGroup@{u}} (E F : AbSES B A)
-  := {phi : Hom (A:=Group) E F
+  := {phi : Hom (A:=AbGroup) E F
             & (phi $o inclusion _ == inclusion _)
               * (projection _ == projection _ $o phi)}.
 

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -119,10 +119,7 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_abext `{Univalence}
-  : Is0Bifunctor (A:=AbGroup^op) ab_ext.
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (A:=AbGroup^op) ab_ext := Build_Is0Bifunctor'' _.
 
 Global Instance is1bifunctor_abext `{Univalence}
   : Is1Bifunctor (A:=AbGroup^op) ab_ext.

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -119,7 +119,8 @@ Proof.
 Defined.
 
 Global Instance is0bifunctor_abext `{Univalence}
-  : Is0Bifunctor (A:=AbGroup^op) ab_ext := Build_Is0Bifunctor'' _.
+  : Is0Bifunctor (A:=AbGroup^op) ab_ext 
+  := Build_Is0Bifunctor'' _.
 
 Global Instance is1bifunctor_abext `{Univalence}
   : Is1Bifunctor (A:=AbGroup^op) ab_ext.

--- a/theories/Algebra/Categorical/MonoidObject.v
+++ b/theories/Algebra/Categorical/MonoidObject.v
@@ -205,7 +205,7 @@ Defined.
 Section MonoidEnriched.
   Context {A : Type} `{HasEquivs A} `{!HasBinaryProducts A}
     (unit : A) `{!IsTerminal unit} {x y : A}
-    `{!HasMorExt A} `{forall x y, IsHSet (x $-> y)}.
+    `{!HasMorExt A} `{forall x y : A, IsHSet (x $-> y)}.
 
   Section Monoid.
     Context `{!IsMonoidObject _ _ y}.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -771,6 +771,7 @@ Defined.
 Global Instance isgraph_group : IsGraph Group
   := Build_IsGraph Group GroupHomomorphism.
 
+(** We add this coercion to make it easier to use a group isomorphism where Coq expects a category morphism. *)
 Definition isHom_GroupIsomorphism (G H : Group) : GroupIsomorphism G H -> Hom G H := idmap.
 Coercion isHom_GroupIsomorphism  : GroupIsomorphism >-> Hom.
 

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -771,6 +771,9 @@ Defined.
 Global Instance isgraph_group : IsGraph Group
   := Build_IsGraph Group GroupHomomorphism.
 
+Definition isHom_GroupIsomorphism (G H : Group) : GroupIsomorphism G H -> Hom G H := idmap.
+Coercion isHom_GroupIsomorphism  : GroupIsomorphism >-> Hom.
+
 Global Instance is01cat_group : Is01Cat Group :=
   Build_Is01Cat Group _ (@grp_homo_id) (@grp_homo_compose).
 

--- a/theories/Algebra/Rings/Module.v
+++ b/theories/Algebra/Rings/Module.v
@@ -419,7 +419,7 @@ Global Instance isgraph_leftmodule {R : Ring} : IsGraph (LeftModule R)
   := Build_IsGraph _ LeftModuleHomomorphism.
 
 Global Instance is01cat_leftmodule {R : Ring} : Is01Cat (LeftModule R)
-  := Build_Is01Cat _ _ lm_homo_id (@lm_homo_compose R).
+  := Build_Is01Cat (LeftModule R) _ lm_homo_id (@lm_homo_compose R).
 
 Global Instance is2graph_leftmodule {R : Ring} : Is2Graph (LeftModule R)
   := fun M N => isgraph_induced (@lm_homo_map R M N).

--- a/theories/Algebra/Rings/Ring.v
+++ b/theories/Algebra/Rings/Ring.v
@@ -261,7 +261,7 @@ Global Instance isgraph_ring : IsGraph Ring
   := Build_IsGraph _ RingHomomorphism.
 
 Global Instance is01cat_ring : Is01Cat Ring
-  := Build_Is01Cat _ _ rng_homo_id (@rng_homo_compose).
+  := Build_Is01Cat Ring _ rng_homo_id (@rng_homo_compose).
 
 Global Instance is2graph_ring : Is2Graph Ring
   := fun A B => isgraph_induced (@rng_homo_map A B : _ -> (group_type _ $-> _)).

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -270,7 +270,7 @@ End Subgroups.
 Global Instance isgraph_oogroup : IsGraph ooGroup
   := Build_IsGraph _ ooGroupHom.
 Global Instance is01cat_oogroup : Is01Cat ooGroup
-  := Build_Is01Cat _ _ grouphom_idmap (@grouphom_compose).
+  := Build_Is01Cat ooGroup _ grouphom_idmap (@grouphom_compose).
 Global Instance is2graph_oogroup : Is2Graph ooGroup
   := is2graph_induced classifying_space.
 Global Instance is1cat_oogroup : Is1Cat ooGroup

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -9,6 +9,8 @@ Class IsGraph (A : Type) :=
   Hom : A -> A -> Type
 }.
 
+Hint Mode IsGraph ! : typeclass_instances.
+
 Notation "a $-> b" := (Hom a b).
 
 Definition graph_hfiber {B C : Type} `{IsGraph C} (F : B -> C) (c : C)
@@ -46,7 +48,7 @@ Global Instance reflexive_GpdHom {A} `{Is0Gpd A}
   := fun a => Id a.
 
 Global Instance reflexive_Hom {A} `{Is01Cat A}
-  : Reflexive Hom
+  : Reflexive Hom (A:=A)
   := fun a => Id a.
 
 Definition gpd_comp {A} `{Is0Gpd A} {a b c : A}
@@ -55,21 +57,21 @@ Definition gpd_comp {A} `{Is0Gpd A} {a b c : A}
 Infix "$@" := gpd_comp.
 
 Global Instance transitive_GpdHom {A} `{Is0Gpd A}
-  : Transitive GpdHom
+  : Transitive GpdHom (A:=A)
   := fun a b c f g => f $@ g.
 
 Global Instance transitive_Hom {A} `{Is01Cat A}
-  : Transitive Hom
+  : Transitive Hom (A:=A)
   := fun a b c f g => g $o f.
 
 Notation "p ^$" := (gpd_rev p).
 
 Global Instance symmetric_GpdHom {A} `{Is0Gpd A}
-  : Symmetric GpdHom
+  : Symmetric GpdHom (A:=A)
   := fun a b f => f^$.
 
 Global Instance symmetric_GpdHom' {A} `{Is0Gpd A}
-  : Symmetric Hom
+  : Symmetric Hom (A:=A)
   := fun a b f => f^$.
 
 Definition Hom_path {A : Type} `{Is01Cat A} {a b : A} (p : a = b) : (a $-> b).
@@ -296,7 +298,7 @@ Class Faithful {A B : Type} (F : A -> B) `{Is1Functor A B F} :=
 
 Section IdentityFunctor.
 
-  Global Instance is0functor_idmap {A : Type} `{IsGraph A} : Is0Functor idmap.
+  Global Instance is0functor_idmap {A : Type} `{IsGraph A} : Is0Functor (A:=A) idmap.
   Proof.
     by apply Build_Is0Functor.
   Defined.

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -9,6 +9,7 @@ Class IsGraph (A : Type) :=
   Hom : A -> A -> Type
 }.
 
+(** This tells Coq to not perform typeclass search on a goal of the form `IsGraph A` when the head of `A` is an evar, avoiding what is often a search involving all possible graph structures on all types.  With this hint in place, we need to occasionally annotate our terms to explicitly give the underlying type. *) 
 Hint Mode IsGraph ! : typeclass_instances.
 
 Notation "a $-> b" := (Hom a b).
@@ -48,7 +49,7 @@ Global Instance reflexive_GpdHom {A} `{Is0Gpd A}
   := fun a => Id a.
 
 Global Instance reflexive_Hom {A} `{Is01Cat A}
-  : Reflexive Hom (A:=A)
+  : Reflexive (A:=A) Hom
   := fun a => Id a.
 
 Definition gpd_comp {A} `{Is0Gpd A} {a b c : A}
@@ -57,21 +58,21 @@ Definition gpd_comp {A} `{Is0Gpd A} {a b c : A}
 Infix "$@" := gpd_comp.
 
 Global Instance transitive_GpdHom {A} `{Is0Gpd A}
-  : Transitive GpdHom (A:=A)
+  : Transitive (A:=A) GpdHom
   := fun a b c f g => f $@ g.
 
 Global Instance transitive_Hom {A} `{Is01Cat A}
-  : Transitive Hom (A:=A)
+  : Transitive (A:=A) Hom
   := fun a b c f g => g $o f.
 
 Notation "p ^$" := (gpd_rev p).
 
 Global Instance symmetric_GpdHom {A} `{Is0Gpd A}
-  : Symmetric GpdHom (A:=A)
+  : Symmetric (A:=A) GpdHom
   := fun a b f => f^$.
 
 Global Instance symmetric_GpdHom' {A} `{Is0Gpd A}
-  : Symmetric Hom (A:=A)
+  : Symmetric (A:=A) Hom
   := fun a b f => f^$.
 
 Definition Hom_path {A : Type} `{Is01Cat A} {a b : A} (p : a = b) : (a $-> b).

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -9,7 +9,7 @@ Class IsGraph (A : Type) :=
   Hom : A -> A -> Type
 }.
 
-(** This tells Coq to not perform typeclass search on a goal of the form `IsGraph A` when the head of `A` is an evar, avoiding what is often a search involving all possible graph structures on all types.  With this hint in place, we need to occasionally annotate our terms to explicitly give the underlying type. *) 
+(** This tells Coq to not perform typeclass search on a goal of the form [IsGraph A] when the head of [A] is an evar, avoiding what is often a search involving all possible graph structures on all types.  With this hint in place, we need to occasionally annotate our terms to explicitly give the underlying type. *) 
 Hint Mode IsGraph ! : typeclass_instances.
 
 Notation "a $-> b" := (Hom a b).

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -24,7 +24,7 @@ Local Existing Instances isgraph_paths is2graph_paths is3graph_paths | 10.
 
 (** Any type has composition and identity morphisms given by path concatenation and reflexivity. *)
 Global Instance is01cat_paths (A : Type) : Is01Cat A
-  := {| Id := @idpath _ ; cat_comp := fun _ _ _ x y => concat y x |}.
+  := { Id := @idpath _ ; cat_comp := fun _ _ _ x y => concat y x }.
 
 (** Any type has a 0-groupoid structure with inverse morphisms given by path inversion. *)
 Global Instance is0gpd_paths (A : Type) : Is0Gpd A


### PR DESCRIPTION
This pull request is similar to the previous one, where the `Hint Mode` of `IsGraph` is changed to `!`, meaning that typeclass search will never try to solve `IsGraph ?A` unless `?A` is known.

I've done some more experimenting and debugging and I feel I have a little more to say regarding Coq's unification, elaboration and typeclass inference. Elaboration is a complex beast and there's a lot I really don't understand and I'm early in learning. Still, I learned a lot in the process of working on this so I'd like to document what I learned.

Let me start with the justification for this PR: I claim that the current setup makes the `rapply` tactic slow and inefficient, and to explain this I will discuss the refine tactic and elaboration in Coq.

In short, the way elaboration works in Coq for an incomplete term `t` declared to be of type `T` is:
1. Coq computes a type `U = type(t)` for `t`, which may contain holes.
2. Coq tries to unify `T` with `U`, solving all holes in the process.

This is very much a "bottom up" process: the declared type `T` has no effect at all at stage 1. It's possible to change this now using bidirectionality hints, which are not part of this PR, but I'll comment on these later, I think they could be useful.

Actually this process is apparently recursive, in the sense that while traversing the term `t` from the ground up, both steps are repeated for each subterm. For example, if `f a` is a small subterm of `t`, where `f` is a variable of declared type `forall x :A, B x` and `a` is a complex term, then: 
1. Coq computes a type `U_a = type(a)`, which may contain holes, and
2. Coq tries to unify `U_a` with `A` and if successful reports `B a` as the type of `f a`.

Typeclass search seems to be part of step 2; if unification fails, then by default we launch a typeclass search to instantiate the values within terms (if this flag is set to its default value, [Typeclass resolution for conversion](https://coq.inria.fr/doc/V8.18.0/refman/addendum/type-classes.html#coq:flag.Typeclass-Resolution-For-Conversion)).

Typeclass search seems to be regarded as a "success" for a given subterm if it successfully instantiates all the typeclass holes in a consistent way, even if these choices cause elaboration of the broader term to fail.

An important thing that can interfere with this process is coercions. In order for coercions `x -> f x` to work right in partially elaborated terms, we need to know the type that `x` needs to be in order to apply the coercion. For example, `g $o f` will fail in general if `g` needs to be coerced (say, from `Iso x y` to `Hom x y`) in order to be of the correct type, because we can't derive the Hom type from `g` alone.

Some of the downstream changes I made have a simple, obvious explanation. For example, in
```
Global Instance reflexive_Hom {A} `{Is01Cat A}
  : Reflexive Hom
  := fun a => Id a.
```
it should be clear that there is no way to "honestly" elaborate the expected type `Reflexive Hom` or `fun a => Id a` by deriving it from constraints, because `A` is not mentioned. Instead, in trying to elaborate `Hom ?A ?IsGraph ?Is01Cat`,
typeclass search would in theory search through the entire database plugging in all possible values of `?IsGraph`, but it starts with the hints prioritized in the context, and since the hints in the context give a valid solution to the typing problem, there's no need to continue the rest of the search. This seems harmless, although I think I have an aesthetic preference for explicit specification when things cannot be uniquely derived.

I think there are a few points in the code base where we are relying on a somewhat surprising elaboration strategy for terms. I will attach a small example, which is a paraphrased version of one of the changes in this commit.

```
Require Import WildCat.Core.
Require Import Algebra.AbGroups.AbelianGroup.
Axiom inv : forall (A : AbGroup), GroupIsomorphism A A.
Set Printing All.
Set Typeclasses Debug.
Set Debug "unification".
Definition abc1 (A B  : AbGroup) (f : Hom A B) := (inv B) $o f.
```
From reading the unification debug logs, the first thing that happens (after `f : Hom A B` is fully elaborated) is that we try to check that the application of `cat_comp` to `inv B` is valid by unifying the type of `inv B`, `GroupIsomorphism B B`, with `Hom ?A ?IsGraph ?Is01Cat ?x ?y` This unification fails almost immediately (thank you very much Gaetan Gilbert for helping me understand why!) so we try and elaborate both the type of `inv B` and `Hom ?A ?IsGraph ?Is01Cat ?x ?y` independently using typeclass search. 
 It's important to note here that when we are trying to elaborate this latter term, we are truly starting from scratch and starting to "elaborate" the term `Hom _ _ _ _ _` from nothing. The typeclass search is not being driven by the type argument, because there is no type argument, so it is just generating any arbitrary typeclasses of the form `Is01Cat` and `IsGraph`, and instantiating the type this way. In this case we get lucky and get the right answer, but only by the coincidence that `isgraph_abgroup` happened to be the most recent hint in the database - if you change `AbGroup` to `Group` in `inv` and `abc1`, it will fail because it still finds `isgraph_abgroup` as the most recent hint in the database and we can't convert a Group to an AbGroup.

So, in my opinion, this is not very robust, we are getting lucky, and I think we shouldn't rely on this elaboration technique, if possible we should try and understand why unification is failing and fix it. This is one argument for using `Hint Mode +` in some cases.

Now let me return to the discussion of `rapply`. Something like `Build_Is0Bifunctor''` takes, say, a dozen arguments, so we want `refine Build_Is0Bifunctor'' || refine Build_Is0Bifunctor'' _ || refine Build_Is0Bifunctor''  _ _` to fail quickly at each case so we quickly reach 12 arguments. The way this works is that we try to unify the type of `(Build_Is01Bifunctor'' _ _ _ _ _ _)` with the type of the goal, and if this fails, we launch typeclass search to elaborate the term and try again, but this is *not guided from the top down*, so we are trying every combination of hints in the database for the typeclass holes. This is very expensive. Using `Hint Mode !` on the parameter types would make this faster because we basically wouldn't carry out a typeclass search at all unless unification succeeded in instantiating the parameter types.

Now, bidirectionality is complementary to this. If we write 
```
Arguments Build_Is0Bifunctor'' {A B C} & { H H0 H1 _ } F _ _
```
then whenever we call `Build_Is0Bifunctor''`, it will first look to the context of the expected type to solve for `A, B, C`, and then try to elaborate the rest of everything from this. In this situation, as long as `Build_Is0Bifunctor` is being used in a situation where the correct types can be inferred from the external context then you will not have this unguided typeclass search. And in many cases where we remove typeclass inference with `Hint Mode +` we could restore the same elaboration behavior with bidirectionality hints, so hopefully not too many more annotations. On the other hand if unification fails completely (as in the first few iterations of `rapply`) then typeclass search will still start from a blank slate, so bidirectionality will not make as much of an impact there.

I experimented with bidirectionality and I found that in some cases you want to use it and in some you don't. If you have `cat_comp _ _ _ g f` where `g` needs to be coerced from `Iso x y -> Hom x y` or something, then bidirectionality is helping you, because deriving the category structure from `Iso x y` would give you the wrong answer. But if `g, f` are (say) group homomorphisms and you have a function application `(cat_comp _ _ _ g f) x`, then bidirectionality could hurt you here because based on the application it will derive that `(cat_comp _ _ _ g f)` should be of a function type, and therefore `Hom x y` should be a function type, and maybe it will now coerce `g, f` from group homomorphisms to functions before composing them. Or, if this unification fails, it will carry out typeclass search and just find any type with a category structure whose homs are function types.

In some of the commits below, we have to add additional type annotations. 
In some, `rapply` takes too much time to run; I checked that these can be fixed by adding more `Hint Mode +` types to make `rapply ` fail faster, but I chose a simpler patch.

A complementary fix for `rapply` would be perhaps to replace `refine (f _ _ _ _)` with `notypeclasses refine (f _ _ _ _); try(typeclasses eauto)` which should fail faster if it cannot successfully unify the type of the input with the type of the term at all, making the earlier stages much faster.