### PR TITLE
chore: fix warnings in test/

### DIFF
--- a/test/Tactics/napply.v
+++ b/test/Tactics/napply.v
@@ -13,7 +13,7 @@ Fail Definition test1 : test1_type := ltac:(tapply exist).
 Succeed Definition test1 : test1_type := ltac:(napply exist; exact _).
 
 (** Testing deprecated tactics *)
-Fail Definition test1 : test1_type := ltac:(nrapply exist).
-Fail Definition test1 : test1_type := ltac:(snrapply exist).
-
-
+Fail #[warnings="+deprecated-tactic-notation-since-2025-03-11"]
+Definition test1 : test1_type := ltac:(nrapply exist).
+Fail #[warnings="+deprecated-tactic-notation-since-2025-03-11"]
+Definition test1 : test1_type := ltac:(snrapply exist).


### PR DESCRIPTION
We mark these warnings as fatal so that they can trigger the `Fail` command more reliably and not litter the CI with warnings. 