### PR TITLE
unboxed HasMorExt and IsUnivalent1Cat

### DIFF
--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -296,8 +296,7 @@ Defined.
 Instance hasmorext_abses `{Funext} {A B : AbGroup@{u}}
   : HasMorExt (AbSES B A).
 Proof.
-  srapply Build_HasMorExt;
-    intros E F f g.
+  intros E F f g.
   srapply isequiv_homotopic'; cbn.
   1: exact (((equiv_path_groupisomorphism _ _)^-1%equiv)
               oE (equiv_path_sigma_hprop _ _)^-1%equiv).

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -817,7 +817,6 @@ Defined.
 (** Under [Funext], the category of groups has morphism extensionality. *)
 Instance hasmorext_group `{Funext} : HasMorExt Group.
 Proof.
-  srapply Build_HasMorExt.
   intros A B f g; cbn in *.
   snapply @isequiv_homotopic.
   1: exact (equiv_path_grouphomomorphism^-1%equiv).

--- a/theories/Algebra/Rings/Ring.v
+++ b/theories/Algebra/Rings/Ring.v
@@ -293,7 +293,6 @@ Defined.
 
 Instance hasmorext_ring `{Funext} : HasMorExt Ring.
 Proof.
-  srapply Build_HasMorExt.
   intros A B f g; cbn in *.
   snapply @isequiv_homotopic.
   1: exact (equiv_path_ringhomomorphism^-1%equiv).

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -985,7 +985,7 @@ Defined.
 (** Under funext, [pType] has morphism extensionality *)
 Instance hasmorext_ptype `{Funext} : HasMorExt pType.
 Proof.
-  srapply Build_HasMorExt; intros A B f g.
+  intros A B f g.
   refine (isequiv_homotopic (equiv_path_pforall f g)^-1%equiv _).
   intros []; reflexivity.
 Defined.
@@ -1020,7 +1020,7 @@ Defined.
 (** [pType] is a univalent 1-coherent 1-category *)
 Instance isunivalent_ptype `{Univalence} : IsUnivalent1Cat pType.
 Proof.
-  srapply Build_IsUnivalent1Cat; intros A B.
+  intros A B.
   (* [cate_equiv_path] is almost definitionally equal to [pequiv_path].  Both are defined by path induction, sending [idpath A] to [id_cate A] and [pequiv_pmap_idmap A], respectively.  [id_cate A] is almost definitionally equal to [pequiv_pmap_idmap A], except that the former uses [catie_adjointify], so the adjoint law is different. However, the underlying pointed maps are definitionally equal. *)
   refine (isequiv_homotopic pequiv_path _).
   intros [].

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -243,7 +243,6 @@ Definition mor_terminal_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal 
 (** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
 Class HasMorExt (A : Type) `{Is1Cat A} :=
   isequiv_Htpy_path :: forall (a b : A) f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g).
-#[export] Typeclasses Opaque HasMorExt.
 
 Definition path_hom {A} `{HasMorExt A} {a b : A} {f g : a $-> b} (p : f $== g)
   : f = g

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -241,9 +241,9 @@ Definition mor_terminal_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal 
   := (h x).2 f.
 
 (** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
-Class HasMorExt (A : Type) `{Is1Cat A} := {
-  isequiv_Htpy_path :: forall (a b : A) f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
-}.
+Class HasMorExt (A : Type) `{Is1Cat A} :=
+  isequiv_Htpy_path :: forall (a b : A) f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g).
+#[export] Typeclasses Opaque HasMorExt.
 
 Definition path_hom {A} `{HasMorExt A} {a b : A} {f g : a $-> b} (p : f $== g)
   : f = g

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -550,7 +550,6 @@ Instance isunivalent1cat_total {A} `{IsUnivalent1Cat A} (D : A -> Type)
   `{!IsDUnivalent1Cat D}
   : IsUnivalent1Cat (sig D).
 Proof.
-  snapply Build_IsUnivalent1Cat.
   intros aa' bb'.
   apply (isequiv_homotopic
           (dcat_equiv_path_total _ _ o (path_sigma_uncurried D aa' bb')^-1)).

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -496,8 +496,8 @@ Proof.
 Defined.
 
 Class IsUnivalent1Cat (A : Type) `{HasEquivs A}
-  := { isequiv_cat_equiv_path : forall a b, IsEquiv (@cat_equiv_path A _ _ _ _ _ a b) }.
-Existing Instance isequiv_cat_equiv_path.
+  := isequiv_cat_equiv_path :: forall a b, IsEquiv (@cat_equiv_path A _ _ _ _ _ a b).
+#[export] Typeclasses Opaque IsUnivalent1Cat.
 
 Definition cat_path_equiv {A : Type} `{IsUnivalent1Cat A} (a b : A)
   : (a $<~> b) -> (a = b)
@@ -623,7 +623,6 @@ Instance hasmorext_core {A : Type} `{HasEquivs A, !HasMorExt A}
   `{forall (x y : core A) (f g : uncore x $<~> uncore y), IsEquiv (ap (x := f) (y := g) cate_fun)}
   : HasMorExt (core A).
 Proof.
-  snapply Build_HasMorExt.
   intros X Y f g; cbn in *.
   snapply isequiv_homotopic.
   - exact (GpdHom_path o (ap (x:=f) (y:=g) cate_fun)).

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -497,7 +497,6 @@ Defined.
 
 Class IsUnivalent1Cat (A : Type) `{HasEquivs A}
   := isequiv_cat_equiv_path :: forall a b, IsEquiv (@cat_equiv_path A _ _ _ _ _ a b).
-#[export] Typeclasses Opaque IsUnivalent1Cat.
 
 Definition cat_path_equiv {A : Type} `{IsUnivalent1Cat A} (a b : A)
   : (a $<~> b) -> (a = b)

--- a/theories/WildCat/Induced.v
+++ b/theories/WildCat/Induced.v
@@ -70,7 +70,7 @@ Section Induced_category.
 
   Instance hasmorext_induced `{HasMorExt B} : HasMorExt A.
   Proof.
-    constructor. intros_of_type A; cbn. rapply isequiv_Htpy_path.
+    intros a b; cbn. rapply isequiv_Htpy_path.
   Defined.
 
   Definition hasequivs_induced `{HasEquivs B} : HasEquivs A.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -120,7 +120,6 @@ Instance is1functor_op' A B (F : A^op -> B^op)
 Instance hasmorext_op {A : Type} `{H0 : HasMorExt A}
   : HasMorExt A^op.
 Proof.
-  snapply Build_HasMorExt.
   intros a b f g.
   exact (@isequiv_Htpy_path _ _ _ _ _ H0 b a f g).
 Defined.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -51,7 +51,6 @@ Defined.
 
 Instance hasmorext_type `{Funext} : HasMorExt Type.
 Proof.
-  srapply Build_HasMorExt.
   intros A B f g; cbn in *.
   refine (isequiv_homotopic (@apD10 A (fun _ => B) f g) _).
   intros p.


### PR DESCRIPTION
This commit "unboxes" `HasMorExt` and `IsUnivalent1Cat`, removing the constructor term necessary to build an instance of these, which will make terms slightly smaller. I guess the performance gains are slightly offset because the definition still has to be unfolded.

Of course the proofs are shorter by one line because one no longer has to apply the constructor.

What do you think, is this a good idea?

@Alizter suggested I use "Typeclasses Opaque" after this, but the documentation says:
> Definitional typeclasses are not wrapped inside records, and the trivial projection of an instance of such a typeclass is convertible to the instance itself. This can be useful to make instances of existing objects easily and to reduce proof size by not inserting useless trivial projections. **The typeclass [constant](https://rocq-prover.org/doc/V9.0.0/refman/language/core/definitions.html#term-constant) itself is declared rigid during resolution so that the typeclass abstraction is maintained.**

And this makes me wonder if the extra "Typeclasses Opaque" command is really necessary.

(There are other singleton classes in the library which could be unboxed, so based on this discussion we could decide to unbox other classes as well.)