### PR TITLE
Clean annotations

### DIFF
--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -2,6 +2,10 @@ Require Import Basics Types.
 Require Import WildCat HSet Truncations.Core Modalities.ReflectiveSubuniverse.
 Require Import Groups.Group Groups.QuotientGroup AbelianGroup Biproduct.
 
+(* If Hint A about groups appears before Hint B about Abelian groups appears in the typeclass database,
+   Coq may coerce an Abelian group to a group to apply A, so we position some hints carefully. *)
+Existing Instance is01cat_hom | 0.
+
 (** * Homomorphisms from a group to an abelian group form an abelian group. *)
 
 (** In this file, we use additive notation for the group operation, even though some of the groups we deal with are not assumed to be abelian. *)
@@ -40,7 +44,7 @@ Defined.
 (** ** Coequalizers *)
 
 (** Using the cokernel and addition and negation for the homs of abelian groups, we can define the coequalizer of two group homomorphisms as the cokernel of their difference. *)
-Definition ab_coeq {A B : AbGroup} (f g : GroupHomomorphism A B)
+Definition ab_coeq {A B : AbGroup} (f g : A $-> B)
   := ab_cokernel ((-f) + g).
 
 Definition ab_coeq_in {A B : AbGroup} {f g : A $-> B} : B $-> ab_coeq f g.
@@ -135,7 +139,7 @@ Proof.
 Defined.
 
 Definition functor_ab_coeq_id {A B : AbGroup} (f g : A $-> B)
-  : functor_ab_coeq (f:=f) (g:=g) (Id _) (Id _) (hrefl _) (hrefl _) $== Id _.
+  : functor_ab_coeq (Id _) (Id _) (hrefl f) (hrefl g) $== Id _.
 Proof.
   snapply ab_coeq_ind_homotopy.
   reflexivity.
@@ -148,13 +152,13 @@ Definition grp_iso_ab_coeq {A B : AbGroup} {f g : A $-> B}
 Proof.
   snapply cate_adjointify.
   - exact (functor_ab_coeq a b p q).
-  - exact (functor_ab_coeq a^-1$ b^-1$ (hinverse _ _ p) (hinverse _ _ q)).
+  - exact (functor_ab_coeq a^-1$ b^-1$ (hinverse a _ p) (hinverse a _ q)).
   - nrefine (functor_ab_coeq_compose _ _ _ _ _ _ _ _
       $@ functor2_ab_coeq _ _ _ _ _ $@ functor_ab_coeq_id _ _).
-    tapply cate_isretr.
+    exact (cate_isretr b).
   - nrefine (functor_ab_coeq_compose _ _ _ _ _ _ _ _
       $@ functor2_ab_coeq _ _ _ _ _ $@ functor_ab_coeq_id _ _).
-    tapply cate_issect.
+    exact (cate_issect b).
 Defined.
 
 (** ** The bifunctor [ab_hom] *)

--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -207,10 +207,8 @@ Proof.
 Defined.
 
 Instance is0bifunctor_ab_hom `{Funext}
-  : Is0Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup)
+  := Build_Is0Bifunctor'' _.
 
 Instance is1bifunctor_ab_hom `{Funext}
   : Is1Bifunctor (ab_hom : Group^op -> AbGroup -> AbGroup).

--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -2,10 +2,6 @@ Require Import Basics Types.
 Require Import WildCat HSet Truncations.Core Modalities.ReflectiveSubuniverse.
 Require Import Groups.Group Groups.QuotientGroup AbelianGroup Biproduct.
 
-(* If Hint A about groups appears before Hint B about Abelian groups appears in the typeclass database,
-   Coq may coerce an Abelian group to a group to apply A, so we position some hints carefully. *)
-Existing Instance is01cat_hom | 0.
-
 (** * Homomorphisms from a group to an abelian group form an abelian group. *)
 
 (** In this file, we use additive notation for the group operation, even though some of the groups we deal with are not assumed to be abelian. *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -145,14 +145,17 @@ Instance isgraph_abgroup : IsGraph AbGroup
 Instance is01cat_abgroup : Is01Cat AbGroup
   := is01cat_induced abgroup_group.
 
-Instance is01cat_grouphomomorphism {A B : AbGroup} : Is01Cat (A $-> B)
-  := is01cat_induced (@grp_homo_map A B).
-
-Instance is0gpd_grouphomomorphism {A B : AbGroup} : Is0Gpd (A $-> B)
-  := is0gpd_induced (@grp_homo_map A B).
-
 Instance is2graph_abgroup : Is2Graph AbGroup
   := is2graph_induced abgroup_group.
+
+Instance isgraph_abgrouphomomorphism {A B : AbGroup} : IsGraph (A $-> B)
+  := is2graph_induced abgroup_group A B.
+
+Instance is01cat_abgrouphomomorphism {A B : AbGroup} : Is01Cat (A $-> B)
+  := is01cat_induced (@grp_homo_map A B).
+
+Instance is0gpd_abgrouphomomorphism {A B : AbGroup} : Is0Gpd (A $-> B)
+  := is0gpd_induced (@grp_homo_map A B).
 
 (** [AbGroup] forms a 1Cat *)
 Instance is1cat_abgroup : Is1Cat AbGroup

--- a/theories/Algebra/AbGroups/TensorProduct.v
+++ b/theories/Algebra/AbGroups/TensorProduct.v
@@ -473,7 +473,7 @@ Proof.
 Defined. 
 
 (** [ab_tensor_swap] is natural in both arguments. This means that it also acts on tensor functors. *)
-Definition ab_tensor_swap_natural {A B A' B'} (f : A $-> A') (g : B $-> B')
+Definition ab_tensor_swap_natural {A B A' B' : AbGroup} (f : A $-> A') (g : B $-> B')
   : ab_tensor_swap $o functor_ab_tensor_prod f g
     $== functor_ab_tensor_prod g f $o ab_tensor_swap.
 Proof.
@@ -543,7 +543,7 @@ Proof.
 Defined.
 
 (** The twist map is natural in all 3 arguments. This means that the twist map acts on the triple tensor functor in the same way. *)
-Definition ab_tensor_prod_twist_natural {A B C A' B' C'}
+Definition ab_tensor_prod_twist_natural {A B C A' B' C' : AbGroup}
   (f : A $-> A') (g : B $-> B') (h : C $-> C')
   : ab_tensor_prod_twist $o fmap11 ab_tensor_prod f (fmap11 ab_tensor_prod g h)
     $== fmap11 ab_tensor_prod g (fmap11 ab_tensor_prod f h) $o ab_tensor_prod_twist.
@@ -686,7 +686,7 @@ Instance issymmmetricmonoidal_ab_tensor_prod
 (** The tensor product of abelian groups preserves coequalizers, meaning that the coequalizer of two tensored groups is the tensor of the coequalizer. We show this is the case on the left and the right. *)
 
 (** Tensor products preserve coequalizers on the right. *)
-Definition grp_iso_ab_tensor_prod_coeq_l A {B C} (f g : B $-> C)
+Definition grp_iso_ab_tensor_prod_coeq_l A {B C : AbGroup} (f g : B $-> C)
   : ab_coeq (fmap01 ab_tensor_prod A f) (fmap01 ab_tensor_prod A g)
     $<~> ab_tensor_prod A (ab_coeq f g).
 Proof.
@@ -720,7 +720,7 @@ Proof.
 Defined.
 
 (** The equivalence respects the natural maps from [ab_tensor_prod A C]. *)
-Definition ab_tensor_prod_coeq_l_triangle A {B C} (f g : B $-> C)
+Definition ab_tensor_prod_coeq_l_triangle A {B C : AbGroup} (f g : B $-> C)
   : grp_iso_ab_tensor_prod_coeq_l A f g $o ab_coeq_in
     $== fmap01 ab_tensor_prod A ab_coeq_in.
 Proof.
@@ -729,7 +729,7 @@ Proof.
 Defined.
 
 (** Tensor products preserve coequalizers on the left. *)
-Definition grp_iso_ab_tensor_prod_coeq_r {A B} (f g : A $-> B) C
+Definition grp_iso_ab_tensor_prod_coeq_r {A B : AbGroup} (f g : A $-> B) C
   : ab_coeq (fmap10 ab_tensor_prod f C) (fmap10 ab_tensor_prod g C)
     $<~> ab_tensor_prod (ab_coeq f g) C.
 Proof.
@@ -741,7 +741,7 @@ Proof.
 Defined.
 
 (** The equivalence respects the natural maps from [ab_tensor_prod B C]. *)
-Definition ab_tensor_prod_coeq_r_triangle {A B} (f g : A $-> B) C
+Definition ab_tensor_prod_coeq_r_triangle {A B : AbGroup} (f g : A $-> B) C
   : grp_iso_ab_tensor_prod_coeq_r f g C $o ab_coeq_in
     $== fmap10 ab_tensor_prod ab_coeq_in C.
 Proof.

--- a/theories/Algebra/AbSES/BaerSum.v
+++ b/theories/Algebra/AbSES/BaerSum.v
@@ -52,10 +52,8 @@ Proof.
 Defined.
 
 Instance is0bifunctor_abses' `{Univalence}
-  : Is0Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type).
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type)
+  := Build_Is0Bifunctor'' _.
 
 Instance is1bifunctor_abses' `{Univalence}
   : Is1Bifunctor (AbSES' : AbGroup^op -> AbGroup -> Type).
@@ -230,10 +228,8 @@ Proof.
 Defined.
 
 Instance is0bifunctor_abses `{Univalence}
-  : Is0Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType).
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType)
+  := Build_Is0Bifunctor'' _.
 
 Instance is1bifunctor_abses `{Univalence}
   : Is1Bifunctor (AbSES : AbGroup^op -> AbGroup -> pType).

--- a/theories/Algebra/AbSES/Ext.v
+++ b/theories/Algebra/AbSES/Ext.v
@@ -119,10 +119,8 @@ Proof.
 Defined.
 
 Instance is0bifunctor_abext `{Univalence}
-  : Is0Bifunctor (A:=AbGroup^op) ab_ext.
-Proof.
-  rapply Build_Is0Bifunctor''.
-Defined.
+  : Is0Bifunctor (A:=AbGroup^op) ab_ext
+  := Build_Is0Bifunctor'' _.
 
 Instance is1bifunctor_abext `{Univalence}
   : Is1Bifunctor (A:=AbGroup^op) ab_ext.

--- a/theories/Algebra/Categorical/MonoidObject.v
+++ b/theories/Algebra/Categorical/MonoidObject.v
@@ -205,7 +205,7 @@ Defined.
 Section MonoidEnriched.
   Context {A : Type} `{HasEquivs A} `{!HasBinaryProducts A}
     (I : A) `{!IsTerminal I} {x y : A}
-    `{!HasMorExt A} `{forall x y, IsHSet (x $-> y)}.
+    `{!HasMorExt A} `{forall x y : A, IsHSet (x $-> y)}.
   
   Section Monoid.
 

--- a/theories/Algebra/Universal/Homomorphism.v
+++ b/theories/Algebra/Universal/Homomorphism.v
@@ -120,7 +120,7 @@ Section homomorphism_compose.
 End homomorphism_compose.
 
 Instance is01cat_algebra (σ : Signature) : Is01Cat (Algebra σ)
-  := Build_Is01Cat (Algebra σ) _
+  := Build_Is01Cat _ _
       (fun _ => homomorphism_id) (fun _ _ _ => homomorphism_compose).
 
 Lemma assoc_homomorphism_compose `{Funext} {σ}

--- a/theories/WildCat/Coproducts.v
+++ b/theories/WildCat/Coproducts.v
@@ -156,7 +156,7 @@ Definition cat_inr {A : Type} `{Is1Cat A} {x y : A} `{!BinaryCoproduct x y}
 
 (** A category with binary coproducts is a category with a binary coproduct for each pair of objects. *)
 Class HasBinaryCoproducts (A : Type) `{Is1Cat A}
-  := binary_coproducts :: forall x y, BinaryCoproduct x y.
+  := binary_coproducts :: forall x y : A, BinaryCoproduct x y.
 
 Instance hasbinarycoproducts_hascoproductsbool {A : Type}
   `{HasCoproducts Bool A}

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -23,6 +23,7 @@ Class Is01Cat (A : Type) `{IsGraph A} :=
   cat_comp : forall (a b c : A), (b $-> c) -> (a $-> b) -> (a $-> c);
 }.
 
+Arguments Build_Is01Cat A &.
 Arguments cat_comp {A _ _ a b c} _ _.
 Notation "g $o f" := (cat_comp g f).
 

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -23,6 +23,7 @@ Class Is01Cat (A : Type) `{IsGraph A} :=
   cat_comp : forall (a b c : A), (b $-> c) -> (a $-> b) -> (a $-> c);
 }.
 
+(** The [&] symbol here is a "bidirectionality hint". It directs Rocq to typecheck the application of [Build_Is01Cat] to the argument [A] before computing the type of the full term and trying to unify it with the goal, and only afterwards to typecheck the remaining arguments; it will be easier for Rocq to elaborate and typecheck the later arguments [Id] and [cat_comp] if [A] is already known. *)
 Arguments Build_Is01Cat A &.
 Arguments cat_comp {A _ _ a b c} _ _.
 Notation "g $o f" := (cat_comp g f).

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -244,7 +244,7 @@ Definition mor_terminal_unique {A : Type} `{Is1Cat A} (x y : A) {h : IsTerminal 
 
 (** Generalizing function extensionality, "Morphism extensionality" states that homwise [GpdHom_path] is an equivalence. *)
 Class HasMorExt (A : Type) `{Is1Cat A} := {
-  isequiv_Htpy_path : forall a b f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
+  isequiv_Htpy_path : forall (a b : A) f g, IsEquiv (@GpdHom_path (a $-> b) _ _ _ f g)
 }.
 
 Existing Instance isequiv_Htpy_path.

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -30,7 +30,7 @@ Class DHasEquivs {A : Type} `{HasEquivs A}
     DGpdHom (cate_issect' _ _ f) (dcate_inv' f' $o' dcate_fun f') (DId a');
   dcate_isretr' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
     DGpdHom (cate_isretr' _ _ f) (dcate_fun f' $o' dcate_inv' f') (DId b');
-  dcatie_adjointify : forall {a b} {f : a $-> b} {g : b $-> a}
+  dcatie_adjointify : forall {a b : A} {f : a $-> b} {g : b $-> a}
     {r : f $o g $== Id b} {s : g $o f $== Id a} {a'} {b'} (f' : DHom f a' b')
     (g' : DHom g b' a') (r' : DGpdHom r (f' $o' g') (DId b'))
     (s' : DGpdHom s (g' $o' f') (DId a')),

--- a/theories/WildCat/DisplayedEquiv.v
+++ b/theories/WildCat/DisplayedEquiv.v
@@ -10,25 +10,25 @@ Require Import WildCat.Equiv.
 Class DHasEquivs {A : Type} `{HasEquivs A}
   (D : A -> Type) `{!IsDGraph D, !IsD2Graph D, !IsD01Cat D, !IsD1Cat D} :=
 {
-  DCatEquiv : forall {a b}, (a $<~> b) -> D a -> D b -> Type;
-  DCatIsEquiv : forall {a b} {f : a $-> b} {fe : CatIsEquiv f} {a'} {b'},
+  DCatEquiv : forall {a b : A}, (a $<~> b) -> D a -> D b -> Type;
+  DCatIsEquiv : forall {a b : A} {f : a $-> b} {fe : CatIsEquiv f} {a'} {b'},
     DHom f a' b' -> Type;
-  dcate_fun : forall {a b} {f : a $<~> b} {a'} {b'},
+  dcate_fun : forall {a b : A} {f : a $<~> b} {a'} {b'},
     DCatEquiv f a' b' -> DHom f a' b';
-  dcate_isequiv : forall {a b} {f : a $<~> b} {a'} {b'}
+  dcate_isequiv : forall {a b : A} {f : a $<~> b} {a'} {b'}
     (f' : DCatEquiv f a' b'), DCatIsEquiv (dcate_fun f');
-  dcate_buildequiv : forall {a b} {f : a $-> b} `{!CatIsEquiv f} {a'} {b'}
+  dcate_buildequiv : forall {a b : A} {f : a $-> b} `{!CatIsEquiv f} {a'} {b'}
     (f' : DHom f a' b') {fe' : DCatIsEquiv f'},
     DCatEquiv (Build_CatEquiv f) a' b';
-  dcate_buildequiv_fun : forall {a b} {f : a $-> b} `{!CatIsEquiv f}
+  dcate_buildequiv_fun : forall {a b : A} {f : a $-> b} `{!CatIsEquiv f}
     {a'} {b'} (f' : DHom f a' b') {fe' : DCatIsEquiv f'},
     DGpdHom (cate_buildequiv_fun f)
     (dcate_fun (dcate_buildequiv f' (fe':=fe'))) f';
-  dcate_inv' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
+  dcate_inv' : forall {a b : A} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
     DHom (cate_inv' _ _ f) b' a';
-  dcate_issect' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
+  dcate_issect' : forall {a b : A} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
     DGpdHom (cate_issect' _ _ f) (dcate_inv' f' $o' dcate_fun f') (DId a');
-  dcate_isretr' : forall {a b} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
+  dcate_isretr' : forall {a b : A} {f : a $<~> b} {a'} {b'} (f' : DCatEquiv f a' b'),
     DGpdHom (cate_isretr' _ _ f) (dcate_fun f' $o' dcate_inv' f') (DId b');
   dcatie_adjointify : forall {a b : A} {f : a $-> b} {g : b $-> a}
     {r : f $o g $== Id b} {s : g $o f $== Id a} {a'} {b'} (f' : DHom f a' b')

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -106,7 +106,7 @@ Instance isequiv_op {A : Type} `{HasEquivs A}
   : @CatIsEquiv A^op _ _ _ _ _ b a f
   := ief.
 
-Definition cate_issect {A} `{HasEquivs A} {a b} (f : a $<~> b)
+Definition cate_issect {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
   : f^-1$ $o f $== Id a.
 Proof.
   refine (_ $@ cate_issect' a b f).
@@ -114,12 +114,12 @@ Proof.
   apply cate_buildequiv_fun'.
 Defined.
 
-Definition cate_isretr {A} `{HasEquivs A} {a b} (f : a $<~> b)
+Definition cate_isretr {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
   : f $o f^-1$ $== Id b
   := cate_issect (A:=A^op) (b:=a) (a:=b) f.
 
 (** If [g] is a section of an equivalence, then it is the inverse. *)
-Definition cate_inverse_sect {A} `{HasEquivs A} {a b} (f : a $<~> b)
+Definition cate_inverse_sect {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
   (g : b $-> a) (p : f $o g $== Id b)
   : cate_fun f^-1$ $== g.
 Proof.
@@ -131,7 +131,7 @@ Proof.
 Defined.
 
 (** If [g] is a retraction of an equivalence, then it is the inverse. *)
-Definition cate_inverse_retr {A} `{HasEquivs A} {a b} (f : a $<~> b)
+Definition cate_inverse_retr {A} `{HasEquivs A} {a b : A} (f : a $<~> b)
   (g : b $-> a) (p : g $o f $== Id a)
   : cate_fun f^-1$ $== g
   := cate_inverse_sect (A:=A^op) (a:=b) (b:=a) f g p.
@@ -620,7 +620,7 @@ Proof.
 Defined.
 
 Instance hasmorext_core {A : Type} `{HasEquivs A, !HasMorExt A}
-  `{forall x y (f g : uncore x $<~> uncore y), IsEquiv (ap (x := f) (y := g) cate_fun)}
+  `{forall (x y : core A) (f g : uncore x $<~> uncore y), IsEquiv (ap (x := f) (y := g) cate_fun)}
   : HasMorExt (core A).
 Proof.
   snapply Build_HasMorExt.

--- a/theories/WildCat/FunctorCat.v
+++ b/theories/WildCat/FunctorCat.v
@@ -179,7 +179,8 @@ Instance is0functor_fun01_postcomp {A B C}
 Proof.
   apply Build_Is0Functor.
   intros a b f.
-  rapply nattrans_postwhisker.
+  napply nattrans_postwhisker.
+  1: exact _.
   exact f.
 Defined.
 

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -255,7 +255,7 @@ Section SymmetricBraid.
     : F a b $<~> F b a
     := Build_CatEquiv (braid a b).
 
-  Definition moveL_braidL a b c f (g : c $-> _)
+  Definition moveL_braidL (a b c : A) f (g : c $-> _)
     : braid a b $o f $== g -> f $== braid b a $o g.
   Proof.
     intros p.
@@ -266,7 +266,7 @@ Section SymmetricBraid.
     apply braid_braid.
   Defined.
 
-  Definition moveL_braidR a b c f (g : _ $-> c)
+  Definition moveL_braidR (a b c : A) f (g : _ $-> c)
     : f $o braid a b $== g -> f $== g $o braid b a.
   Proof.
     intros p.
@@ -279,13 +279,13 @@ Section SymmetricBraid.
     exact p.
   Defined.
 
-  Definition moveR_braidL a b c f (g : c $-> _)
+  Definition moveR_braidL (a b c : A) f (g : c $-> _)
     : f $== braid b a $o g -> braid a b $o f $== g.
   Proof.
     intros p; symmetry; apply moveL_braidL; symmetry; exact p.
   Defined.
 
-  Definition moveR_braidR a b c f (g : _ $-> c)
+  Definition moveR_braidR (a b c : A) f (g : _ $-> c)
     : f $== g $o braid b a -> f $o braid a b $== g.
   Proof.
     intros p; symmetry; apply moveL_braidR; symmetry; exact p.

--- a/theories/WildCat/Monoidal.v
+++ b/theories/WildCat/Monoidal.v
@@ -255,7 +255,7 @@ Section SymmetricBraid.
     : F a b $<~> F b a
     := Build_CatEquiv (braid a b).
 
-  Definition moveL_braidL (a b c : A) f (g : c $-> _)
+  Definition moveL_braidL {a b c : A} f (g : c $-> _)
     : braid a b $o f $== g -> f $== braid b a $o g.
   Proof.
     intros p.
@@ -266,7 +266,7 @@ Section SymmetricBraid.
     apply braid_braid.
   Defined.
 
-  Definition moveL_braidR (a b c : A) f (g : _ $-> c)
+  Definition moveL_braidR {a b c : A} f (g : _ $-> c)
     : f $o braid a b $== g -> f $== g $o braid b a.
   Proof.
     intros p.
@@ -279,19 +279,19 @@ Section SymmetricBraid.
     exact p.
   Defined.
 
-  Definition moveR_braidL (a b c : A) f (g : c $-> _)
+  Definition moveR_braidL {a b c : A} f (g : c $-> _)
     : f $== braid b a $o g -> braid a b $o f $== g.
   Proof.
     intros p; symmetry; apply moveL_braidL; symmetry; exact p.
   Defined.
 
-  Definition moveR_braidR (a b c : A) f (g : _ $-> c)
+  Definition moveR_braidR {a b c : A} f (g : _ $-> c)
     : f $== g $o braid b a -> f $o braid a b $== g.
   Proof.
     intros p; symmetry; apply moveL_braidR; symmetry; exact p.
   Defined.
 
-  Definition moveL_fmap01_braidL a b c d f (g : d $-> _)
+  Definition moveL_fmap01_braidL {a b c d : A} f (g : d $-> _)
     : fmap01 F a (braid b c) $o f $== g
       -> f $== fmap01 F a (braid c b) $o g.
   Proof.
@@ -310,7 +310,7 @@ Section SymmetricBraid.
     apply cate_buildequiv_fun.
   Defined.
 
-  Definition moveL_fmap01_braidR a b c d f (g : _ $-> d)
+  Definition moveL_fmap01_braidR {a b c d : A} f (g : _ $-> d)
     :  f $o fmap01 F a (braid b c) $== g
       -> f $== g $o fmap01 F a (braid c b).
   Proof.
@@ -329,21 +329,21 @@ Section SymmetricBraid.
     apply cate_buildequiv_fun.
   Defined.
 
-  Definition moveR_fmap01_braidL a b c d f (g : d $-> _)
+  Definition moveR_fmap01_braidL {a b c d : A} f (g : d $-> _)
     : f $== fmap01 F a (braid c b) $o g
       -> fmap01 F a (braid b c) $o f $== g.
   Proof.
     intros p; symmetry; apply moveL_fmap01_braidL; symmetry; exact p.
   Defined.
 
-  Definition moveR_fmap01_braidR a b c d f (g : _ $-> d)
+  Definition moveR_fmap01_braidR {a b c d : A} f (g : _ $-> d)
     : f $== g $o fmap01 F a (braid c b)
       -> f $o fmap01 F a (braid b c) $== g.
   Proof.
     intros p; symmetry; apply moveL_fmap01_braidR; symmetry; exact p.
   Defined.
 
-  Definition moveL_fmap01_fmap01_braidL a b c d e f (g : e $-> _)
+  Definition moveL_fmap01_fmap01_braidL {a b c d e : A} f (g : e $-> _)
     : fmap01 F a (fmap01 F b (braid c d)) $o f $== g
       -> f $== fmap01 F a (fmap01 F b (braid d c)) $o g.
   Proof.
@@ -366,7 +366,7 @@ Section SymmetricBraid.
     apply cate_buildequiv_fun.
   Defined.
 
-  Definition moveL_fmap01_fmap01_braidR a b c d e f (g : _ $-> e)
+  Definition moveL_fmap01_fmap01_braidR {a b c d e : A} f (g : _ $-> e)
     : f $o fmap01 F a (fmap01 F b (braid c d)) $== g
       -> f $== g $o fmap01 F a (fmap01 F b (braid d c)).
   Proof.
@@ -389,14 +389,14 @@ Section SymmetricBraid.
     apply cate_buildequiv_fun.
   Defined.
 
-  Definition moveR_fmap01_fmap01_braidL a b c d e f (g : e $-> _)
+  Definition moveR_fmap01_fmap01_braidL {a b c d e : A} f (g : e $-> _)
     : f $== fmap01 F a (fmap01 F b (braid d c)) $o g
       -> fmap01 F a (fmap01 F b (braid c d)) $o f $== g.
   Proof.
     intros p; symmetry; apply moveL_fmap01_fmap01_braidL; symmetry; exact p.
   Defined.
 
-  Definition moveR_fmap01_fmap01_braidR a b c d e f (g : _ $-> e)
+  Definition moveR_fmap01_fmap01_braidR {a b c d e : A} f (g : _ $-> e)
     : f $== g $o fmap01 F a (fmap01 F b (braid d c))
       -> f $o fmap01 F a (fmap01 F b (braid c d)) $== g.
   Proof.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -28,7 +28,7 @@ Instance is01cat_paths (A : Type) : Is01Cat A
 
 (** Any type has a 0-groupoid structure with inverse morphisms given by path inversion. *)
 Instance is0gpd_paths (A : Type) : Is0Gpd A
-  := {| gpd_rev := @inverse _ |}.
+  := { gpd_rev := @inverse _ }.
 
 (** Postcomposition is a 0-functor when the 2-cells are paths. *)
 Instance is0functor_cat_postcomp_paths (A : Type) `{Is01Cat A}

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -58,17 +58,13 @@ Existing Instance is1natural_cat_idr.
 
 Definition cat_postwhisker_pp {A} `{Is21Cat A} {a b c : A}
   {f g h : a $-> b} (k : b $-> c) (p : f $== g) (q : g $== h)
-  : k $@L (p $@ q) $== (k $@L p) $@ (k $@L q).
-Proof.
-  rapply fmap_comp.
-Defined.
+  : k $@L (p $@ q) $== (k $@L p) $@ (k $@L q)
+  := fmap_comp _ _ _.
 
 Definition cat_prewhisker_pp {A} `{Is21Cat A} {a b c : A}
   {f g h : b $-> c} (k : a $-> b) (p : f $== g) (q : g $== h)
-  : (p $@ q) $@R k $== (p $@R k) $@ (q $@R k).
-Proof.
-  rapply fmap_comp.
-Defined.
+  : (p $@ q) $@R k $== (p $@R k) $@ (q $@R k)
+  := fmap_comp _ _ _.
 
 (** *** Exchange law *)
 


### PR DESCRIPTION
This collects a few changes from the `Hint Mode` rewrite which I deemed sufficiently unobtrusive that I think they are worth submitting again in a separate PR.

Each of these changes is motivated by identifying breakages in the code due to the `Hint Mode +` changes in the WildCat library, I have previously argued that this elaboration behavior is not robust, so my motivation for this PR is that I think these fix potential future bugs due to refactoring (e.g., the current PR I have outstanding to refactor (2,1)-cats so that they depend on the definition of a bicategory)

Some of the changes are clear improvements to the existing code as well and are unlikely to be controversial.

I believe the only change in this PR which could affect downstream users is that I defined one or two new typeclass instances in AbelianGroups.v. There is also what I would call a "naming bug" in this file where some things are called "group" where they should be called "abgroup"

@jdchristensen I tried using Magit this time to organize the changes. :smile: 