### PR TITLE
EMSpace: add #[export] to the instances

### DIFF
--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -29,19 +29,19 @@ Notation "'K(' G , n )" := (EilenbergMacLane G n).
 Section EilenbergMacLane.
   Context `{Univalence}.
 
-  Instance istrunc_em {G : Group} {n : nat} : IsTrunc n K(G, n).
+  #[export] Instance istrunc_em {G : Group} {n : nat} : IsTrunc n K(G, n).
   Proof.
     destruct n as [|[]]; exact _.
   Defined.
 
   (** This is subsumed by the next result, but Coq doesn't always find the next result when it should. *)
-  Instance isconnected_em {G : Group} (n : nat)
+  #[export] Instance isconnected_em {G : Group} (n : nat)
     : IsConnected n K(G, n.+1).
   Proof.
     induction n; exact _.
   Defined.
 
-  Instance isconnected_em' {G : Group} (n : nat)
+  #[export] Instance isconnected_em' {G : Group} (n : nat)
     : IsConnected n.-1 K(G, n).
   Proof.
     destruct n.
@@ -49,7 +49,7 @@ Section EilenbergMacLane.
     apply isconnected_em.
   Defined.
 
-  Instance is0connected_em {G : Group} (n : nat)
+  #[export] Instance is0connected_em {G : Group} (n : nat)
     : IsConnected 0 K(G, n.+1).
   Proof.
     rapply (is0connected_isconnected n.-2).


### PR DESCRIPTION
These were accidentally switched to local instances in #2244.

@patrick-nicodemus Any chance you can create a file that imports HoTT.v and then prints the typeclass database, and then use this to compare the sorted outputs before and after #2244 and #2239?  Ideally, the change in #2247 to Rings.v would be in place during both checks, for the most coverage.