### PR TITLE
Using new syntax for projection instance declarations

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -509,22 +509,33 @@ IsTrunc n (P a)`, and similarly for other data types. For instance,
 
 ### 3.7. Coercions and Existing Instances
 
-A "coercion" from `A` to `B` is a function that Coq will insert
-silently if given an `A` when it expects a `B`, and which it doesn't
-display. For example, we have declared `equiv_fun` as a coercion from
-`A <~> B` to `A -> B`, so that we can use an equivalence as a function
-without needing to manually apply the projection `equiv_fun`.
-Coercions can make code easier to read and write, but when used
-carelessly they can have the opposite effect.
+A ["coercion" from `A` to
+`B`](https://rocq-prover.org/refman/addendum/implicit-coercions.html)
+is a function that Coq will insert silently if given an `A` when it
+expects a `B`, and which it doesn't display. For example, we have
+declared `equiv_fun` as a coercion from `A <~> B` to `A -> B`, so that
+we can use an equivalence as a function without needing to manually
+apply the projection `equiv_fun`. Coercions can make code easier to
+read and write, but when used carelessly they can have the opposite
+effect.
 
-When defining a `Record`, Coq allows you to declare a field as a
-coercion by writing its type with `:>` instead of `:`.
-When defining a `Class`, the `:>` notation has a
-different meaning: it declares a field as an `Existing Instance`.
+When making a record field `proj1` into a coercion, we prefer that the
+coercion should not be reversible, because of the additional
+complexity that reversible coercions add to unification problems, and
+we prefer that coercions be conspicuous when reading the source code.
+Therefore, define the coercion on its own line after the record
+declaration as `Coercion proj1 : MyRec >-> FieldType` rather than
+using the reversible coercion syntax `proj1 :> FieldType`.
 
-(In addition, the `:>` notation is used when needed for path types
-to indicate the type in which the paths are taken: `x = y :> A`
-for `x, y : A`.)
+(This library also uses the `:>` notation when needed for path types
+to indicate the type in which the paths are taken: `x = y :> A` for
+`x, y : A`.)
+
+If `proj1` is a record field whose type is a typeclass, then we prefer
+the concise ["substructure"
+notation](https://rocq-prover.org/refman/addendum/type-classes.html#substructures)
+`proj1 :: ClassType` over the separate vernacular command
+`Existing Instance proj1.` after the record declaration.
 
 ## 4. Axioms
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -531,7 +531,8 @@ using the reversible coercion syntax `proj1 :> FieldType`.
 to indicate the type in which the paths are taken: `x = y :> A` for
 `x, y : A`.)
 
-If `proj1` is a record field whose type is a typeclass and we'd like to add this field as a typeclass instance, then we prefer
+If `proj1` is a record field whose type is a typeclass and we'd
+like to add this field as a typeclass instance, then we prefer
 the concise ["substructure"
 notation](https://rocq-prover.org/refman/addendum/type-classes.html#substructures)
 `proj1 :: ClassType` over the separate vernacular command

--- a/STYLE.md
+++ b/STYLE.md
@@ -531,7 +531,7 @@ using the reversible coercion syntax `proj1 :> FieldType`.
 to indicate the type in which the paths are taken: `x = y :> A` for
 `x, y : A`.)
 
-If `proj1` is a record field whose type is a typeclass, then we prefer
+If `proj1` is a record field whose type is a typeclass and we'd like to add this field as a typeclass instance, then we prefer
 the concise ["substructure"
 notation](https://rocq-prover.org/refman/addendum/type-classes.html#substructures)
 `proj1 :: ClassType` over the separate vernacular command

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -18,11 +18,10 @@ Local Open Scope mc_add_scope.
 
 Record AbGroup := {
   abgroup_group : Group;
-  abgroup_commutative : @Commutative abgroup_group _ (+);
-}.
+  abgroup_commutative :: @Commutative abgroup_group _ (+);
+  }.
 
 Coercion abgroup_group : AbGroup >-> Group.
-Existing Instance abgroup_commutative.
 
 Definition zero_abgroup (A : AbGroup) : Zero A := mon_unit.
 Definition negate_abgroup (A : AbGroup) : Negate A := inv.

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -19,7 +19,7 @@ Local Open Scope mc_add_scope.
 Record AbGroup := {
   abgroup_group : Group;
   abgroup_commutative :: @Commutative abgroup_group _ (+);
-  }.
+}.
 
 Coercion abgroup_group : AbGroup >-> Group.
 

--- a/theories/Algebra/AbGroups/Abelianization.v
+++ b/theories/Algebra/AbGroups/Abelianization.v
@@ -21,9 +21,8 @@ Definition group_precomp {a b} := @cat_precomp Group _ _ a b.
 
 Class IsAbelianization {G : Group} (G_ab : AbGroup)
       (eta : GroupHomomorphism G G_ab)
-  := issurjinj_isabel : forall (A : AbGroup),
+  := issurjinj_isabel :: forall (A : AbGroup),
       IsSurjInj (group_precomp A eta).
-Existing Instance issurjinj_isabel.
 
 Definition isequiv_group_precomp_isabelianization `{Funext}
   {G : Group} {G_ab : AbGroup} (eta : GroupHomomorphism G G_ab)

--- a/theories/Algebra/AbGroups/FreeAbelianGroup.v
+++ b/theories/Algebra/AbGroups/FreeAbelianGroup.v
@@ -13,9 +13,8 @@ Definition FactorsThroughFreeAbGroup (S : Type) (F_S : AbGroup)
 
 (** Universal property of a free abelian group on a set (type). *)
 Class IsFreeAbGroupOn (S : Type) (F_S : AbGroup) (i : S -> F_S)
-  := contr_isfreeabgroupon : forall (A : AbGroup) (g : S -> A),
+  := contr_isfreeabgroupon :: forall (A : AbGroup) (g : S -> A),
       Contr (FactorsThroughFreeAbGroup S F_S i A g).
-Existing Instance contr_isfreeabgroupon.
 
 (** A abelian group is free if there exists a generating type on which it is a free group (a basis). *)
 Class IsFreeAbGroup (F_S : AbGroup)

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -22,15 +22,13 @@ Record AbSES' {B A : AbGroup@{u}} := Build_AbSES {
     middle :  AbGroup@{u};
     inclusion : A $-> middle;
     projection : middle $-> B;
-    isembedding_inclusion : IsEmbedding inclusion;
-    issurjection_projection : IsSurjection projection;
-    isexact_inclusion_projection : IsExact (Tr (-1)) inclusion projection;
+    isembedding_inclusion :: IsEmbedding inclusion;
+    issurjection_projection :: IsSurjection projection;
+    isexact_inclusion_projection :: IsExact (Tr (-1)) inclusion projection;
   }.
 
 (** Given a short exact sequence [A -> E -> B : AbSES B A], we coerce it to [E]. *)
 Coercion middle : AbSES' >-> AbGroup.
-
-Existing Instances isembedding_inclusion issurjection_projection isexact_inclusion_projection.
 
 Arguments AbSES' B A : clear implicits.
 Arguments Build_AbSES {B A}.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -1153,9 +1153,8 @@ Definition FactorsThroughFreeGroup (S : Type) (F_S : Group)
 
 (** Universal property of a free group on a set (type). *)
 Class IsFreeGroupOn (S : Type) (F_S : Group) (i : S -> F_S)
-  := contr_isfreegroupon : forall (A : Group) (g : S -> A),
+  := contr_isfreegroupon :: forall (A : Group) (g : S -> A),
       Contr (FactorsThroughFreeGroup S F_S i A g).
-Existing Instance contr_isfreegroupon.
 
 (** A group is free if there exists a generating type on which it is a free group. *)
 Class IsFreeGroup (F_S : Group)

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -14,13 +14,11 @@ Generalizable Variables G H A B C N f g.
 
 (** A subgroup H of a group G is a predicate (i.e. an hProp-valued type family) on G which is closed under the group operations. The group underlying H is given by the total space { g : G & H g }, defined in [subgroup_group] below. *)
 Class IsSubgroup {G : Group} (H : G -> Type) := {
-  issubgroup_predicate : forall x, IsHProp (H x) ;
+  issubgroup_predicate :: forall x, IsHProp (H x) ;
   issubgroup_in_unit : H mon_unit ;
   issubgroup_in_op : forall x y, H x -> H y -> H (x * y) ;
   issubgroup_in_inv : forall x, H x -> H x^ ;
 }.
-
-Existing Instance issubgroup_predicate.
 
 Definition issig_issubgroup {G : Group} (H : G -> Type) : _ <~> IsSubgroup H
   := ltac:(issig).
@@ -129,12 +127,9 @@ Defined.
 
 (** The type (set) of subgroups of a group G. *)
 Record Subgroup (G : Group) := {
-  subgroup_pred : G -> Type ;
-  subgroup_issubgroup : IsSubgroup subgroup_pred ;
+  subgroup_pred :> G -> Type ;
+  subgroup_issubgroup :: IsSubgroup subgroup_pred ;
 }.
-
-Coercion subgroup_pred : Subgroup >-> Funclass.
-Existing Instance subgroup_issubgroup.
 
 Definition issig_subgroup {G : Group} : _ <~> Subgroup G
   := ltac:(issig).
@@ -441,14 +436,11 @@ Class IsNormalSubgroup {G : Group} (N : Subgroup G)
   := isnormal : forall {x y}, N (x * y) -> N (y * x).
 
 Record NormalSubgroup (G : Group) := {
-  normalsubgroup_subgroup : Subgroup G ;
-  normalsubgroup_isnormal : IsNormalSubgroup normalsubgroup_subgroup ;
+  normalsubgroup_subgroup :> Subgroup G ;
+  normalsubgroup_isnormal :: IsNormalSubgroup normalsubgroup_subgroup ;
 }.
 
 Arguments Build_NormalSubgroup G N _ : rename.
-
-Coercion normalsubgroup_subgroup : NormalSubgroup >-> Subgroup.
-Existing Instance normalsubgroup_isnormal.
 
 Definition equiv_symmetric_in_normalsubgroup {G : Group}
   (N : Subgroup G) `{!IsNormalSubgroup N}

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -127,9 +127,11 @@ Defined.
 
 (** The type (set) of subgroups of a group G. *)
 Record Subgroup (G : Group) := {
-  subgroup_pred :> G -> Type ;
+  subgroup_pred : G -> Type ;
   subgroup_issubgroup :: IsSubgroup subgroup_pred ;
 }.
+
+Coercion subgroup_pred : Subgroup >-> Funclass.
 
 Definition issig_subgroup {G : Group} : _ <~> Subgroup G
   := ltac:(issig).
@@ -436,11 +438,13 @@ Class IsNormalSubgroup {G : Group} (N : Subgroup G)
   := isnormal : forall {x y}, N (x * y) -> N (y * x).
 
 Record NormalSubgroup (G : Group) := {
-  normalsubgroup_subgroup :> Subgroup G ;
+  normalsubgroup_subgroup : Subgroup G ;
   normalsubgroup_isnormal :: IsNormalSubgroup normalsubgroup_subgroup ;
 }.
 
 Arguments Build_NormalSubgroup G N _ : rename.
+
+Coercion normalsubgroup_subgroup : NormalSubgroup >-> Subgroup.
 
 Definition equiv_symmetric_in_normalsubgroup {G : Group}
   (N : Subgroup G) `{!IsNormalSubgroup N}

--- a/theories/Algebra/Rings/Ring.v
+++ b/theories/Algebra/Rings/Ring.v
@@ -33,7 +33,6 @@ Record Ring := Build_Ring' {
   ring_mult_assoc_opp : forall z y x, (x * y) * z = x * (y * z);
 }.
 
-
 Arguments ring_mult {R} : rename.
 Arguments ring_one {R} : rename.
 Arguments ring_isring {R} : rename.
@@ -144,12 +143,11 @@ End RingHomoLaws.
 (** Isomorphisms of commutative rings *)
 Record RingIsomorphism (A B : Ring) := {
   rng_iso_homo : RingHomomorphism A B ;
-  isequiv_rng_iso_homo : IsEquiv rng_iso_homo ;
+  isequiv_rng_iso_homo :: IsEquiv rng_iso_homo ;
 }.
 
 Arguments rng_iso_homo {_ _ }.
 Coercion rng_iso_homo : RingIsomorphism >-> RingHomomorphism.
-Existing Instance isequiv_rng_iso_homo.
 
 Definition issig_RingIsomorphism {A B : Ring}
   : _ <~> RingIsomorphism A B := ltac:(issig).

--- a/theories/Algebra/Universal/Algebra.v
+++ b/theories/Algebra/Universal/Algebra.v
@@ -38,14 +38,10 @@ Record Signature := Build_Signature
   { Sort : Type
   ; Symbol : Type
   ; symbol_types : Symbol -> SymbolTypeOf Sort
-  ; hset_sort : IsHSet Sort
-  ; hset_symbol : IsHSet Symbol }.
+  ; hset_sort :: IsHSet Sort
+  ; hset_symbol :: IsHSet Symbol }.
 
 Notation SymbolType σ := (SymbolTypeOf (Sort σ)).
-
-Existing Instance hset_sort.
-
-Existing Instance hset_symbol.
 
 Global Coercion symbol_types : Signature >-> Funclass.
 
@@ -81,13 +77,11 @@ Definition Operation {σ} (A : Carriers σ) (w : SymbolType σ) : Type
 Record Algebra {σ : Signature} : Type := Build_Algebra
   { carriers : Carriers σ
   ; operations : forall (u : Symbol σ), Operation carriers (σ u)
-  ; hset_algebra : forall (s : Sort σ), IsHSet (carriers s) }.
+  ; hset_algebra :: forall (s : Sort σ), IsHSet (carriers s) }.
 
 Arguments Algebra : clear implicits.
 
 Arguments Build_Algebra {σ} carriers operations {hset_algebra}.
-
-Existing Instance hset_algebra.
 
 Global Coercion carriers : Algebra >-> Funclass.
 

--- a/theories/Algebra/Universal/Congruence.v
+++ b/theories/Algebra/Universal/Congruence.v
@@ -53,19 +53,13 @@ Section congruence.
       mere equivalence relations and [OpsCompatible A Φ] holds. *)
 
   Class IsCongruence : Type := Build_IsCongruence
-   { is_mere_relation_cong : forall (s : Sort σ), is_mere_relation (A s) (Φ s)
-   ; equiv_rel_cong : forall (s : Sort σ), EquivRel (Φ s)
-   ; ops_compatible_cong : OpsCompatible }.
+   { is_mere_relation_cong :: forall (s : Sort σ), is_mere_relation (A s) (Φ s)
+   ; equiv_rel_cong :: forall (s : Sort σ), EquivRel (Φ s)
+   ; ops_compatible_cong :: OpsCompatible }.
 
   Global Arguments Build_IsCongruence {is_mere_relation_cong}
                                       {equiv_rel_cong}
                                       {ops_compatible_cong}.
-
-  #[export] Existing Instance is_mere_relation_cong.
-
-  #[export] Existing Instance equiv_rel_cong.
-
-  #[export] Existing Instance ops_compatible_cong.
 
   #[export] Instance hprop_is_congruence `{Funext} : IsHProp IsCongruence.
   Proof.

--- a/theories/Algebra/Universal/Homomorphism.v
+++ b/theories/Algebra/Universal/Homomorphism.v
@@ -38,15 +38,13 @@ End is_homomorphism.
 
 Record Homomorphism {σ} {A B : Algebra σ} : Type := Build_Homomorphism
   { def_homomorphism : forall (s : Sort σ), A s -> B s
-  ; is_homomorphism : IsHomomorphism def_homomorphism }.
+  ; is_homomorphism :: IsHomomorphism def_homomorphism }.
 
 Arguments Homomorphism {σ}.
 
 Arguments Build_Homomorphism {σ A B} def_homomorphism {is_homomorphism}.
 
 Global Coercion def_homomorphism : Homomorphism >-> Funclass.
-
-Existing Instance is_homomorphism.
 
 Instance isgraph_algebra (σ : Signature) : IsGraph (Algebra σ)
   := Build_IsGraph (Algebra σ) Homomorphism.

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -20,10 +20,8 @@ Local Unset Keyed Unification.
 
 Record ooGroup :=
   { classifying_space : pType ;
-    isconn_classifying_space : IsConnected 0 classifying_space
+    isconn_classifying_space :: IsConnected 0 classifying_space
   }.
-
-Existing Instance isconn_classifying_space.
 
 Local Notation B := classifying_space.
 

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -67,8 +67,7 @@ Ltac decidable_false p n :=
   try intro.
 
 Class DecidablePaths (A : Type) :=
-  dec_paths : forall (x y : A), Decidable (x = y).
-Existing Instance dec_paths.
+  dec_paths :: forall (x y : A), Decidable (x = y).
 
 Class Stable P := stable : ~~P -> P.
 
@@ -199,13 +198,11 @@ Defined.
 (** A type is collapsible if it admits a weakly constant endomap. *)
 Class Collapsible (A : Type) :=
   { collapse : A -> A ;
-    wconst_collapse : WeaklyConstant collapse
+    wconst_collapse :: WeaklyConstant collapse
   }.
-Existing Instance wconst_collapse.
 
 Class PathCollapsible (A : Type) :=
-  path_coll : forall (x y : A), Collapsible (x = y).
-Existing Instance path_coll.
+  path_coll :: forall (x y : A), Collapsible (x = y).
 
 Instance collapsible_decidable (A : Type) `{Decidable A}
 : Collapsible A.

--- a/theories/Basics/Overture.v
+++ b/theories/Basics/Overture.v
@@ -92,11 +92,8 @@ Class Transitive {A} (R : Relation A) :=
 
 (** A [PreOrder] is both Reflexive and Transitive. *)
 Class PreOrder {A} (R : Relation A) :=
-  { PreOrder_Reflexive : Reflexive R | 2 ;
-    PreOrder_Transitive : Transitive R | 2 }.
-
-Existing Instance PreOrder_Reflexive.
-Existing Instance PreOrder_Transitive.
+  { PreOrder_Reflexive :: Reflexive R | 2 ;
+    PreOrder_Transitive :: Transitive R | 2 }.
 
 Arguments reflexivity {A R _} / _.
 Arguments symmetry {A R _} / _ _ _.
@@ -488,12 +485,10 @@ Global Opaque eisadj.
 (** A record that includes all the data of an adjoint equivalence. *)
 Record Equiv A B := {
   equiv_fun : A -> B ;
-  equiv_isequiv : IsEquiv equiv_fun
+  equiv_isequiv :: IsEquiv equiv_fun
 }.
 
 Coercion equiv_fun : Equiv >-> Funclass.
-
-Existing Instance equiv_isequiv.
 
 Arguments equiv_fun {A B} _ _.
 Arguments equiv_isequiv {A B} _.
@@ -728,11 +723,9 @@ Arguments point A {_}.
 
 Record pType :=
   { pointed_type : Type ;
-    ispointed_type : IsPointed pointed_type }.
+    ispointed_type :: IsPointed pointed_type }.
 
 Coercion pointed_type : pType >-> Sortclass.
-
-Existing Instance ispointed_type.
 
 (** *** Homotopy fibers *)
 

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -378,9 +378,7 @@ Definition istrunc_equiv_istrunc A {B} (f : A <~> B) `{IsTrunc n A}
 (** ** Truncated morphisms *)
 
 Class IsTruncMap (n : trunc_index) {X Y : Type} (f : X -> Y)
-  := istruncmap_fiber : forall y:Y, IsTrunc n (hfiber f y).
-
-Existing Instance istruncmap_fiber.
+  := istruncmap_fiber :: forall y:Y, IsTrunc n (hfiber f y).
 
 Notation IsEmbedding := (IsTruncMap (-1)).
 
@@ -390,7 +388,7 @@ Notation IsEmbedding := (IsTruncMap (-1)).
 
 Record TruncType (n : trunc_index) := {
   trunctype_type : Type ;
-  trunctype_istrunc : IsTrunc n trunctype_type
+  trunctype_istrunc :: IsTrunc n trunctype_type
 }.
 
 Arguments Build_TruncType _ _ {_}.
@@ -398,7 +396,6 @@ Arguments trunctype_type {_} _.
 Arguments trunctype_istrunc [_] _.
 
 Coercion trunctype_type : TruncType >-> Sortclass.
-Existing Instance trunctype_istrunc.
 
 Notation "n -Type" := (TruncType n) : type_scope.
 Notation HProp := (-1)-Type.

--- a/theories/Categories/Category/Core.v
+++ b/theories/Categories/Category/Core.v
@@ -71,7 +71,7 @@ Record PreCategory :=
       (** Ask for the double-identity version so that [InitialTerminalCategory.Functors.from_terminal Cᵒᵖ X] and [(InitialTerminalCategory.Functors.from_terminal C X)ᵒᵖ] are convertible. *)
       identity_identity : forall x, identity x o identity x = identity x;
 
-      trunc_morphism : forall s d, IsHSet (morphism s d)
+      trunc_morphism :: forall s d, IsHSet (morphism s d)
     }.
 
 Bind Scope category_scope with PreCategory.
@@ -105,8 +105,6 @@ Definition Build_PreCategory
        left_identity
        right_identity
        (fun _ => left_identity _ _ _).
-
-Existing Instance trunc_morphism.
 
 (** create a hint db for all category theory things *)
 Create HintDb category discriminated.

--- a/theories/Categories/Category/Morphisms.v
+++ b/theories/Categories/Category/Morphisms.v
@@ -32,19 +32,14 @@ Hint Rewrite @left_inverse @right_inverse : morphism.
 Class Isomorphic {C : PreCategory} s d :=
   {
     morphism_isomorphic : morphism C s d;
-    isisomorphism_isomorphic : IsIsomorphism morphism_isomorphic
+    isisomorphism_isomorphic :: IsIsomorphism morphism_isomorphic
   }.
 
 (*Coercion Build_Isomorphic : IsIsomorphism >-> Isomorphic.*)
 Coercion morphism_isomorphic : Isomorphic >-> morphism.
-(* Use :> and remove the two following lines,
-   once Coq 8.16 is the minimum required version. *)
-#[export] Existing Instance isisomorphism_isomorphic.
 Coercion isisomorphism_isomorphic : Isomorphic >-> IsIsomorphism.
 
 Local Infix "<~=~>" := Isomorphic : category_scope.
-
-Existing Instance isisomorphism_isomorphic.
 
 (** ** Theorems about isomorphisms *)
 Section iso_contr.

--- a/theories/Categories/Functor/Attributes.v
+++ b/theories/Categories/Functor/Attributes.v
@@ -143,8 +143,5 @@ Class IsEssentiallySurjective A B (F : Functor A B)
     We say [F] is a _weak equivalence_ if it is fully faithful and
     essentially surjective. *)
 Class IsWeakEquivalence `{Funext} A B (F : Functor A B)
-  := { is_fully_faithful__is_weak_equivalence : IsFullyFaithful F;
-       is_essentially_surjective__is_weak_equivalence : IsEssentiallySurjective F }.
-#[export] Existing Instances
-  is_fully_faithful__is_weak_equivalence
-  is_essentially_surjective__is_weak_equivalence.
+  := { is_fully_faithful__is_weak_equivalence :: IsFullyFaithful F;
+       is_essentially_surjective__is_weak_equivalence :: IsEssentiallySurjective F }.

--- a/theories/Classes/interfaces/abstract_algebra.v
+++ b/theories/Classes/interfaces/abstract_algebra.v
@@ -29,16 +29,11 @@ Setoid_Morphism as a substructure, setoid rewriting will become horribly slow.
 (* An unbundled variant of the former CoRN CSetoid. We do not
   include a proof that A is a Setoid because it can be derived. *)
 Class IsApart A {Aap : Apart A} : Type :=
-  { apart_set : IsHSet A
-  ; apart_mere : is_mere_relation _ apart
-  ; apart_symmetric : Symmetric (≶)
-  ; apart_cotrans : CoTransitive (≶)
+  { apart_set :: IsHSet A
+  ; apart_mere :: is_mere_relation _ apart
+  ; apart_symmetric :: Symmetric (≶)
+  ; apart_cotrans :: CoTransitive (≶)
   ; tight_apart : forall x y, ~(x ≶ y) <-> x = y }.
-#[export] Existing Instances
-  apart_set
-  apart_mere
-  apart_symmetric
-  apart_cotrans.
 
 Instance apart_irrefl `{IsApart A} : Irreflexive (≶).
 Proof.
@@ -80,68 +75,49 @@ Section upper_classes.
   Local Open Scope mc_mult_scope.
 
   Class IsSemiGroup {Aop: SgOp A} :=
-    { sg_set : IsHSet A
-    ; sg_ass : Associative (.*.) }.
-    #[export] Existing Instances sg_set sg_ass.
+    { sg_set :: IsHSet A
+    ; sg_ass :: Associative (.*.) }.
 
   Class IsCommutativeSemiGroup {Aop : SgOp A} :=
-    { comsg_sg : @IsSemiGroup (.*.)
-    ; comsg_comm : Commutative (.*.) }.
-  #[export] Existing Instances comsg_sg comsg_comm.
+    { comsg_sg :: @IsSemiGroup (.*.)
+    ; comsg_comm :: Commutative (.*.) }.
 
   Class IsSemiLattice {Aop : SgOp A} :=
-    { semilattice_sg : @IsCommutativeSemiGroup (.*.)
-    ; semilattice_idempotent : BinaryIdempotent (.*.)}.
-  #[export] Existing Instances semilattice_sg semilattice_idempotent.
+    { semilattice_sg :: @IsCommutativeSemiGroup (.*.)
+    ; semilattice_idempotent :: BinaryIdempotent (.*.)}.
 
   Class IsMonoid {Aop : SgOp A} {Aunit : MonUnit A} :=
-    { monoid_semigroup : IsSemiGroup
-    ; monoid_left_id : LeftIdentity (.*.) mon_unit
-    ; monoid_right_id : RightIdentity (.*.) mon_unit }.
-  #[export] Existing Instances
-    monoid_semigroup
-    monoid_left_id
-    monoid_right_id.
+    { monoid_semigroup :: IsSemiGroup
+    ; monoid_left_id :: LeftIdentity (.*.) mon_unit
+    ; monoid_right_id :: RightIdentity (.*.) mon_unit }.
 
   Class IsCommutativeMonoid {Aop : SgOp A} {Aunit : MonUnit A} :=
-    { commonoid_mon : @IsMonoid (.*.) Aunit
-    ; commonoid_commutative : Commutative (.*.) }.
-  #[export] Existing Instances
-    commonoid_mon
-    commonoid_commutative.
+    { commonoid_mon :: @IsMonoid (.*.) Aunit
+    ; commonoid_commutative :: Commutative (.*.) }.
 
   Class IsGroup {Aop : SgOp A} {Aunit : MonUnit A} {Ainv : Inverse A} :=
-    { group_monoid : @IsMonoid (.*.) mon_unit
-    ; inverse_l : LeftInverse (.*.) (^) mon_unit
-    ; inverse_r: RightInverse (.*.) (^) mon_unit
+    { group_monoid :: @IsMonoid (.*.) mon_unit
+    ; inverse_l :: LeftInverse (.*.) (^) mon_unit
+    ; inverse_r :: RightInverse (.*.) (^) mon_unit
     }.
-  #[export] Existing Instances
-    group_monoid
-    inverse_l
-    inverse_r.
 
   Class IsBoundedSemiLattice {Aop : SgOp A} {Aunit : MonUnit A} :=
-    { bounded_semilattice_mon : @IsCommutativeMonoid (.*.) Aunit
-    ; bounded_semilattice_idempotent : BinaryIdempotent (.*.)}.
-  #[export] Existing Instances
-    bounded_semilattice_mon
-    bounded_semilattice_idempotent.
+    { bounded_semilattice_mon :: @IsCommutativeMonoid (.*.) Aunit
+    ; bounded_semilattice_idempotent :: BinaryIdempotent (.*.)}.
   
   Local Close Scope mc_mult_scope.
 
   Class IsAbGroup {Aop : SgOp A} {Aunit : MonUnit A} {Ainv : Inverse A} :=
-    { abgroup_group : @IsGroup Aop Aunit Ainv
-    ; abgroup_commutative : Commutative Aop }.
-  #[export] Existing Instances abgroup_group abgroup_commutative.
+    { abgroup_group :: @IsGroup Aop Aunit Ainv
+    ; abgroup_commutative :: Commutative Aop }.
 
   Context {Aplus : Plus A} {Amult : Mult A} {Azero : Zero A} {Aone : One A}.
 
   Class IsSemiCRing :=
-    { semiplus_monoid : @IsCommutativeMonoid (+) 0
-    ; semimult_monoid : @IsCommutativeMonoid (.*.) 1
-    ; semiring_distr : LeftDistribute (.*.) (+)
-    ; semiring_left_absorb : LeftAbsorb (.*.) 0 }.
-  #[export] Existing Instances semiplus_monoid semimult_monoid semiring_distr semiring_left_absorb.
+    { semiplus_monoid :: @IsCommutativeMonoid (+) 0
+    ; semimult_monoid :: @IsCommutativeMonoid (.*.) 1
+    ; semiring_distr :: LeftDistribute (.*.) (+)
+    ; semiring_left_absorb :: LeftAbsorb (.*.) 0 }.
 
   Context {Anegate : Negate A}.
 
@@ -153,11 +129,9 @@ Section upper_classes.
   }.
 
   Class IsCRing :=
-    { cring_group : @IsAbGroup (+) 0 (-)
-    ; cring_monoid : @IsCommutativeMonoid (.*.) 1
-    ; cring_dist : LeftDistribute (.*.) (+) }.
-
-  #[export] Existing Instances cring_group cring_monoid cring_dist.
+    { cring_group :: @IsAbGroup (+) 0 (-)
+    ; cring_monoid :: @IsCommutativeMonoid (.*.) 1
+    ; cring_dist :: LeftDistribute (.*.) (+) }.
 
   #[export] Instance isring_iscring : IsCRing -> IsRing.
   Proof.
@@ -172,33 +146,26 @@ Section upper_classes.
   Class IsIntegralDomain :=
     { intdom_ring : IsCRing
     ; intdom_nontrivial : PropHolds (not (1 = 0))
-    ; intdom_nozeroes : NoZeroDivisors A }.
-  #[export] Existing Instances intdom_nozeroes.
+    ; intdom_nozeroes :: NoZeroDivisors A }.
 
   (* We do not include strong extensionality for (-) and (/)
     because it can be derived *)
   Class IsField {Aap: Apart A} {Arecip: Recip A} :=
-    { field_ring : IsCRing
-    ; field_apart : IsApart A
-    ; field_plus_ext : StrongBinaryExtensionality (+)
-    ; field_mult_ext : StrongBinaryExtensionality (.*.)
+    { field_ring :: IsCRing
+    ; field_apart :: IsApart A
+    ; field_plus_ext :: StrongBinaryExtensionality (+)
+    ; field_mult_ext :: StrongBinaryExtensionality (.*.)
     ; field_nontrivial : PropHolds (1 ≶ 0)
     ; recip_inverse : forall x, x.1 // x = 1 }.
-  #[export] Existing Instances
-    field_ring
-    field_apart
-    field_plus_ext
-    field_mult_ext.
 
   (* We let /0 = 0 so properties as Injective (/),
     f (/x) = / (f x), / /x = x, /x * /y = /(x * y)
     hold without any additional assumptions *)
   Class IsDecField {Adec_recip : DecRecip A} :=
-    { decfield_ring : IsCRing
+    { decfield_ring :: IsCRing
     ; decfield_nontrivial : PropHolds (1 <> 0)
     ; dec_recip_0 : /0 = 0
     ; dec_recip_inverse : forall x, x <> 0 -> x / x = 1 }.
-  #[export] Existing Instances decfield_ring.
 
   Class FieldCharacteristic@{j} {Aap : Apart@{i j} A} (k : nat) : Type@{j}
     := field_characteristic : forall n : nat,
@@ -238,48 +205,35 @@ Section lattice.
   Context A {Ajoin: Join A} {Ameet: Meet A} {Abottom : Bottom A} {Atop : Top A}.
 
   Class IsJoinSemiLattice :=
-    join_semilattice : @IsSemiLattice A join_is_sg_op.
-  #[export] Existing Instance join_semilattice.
-  Class IsBoundedJoinSemiLattice :=
-    bounded_join_semilattice : @IsBoundedSemiLattice A
-      join_is_sg_op bottom_is_mon_unit.
-  #[export] Existing Instance bounded_join_semilattice.
-  Class IsMeetSemiLattice :=
-    meet_semilattice : @IsSemiLattice A meet_is_sg_op.
-  #[export] Existing Instance meet_semilattice.
-  Class IsBoundedMeetSemiLattice :=
-    bounded_meet_semilattice : @IsBoundedSemiLattice A
-      meet_is_sg_op top_is_mon_unit.
-  #[export] Existing Instance bounded_meet_semilattice.
+    join_semilattice :: @IsSemiLattice A join_is_sg_op.
 
+  Class IsBoundedJoinSemiLattice :=
+    bounded_join_semilattice :: @IsBoundedSemiLattice A
+      join_is_sg_op bottom_is_mon_unit.
+
+  Class IsMeetSemiLattice :=
+    meet_semilattice :: @IsSemiLattice A meet_is_sg_op.
+
+  Class IsBoundedMeetSemiLattice :=
+    bounded_meet_semilattice :: @IsBoundedSemiLattice A
+      meet_is_sg_op top_is_mon_unit.
 
   Class IsLattice :=
-    { lattice_join : IsJoinSemiLattice
-    ; lattice_meet : IsMeetSemiLattice
-    ; join_meet_absorption : Absorption (⊔) (⊓)
-    ; meet_join_absorption : Absorption (⊓) (⊔) }.
-  #[export] Existing Instances
-    lattice_join
-    lattice_meet
-    join_meet_absorption
-    meet_join_absorption.
+    { lattice_join :: IsJoinSemiLattice
+    ; lattice_meet :: IsMeetSemiLattice
+    ; join_meet_absorption :: Absorption (⊔) (⊓)
+    ; meet_join_absorption :: Absorption (⊓) (⊔) }.
 
   Class IsBoundedLattice :=
-    { boundedlattice_join : IsBoundedJoinSemiLattice
-    ; boundedlattice_meet : IsBoundedMeetSemiLattice
-    ; boundedjoin_meet_absorption : Absorption (⊔) (⊓)
-    ; boundedmeet_join_absorption : Absorption (⊓) (⊔)}.
-  #[export] Existing Instances
-    boundedlattice_join
-    boundedlattice_meet
-    boundedjoin_meet_absorption
-    boundedmeet_join_absorption.
-
+    { boundedlattice_join :: IsBoundedJoinSemiLattice
+    ; boundedlattice_meet :: IsBoundedMeetSemiLattice
+    ; boundedjoin_meet_absorption :: Absorption (⊔) (⊓)
+    ; boundedmeet_join_absorption :: Absorption (⊓) (⊔)}.
 
   Class IsDistributiveLattice :=
-    { distr_lattice_lattice : IsLattice
-    ; join_meet_distr_l : LeftDistribute (⊔) (⊓) }.
-  #[export] Existing Instances distr_lattice_lattice join_meet_distr_l.
+    { distr_lattice_lattice :: IsLattice
+    ; join_meet_distr_l :: LeftDistribute (⊔) (⊓) }.
+
 End lattice.
 
 Section morphism_classes.
@@ -297,9 +251,9 @@ Section morphism_classes.
     preserves_mon_unit : f mon_unit = mon_unit.
 
   Class IsMonoidPreserving (f : A -> B) :=
-    { monmor_sgmor : IsSemiGroupPreserving f
-    ; monmor_unitmor : IsUnitPreserving f }.
-  #[export] Existing Instances monmor_sgmor monmor_unitmor.
+    { monmor_sgmor :: IsSemiGroupPreserving f
+    ; monmor_unitmor :: IsUnitPreserving f }.
+
   End sgmorphism_classes.
 
   Section ringmorphism_classes.
@@ -308,17 +262,16 @@ Section morphism_classes.
     {Aone : One A} {Bone : One B}.
 
   Class IsSemiRingPreserving (f : A -> B) :=
-    { semiringmor_plus_mor : @IsMonoidPreserving A B
+    { semiringmor_plus_mor :: @IsMonoidPreserving A B
         (+) (+) 0 0 f
-    ; semiringmor_mult_mor : @IsMonoidPreserving A B
+    ; semiringmor_mult_mor :: @IsMonoidPreserving A B
         (.*.) (.*.) 1 1 f }.
-  #[export] Existing Instances semiringmor_plus_mor semiringmor_mult_mor.
 
   Context {Aap : Apart A} {Bap : Apart B}.
   Class IsSemiRingStrongPreserving (f : A -> B) :=
-    { strong_semiringmor_sr_mor : IsSemiRingPreserving f
-    ; strong_semiringmor_strong_mor : StrongExtensionality f }.
-  #[export] Existing Instances strong_semiringmor_sr_mor strong_semiringmor_strong_mor.
+    { strong_semiringmor_sr_mor :: IsSemiRingPreserving f
+    ; strong_semiringmor_strong_mor :: StrongExtensionality f }.
+
   End ringmorphism_classes.
 
   Section latticemorphism_classes.
@@ -326,25 +279,20 @@ Section morphism_classes.
     {Ameet : Meet A} {Bmeet : Meet B}.
 
   Class IsJoinPreserving (f : A -> B) :=
-    join_slmor_sgmor : @IsSemiGroupPreserving A B join_is_sg_op join_is_sg_op f.
-  #[export] Existing Instances join_slmor_sgmor.
+    join_slmor_sgmor :: @IsSemiGroupPreserving A B join_is_sg_op join_is_sg_op f.
 
   Class IsMeetPreserving (f : A -> B) :=
-    meet_slmor_sgmor : @IsSemiGroupPreserving A B meet_is_sg_op meet_is_sg_op f.
-  #[export] Existing Instances meet_slmor_sgmor.
+    meet_slmor_sgmor :: @IsSemiGroupPreserving A B meet_is_sg_op meet_is_sg_op f.
 
   Context {Abottom : Bottom A} {Bbottom : Bottom B}.
   Class IsBoundedJoinPreserving (f : A -> B) := bounded_join_slmor_monmor
-      : @IsMonoidPreserving A B join_is_sg_op join_is_sg_op
+      :: @IsMonoidPreserving A B join_is_sg_op join_is_sg_op
          bottom_is_mon_unit bottom_is_mon_unit f.
-  #[export] Existing Instances bounded_join_slmor_monmor.
 
   Class IsLatticePreserving (f : A -> B) :=
-    { latticemor_join_mor : IsJoinPreserving f
-    ; latticemor_meet_mor : IsMeetPreserving f }.
-  #[export] Existing Instances
-    latticemor_join_mor
-    latticemor_meet_mor.
+    { latticemor_join_mor :: IsJoinPreserving f
+    ; latticemor_meet_mor :: IsMeetPreserving f }.
+
   End latticemorphism_classes.
 End morphism_classes.
 

--- a/theories/Classes/interfaces/canonical_names.v
+++ b/theories/Classes/interfaces/canonical_names.v
@@ -43,9 +43,8 @@ Notation "(≶ x )" := (fun y => apart y x) (only parsing) : mc_scope.
 (* Even for setoids with decidable equality x <> y does not imply x ≶ y.
 Therefore we introduce the following class. *)
 Class TrivialApart A {Aap : Apart A} :=
-  { trivial_apart_prop : is_mere_relation A apart
+  { trivial_apart_prop :: is_mere_relation A apart
   ; trivial_apart : forall x y, x ≶ y <-> x <> y }.
-#[export] Existing Instance trivial_apart_prop.
 
 Definition sig_apart `{Apart A} (P: A -> Type) : Apart (sig P) := fun x y => x.1 ≶ y.1.
 #[export]
@@ -253,8 +252,7 @@ Class Idempotent `(f: A -> A -> A) (x : A) : Type := idempotency: f x x = x.
 Arguments idempotency {A} _ _ {Idempotent}.
 
 Class UnaryIdempotent {A} (f: A -> A) : Type :=
-  unary_idempotent : Idempotent Compose f.
-#[export] Existing Instances unary_idempotent.
+  unary_idempotent :: Idempotent Compose f.
 
 Lemma unary_idempotency `{UnaryIdempotent A f} x : f (f x) = f x.
 Proof.
@@ -265,8 +263,7 @@ apply idempotency. exact _.
 Qed.
 
 Class BinaryIdempotent `(op: A -> A -> A) : Type
-  := binary_idempotent : forall x, Idempotent op x.
-#[export] Existing Instances binary_idempotent.
+  := binary_idempotent :: forall x, Idempotent op x.
 
 Class LeftIdentity {A B} (op : A -> B -> B) (x : A): Type
   := left_identity: forall y, op x y = y.
@@ -322,8 +319,7 @@ Class HeteroAssociative {A B C AB BC ABC}
   (fAB_C: AB -> C -> ABC) (fAB : A -> B -> AB): Type
   := associativity : forall x y z, fA_BC x (fBC y z) = fAB_C (fAB x y) z.
 Class Associative {A} (f : A -> A -> A)
-  := simple_associativity : HeteroAssociative f f f f.
-#[export] Existing Instances simple_associativity.
+  := simple_associativity :: HeteroAssociative f f f f.
 
 Instance istrunc_associative `{Funext} A n f `{IsTrunc n.+1 A}
   : IsTrunc n (@Associative A f).
@@ -355,10 +351,9 @@ Class CoTransitive `(R : Relation A) : Type := cotransitive
 Arguments cotransitive {A R CoTransitive x y} _ _.
 
 Class EquivRel `(R : Relation A) : Type := Build_EquivRel
-  { EquivRel_Reflexive : Reflexive R ;
-    EquivRel_Symmetric : Symmetric R ;
-    EquivRel_Transitive : Transitive R }.
-#[export] Existing Instances EquivRel_Reflexive EquivRel_Symmetric EquivRel_Transitive.
+  { EquivRel_Reflexive :: Reflexive R ;
+    EquivRel_Symmetric :: Symmetric R ;
+    EquivRel_Transitive :: Transitive R }.
 
 Definition SigEquivRel {A:Type} (R : Relation A) : Type :=
   {_ : Reflexive R | { _ : Symmetric R | Transitive R}}.
@@ -406,12 +401,10 @@ Class RightHeteroDistribute {A B C}
   (f : A -> B -> C) (g_l : A -> A -> A) (g : C -> C -> C) : Type
   := distribute_r: forall a b c, f (g_l a b) c = g (f a c) (f b c).
 Class LeftDistribute {A} (f g: A -> A -> A)
-  := simple_distribute_l : LeftHeteroDistribute f g g.
-#[export] Existing Instances simple_distribute_l.
-Class RightDistribute {A} (f g: A -> A -> A)
-  := simple_distribute_r : RightHeteroDistribute f g g.
-#[export] Existing Instances simple_distribute_r.
+  := simple_distribute_l :: LeftHeteroDistribute f g g.
 
+Class RightDistribute {A} (f g: A -> A -> A)
+  := simple_distribute_r :: RightHeteroDistribute f g g.
 
 Class HeteroSymmetric {A} {T : A -> A -> Type}
   (R : forall {x y}, T x y -> T y x -> Type) : Type
@@ -495,8 +488,8 @@ Class Bind (M : Type -> Type) := bind : forall {A B}, M A -> (A -> M B) -> M B.
 
 Class Enumerable@{i} (A : Type@{i}) :=
   { enumerator : nat -> A
-  ; enumerator_issurj : IsSurjection enumerator }.
-#[export] Existing Instance enumerator_issurj.
+  ; enumerator_issurj :: IsSurjection enumerator }.
+
 Arguments enumerator A {_} _.
 Arguments enumerator_issurj A {_} _.
 

--- a/theories/Classes/interfaces/integers.v
+++ b/theories/Classes/interfaces/integers.v
@@ -10,12 +10,11 @@ Arguments integers_to_ring A {_} R {_ _ _ _ _ _} _.
 
 Class Integers A {Aap:Apart A} {Aplus Amult Azero Aone Anegate Ale Alt}
   `{U : IntegersToRing A} :=
-  { integers_ring : @IsCRing A Aplus Amult Azero Aone Anegate
-  ; integers_order : FullPseudoSemiRingOrder Ale Alt
-  ; integers_to_ring_mor : forall {B} `{IsCRing B}, IsSemiRingPreserving (integers_to_ring A B)
+  { integers_ring :: @IsCRing A Aplus Amult Azero Aone Anegate
+  ; integers_order :: FullPseudoSemiRingOrder Ale Alt
+  ; integers_to_ring_mor :: forall {B} `{IsCRing B}, IsSemiRingPreserving (integers_to_ring A B)
   ; integers_initial: forall {B} `{IsCRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
       integers_to_ring A B x = h x}.
-#[export] Existing Instances integers_ring integers_order integers_to_ring_mor.
 
 Section specializable.
   Context (Z N : Type) `{Integers Z} `{Naturals N}.

--- a/theories/Classes/interfaces/naturals.v
+++ b/theories/Classes/interfaces/naturals.v
@@ -9,13 +9,12 @@ Arguments naturals_to_semiring A {_} B {_ _ _ _ _} _.
 
 Class Naturals A {Aap:Apart A} {Aplus Amult Azero Aone Ale Alt}
   `{U: NaturalsToSemiRing A} :=
-  { naturals_ring : @IsSemiCRing A Aplus Amult Azero Aone
-  ; naturals_order : FullPseudoSemiRingOrder Ale Alt
-  ; naturals_to_semiring_mor : forall {B} `{IsSemiCRing B},
+  { naturals_ring :: @IsSemiCRing A Aplus Amult Azero Aone
+  ; naturals_order :: FullPseudoSemiRingOrder Ale Alt
+  ; naturals_to_semiring_mor :: forall {B} `{IsSemiCRing B},
     IsSemiRingPreserving (naturals_to_semiring A B)
   ; naturals_initial: forall {B} `{IsSemiCRing B} {h : A -> B} `{!IsSemiRingPreserving h} x,
     naturals_to_semiring A B x = h x }.
-#[export] Existing Instances naturals_ring naturals_order naturals_to_semiring_mor.
 
 (* Specializable operations: *)
 Class NatDistance N `{Plus N}

--- a/theories/Classes/interfaces/orders.v
+++ b/theories/Classes/interfaces/orders.v
@@ -20,22 +20,14 @@ usual properties like [Trichotomy (<)] and [TotalRelation (≤)].
 *)
 
 Class PartialOrder `(Ale : Le A) :=
-  { po_hset : IsHSet A
-  ; po_hprop : is_mere_relation A Ale
-  ; po_preorder : PreOrder (≤)
-  ; po_antisym : AntiSymmetric (≤) }.
-#[export] Existing Instances
-  po_hset
-  po_hprop
-  po_preorder
-  po_antisym. 
+  { po_hset :: IsHSet A
+  ; po_hprop :: is_mere_relation A Ale
+  ; po_preorder :: PreOrder (≤)
+  ; po_antisym :: AntiSymmetric (≤) }.
 
 Class TotalOrder `(Ale : Le A) :=
-  { total_order_po : PartialOrder (≤)
-  ; total_order_total : TotalRelation (≤) }.
-#[export] Existing Instances
-  total_order_po
-  total_order_total.
+  { total_order_po :: PartialOrder (≤)
+  ; total_order_total :: TotalRelation (≤) }.
 
 (*
 We define a variant of the order theoretic definition of meet and join
@@ -47,57 +39,50 @@ This is needed to prove equivalence with the algebraic definition. We
 do this in orders.lattices.
 *)
 Class MeetSemiLatticeOrder `(Ale : Le A) `{Meet A} :=
-  { meet_sl_order : PartialOrder (≤)
+  { meet_sl_order :: PartialOrder (≤)
   ; meet_lb_l : forall x y, x ⊓ y ≤ x
   ; meet_lb_r : forall x y, x ⊓ y ≤ y
   ; meet_glb : forall x y z, z ≤ x -> z ≤ y -> z ≤ x ⊓ y }.
-#[export] Existing Instances meet_sl_order.
 
 Class JoinSemiLatticeOrder `(Ale : Le A) `{Join A} :=
-  { join_sl_order : PartialOrder (≤)
+  { join_sl_order :: PartialOrder (≤)
   ; join_ub_l : forall x y, x ≤ x ⊔ y
   ; join_ub_r : forall x y, y ≤ x ⊔ y
   ; join_lub : forall x y z, x ≤ z -> y ≤ z -> x ⊔ y ≤ z }.
-#[export] Existing Instances join_sl_order.
 
 Class LatticeOrder `(Ale : Le A) `{Meet A} `{Join A} :=
-  { lattice_order_meet : MeetSemiLatticeOrder (≤)
-  ; lattice_order_join : JoinSemiLatticeOrder (≤) }.
-#[export] Existing Instances lattice_order_meet lattice_order_join.
+  { lattice_order_meet :: MeetSemiLatticeOrder (≤)
+  ; lattice_order_join :: JoinSemiLatticeOrder (≤) }.
 
 Class StrictOrder `(Alt : Lt A) :=
-  { strict_order_mere : is_mere_relation A lt
-  ; strictorder_irrefl : Irreflexive (<)
-  ; strictorder_trans : Transitive (<) }.
-#[export] Existing Instances strict_order_mere strictorder_irrefl strictorder_trans.
+  { strict_order_mere :: is_mere_relation A lt
+  ; strictorder_irrefl :: Irreflexive (<)
+  ; strictorder_trans :: Transitive (<) }.
 
 (** The constructive notion of a total strict total order.
    We will prove that [(<)] is in fact a [StrictOrder]. *)
 Class PseudoOrder `{Aap : Apart A} (Alt : Lt A) :=
 { pseudo_order_apart : IsApart A
-  ; pseudo_order_mere_lt : is_mere_relation A lt
+  ; pseudo_order_mere_lt :: is_mere_relation A lt
   ; pseudo_order_antisym : forall x y, ~(x < y /\ y < x)
-  ; pseudo_order_cotrans : CoTransitive (<)
+  ; pseudo_order_cotrans :: CoTransitive (<)
   ; apart_iff_total_lt : forall x y, x ≶ y <-> x < y |_| y < x }.
-#[export] Existing Instances pseudo_order_mere_lt pseudo_order_cotrans.
 
 (** A partial order [(≤)] with a corresponding [(<)]. We will prove that [(<)] is in fact
   a [StrictOrder] *)
 Class FullPartialOrder `{Aap : Apart A} (Ale : Le A) (Alt : Lt A) :=
   { strict_po_apart : IsApart A
   ; strict_po_mere_lt : is_mere_relation A lt
-  ; strict_po_po : PartialOrder (≤)
-  ; strict_po_trans : Transitive (<)
+  ; strict_po_po :: PartialOrder (≤)
+  ; strict_po_trans :: Transitive (<)
   ; lt_iff_le_apart : forall x y, x < y <-> x ≤ y /\ x ≶ y }.
-#[export] Existing Instances strict_po_po strict_po_trans.
 
 (** A pseudo order [(<)] with a corresponding [(≤)]. We will prove that [(≤)] is in fact
   a [PartialOrder]. *)
 Class FullPseudoOrder `{Aap : Apart A} (Ale : Le A) (Alt : Lt A) :=
-  { fullpseudo_le_hprop : is_mere_relation A Ale
-  ; full_pseudo_order_pseudo : PseudoOrder Alt
+  { fullpseudo_le_hprop :: is_mere_relation A Ale
+  ; full_pseudo_order_pseudo :: PseudoOrder Alt
   ; le_iff_not_lt_flip : forall x y, x ≤ y <-> ~(y < x) }.
-#[export] Existing Instances fullpseudo_le_hprop full_pseudo_order_pseudo.
 
 Section order_maps.
   Context {A B : Type} {Ale: Le A} {Ble: Le B}(f : A -> B).
@@ -107,9 +92,9 @@ Section order_maps.
   Class OrderReflecting := order_reflecting : forall x y, (f x ≤ f y -> x ≤ y).
 
   Class OrderEmbedding :=
-    { order_embedding_preserving : OrderPreserving
-    ; order_embedding_reflecting : OrderReflecting }.
-  #[export] Existing Instances order_embedding_preserving order_embedding_reflecting.
+    { order_embedding_preserving :: OrderPreserving
+    ; order_embedding_reflecting :: OrderReflecting }.
+
 End order_maps.
 
 Section srorder_maps.
@@ -122,9 +107,9 @@ Section srorder_maps.
     : forall x y, (f x < f y -> x < y).
 
   Class StrictOrderEmbedding :=
-    { strict_order_embedding_preserving : StrictlyOrderPreserving
-    ; strict_order_embedding_reflecting : StrictlyOrderReflecting }.
-  #[export] Existing Instances strict_order_embedding_preserving strict_order_embedding_reflecting.
+    { strict_order_embedding_preserving :: StrictlyOrderPreserving
+    ; strict_order_embedding_reflecting :: StrictlyOrderReflecting }.
+
 End srorder_maps.
 
 #[export]
@@ -141,38 +126,34 @@ Davorin Lešnik's PhD thesis.
 *)
 Class SemiRingOrder `{Plus A} `{Mult A}
     `{Zero A} `{One A} (Ale : Le A) :=
-  { srorder_po : PartialOrder Ale
+  { srorder_po :: PartialOrder Ale
   ; srorder_partial_minus : forall x y, x ≤ y -> exists z, y = x + z
-  ; srorder_plus : forall z, OrderEmbedding (z +)
+  ; srorder_plus :: forall z, OrderEmbedding (z +)
   ; nonneg_mult_compat : forall x y, PropHolds (0 ≤ x) -> PropHolds (0 ≤ y) ->
                                 PropHolds (0 ≤ x * y) }.
-#[export] Existing Instances srorder_po srorder_plus.
 
 Class StrictSemiRingOrder `{Plus A} `{Mult A}
     `{Zero A} `{One A} (Alt : Lt A) :=
-  { strict_srorder_so : StrictOrder Alt
+  { strict_srorder_so :: StrictOrder Alt
   ; strict_srorder_partial_minus : forall x y, x < y -> exists z, y = x + z
-  ; strict_srorder_plus : forall z, StrictOrderEmbedding (z +)
+  ; strict_srorder_plus :: forall z, StrictOrderEmbedding (z +)
   ; pos_mult_compat : forall x y, PropHolds (0 < x) -> PropHolds (0 < y) ->
                              PropHolds (0 < x * y) }.
-#[export] Existing Instances strict_srorder_so strict_srorder_plus.
 
 Class PseudoSemiRingOrder `{Apart A} `{Plus A}
     `{Mult A} `{Zero A} `{One A} (Alt : Lt A) :=
-  { pseudo_srorder_strict : PseudoOrder Alt
+  { pseudo_srorder_strict :: PseudoOrder Alt
   ; pseudo_srorder_partial_minus : forall x y, ~(y < x) -> exists z, y = x + z
-  ; pseudo_srorder_plus : forall z, StrictOrderEmbedding (z +)
-  ; pseudo_srorder_mult_ext : StrongBinaryExtensionality (.*.)
+  ; pseudo_srorder_plus :: forall z, StrictOrderEmbedding (z +)
+  ; pseudo_srorder_mult_ext :: StrongBinaryExtensionality (.*.)
   ; pseudo_srorder_pos_mult_compat : forall x y, PropHolds (0 < x) -> PropHolds (0 < y) ->
                                             PropHolds (0 < x * y) }.
-#[export] Existing Instances pseudo_srorder_strict pseudo_srorder_plus pseudo_srorder_mult_ext.
 
 Class FullPseudoSemiRingOrder `{Apart A} `{Plus A}
     `{Mult A} `{Zero A} `{One A} (Ale : Le A) (Alt : Lt A) :=
-  { full_pseudo_srorder_le_hprop : is_mere_relation A Ale
-  ; full_pseudo_srorder_pso : PseudoSemiRingOrder Alt
+  { full_pseudo_srorder_le_hprop :: is_mere_relation A Ale
+  ; full_pseudo_srorder_pso :: PseudoSemiRingOrder Alt
   ; full_pseudo_srorder_le_iff_not_lt_flip : forall x y, x ≤ y <-> ~(y < x) }.
-#[export] Existing Instances full_pseudo_srorder_le_hprop full_pseudo_srorder_pso.
 
 (* Due to bug #2528 *)
 #[export]
@@ -212,11 +193,7 @@ HoTT book chapter 11. *)
 Class OrderedField (A : Type) {Alt : Lt A} {Ale : Le A} {Aap : Apart A} {Azero : Zero A}
       {Aone : One A} {Aplus : Plus A} {Anegate : Negate A} {Amult : Mult A}
       {Arecip : Recip A} {Ajoin : Join A} {Ameet : Meet A} :=
-  { ordered_field_field : @IsField A Aplus Amult Azero Aone Anegate Aap Arecip
-  ; ordered_field_lattice : LatticeOrder Ale
-  ; ordered_field_fssro : @FullPseudoSemiRingOrder A _ _ _ Azero _ _ _
+  { ordered_field_field :: @IsField A Aplus Amult Azero Aone Anegate Aap Arecip
+  ; ordered_field_lattice :: LatticeOrder Ale
+  ; ordered_field_fssro :: @FullPseudoSemiRingOrder A _ _ _ Azero _ _ _
   }.
-#[export] Existing Instances
-  ordered_field_field
-  ordered_field_lattice
-  ordered_field_fssro.

--- a/theories/Classes/interfaces/rationals.v
+++ b/theories/Classes/interfaces/rationals.v
@@ -19,11 +19,10 @@ Arguments rationals_to_field A {_} B {_ _ _ _ _ _ _ _ _} _.
 
 Class Rationals A {Aap : Apart A} {Aplus Amult Azero Aone Aneg Arecip Ale Alt}
   `{U : !RationalsToField A} :=
-  { rationals_field : @IsDecField A Aplus Amult Azero Aone Aneg Arecip
-  ; rationals_order : FullPseudoSemiRingOrder Ale Alt
-  ; rationals_to_field_mor : forall {B} `{IsField B} `{!FieldCharacteristic B 0},
+  { rationals_field :: @IsDecField A Aplus Amult Azero Aone Aneg Arecip
+  ; rationals_order :: FullPseudoSemiRingOrder Ale Alt
+  ; rationals_to_field_mor :: forall {B} `{IsField B} `{!FieldCharacteristic B 0},
     IsSemiRingPreserving (rationals_to_field A B)
   ; rationals_initial : forall {B} `{IsField B} `{!FieldCharacteristic B 0}
     {h : A -> B} `{!IsSemiRingPreserving h} x,
     rationals_to_field A B x = h x }.
-#[export] Existing Instances rationals_field rationals_order rationals_to_field_mor.

--- a/theories/Classes/interfaces/ua_algebra.v
+++ b/theories/Classes/interfaces/ua_algebra.v
@@ -171,9 +171,7 @@ Proof.
 Defined.
 
 Class IsTruncAlgebra (n : trunc_index) {σ : Signature} (A : Algebra σ)
-  := trunc_carriers_algebra : ∀ (s : Sort σ), IsTrunc n (A s).
-
-Existing Instance trunc_carriers_algebra.
+  := trunc_carriers_algebra :: ∀ (s : Sort σ), IsTrunc n (A s).
 
 Notation IsHSetAlgebra := (IsTruncAlgebra 0).
 

--- a/theories/Classes/interfaces/ua_congruence.v
+++ b/theories/Classes/interfaces/ua_congruence.v
@@ -42,19 +42,13 @@ Section congruence.
       mere equivalence relations and [OpsCompatible A Φ] holds. *)
 
   Class IsCongruence : Type := BuildIsCongruence
-   { is_mere_relation_cong : ∀ (s : Sort σ), is_mere_relation (A s) (Φ s)
-   ; equiv_rel_cong : ∀ (s : Sort σ), EquivRel (Φ s)
-   ; ops_compatible_cong : OpsCompatible }.
+   { is_mere_relation_cong :: ∀ (s : Sort σ), is_mere_relation (A s) (Φ s)
+   ; equiv_rel_cong :: ∀ (s : Sort σ), EquivRel (Φ s)
+   ; ops_compatible_cong :: OpsCompatible }.
 
   Global Arguments BuildIsCongruence {is_mere_relation_cong}
                                      {equiv_rel_cong}
                                      {ops_compatible_cong}.
-
-  #[export] Existing Instance is_mere_relation_cong.
-
-  #[export] Existing Instance equiv_rel_cong.
-
-  #[export] Existing Instance ops_compatible_cong.
 
   #[export] Instance hprop_is_congruence `{Funext} : IsHProp IsCongruence.
   Proof.

--- a/theories/Classes/interfaces/ua_setalgebra.v
+++ b/theories/Classes/interfaces/ua_setalgebra.v
@@ -6,11 +6,9 @@ Require Export HoTT.Classes.interfaces.ua_algebra.
 
 Record SetAlgebra {σ : Signature} : Type := BuildSetAlgebra
   { algebra_setalgebra : Algebra σ
-  ; is_hset_algebra_setalgebra : IsHSetAlgebra algebra_setalgebra }.
+  ; is_hset_algebra_setalgebra :: IsHSetAlgebra algebra_setalgebra }.
 
 Arguments SetAlgebra : clear implicits.
-
-Existing Instance is_hset_algebra_setalgebra.
 
 Global Coercion algebra_setalgebra : SetAlgebra >-> Algebra.
 

--- a/theories/Classes/theory/premetric.v
+++ b/theories/Classes/theory/premetric.v
@@ -38,19 +38,12 @@ Class Rounded@{i j} (A:Type@{i}) `{Closeness A}
       e = d + d' /\ close d u v)))).
 
 Class PreMetric@{i j} (A:Type@{i}) {Aclose : Closeness A} :=
-  { premetric_prop : forall e, is_mere_relation A (close e)
-  ; premetric_refl : forall e, Reflexive (close (A:=A) e)
-  ; premetric_symm : forall e, Symmetric (close (A:=A) e)
-  ; premetric_separated : Separated A
-  ; premetric_triangular : Triangular A
-  ; premetric_rounded : Rounded@{i j} A }.
-#[export] Existing Instances
-  premetric_prop
-  premetric_refl
-  premetric_symm
-  premetric_separated
-  premetric_triangular
-  premetric_rounded.
+  { premetric_prop :: forall e, is_mere_relation A (close e)
+  ; premetric_refl :: forall e, Reflexive (close (A:=A) e)
+  ; premetric_symm :: forall e, Symmetric (close (A:=A) e)
+  ; premetric_separated :: Separated A
+  ; premetric_triangular :: Triangular A
+  ; premetric_rounded :: Rounded@{i j} A }.
 
 Instance premetric_hset@{i j} `{Funext}
   {A:Type@{i} } `{PreMetric@{i j} A} : IsHSet A.

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -56,7 +56,7 @@ End is_homomorphism.
 
 Record Homomorphism {σ} {A B : Algebra σ} : Type := BuildHomomorphism
   { def_hom : ∀ (s : Sort σ), A s → B s
-  ; is_homomorphism_hom : IsHomomorphism def_hom }.
+  ; is_homomorphism_hom :: IsHomomorphism def_hom }.
 
 Arguments Homomorphism {σ}.
 
@@ -64,10 +64,7 @@ Arguments BuildHomomorphism {σ A B} def_hom {is_homomorphism_hom}.
 
 (** We the implicit coercion from [Homomorphism A B] to the family
     of functions [∀ s, A s → B s]. *)
-
 Global Coercion def_hom : Homomorphism >-> Funclass.
-
-Existing Instance is_homomorphism_hom.
 
 Lemma apD10_homomorphism {σ} {A B : Algebra σ} {f g : Homomorphism A B}
   : f = g → ∀ s, f s == g s.
@@ -125,9 +122,7 @@ Defined.
 
 Class IsIsomorphism {σ : Signature} {A B : Algebra σ}
   (f : ∀ s, A s → B s) `{!IsHomomorphism f}
-  := isequiv_isomorphism : ∀ (s : Sort σ), IsEquiv (f s).
-
-Existing Instance isequiv_isomorphism.
+  := isequiv_isomorphism :: ∀ (s : Sort σ), IsEquiv (f s).
 
 Definition equiv_isomorphism {σ : Signature} {A B : Algebra σ}
   (f : ∀ s, A s → B s) `{IsIsomorphism σ A B f}

--- a/theories/Classes/theory/ua_isomorphic.v
+++ b/theories/Classes/theory/ua_isomorphic.v
@@ -12,8 +12,8 @@ Require Import
 
 Record Isomorphic {σ : Signature} (A B : Algebra σ) := BuildIsomorphic
   { def_isomorphic : ∀ s, A s → B s
-  ; is_homomorphism_isomorphic : IsHomomorphism def_isomorphic
-  ; is_isomorphism_isomorphic : IsIsomorphism def_isomorphic }.
+  ; is_homomorphism_isomorphic :: IsHomomorphism def_isomorphic
+  ; is_isomorphism_isomorphic :: IsIsomorphism def_isomorphic }.
 
 Arguments BuildIsomorphic {σ A B} def_isomorphic
             {is_homomorphism_isomorphic} {is_isomorphism_isomorphic}.
@@ -21,9 +21,6 @@ Arguments BuildIsomorphic {σ A B} def_isomorphic
 Arguments def_isomorphic {σ A B}.
 Arguments is_homomorphism_isomorphic {σ A B}.
 Arguments is_isomorphism_isomorphic {σ A B}.
-
-Existing Instance is_homomorphism_isomorphic.
-Existing Instance is_isomorphism_isomorphic.
 
 Module isomorphic_notations.
   Global Notation "A ≅ B" := (Isomorphic A B) : Algebra_scope.

--- a/theories/Classes/theory/ua_subalgebra.v
+++ b/theories/Classes/theory/ua_subalgebra.v
@@ -56,7 +56,7 @@ Section subalgebra_predicate.
 
   Class IsSubalgebraPredicate
     := BuildIsSubalgebraPredicate
-    { hprop_subalgebra_predicate : ∀ s x, IsHProp (P s x);
+    { hprop_subalgebra_predicate :: ∀ s x, IsHProp (P s x);
       is_closed_under_ops_subalgebra_predicate : IsClosedUnderOps A P }.
 
   #[export] Instance hprop_is_subalgebra_predicate `{Funext}
@@ -69,8 +69,6 @@ Section subalgebra_predicate.
 End subalgebra_predicate.
 
 Global Arguments BuildIsSubalgebraPredicate {σ A P hprop_subalgebra_predicate}.
-
-Existing Instance hprop_subalgebra_predicate.
 
 (** The next section defines subalgebra. *)
 

--- a/theories/Colimits/Colimit.v
+++ b/theories/Colimits/Colimit.v
@@ -17,13 +17,10 @@ Generalizable All Variables.
 
 (** A colimit is the extremity of a cocone. *)
 Class IsColimit `(D: Diagram G) (Q: Type) := {
-  iscolimit_cocone : Cocone D Q;
+  iscolimit_cocone :: Cocone D Q;
   iscolimit_unicocone : UniversalCocone iscolimit_cocone;
 }.
 
-(* Use :> and remove the two following lines,
-   once Coq 8.16 is the minimum required version. *)
-#[export] Existing Instance iscolimit_cocone.
 Coercion iscolimit_cocone : IsColimit >-> Cocone.
 
 Arguments Build_IsColimit {G D Q} C H : rename.

--- a/theories/Diagrams/Cocone.v
+++ b/theories/Diagrams/Cocone.v
@@ -83,11 +83,8 @@ Section Cocone.
   (** A cocone [C] over [D] to [X] is said universal when for all [Y] the map [cocone_postcompose] is an equivalence. In particular, given another cocone [C'] over [D] to [X'] the inverse of the map allows to recover a map [h] : [X] -> [X'] such that [C'] is [C] postcomposed with [h]. The fact that [cocone_postcompose] is an equivalence is an elegant way of stating the usual "unique existence" of category theory. *)
 
   Class UniversalCocone (C : Cocone D X) := {
-    is_universal : forall Y, IsEquiv (@cocone_postcompose C Y);
+    is_universal :: forall Y, IsEquiv (@cocone_postcompose C Y);
   }.
-  (* Use :> and remove the two following lines,
-     once Coq 8.16 is the minimum required version. *)
-  #[export] Existing Instance is_universal.
   Coercion is_universal : UniversalCocone >-> Funclass.
 
 End Cocone.

--- a/theories/Diagrams/Cone.v
+++ b/theories/Diagrams/Cone.v
@@ -81,11 +81,8 @@ Section Cone.
   (** A cone [C] over [D] from [X] is said universal when for all [Y] the map [cone_precompose] is an equivalence. In particular, given another cone [C'] over [D] from [X'] the inverse of the map allows us to recover a map [h] : [X] -> [X'] such that [C'] is [C] precomposed with [h]. The fact that [cone_precompose] is an equivalence is an elegant way of stating the usual "unique existence" of category theory. *)
 
   Class UniversalCone (C : Cone X D) := {
-    is_universal : forall Y, IsEquiv (@cone_precompose C Y);
+    is_universal :: forall Y, IsEquiv (@cone_precompose C Y);
     }.
-  (* Use :> and remove the two following lines,
-     once Coq 8.16 is the minimum required version. *)
-  #[export] Existing Instance is_universal.
   Coercion is_universal : UniversalCone >-> Funclass.
 
 End Cone.

--- a/theories/Diagrams/DDiagram.v
+++ b/theories/Diagrams/DDiagram.v
@@ -34,6 +34,5 @@ Definition DDiagram {G : Graph} (D : Diagram G)
 
   Class Equifibered {G : Graph} {D : Diagram G} (E : DDiagram D) := {
     isequifibered i j (g : G i j) (x : D i)
-      : IsEquiv (@arr _ E (i; x) (j; D _f g x) (g; idpath));
+      :: IsEquiv (@arr _ E (i; x) (j; D _f g x) (g; idpath));
   }.
-  #[export] Existing Instance isequifibered.

--- a/theories/Equiv/Relational.v
+++ b/theories/Equiv/Relational.v
@@ -11,12 +11,10 @@ Generalizable Variables A B f.
 
 Record RelEquiv A B :=
   { equiv_rel : A -> B -> Type;
-    relequiv_contr_f : forall a, Contr { b : B & equiv_rel a b };
-    relequiv_contr_g : forall b, Contr { a : A & equiv_rel a b } }.
+    relequiv_contr_f :: forall a, Contr { b : B & equiv_rel a b };
+    relequiv_contr_g :: forall b, Contr { a : A & equiv_rel a b } }.
 
 Arguments equiv_rel {A B} _ _ _.
-Existing Instance relequiv_contr_f.
-Existing Instance relequiv_contr_g.
 
 Definition issig_relequiv {A B}
   : { equiv_rel : A -> B -> Type

--- a/theories/Factorization.v
+++ b/theories/Factorization.v
@@ -100,12 +100,12 @@ Coercion intermediate : Factorization >-> Sortclass.
 (** A ("unique" or "orthogonal") factorization system consists of a couple of classes of maps, closed under composition, such that every map admits a unique factorization. *)
 Record FactorizationSystem@{i j k} :=
   { class1 : forall {X Y : Type@{i}}, (X -> Y) -> Type@{j} ;
-    ishprop_class1 : forall {X Y : Type@{i}} (g:X->Y), IsHProp (class1 g) ;
+    ishprop_class1 :: forall {X Y : Type@{i}} (g:X->Y), IsHProp (class1 g) ;
     class1_isequiv : forall {X Y : Type@{i}} (g:X->Y) {geq:IsEquiv g}, class1 g ;
     class1_compose : forall {X Y Z : Type@{i}} (g:X->Y) (h:Y->Z),
                        class1 g -> class1 h -> class1 (h o g) ;
     class2 : forall {X Y : Type@{i}}, (X -> Y) -> Type@{k} ;
-    ishprop_class2 : forall {X Y : Type@{i}} (g:X->Y), IsHProp (class2 g) ;
+    ishprop_class2 :: forall {X Y : Type@{i}} (g:X->Y), IsHProp (class2 g) ;
     class2_isequiv : forall {X Y : Type@{i}} (g:X->Y) {geq:IsEquiv g}, class2 g ;
     class2_compose : forall {X Y Z : Type@{i}} (g:X->Y) (h:Y->Z),
                        class2 g -> class2 h -> class2 (h o g) ;
@@ -116,8 +116,6 @@ Record FactorizationSystem@{i j k} :=
                          (fact' : Factorization@{i} (@class1) (@class2) f),
                     PathFactorization@{i} fact fact'
   }.
-
-Existing Instances ishprop_class1 ishprop_class2.
 
 (** The type of factorizations is, as promised, contractible. *)
 Theorem contr_factor `{Univalence} (factsys : FactorizationSystem)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -117,7 +117,7 @@ Class CayleyDicksonImaginaroid (A : Type) := {
   cdi_susp_hspace :: IsHSpace (psusp A);
   cdi_susp_factorneg_r :: FactorNegRight (negate_susp A cdi_negate) hspace_op;
   cdi_susp_conjug_left_inv :: LeftInverse hspace_op (conjugate_susp A cdi_negate) mon_unit;
-  cdi_susp_conjug_distr :: DistrOpp hspace_op (conjugate_susp A cdi_negate)
+  cdi_susp_conjug_distr :: DistrOpp hspace_op (conjugate_susp A cdi_negate);
 }.
 
 Instance isunitpreserving_conjugate_susp {A} `(CayleyDicksonImaginaroid A)

--- a/theories/Homotopy/CayleyDickson.v
+++ b/theories/Homotopy/CayleyDickson.v
@@ -29,28 +29,17 @@ This is done by postulating a structure called a "Cayley-Dickson imaginaroid" on
   7. [x* x = 1]
 Note that the above laws are written in pseudocode since we cannot define multiplication by juxtaposition in Coq, and * is used to denote conjugation. *)
 Class CayleyDicksonSpheroid (X : pType) := {
-  cds_hspace : IsHSpace X;
-  cds_negate : Negate X;
-  cds_conjug : Conjugate X;
-  cds_negate_inv : Involutive cds_negate;
-  cds_conjug_inv : Involutive cds_conjug;
-  cds_conjug_unit_pres : IsUnitPreserving cds_conjug;
-  cds_conjug_left_inv : LeftInverse (.*.) cds_conjug mon_unit;
-  cds_conjug_distr : DistrOpp (.*.) cds_conjug;
-  cds_swapop : SwapOp (-) cds_conjug;
-  cds_factorneg_r : FactorNegRight (-) (.*.);
+  cds_hspace :: IsHSpace X;
+  cds_negate :: Negate X;
+  cds_conjug :: Conjugate X;
+  cds_negate_inv :: Involutive cds_negate;
+  cds_conjug_inv :: Involutive cds_conjug;
+  cds_conjug_unit_pres :: IsUnitPreserving cds_conjug;
+  cds_conjug_left_inv :: LeftInverse (.*.) cds_conjug mon_unit;
+  cds_conjug_distr :: DistrOpp (.*.) cds_conjug;
+  cds_swapop :: SwapOp (-) cds_conjug;
+  cds_factorneg_r :: FactorNegRight (-) (.*.)
 }.
-#[export] Existing Instances
-  cds_hspace
-  cds_negate
-  cds_conjug
-  cds_negate_inv
-  cds_conjug_inv
-  cds_conjug_unit_pres
-  cds_conjug_left_inv
-  cds_conjug_distr
-  cds_swapop
-  cds_factorneg_r.
 
 Section CayleyDicksonSpheroid_Properties.
 
@@ -123,20 +112,13 @@ Defined.
 (** ** Cayley-Dickson imaginaroids *)
 
 Class CayleyDicksonImaginaroid (A : Type) := {
-  cdi_negate : Negate A;
-  cdi_negate_involutive : Involutive cdi_negate;
-  cdi_susp_hspace : IsHSpace (psusp A);
-  cdi_susp_factorneg_r : FactorNegRight (negate_susp A cdi_negate) hspace_op;
-  cdi_susp_conjug_left_inv : LeftInverse hspace_op (conjugate_susp A cdi_negate) mon_unit;
-  cdi_susp_conjug_distr : DistrOpp hspace_op (conjugate_susp A cdi_negate);
+  cdi_negate :: Negate A;
+  cdi_negate_involutive :: Involutive cdi_negate;
+  cdi_susp_hspace :: IsHSpace (psusp A);
+  cdi_susp_factorneg_r :: FactorNegRight (negate_susp A cdi_negate) hspace_op;
+  cdi_susp_conjug_left_inv :: LeftInverse hspace_op (conjugate_susp A cdi_negate) mon_unit;
+  cdi_susp_conjug_distr :: DistrOpp hspace_op (conjugate_susp A cdi_negate)
 }.
-#[export] Existing Instances
-  cdi_negate
-  cdi_negate_involutive
-  cdi_susp_hspace
-  cdi_susp_factorneg_r
-  cdi_susp_conjug_left_inv
-  cdi_susp_conjug_distr.
 
 Instance isunitpreserving_conjugate_susp {A} `(CayleyDicksonImaginaroid A)
   : @IsUnitPreserving _ _ pt pt (conjugate_susp A cdi_negate)

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -137,10 +137,8 @@ Instance ishprop_iscomplex_hset `{Funext} {F X Y : pType} `{IsHSet Y}
 Cumulative Class IsExact (n : Modality) {F X Y : pType} (i : F ->* X) (f : X ->* Y) :=
 {
   cx_isexact : IsComplex i f ;
-  conn_map_isexact : IsConnMap n (cxfib cx_isexact)
+  conn_map_isexact :: IsConnMap n (cxfib cx_isexact)
 }.
-
-Existing Instance conn_map_isexact.
 
 Definition issig_isexact (n : Modality) {F X Y : pType} (i : F ->* X) (f : X ->* Y)
   : _ <~> IsExact n i f := ltac:(issig).
@@ -501,12 +499,11 @@ Record LongExactSequence (k : Modality) (N : SuccStr) : Type :=
 {
   les_carrier : N -> pType;
   les_fn : forall n, les_carrier n.+1 ->* les_carrier n;
-  les_isexact : forall n, IsExact k (les_fn n.+1) (les_fn n)
+  les_isexact :: forall n, IsExact k (les_fn n.+1) (les_fn n)
 }.
 
 Coercion les_carrier : LongExactSequence >-> Funclass.
 Arguments les_fn {k N} S n : rename.
-Existing Instance les_isexact.
 
 (** Long exact sequences are preserved by truncation. *)
 Definition trunc_les `{Univalence} (k : trunc_index) {N : SuccStr}

--- a/theories/Homotopy/HSpace/Coherent.v
+++ b/theories/Homotopy/HSpace/Coherent.v
@@ -11,10 +11,10 @@ Class IsCoherent (X : pType) `{IsHSpace X} :=
   iscoherent : left_identity pt = right_identity pt.
 
 Record IsCohHSpace (A : pType) := {
-    ishspace_cohhspace : IsHSpace A;
-    iscoherent_cohhspace : IsCoherent A;
+    ishspace_cohhspace :: IsHSpace A;
+    iscoherent_cohhspace :: IsCoherent A;
   }.
-#[export] Existing Instances ishspace_cohhspace iscoherent_cohhspace.
+
 
 Definition issig_iscohhspace (A : pType)
   : { hspace_op : SgOp A

--- a/theories/Homotopy/HSpace/Coherent.v
+++ b/theories/Homotopy/HSpace/Coherent.v
@@ -15,7 +15,6 @@ Record IsCohHSpace (A : pType) := {
     iscoherent_cohhspace :: IsCoherent A;
   }.
 
-
 Definition issig_iscohhspace (A : pType)
   : { hspace_op : SgOp A
     & { hspace_left_identity : LeftIdentity hspace_op pt

--- a/theories/Homotopy/HSpace/Core.v
+++ b/theories/Homotopy/HSpace/Core.v
@@ -16,11 +16,10 @@ Local Open Scope path_scope.
 (** A (non-coherent) H-space [X] is a pointed type with a binary operation for which the base point is a both a left and a right identity. (See Coherent.v for the notion of a coherent H-space.) We say [X] is left-invertible if left multiplication by any element is an equivalence, and dually for right-invertible. *)
 
 Class IsHSpace (X : pType) := {
-  hspace_op : SgOp X;
-  hspace_left_identity : LeftIdentity hspace_op pt;
-  hspace_right_identity : RightIdentity hspace_op pt;
+  hspace_op :: SgOp X;
+  hspace_left_identity :: LeftIdentity hspace_op pt;
+  hspace_right_identity :: RightIdentity hspace_op pt;
 }.
-#[export] Existing Instances hspace_left_identity hspace_right_identity hspace_op.
 
 #[export] Instance hspace_mon_unit {X : pType} `{IsHSpace X} : MonUnit X := pt.
 

--- a/theories/Limits/Limit.v
+++ b/theories/Limits/Limit.v
@@ -14,12 +14,9 @@ Generalizable All Variables.
 (** A Limit is the extremity of a cone. *)
 
 Class IsLimit `(D : Diagram G) (Q : Type) := {
-  islimit_cone : Cone Q D;
+  islimit_cone :: Cone Q D;
   islimit_unicone : UniversalCone islimit_cone;
 }.
-(* Use :> and remove the two following lines,
-   once Coq 8.16 is the minimum required version. *)
-#[export] Existing Instance islimit_cone.
 Coercion islimit_cone : IsLimit >-> Cone.
 
 Arguments Build_IsLimit {G D Q} C H : rename.

--- a/theories/Misc/UStructures.v
+++ b/theories/Misc/UStructures.v
@@ -11,13 +11,11 @@ Local Open Scope nat_scope.
 (** A uniform structure on a type consists of an equivalence relation for every natural number, each one being stronger than its predecessor. *)
 Class UStructure (us_type : Type) := {
   us_rel : nat -> Relation us_type;
-  us_reflexive : forall n : nat, Reflexive (us_rel n);
-  us_symmetric : forall n : nat, Symmetric (us_rel n);
-  us_transitive : forall n : nat, Transitive (us_rel n);
+  us_reflexive :: forall n : nat, Reflexive (us_rel n);
+  us_symmetric :: forall n : nat, Symmetric (us_rel n);
+  us_transitive :: forall n : nat, Transitive (us_rel n);
   us_pred : forall (n : nat) (x y : us_type), us_rel n.+1 x y -> us_rel n x y
 }.
-
-Existing Instances us_reflexive us_symmetric us_transitive.
 
 Notation "u =[ n ] v" := (us_rel n u v)
   (at level 70, format "u  =[ n ]  v").

--- a/theories/Modalities/Descent.v
+++ b/theories/Modalities/Descent.v
@@ -20,7 +20,7 @@ Class Descends@{i} (O' O : Subuniverse@{i}) (T : Type@{i})
   OO_descend :
     forall (P : T -> Type@{i}) {P_inO : forall x, In O (P x)},
       O_reflector O' T -> Type@{i} ;
-  OO_descend_inO :
+  OO_descend_inO ::
     forall (P : T -> Type@{i}) {P_inO : forall x, In O (P x)} (x : O_reflector O' T),
       In O (OO_descend P x) ;
   OO_descend_beta :
@@ -28,16 +28,14 @@ Class Descends@{i} (O' O : Subuniverse@{i}) (T : Type@{i})
       OO_descend P (to O' T x) <~> P x ;
 }.
 
-Existing Instance OO_descend_inO.
 Arguments OO_descend O' O {T _ _ _} P {P_inO} x.
 Arguments OO_descend_inO O' O {T _ _ _} P {P_inO} x.
 Arguments OO_descend_beta O' O {T _ _ _} P {P_inO} x.
 
 Class O_lex_leq (O1 O2 : ReflectiveSubuniverse) `{O1 << O2} :=
-  O_lex_leq_descends : forall A, Descends O2 O1 A.
+  O_lex_leq_descends :: forall A, Descends O2 O1 A.
 
 Infix "<<<" := O_lex_leq : subuniverse_scope.
-Existing Instance O_lex_leq_descends.
 
 (** Unfortunately, it seems that generalizing binders don't work on notations: writing [`{O <<< O'}] doesn't automatically add the precondition [O << O'], although writing [`{O_lex_leq O O'}] does. *)
 

--- a/theories/Modalities/Modality.v
+++ b/theories/Modalities/Modality.v
@@ -86,8 +86,7 @@ Defined.
 
 (** Note the reversal of the order: [O1 << O2] means that [O2] has dependent eliminators into [O1]. *)
 Class O_strong_leq (O1 O2 : ReflectiveSubuniverse)
-  := reflectsD_strong_leq : forall A, ReflectsD O2 O1 A.
-Existing Instance reflectsD_strong_leq.
+  := reflectsD_strong_leq :: forall A, ReflectsD O2 O1 A.
 
 Infix "<<" := O_strong_leq : subuniverse_scope.
 Open Scope subuniverse_scope.
@@ -125,11 +124,10 @@ Record Modality@{i} := Build_Modality'
   modality_subuniv : Subuniverse@{i} ;
   modality_prereflects : forall (T : Type@{i}),
       PreReflects modality_subuniv T ;
-  modality_reflectsD : forall (T : Type@{i}),
+  modality_reflectsD :: forall (T : Type@{i}),
       ReflectsD modality_subuniv modality_subuniv T ;
 }.
 
-Existing Instance modality_reflectsD.
 (** We don't declare [modality_subuniv] as a coercion or [modality_prereflects] as a global instance, because we want them only to be found by way of the following "unbundling" coercion to reflective subuniverses. *)
 
 Definition modality_to_reflective_subuniverse (O : Modality@{i})

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -83,9 +83,7 @@ Instance inO_TypeO {O : Subuniverse} (A : Type_ O) : In O A
 
 (** A map is O-local if all its fibers are. *)
 Class MapIn (O : Subuniverse) {A B : Type} (f : A -> B)
-  := inO_hfiber_ino_map : forall (b:B), In O (hfiber f b).
-
-Existing Instance inO_hfiber_ino_map.
+  := inO_hfiber_ino_map :: forall (b:B), In O (hfiber f b).
 
 Section Subuniverse.
   Context (O : Subuniverse).
@@ -141,14 +139,13 @@ End Subuniverse.
 Class PreReflects@{i} (O : Subuniverse@{i}) (T : Type@{i}) :=
 {
   O_reflector : Type@{i} ;
-  O_inO : In O O_reflector ;
+  O_inO :: In O O_reflector ;
   to : T -> O_reflector ;
 }.
 
 Arguments O_reflector O T {_}.
 Arguments to O T {_}.
 Arguments O_inO {O} T {_}.
-Existing Instance O_inO.
 
 (** It is a reflection if it has the requisite universal property. *)
 Class Reflects@{i} (O : Subuniverse@{i}) (T : Type@{i})
@@ -187,13 +184,11 @@ Defined.
 Record ReflectiveSubuniverse@{i} :=
 {
   rsu_subuniv : Subuniverse@{i} ;
-  rsu_prereflects : forall (T : Type@{i}), PreReflects rsu_subuniv T ;
-  rsu_reflects : forall (T : Type@{i}), Reflects rsu_subuniv T ;
+  rsu_prereflects :: forall (T : Type@{i}), PreReflects rsu_subuniv T ;
+  rsu_reflects :: forall (T : Type@{i}), Reflects rsu_subuniv T ;
 }.
 
 Coercion rsu_subuniv : ReflectiveSubuniverse >-> Subuniverse.
-Existing Instance rsu_prereflects.
-Existing Instance rsu_reflects.
 
 (** We allow the name of a subuniverse or modality to be used as the name of its reflector.  This means that when defining a particular example, you should generally put the parametrizing family in a wrapper, so that you can notate the subuniverse as parameterized by, rather than identical to, its parameter.  See Modality.v, Truncations.v, and Localization.v for examples. *)
 Definition rsu_reflector (O : ReflectiveSubuniverse) (T : Type) : Type
@@ -1344,9 +1339,7 @@ Question: is there a definition of connectedness (say, for n-types) that neither
 
 (** We give annotations to reduce the number of universe parameters. *)
 Class IsConnected (O : ReflectiveSubuniverse@{i}) (A : Type@{i})
-  := isconnected_contr_O : Contr@{i} (O A).
-
-Existing Instance isconnected_contr_O.
+  := isconnected_contr_O :: Contr@{i} (O A).
 
 Section ConnectedTypes.
   Context (O : ReflectiveSubuniverse).
@@ -1604,9 +1597,7 @@ Class IsConnMap (O : ReflectiveSubuniverse@{i})
       {A : Type@{i}} {B : Type@{i}} (f : A -> B)
   := isconnected_hfiber_conn_map
      (** The extra universe [k] is >= max(i,j). *)
-     : forall b:B, IsConnected@{i} O (hfiber@{i i} f b).
-
-Existing Instance isconnected_hfiber_conn_map.
+     :: forall b:B, IsConnected@{i} O (hfiber@{i i} f b).
 
 Section ConnectedMaps.
   Universe i.
@@ -2044,11 +2035,9 @@ Defined.
 (** Two subuniverses are the same if they have the same modal types.  The universe parameters are the same as for [O_leq]: [O1] and [O2] are reflective subuniverses of [Type@{i1}] and [Type@{i2}], and the relation says that they agree when restricted to [Type@{j}], where [j <= i1] and [j <= i2]. *)
 Class O_eq@{i1 i2 j} (O1 : Subuniverse@{i1}) (O2 : Subuniverse@{i2}) :=
 {
-  O_eq_l : O_leq@{i1 i2 j} O1 O2 ;
-  O_eq_r : O_leq@{i2 i1 j} O2 O1 ;
+  O_eq_l :: O_leq@{i1 i2 j} O1 O2 ;
+  O_eq_r :: O_leq@{i2 i1 j} O2 O1 ;
 }.
-
-Existing Instances O_eq_l O_eq_r.
 
 Infix "<=>" := O_eq : subuniverse_scope.
 

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -124,7 +124,7 @@ Defined.
 (** A pointed equivalence is a pointed map and a proof that it is an equivalence *)
 Record pEquiv (A B : pType) := {
   pointed_equiv_fun : pForall A (pfam_const B) ;
-  pointed_isequiv : IsEquiv pointed_equiv_fun ;
+  pointed_isequiv :: IsEquiv pointed_equiv_fun ;
 }.
 
 (** TODO: It might be better behaved to define [pEquiv] as an equivalence and a proof that this equivalence is pointed. In pEquiv.v we have another constructor [Build_pEquiv'] which Coq can infer faster than [Build_pEquiv]. *)
@@ -133,7 +133,6 @@ Infix "<~>*" := pEquiv : pointed_scope.
 
 (** Note: because we define [pMap] as a special case of [pForall], we must declare all coercions into [pForall], *not* into [pMap]. *)
 Coercion pointed_equiv_fun : pEquiv >-> pForall.
-Existing Instance pointed_isequiv.
 
 Coercion pointed_equiv_equiv {A B} (f : A <~>* B)
   : A <~> B := Build_Equiv A B f _.

--- a/theories/Sets/Ordinals.v
+++ b/theories/Sets/Ordinals.v
@@ -48,18 +48,12 @@ Proof. unfold Extensional. exact _. Qed.
 (** * Ordinals *)
 
 Class IsOrdinal@{carrier relation} (A : Type@{carrier}) (R : Relation@{carrier relation} A) := {
-  ordinal_is_hset : IsHSet A ;
-  ordinal_relation_is_mere : is_mere_relation A R ;
-  ordinal_extensionality : Extensional R ;
-  ordinal_well_foundedness : WellFounded R ;
-  ordinal_transitivity : Transitive R ;
+  ordinal_is_hset :: IsHSet A ;
+  ordinal_relation_is_mere :: is_mere_relation A R ;
+  ordinal_extensionality :: Extensional R ;
+  ordinal_well_foundedness :: WellFounded R ;
+  ordinal_transitivity :: Transitive R ;
 }.
-#[export] Existing Instances
-  ordinal_is_hset
-  ordinal_relation_is_mere
-  ordinal_extensionality
-  ordinal_well_foundedness
-  ordinal_transitivity.
 
 Instance ishprop_IsOrdinal `{Funext} A R
   : IsHProp (IsOrdinal A R).
@@ -72,11 +66,9 @@ Qed.
 
 Record Ordinal@{carrier relation +} :=
   { ordinal_carrier : Type@{carrier}
-    ; ordinal_relation : Lt@{carrier relation} ordinal_carrier
-    ; ordinal_property : IsOrdinal@{carrier relation} ordinal_carrier (<)
+    ; ordinal_relation :: Lt@{carrier relation} ordinal_carrier
+    ; ordinal_property :: IsOrdinal@{carrier relation} ordinal_carrier (<)
   }.
-
-Existing Instances ordinal_relation ordinal_property.
 
 Coercion ordinal_as_hset (A : Ordinal) : HSet
   := Build_HSet (ordinal_carrier A).

--- a/theories/Spaces/No/Addition.v
+++ b/theories/Spaces/No/Addition.v
@@ -8,12 +8,10 @@ Local Open Scope surreal_scope.
 
 (** Addition requires the option sorts to be closed under finite sums. *)
 Class HasAddition (S : OptionSort) :=
-  { empty_options : InSort S Empty Empty
-    ; sum_options : forall L R L' R',
+  { empty_options :: InSort S Empty Empty
+    ; sum_options :: forall L R L' R',
         InSort S L R -> InSort S L' R' -> InSort S (L + L') (R + R')
   }.
-Existing Instance empty_options.
-Existing Instance sum_options.
 
 Instance hasaddition_maxsort : HasAddition MaxSort
   := { empty_options := tt ;

--- a/theories/Spaces/No/Negation.v
+++ b/theories/Spaces/No/Negation.v
@@ -8,8 +8,7 @@ Local Open Scope surreal_scope.
 
 (** Negation requires the option sorts to be symmetric. *)
 Class HasNegation (S : OptionSort) 
-  := symmetric_options : forall L R, InSort S L R -> InSort S R L.
-Existing Instance symmetric_options.
+  := symmetric_options :: forall L R, InSort S L R -> InSort S R L.
 
 Instance hasnegation_maxsort : HasNegation MaxSort
   := fun _ _ _ => tt.

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -15,9 +15,7 @@ Record Prespectrum :=
     ; glue : forall n, deloop n ->* loops (deloop (n .+1)) }.
 
 Class IsSpectrum (E : Prespectrum) :=
-  is_equiv_glue : forall n, IsEquiv (glue E n).
-
-Existing Instance is_equiv_glue.
+  is_equiv_glue :: forall n, IsEquiv (glue E n).
 
 Definition equiv_glue (E : Prespectrum) `{IsSpectrum E}
 : forall n, E n <~>* loops (E n.+1)
@@ -25,9 +23,7 @@ Definition equiv_glue (E : Prespectrum) `{IsSpectrum E}
 
 Record Spectrum :=
   { to_prespectrum :> Prespectrum
-    ; to_is_spectrum : IsSpectrum to_prespectrum }.
-
-Existing Instance to_is_spectrum.
+    ; to_is_spectrum :: IsSpectrum to_prespectrum }.
 
 (** ** Truncations of spectra *)
 

--- a/theories/Universes/DProp.v
+++ b/theories/Universes/DProp.v
@@ -12,8 +12,8 @@ Local Open Scope path_scope.
 
 Record DProp := {
   dprop_type : Type ;
-  ishprop_dprop : Funext -> IsHProp dprop_type ;
-  dec_dprop : Decidable dprop_type
+  ishprop_dprop :: Funext -> IsHProp dprop_type ;
+  dec_dprop :: Decidable dprop_type
 }.
 
 (** A fancier definition, which would have the property that negation is judgmentally involutive, would be
@@ -33,18 +33,15 @@ Record DProp :=
 At some point we may want to go that route, but it would be more work.  In particular, [Instance]s of [Decidable] wouldn't be automatically computed for us, and the characterization of the homotopy type of [DProp] itself would be a lot harder. *)
 
 Coercion dprop_type : DProp >-> Sortclass.
-Existing Instance ishprop_dprop.
-Existing Instance dec_dprop.
 
 (** Sometimes, however, we have decidable props that are hprops without funext, and we want to remember that. *)
 
 Record DHProp :=
   { dhprop_hprop : HProp ;
-    dec_dhprop : Decidable dhprop_hprop
+    dec_dhprop :: Decidable dhprop_hprop
   }.
 
 Coercion dhprop_hprop : DHProp >-> HProp.
-Existing Instance dec_dhprop.
 
 Definition dhprop_to_dprop : DHProp -> DProp
   := fun P => Build_DProp P (fun _ => _) _.

--- a/theories/WildCat/Adjoint.v
+++ b/theories/WildCat/Adjoint.v
@@ -35,13 +35,13 @@ Record Adjunction {C D : Type} (F : C -> D) (G : D -> C)
   (** Naturality condition in both variable separately *)
   (** The left variable is a bit trickier to state since we have opposite categories involved. *)
   is1natural_equiv_adjunction_l (y : D)
-    : Is1Natural (A := C^op) (yon y o F)
+    :: Is1Natural (A := C^op) (yon y o F)
         (** We have to explicitly give a witness to the functoriality of [yon y o F]. *)
         (is0functor_F := is0functor_compose (A:=C^op) (B:=D^op) (C:=Type) _ _)
         (yon (G y)) (fun x => equiv_adjunction _ y) ;
   (** Naturality in the right variable *)
   is1natural_equiv_adjunction_r (x : C)
-    : Is1Natural (opyon (F x)) (opyon x o G) (equiv_adjunction x) ; 
+    :: Is1Natural (opyon (F x)) (opyon x o G) (equiv_adjunction x) ;
 }.
 
 Arguments equiv_adjunction {C D F G
@@ -56,9 +56,6 @@ Arguments is1natural_equiv_adjunction_r {C D F G
   isgraph_C is2graph_C is01cat_C is1cat_C
   isgraph_D is2graph_D is01cat_D is1cat_D
   is0functor_F is0functor_G} adj x : rename.
-Existing Instances
-  is1natural_equiv_adjunction_l
-  is1natural_equiv_adjunction_r.
 
 Notation "F ⊣ G" := (Adjunction F G).
 

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -96,10 +96,10 @@ Existing Instance isgraph_hom | 20.
 (** ** Wild 1-categorical structures *)
 Class Is1Cat (A : Type) `{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
 {
-  is01cat_hom : forall (a b : A), Is01Cat (a $-> b) ;
-  is0gpd_hom : forall (a b : A), Is0Gpd (a $-> b) ;
-  is0functor_postcomp : forall (a b c : A) (g : b $-> c), Is0Functor (cat_postcomp a g) ;
-  is0functor_precomp : forall (a b c : A) (f : a $-> b), Is0Functor (cat_precomp c f) ;
+  is01cat_hom :: forall (a b : A), Is01Cat (a $-> b) ;
+  is0gpd_hom :: forall (a b : A), Is0Gpd (a $-> b) ;
+  is0functor_postcomp :: forall (a b c : A) (g : b $-> c), Is0Functor (cat_postcomp a g) ;
+  is0functor_precomp :: forall (a b c : A) (f : a $-> b), Is0Functor (cat_precomp c f) ;
   cat_assoc : forall (a b c d : A) (f : a $-> b) (g : b $-> c) (h : c $-> d),
     (h $o g) $o f $== h $o (g $o f);
   cat_assoc_opp : forall (a b c d : A) (f : a $-> b) (g : b $-> c) (h : c $-> d),
@@ -108,10 +108,6 @@ Class Is1Cat (A : Type) `{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
   cat_idr : forall (a b : A) (f : a $-> b), f $o Id a $== f;
 }.
 
-Existing Instance is01cat_hom.
-Existing Instance is0gpd_hom.
-Existing Instance is0functor_postcomp.
-Existing Instance is0functor_precomp.
 Arguments cat_assoc {_ _ _ _ _ _ _ _ _} f g h.
 Arguments cat_assoc_opp {_ _ _ _ _ _ _ _ _} f g h.
 Arguments cat_idl {_ _ _ _ _ _ _} f.
@@ -246,10 +242,8 @@ Definition mor_terminal_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal 
 
 (** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
 Class HasMorExt (A : Type) `{Is1Cat A} := {
-  isequiv_Htpy_path : forall (a b : A) f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
+  isequiv_Htpy_path :: forall (a b : A) f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
 }.
-
-Existing Instance isequiv_Htpy_path.
 
 Definition path_hom {A} `{HasMorExt A} {a b : A} {f g : a $-> b} (p : f $== g)
   : f = g
@@ -562,8 +556,7 @@ Existing Instance isgraph_hom_hom | 30.
 Class PreservesInitial {A B : Type} (F : A -> B)
   `{Is1Functor A B F} : Type
   := isinitial_preservesinitial
-    : forall (x : A), IsInitial x -> IsInitial (F x).
-Existing Instance isinitial_preservesinitial.
+    :: forall (x : A), IsInitial x -> IsInitial (F x).
 
 (** The initial morphism is preserved by such a functor. *)
 Lemma fmap_initial {A B : Type} (F : A -> B)
@@ -576,8 +569,7 @@ Defined.
 Class PreservesTerminal {A B : Type} (F : A -> B)
   `{Is1Functor A B F} : Type
   := isterminal_preservesterminal
-    : forall (x : A), IsTerminal x -> IsTerminal (F x).
-Existing Instance isterminal_preservesterminal.
+    :: forall (x : A), IsTerminal x -> IsTerminal (F x).
 
 (** The terminal morphism is preserved by such a functor. *)
 Lemma fmap_terminal {A B : Type} (F : A -> B)
@@ -592,7 +584,7 @@ Defined.
 Record BasepointPreservingFunctor (B C : Type)
        `{Is01Cat B, Is01Cat C} `{IsPointed B, IsPointed C} := {
     bp_map : B -> C;
-    bp_is0functor : Is0Functor bp_map;
+    bp_is0functor :: Is0Functor bp_map;
     bp_pointed : bp_map (point B) $-> point C
   }.
 
@@ -601,8 +593,6 @@ Arguments Build_BasepointPreservingFunctor {B C}%_type_scope {H H0 H1 H2 H3 H4}
   bp_map%_function_scope {bp_is0functor} bp_pointed.
 
 Coercion bp_map : BasepointPreservingFunctor >-> Funclass.
-
-Existing Instance bp_is0functor.
 
 Notation "B -->* C" := (BasepointPreservingFunctor B C) (at level 70).
 

--- a/theories/WildCat/Displayed.v
+++ b/theories/WildCat/Displayed.v
@@ -78,25 +78,24 @@ Arguments dfmap {A B DA _ _ DB _ _} F {_} F' {_ _ _ _ _ _} f'.
 
 Class IsD2Graph {A : Type} `{Is2Graph A}
   (D : A -> Type) `{!IsDGraph D}
-  := isdgraph_hom : forall {a b} {a'} {b'},
+  := isdgraph_hom :: forall {a b} {a'} {b'},
                       IsDGraph (fun (f:a $-> b) => DHom f a' b').
 
-Existing Instance isdgraph_hom.
 #[global] Typeclasses Transparent IsD2Graph.
 
 Class IsD1Cat {A : Type} `{Is1Cat A}
   (D : A -> Type) `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D} :=
 {
-  isd01cat_hom : forall {a b : A} {a' : D a} {b' : D b},
+  isd01cat_hom :: forall {a b : A} {a' : D a} {b' : D b},
                  IsD01Cat (fun f => DHom f a' b');
-  isd0gpd_hom : forall {a b : A} {a' : D a} {b' : D b},
+  isd0gpd_hom :: forall {a b : A} {a' : D a} {b' : D b},
                 IsD0Gpd (fun f => DHom f a' b');
-  isd0functor_postcomp : forall {a b c : A} {g : b $-> c} {a' : D a}
+  isd0functor_postcomp :: forall {a b c : A} {g : b $-> c} {a' : D a}
                          {b' : D b} {c' : D c} (g' : DHom g b' c'),
                          @IsD0Functor _ _ (fun f => DHom f a' b')
                          _ _ (fun gf => DHom gf a' c')
                          _ _ (cat_postcomp a g) _ (dcat_postcomp g');
-  isd0functor_precomp : forall {a b c : A} {f : a $-> b} {a' : D a}
+  isd0functor_precomp :: forall {a b c : A} {f : a $-> b} {a' : D a}
                         {b' : D b} {c' : D c} (f' : DHom f a' b'),
                         @IsD0Functor _ _ (fun g => DHom g b' c')
                         _ _ (fun gf => DHom gf a' c')
@@ -116,11 +115,6 @@ Class IsD1Cat {A : Type} `{Is1Cat A}
   dcat_idr : forall {a b : A} {f : a $-> b} {a' : D a} {b' : D b}
              (f' : DHom f a' b'), DHom (cat_idr f) (f' $o' DId a') f';
 }.
-
-Existing Instance isd01cat_hom.
-Existing Instance isd0gpd_hom.
-Existing Instance isd0functor_postcomp.
-Existing Instance isd0functor_precomp.
 
 Definition dcat_postwhisker {A : Type} {D : A -> Type} `{IsD1Cat A D}
   {a b c : A} {f g : a $-> b} {h : b $-> c} {p : f $== g}
@@ -256,16 +250,16 @@ Class IsD1Cat_Strong {A : Type} `{Is1Cat_Strong A}
   (D : A -> Type)
   `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D} :=
 {
-  isd01cat_hom_strong : forall {a b : A} {a' : D a} {b' : D b},
+  isd01cat_hom_strong :: forall {a b : A} {a' : D a} {b' : D b},
                         IsD01Cat (fun f => DHom f a' b');
-  isd0gpd_hom_strong : forall {a b : A} {a' : D a} {b' : D b},
+  isd0gpd_hom_strong :: forall {a b : A} {a' : D a} {b' : D b},
                        IsD0Gpd (fun f => DHom f a' b');
-  isd0functor_postcomp_strong : forall {a b c : A} {g : b $-> c} {a' : D a}
+  isd0functor_postcomp_strong :: forall {a b c : A} {g : b $-> c} {a' : D a}
                                 {b' : D b} {c' : D c} (g' : DHom g b' c'),
                                 @IsD0Functor _ _ (fun f => DHom f a' b')
                                 _ _ (fun gf => DHom gf a' c')
                                 _ _ (cat_postcomp a g) _ (dcat_postcomp g');
-  isd0functor_precomp_strong : forall {a b c : A} {f : a $-> b} {a' : D a}
+  isd0functor_precomp_strong :: forall {a b c : A} {f : a $-> b} {a' : D a}
                                 {b' : D b} {c' : D c} (f' : DHom f a' b'),
                                 @IsD0Functor _ _ (fun g => DHom g b' c')
                                 _ _ (fun gf => DHom gf a' c')
@@ -289,11 +283,6 @@ Class IsD1Cat_Strong {A : Type} `{Is1Cat_Strong A}
                     (transport (fun k => DHom k a' b') (cat_idr_strong f)
                     (f' $o' DId a')) = f';
 }.
-
-Existing Instance isd01cat_hom_strong.
-Existing Instance isd0gpd_hom_strong.
-Existing Instance isd0functor_postcomp_strong.
-Existing Instance isd0functor_precomp_strong.
 
 (* If in the future we make a [Build_Is1Cat_Strong'] that lets the user omit the second proof of associativity, this shows how it can be recovered from the original proof:
 Definition dcat_assoc_opp_strong {A : Type} {D : A -> Type} `{IsD1Cat_Strong A D}

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -529,10 +529,9 @@ Defined.
 
 Class IsDUnivalent1Cat {A} (D : A -> Type) `{DHasEquivs A D} :=
 {
-  isequiv_dcat_equiv_path : forall {a b : A} (p : a = b) a' b',
+  isequiv_dcat_equiv_path :: forall {a b : A} (p : a = b) a' b',
     IsEquiv (dcat_equiv_path p a' b')
 }.
-Existing Instance isequiv_dcat_equiv_path.
 
 Definition dcat_path_equiv {A} {D : A -> Type} `{IsDUnivalent1Cat A D}
   {a b : A} (p : a = b) (a' : D a) (b' : D b)

--- a/theories/WildCat/EquivGpd.v
+++ b/theories/WildCat/EquivGpd.v
@@ -19,11 +19,10 @@ Arguments esssurj {A B _ _ _ _ _ _} F {_ _} b.
 Class IsSurjInj {A B : Type} `{Is0Gpd A, Is0Gpd B}
       (F : A -> B) `{!Is0Functor F} :=
 {
-  esssurj_issurjinj : SplEssSurj F ;
+  esssurj_issurjinj :: SplEssSurj F ;
   essinj : forall (x y:A), (F x $== F y) -> (x $== y) ;
 }.
 
-Existing Instance esssurj_issurjinj.
 Arguments essinj {A B _ _ _ _ _ _} F {_ _ x y} f.
 
 Definition surjinj_inv {A B : Type} (F : A -> B) `{IsSurjInj A B F} : B -> A

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -11,11 +11,10 @@ Require Import WildCat.NatTrans.
 
 Record Fun01 (A B : Type) `{IsGraph A} `{IsGraph B} := {
   fun01_F : A -> B;
-  fun01_is0functor : Is0Functor fun01_F;
+  fun01_is0functor :: Is0Functor fun01_F;
 }.
 
 Coercion fun01_F : Fun01 >-> Funclass.
-Existing Instance fun01_is0functor.
 
 Arguments Build_Fun01 A B {isgraph_A isgraph_B} F {fun01_is0functor} : rename.
 Arguments fun01_F {A B isgraph_A isgraph_B} : rename.
@@ -113,13 +112,11 @@ Defined.
 Record Fun11 (A B : Type) `{Is1Cat A} `{Is1Cat B} :=
 {
   fun11_fun : A -> B ;
-  is0functor_fun11 : Is0Functor fun11_fun ;
-  is1functor_fun11 : Is1Functor fun11_fun
+  is0functor_fun11 :: Is0Functor fun11_fun ;
+  is1functor_fun11 :: Is1Functor fun11_fun
 }.
 
 Coercion fun11_fun : Fun11 >-> Funclass.
-Existing Instance is0functor_fun11.
-Existing Instance is1functor_fun11.
 
 Arguments Build_Fun11 A B
   {isgraph_A is2graph_A is01cat_A is1cat_A

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -124,8 +124,8 @@ Class IsMonoidal (A : Type) `{HasEquivs A}
   (** These all satisfy the following properties: *)
   := {
   (** A [cat_tensor] is a 1-bifunctor. *)
-  is0bifunctor_cat_tensor : Is0Bifunctor cat_tensor;
-  is1bifunctor_cat_tensor : Is1Bifunctor cat_tensor;
+  is0bifunctor_cat_tensor :: Is0Bifunctor cat_tensor | 10;
+  is1bifunctor_cat_tensor :: Is1Bifunctor cat_tensor | 10;
   (** A natural isomorphism [associator] witnessing the associativity of the tensor product. *)
   cat_tensor_associator :: Associator cat_tensor;
   (** A natural isomorphism [left_unitor] witnessing the left unit law. *)
@@ -137,9 +137,6 @@ Class IsMonoidal (A : Type) `{HasEquivs A}
   (** The pentagon identity. *)
   cat_tensor_pentagon_identity :: PentagonIdentity cat_tensor;
 }.
-
-Existing Instance is0bifunctor_cat_tensor | 10.
-Existing Instance is1bifunctor_cat_tensor | 10.
 
 (** TODO: Braided monoidal categories *)
 

--- a/theories/WildCat/NatTrans.v
+++ b/theories/WildCat/NatTrans.v
@@ -165,7 +165,7 @@ Record NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} {F G : A -> B}
   {ff : Is0Functor F} {fg : Is0Functor G} := {
   #[reversible=no]
   trans_nattrans :> F $=> G;
-  is1natural_nattrans : Is1Natural F G trans_nattrans;
+  is1natural_nattrans :: Is1Natural F G trans_nattrans;
 }.
 
 Arguments NatTrans {A B} {isgraph_A}
@@ -173,8 +173,6 @@ Arguments NatTrans {A B} {isgraph_A}
   F G {is0functor_F} {is0functor_G} : rename.
 Arguments Build_NatTrans {A B isgraph_A isgraph_B is2graph_B is01cat_B is1cat_B
   F G is0functor_F is0functor_G} alpha isnat_alpha : rename.
-
-Existing Instance is1natural_nattrans.
 
 Definition issig_NatTrans {A B : Type} `{IsGraph A} `{Is1Cat B} (F G : A -> B)
   {ff : Is0Functor F} {fg : Is0Functor G}

--- a/theories/WildCat/PointedCat.v
+++ b/theories/WildCat/PointedCat.v
@@ -5,12 +5,9 @@ Require Import WildCat.Equiv.
 (** A wild category is pointed if the initial and terminal object are the same. *)
 Class IsPointedCat (A : Type) `{Is1Cat A} := {
   zero_object : A;
-  isinitial_zero_object : IsInitial zero_object;
-  isterminal_zero_object : IsTerminal zero_object;
+  isinitial_zero_object :: IsInitial zero_object;
+  isterminal_zero_object :: IsTerminal zero_object;
 }.
-
-Existing Instance isinitial_zero_object.
-Existing Instance isterminal_zero_object.
 
 (** The zero morphism between objects [a] and [b] of a pointed category [A] is the unique morphism that factors through the zero object. *)
 Definition zero_morphism {A : Type} `{IsPointedCat A} {a b : A} : a $-> b
@@ -60,10 +57,9 @@ Local Arguments zero_morphism {_ _ _ _ _ _} _ _.
 (** A functor is pointed if it preserves the zero object. *)
 Class IsPointedFunctor {A B : Type} (F : A -> B) `{Is1Functor A B F} :=
 {
-  preservesinitial_pfunctor : PreservesInitial F ;
-  preservesterminal_pfunctor : PreservesTerminal F ;
+  preservesinitial_pfunctor :: PreservesInitial F ;
+  preservesterminal_pfunctor :: PreservesTerminal F ;
 }.
-Existing Instances preservesinitial_pfunctor preservesterminal_pfunctor.
 
 (** Here is an alternative constructor using preservation of the zero object. This requires more structure on the categories however. *)
 Definition Build_IsPointedFunctor' {A B : Type} (F : A -> B)

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -6,31 +6,31 @@ Require Import WildCat.NatTrans.
 
 Class Is21Cat (A : Type) `{Is1Cat A, !Is3Graph A} :=
 {
-  is1cat_hom : forall (a b : A), Is1Cat (a $-> b) ;
-  is1gpd_hom : forall (a b : A), Is1Gpd (a $-> b) ;
-  is1functor_postcomp : forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) ;
-  is1functor_precomp : forall (a b c : A) (f : a $-> b), Is1Functor (cat_precomp c f) ;
+  is1cat_hom :: forall (a b : A), Is1Cat (a $-> b) ;
+  is1gpd_hom :: forall (a b : A), Is1Gpd (a $-> b) ;
+  is1functor_postcomp :: forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) ;
+  is1functor_precomp :: forall (a b c : A) (f : a $-> b), Is1Functor (cat_precomp c f) ;
   bifunctor_coh_comp : forall {a b c : A} {f f' : a $-> b}  {g g' : b $-> c}
     (p : f $== f') (p' : g $== g'),
     (p' $@R f) $@ (g' $@L p) $== (g $@L p) $@ (p' $@R f') ;
 
   (** Naturality of the associator in each variable separately *)
-  is1natural_cat_assoc_l : forall (a b c d : A) (f : a $-> b) (g : b $-> c),
+  is1natural_cat_assoc_l :: forall (a b c d : A) (f : a $-> b) (g : b $-> c),
       Is1Natural (cat_precomp d f o cat_precomp d g) (cat_precomp d (g $o f))
                  (cat_assoc f g);
-  is1natural_cat_assoc_m : forall (a b c d : A) (f : a $-> b) (h : c $-> d),
+  is1natural_cat_assoc_m :: forall (a b c d : A) (f : a $-> b) (h : c $-> d),
       Is1Natural (cat_precomp d f o cat_postcomp b h) (cat_postcomp a h o cat_precomp c f)
                  (fun g => cat_assoc f g h);
-  is1natural_cat_assoc_r : forall (a b c d : A) (g : b $-> c) (h : c $-> d),
+  is1natural_cat_assoc_r :: forall (a b c d : A) (g : b $-> c) (h : c $-> d),
       Is1Natural (cat_postcomp a (h $o g)) (cat_postcomp a h o cat_postcomp a g)
                  (fun f => cat_assoc f g h);
 
   (** Naturality of the unitors *)
-  is1natural_cat_idl : forall (a b : A),
+  is1natural_cat_idl :: forall (a b : A),
       Is1Natural (cat_postcomp a (Id b)) idmap
                  cat_idl ;
 
-  is1natural_cat_idr : forall (a b : A),
+  is1natural_cat_idr :: forall (a b : A),
       Is1Natural (cat_precomp b (Id a)) idmap
                  cat_idr;
 
@@ -43,16 +43,6 @@ Class Is21Cat (A : Type) `{Is1Cat A, !Is3Graph A} :=
   cat_tril : forall (a b c : A) (f : a $-> b) (g : b $-> c),
       (g $@L cat_idl f) $o (cat_assoc f (Id b) g) $== (cat_idr g $@R f)
 }.
-
-Existing Instance is1cat_hom.
-Existing Instance is1gpd_hom.
-Existing Instance is1functor_precomp.
-Existing Instance is1functor_postcomp.
-Existing Instance is1natural_cat_assoc_l.
-Existing Instance is1natural_cat_assoc_m.
-Existing Instance is1natural_cat_assoc_r.
-Existing Instance is1natural_cat_idl.
-Existing Instance is1natural_cat_idr.
 
 (** *** Whiskering functoriality *)
 

--- a/theories/WildCat/ZeroGroupoid.v
+++ b/theories/WildCat/ZeroGroupoid.v
@@ -9,14 +9,10 @@ Require Import WildCat.Core WildCat.Equiv WildCat.EquivGpd
 
 Record ZeroGpd := {
   carrier :> Type;
-  isgraph_carrier : IsGraph carrier;
-  is01cat_carrier : Is01Cat carrier;
-  is0gpd_carrier : Is0Gpd carrier;
+  isgraph_carrier :: IsGraph carrier;
+  is01cat_carrier :: Is01Cat carrier;
+  is0gpd_carrier :: Is0Gpd carrier;
 }.
-
-Existing Instance isgraph_carrier.
-Existing Instance is01cat_carrier.
-Existing Instance is0gpd_carrier.
 
 Definition zerogpd_graph (C : ZeroGpd) : Graph := {|
     graph_carrier := carrier C;


### PR DESCRIPTION
This commit replaces all `Existing Instance proj1` occurrences in the library with the new `::` syntax.

I have opted not to replace the occurrences of `Coercion` as I didn't realize the `:>` makes it reversible.