### PR TITLE
Make A and B implicit arguments in Build_{pMap,pEquiv,pEquiv'}; add/adjust bidirectionality hint &

### DIFF
--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -378,7 +378,7 @@ Definition pmap_abses_const {B' A' B A : AbGroup@{u}} : AbSES B A -->* AbSES B' 
 
 Definition to_pointed `{Univalence} {B' A' B A : AbGroup@{u}}
   : (AbSES B A -->* AbSES B' A') -> (AbSES B A ->* AbSES B' A')
-  := fun f => Build_pMap _ _ f (equiv_path_abses_iso (bp_pointed f)).
+  := fun f => Build_pMap f (equiv_path_abses_iso (bp_pointed f)).
 
 Lemma pmap_abses_const_to_pointed `{Univalence} {B' A' B A : AbGroup@{u}}
   : pconst ==* to_pointed (@pmap_abses_const B' A' B A).

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -254,7 +254,7 @@ Instance ismonoidpreserving_grp_homo {G H : Group}
 
 (** Group homomorphisms are pointed maps. *)
 Definition pmap_GroupHomomorphism {G H : Group} (f : GroupHomomorphism G H) : G ->* H
-  := Build_pMap G H f (isunitpreserving_grp_homo f).
+  := Build_pMap f (isunitpreserving_grp_homo f).
 Coercion pmap_GroupHomomorphism : GroupHomomorphism >-> pForall.
 
 Definition issig_GroupHomomorphism (G H : Group) : _ <~> GroupHomomorphism G H
@@ -336,7 +336,7 @@ Coercion equiv_groupisomorphism : GroupIsomorphism >-> Equiv.
 (** The underlying pointed equivalence of a group isomorphism. *)
 Definition pequiv_groupisomorphism {A B : Group}
   : GroupIsomorphism A B -> (A <~>* B)
-  := fun f => Build_pEquiv _ _ f _.
+  := fun f => Build_pEquiv f _.
 Coercion pequiv_groupisomorphism : GroupIsomorphism >-> pEquiv.
 
 (** Funext for group isomorphisms. *)

--- a/theories/Algebra/ooGroup.v
+++ b/theories/Algebra/ooGroup.v
@@ -76,7 +76,7 @@ Definition group_loops_functor
            {X Y : pType} (f : X ->* Y)
 : ooGroupHom (group_loops X) (group_loops Y).
 Proof.
-  simple refine (Build_pMap _ _ _ _); simpl.
+  snapply Build_pMap; simpl.
   - intros [x p].
     exists (f x).
     strip_truncations; apply tr.

--- a/theories/Homotopy/ClassifyingSpace.v
+++ b/theories/Homotopy/ClassifyingSpace.v
@@ -201,7 +201,7 @@ Definition pClassifyingSpace_rec {G : Group} (P : pType) `{IsTrunc 1 P}
            (bloop' : G -> loops P)
            (bloop_pp' : forall x y : G, bloop' (x * y) = bloop' x @ bloop' y)
   : B G ->* P
-  := Build_pMap (B G) P (ClassifyingSpace_rec P (point P) bloop' bloop_pp') idpath.
+  := Build_pMap (ClassifyingSpace_rec P (point P) bloop' bloop_pp') idpath.
 
 (** And this is one of the standard facts about adjoint functors: [(R h') o eta = h], where [h : G -> R P], [h' : L G -> P] is the adjunct, and eta ([bloop]) is the unit. *)
 Definition pClassifyingSpace_rec_beta_bloop {G : Group} (P : pType)
@@ -287,7 +287,7 @@ Section EncodeDecode.
 
   (** Pointed version of the defining property. *)
   Definition pequiv_g_loops_bg : G <~>* loops (B G)
-    := Build_pEquiv _ _ pbloop _.
+    := Build_pEquiv pbloop _.
 
   Definition pequiv_loops_bg_g := pequiv_g_loops_bg^-1*%equiv.
 
@@ -562,7 +562,7 @@ Proof.
     intros x y.
     strip_truncations.
     reflexivity. }
-  snapply (Build_pEquiv _ _ f).
+  snapply (Build_pEquiv f).
   (** [f] is an equivalence since [loops_functor f o bloop == tr^-1], and the other two maps are equivalences. *)
   apply isequiv_is0connected_isequiv_loops.
   snapply (cancelR_isequiv bloop).

--- a/theories/Homotopy/Cover.v
+++ b/theories/Homotopy/Cover.v
@@ -55,7 +55,7 @@ Definition pfunctor_O_pcover `{O : ReflectiveSubuniverse} {X Y : pType}
 
 Definition pequiv_pfunctor_O_pcover `{O : ReflectiveSubuniverse} {X Y : pType}
   (f : X ->* Y) `{IsEquiv _ _ f} : O_pcover O X pt <~>* O_pcover O Y pt
-  := Build_pEquiv _ _ (pfunctor_O_pcover f) _.
+  := Build_pEquiv (pfunctor_O_pcover f) _.
 
 (** In the case of truncations, [ptr_natural] gives a better proof of pointedness. *)
 Definition pfunctor_pTr_pcover `{n : trunc_index} {X Y : pType}
@@ -65,7 +65,7 @@ Definition pfunctor_pTr_pcover `{n : trunc_index} {X Y : pType}
 Definition pequiv_pfunctor_pTr_pcover `{n : trunc_index}
   {X Y : pType} (f : X ->* Y) `{IsEquiv _ _ f}
   : O_pcover (Tr n) X pt <~>* O_pcover (Tr n) Y pt
-  := Build_pEquiv _ _ (pfunctor_pTr_pcover f) _.
+  := Build_pEquiv (pfunctor_pTr_pcover f) _.
 
 
 (** * Components *)

--- a/theories/Homotopy/EvaluationFibration.v
+++ b/theories/Homotopy/EvaluationFibration.v
@@ -10,7 +10,7 @@ Definition selfmaps (A : Type) : pType := [A -> A, idmap].
 
 (** The unrestricted evaluation map. *)
 Definition ev (A : pType) : selfmaps A ->* A
-  := Build_pMap _ _ (fun f : selfmaps A => f pt) idpath.
+  := Build_pMap (fun f : selfmaps A => f pt) idpath.
 
 (** The evaluation fibration of an unpointed map [X -> A]. *)
 Definition evfib {X : pType} {A : Type} (f : X -> A) : comp (X -> A) (tr f) -> A
@@ -18,7 +18,7 @@ Definition evfib {X : pType} {A : Type} (f : X -> A) : comp (X -> A) (tr f) -> A
 
 (** If [f] is pointed, then the evaluation fibration of [f] is too. *)
 Definition pevfib {A X : pType} (f : X ->* A) : pcomp (X -> A) f ->* A
-  := Build_pMap _ _ (fun g : pcomp (X -> A) f => g.1 pt) (point_eq f).
+  := Build_pMap (fun g : pcomp (X -> A) f => g.1 pt) (point_eq f).
 
 (* The evaluation map of the identity. *)
 Definition ev1 (A : pType) := pevfib (A:=A) pmap_idmap.

--- a/theories/Homotopy/ExactSequence.v
+++ b/theories/Homotopy/ExactSequence.v
@@ -293,7 +293,7 @@ Defined.
 Definition equiv_cxfib {O : Modality} {F X Y : pType} {i : F ->* X} {f : X ->* Y}
   `{forall y y' : Y, In O (y = y')} `{MapIn O _ _ i} (ex : IsExact O i f)
   : F <~>* pfiber f
-  := Build_pEquiv _ _ _ (isequiv_cxfib ex).
+  := Build_pEquiv _ (isequiv_cxfib ex).
 
 Proposition equiv_cxfib_beta {F X Y : pType} {i : F ->* X} {f : X ->* Y}
   `{forall y y' : Y, In O (y = y')} `{MapIn O _ _ i} (ex : IsExact O i f)
@@ -359,7 +359,7 @@ Defined.
 Definition pequiv_cxfib {F X Y : pType} {i : F ->* X} {f : X ->* Y}
   `{IsExact purely F X Y i f}
   : F <~>* pfiber f
-  := Build_pEquiv _ _ (cxfib cx_isexact) _.
+  := Build_pEquiv (cxfib cx_isexact) _.
 
 Definition fiberseq_isexact_purely {F X Y : pType} (i : F ->* X) (f : X ->* Y)
   `{IsExact purely F X Y i f} : FiberSeq F X Y

--- a/theories/Homotopy/HSpace/Core.v
+++ b/theories/Homotopy/HSpace/Core.v
@@ -52,12 +52,12 @@ Definition equiv_hspace_right_op {X : pType} `{IsHSpace X}
 
 (** Any element of an H-space defines a pointed self-map by left multiplication, in the following sense. *)
 Definition pmap_hspace_left_op {X : pType} `{IsHSpace X} (x : X)
-  : X ->* [X, x] := Build_pMap X [X,x] (x *.) (right_identity x).
+  : X ->* [X, x] := Build_pMap (x *.) (right_identity x).
 
 (** We make [(x *.)] into a pointed equivalence (when possible). In particular, this makes [(pt *.)] into a pointed self-equivalence. We could have also used the left identity to make [(pt *.)] into a pointed self-equivalence, and then we would get a map that's equal to the identity as a pointed map; but without coherence (see Coherent.v) this is not necessarily the case for this map. *)
 Definition pequiv_hspace_left_op {X : pType} `{IsHSpace X}
   (x : X) `{IsEquiv _ _ (x *.)} : X <~>* [X,x]
-  := Build_pEquiv' (B:=[X,x]) (equiv_hspace_left_op x) (right_identity x).
+  := Build_pEquiv' (equiv_hspace_left_op x) (right_identity x).
 
 (** ** Connected H-spaces *)
 

--- a/theories/Homotopy/HomotopyGroup.v
+++ b/theories/Homotopy/HomotopyGroup.v
@@ -295,7 +295,7 @@ Defined.
 Definition pequiv_pi_connmap `{Univalence} (n : nat) {X Y : pType} (f : X ->* Y)
   `{!IsConnMap n f}
   : Pi n X <~>* Pi n Y
-  := Build_pEquiv _ _ (fmap (pPi n) f) _.
+  := Build_pEquiv (fmap (pPi n) f) _.
 
 (** For positive [n], it is a group isomorphism. *)
 Definition grp_iso_pi_connmap `{Univalence} (n : nat) {X Y : pType} (f : X ->* Y)
@@ -310,7 +310,7 @@ Definition isequiv_pi_Tr `{Univalence} (n : nat) (X : pType)
 
 Definition pequiv_pi_Tr `{Univalence} (n : nat) (X : pType)
   : Pi n X <~>* Pi n (pTr n X)
-  := Build_pEquiv _ _ (fmap (pPi n) ptr) _.
+  := Build_pEquiv (fmap (pPi n) ptr) _.
 
 (** For positive [n], it is a group isomorphism. *)
 Definition grp_iso_pi_Tr `{Univalence} (n : nat) (X : pType)

--- a/theories/Homotopy/Smash.v
+++ b/theories/Homotopy/Smash.v
@@ -373,7 +373,7 @@ Defined.
 (** ** Symmetry of the smash product *)
 
 Definition pswap (X Y : pType) : Smash X Y $-> Smash Y X
-  := Build_pMap _ _ (Smash_rec (flip sm) auxr auxl gluer gluel) 1.
+  := Build_pMap (Smash_rec (flip sm) auxr auxl gluer gluel) 1.
 
 Definition pswap_pswap {X Y : pType}
   : pswap X Y $o pswap Y X $== pmap_idmap.

--- a/theories/Homotopy/Wedge.v
+++ b/theories/Homotopy/Wedge.v
@@ -19,10 +19,10 @@ Definition wglue {X Y : pType}
   : pushl (point X) = (pushr (point Y)) :> (X \/ Y) := pglue tt.
 
 Definition wedge_inl {X Y : pType} : X ->* X \/ Y
-  := Build_pMap _ _ pushl 1.
+  := Build_pMap pushl 1.
 
 Definition wedge_inr {X Y : pType} : Y ->* X \/ Y
-  := Build_pMap _ _ pushr wglue^.
+  := Build_pMap pushr wglue^.
 
 (** Wedge recursion into an unpointed type. *)
 Definition wedge_rec' {X Y : pType} {Z : Type}
@@ -32,7 +32,7 @@ Definition wedge_rec' {X Y : pType} {Z : Type}
 
 Definition wedge_rec {X Y : pType} {Z : pType} (f : X ->* Z) (g : Y ->* Z)
   : X \/ Y ->* Z
-  := Build_pMap _ _ (wedge_rec' f g (point_eq f @ (point_eq g)^)) (point_eq f).
+  := Build_pMap (wedge_rec' f g (point_eq f @ (point_eq g)^)) (point_eq f).
 
 Definition wedge_rec_beta_wglue {X Y Z : pType} (f : X ->* Z) (g : Y ->* Z)
   : ap (wedge_rec f g) wglue = point_eq f @ (point_eq g)^
@@ -215,12 +215,12 @@ Defined.
 
 Definition fwedge_in' (I : Type) (X : I -> pType)
   : forall i, X i ->* FamilyWedge I X
-  := fun i => Build_pMap _ _ (fun x => pushl (i; x)) (pglue i).
+  := fun i => Build_pMap (fun x => pushl (i; x)) (pglue i).
 
 (** We have an inclusion map [pushl : sig X -> FamilyWedge X].  When [I] is pointed, so is [sig X], and then this inclusion map is pointed. *)
 Definition fwedge_in (I : pType) (X : I -> pType)
   : psigma (pointed_fam X) ->* FamilyWedge I X
-  := Build_pMap _ _ pushl (pglue pt).
+  := Build_pMap pushl (pglue pt).
 
 (** Recursion principle for the wedge of an indexed family of pointed types. *)
 Definition fwedge_rec (I : Type) (X : I -> pType) (Z : pType)
@@ -308,7 +308,7 @@ Note that this is only a conceptual picture as we aren't working with "reduced s
 (** The pinch map for a suspension. *)
 Definition psusp_pinch (X : pType) : psusp X ->* psusp X \/ psusp X.
 Proof.
-  refine (Build_pMap _ _ (Susp_rec pt pt _) idpath).
+  refine (Build_pMap (Susp_rec pt pt _) idpath).
   intros x.
   refine (ap wedge_inl _ @ wglue @ ap wedge_inr _ @ wglue^).
   1,2: exact (loop_susp_unit X x).

--- a/theories/Pointed/Loops.v
+++ b/theories/Pointed/Loops.v
@@ -47,8 +47,7 @@ Instance is0functor_loops : Is0Functor loops.
 Proof.
   apply Build_Is0Functor.
   intros A B f.
-  refine (Build_pMap (loops A) (loops B)
-            (fun p => (point_eq f)^ @ (ap f p @ point_eq f)) _).
+  refine (Build_pMap (fun p => (point_eq f)^ @ (ap f p @ point_eq f)) _).
   refine (_ @ concat_Vp (point_eq f)).
   apply whiskerL. apply concat_1p.
 Defined.
@@ -180,8 +179,8 @@ Definition equiv_loops_image `{Univalence} n {A B : pType} (f : A ->* B)
   <~> image n (fmap loops f).
 Proof.
   set (C := [image n.+1 f, factor1 (image n.+1 f) (point A)]).
-  pose (g := Build_pMap A C (factor1 (image n.+1 f)) 1).
-  pose (h := Build_pMap C B (factor2 (image n.+1 f)) (point_eq f)).
+  pose (g := @Build_pMap A C (factor1 (image n.+1 f)) 1).
+  pose (h := @Build_pMap C B (factor2 (image n.+1 f)) (point_eq f)).
   transparent assert (I : (Factorization
     (@IsConnMap n) (@MapIn n) (fmap loops f))).
   { refine (@Build_Factorization (@IsConnMap n) (@MapIn n)
@@ -199,7 +198,7 @@ Defined.
 Definition loops_inv (A : pType) : loops A <~>* loops A.
 Proof.
   srapply Build_pEquiv.
-  1: exact (Build_pMap (loops A) (loops A) inverse 1).
+  1: exact (Build_pMap inverse 1).
   apply isequiv_path_inverse.
 Defined.
 

--- a/theories/Pointed/pEquiv.v
+++ b/theories/Pointed/pEquiv.v
@@ -36,19 +36,20 @@ Notation "g o*E f" := (pequiv_compose f g) : pointed_scope.
 (* Sometimes we wish to construct a pEquiv from an equiv and a proof that it is pointed. *)
 Definition Build_pEquiv' {A B : pType} (f : A <~> B)
   (p : f (point A) = point B)
-  : A <~>* B := Build_pEquiv _ _ (Build_pMap _ _ f p) _.
+  : A <~>* B := Build_pEquiv (Build_pMap f p) _.
 
-Arguments Build_pEquiv' & _ _ _ _.
+(** The [&] is a bidirectionality hint that tells Coq to unify with the typing context after type checking the arguments to the left.  In practice, this allows Coq to infer [A] and [B] from the context. *)
+Arguments Build_pEquiv' {A B} & f p.
 
 (* A version of equiv_adjointify for pointed equivalences where all data is pointed. There is a lot of unnecessary data here but sometimes it is easier to prove equivalences using this. *)
 Definition pequiv_adjointify {A B : pType} (f : A ->* B) (f' : B ->* A)
   (r : f o* f' ==* pmap_idmap) (s : f' o* f == pmap_idmap) : A <~>* B
-  := (Build_pEquiv _ _ f (isequiv_adjointify f f' r s)).
+  := (Build_pEquiv f (isequiv_adjointify f f' r s)).
 
 (* In some situations you want the back and forth maps to be pointed but not the sections. *)
 Definition pequiv_adjointify' {A B : pType} (f : A ->* B) (f' : B ->* A)
   (r : f o f' == idmap) (s : f' o f == idmap) : A <~>* B
-  := (Build_pEquiv _ _ f (isequiv_adjointify f f' r s)).
+  := (Build_pEquiv f (isequiv_adjointify f f' r s)).
 
 (** Pointed versions of [moveR_equiv_M] and friends. *)
 Definition moveR_pequiv_Mf {A B C} (f : B <~>* C) (g : A ->* B) (h : A ->* C)

--- a/theories/Pointed/pFiber.v
+++ b/theories/Pointed/pFiber.v
@@ -14,7 +14,7 @@ Instance ispointed_fiber {A B : pType} (f : A ->* B) : IsPointed (hfiber f (poin
 Definition pfiber {A B : pType} (f : A ->* B) : pType := [hfiber f (point B), _].
 
 Definition pfib {A B : pType} (f : A ->* B) : pfiber f ->* A
-  := Build_pMap (pfiber f) A pr1 1.
+  := Build_pMap pr1 1.
 
 (** The double fiber object is equivalent to loops on the base. *)
 Definition pfiber2_loops {A B : pType} (f : A ->* B)
@@ -81,7 +81,7 @@ Definition pequiv_pfiber {A B C D}
            {f : A ->* B} {g : C ->* D} (h : A <~>* C) (k : B <~>* D)
            (p : k o* f ==* g o* h)
   : pfiber f $<~> pfiber g
-  := Build_pEquiv _ _ (functor_pfiber p) _.
+  := Build_pEquiv (functor_pfiber p) _.
 
 Definition square_functor_pfiber {A B C D}
            {f : A ->* B} {g : C ->* D} {h : A ->* C} {k : B ->* D}

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -8,12 +8,12 @@ Local Open Scope pointed_scope.
 (** Not infrequently we have a map between two unpointed types and want to consider it as a pointed map that trivially respects some given point in the domain. *)
 Definition pmap_from_point {A B : Type} (f : A -> B) (a : A)
   : [A, a] ->* [B, f a]
-  := Build_pMap [A, a] [B, f a] f 1%path.
+  := Build_pMap f 1%path.
 
 (** A variant of [pmap_from_point] where the domain is pointed, but the codomain is not. *)
 Definition pmap_from_pointed {A : pType} {B : Type} (f : A -> B)
   : A ->* [B, f (point A)]
-  := Build_pMap A [B, f (point A)] f 1%path.
+  := Build_pMap f 1%path.
 
 (** The same, for a dependent pointed map. *)
 Definition pforall_from_pointed {A : pType} {B : A -> Type} (f : forall x, B x)

--- a/theories/Pointed/pModality.v
+++ b/theories/Pointed/pModality.v
@@ -11,16 +11,16 @@ Local Open Scope pointed_scope.
 
 Definition pto (O : ReflectiveSubuniverse@{u}) (X : pType@{u})
   : X ->* [O X, _]
-  := Build_pMap X [O X, _] (to O X) idpath.
+  := Build_pMap (to O X) idpath.
 
 (** If [A] is already [O]-local, then Coq knows that [pto] is an equivalence, so we can simply define: *)
 Definition pequiv_pto `{O : ReflectiveSubuniverse} {X : pType} `{In O X}
-  : X <~>* [O X, _] := Build_pEquiv _ _ (pto O X) _.
+  : X <~>* [O X, _] := Build_pEquiv (pto O X) _.
 
 (** Applying [O_rec] to a pointed map yields a pointed map. *)
 Definition pO_rec `{O : ReflectiveSubuniverse} {X Y : pType}
   `{In O Y} (f : X ->* Y) : [O X, _] ->* Y
-  := Build_pMap [O X, _] _ (O_rec f) (O_rec_beta _ _ @ point_eq f).
+  := Build_pMap (O_rec f) (O_rec_beta _ _ @ point_eq f).
 
 Definition pO_rec_beta `{O : ReflectiveSubuniverse} {X Y : pType}
   `{In O Y} (f : X ->* Y)
@@ -40,7 +40,7 @@ Definition pequiv_o_pto_O `{Funext}
 Proof.
   snapply Build_pEquiv.
   (* We could just use the map [e] defined in the next bullet, but we want Coq to immediately unfold the underlying map to this. *)
-  - exact (Build_pMap _ _ (fun f => f o* pto O P) 1).
+  - exact (Build_pMap (fun f => f o* pto O P) 1).
   (* We'll give an equivalence that definitionally has the same underlying map. *)
   - transparent assert (e : (([O P, _] ->* Q) <~> (P ->* Q))).
     + refine (issig_pmap P Q oE _ oE (issig_pmap [O P, _] Q)^-1%equiv).
@@ -61,7 +61,7 @@ Definition O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
 (** Coq knows that [O_pfunctor O f] is an equivalence whenever [f] is. *)
 Definition equiv_O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
   (f : X ->* Y) `{IsEquiv _ _ f} : [O X, _] <~>* [O Y, _]
-  := Build_pEquiv _ _ (O_pfunctor O f) _.
+  := Build_pEquiv (O_pfunctor O f) _.
 
 (** Pointed naturality of [O_pfunctor]. *)
 Definition pto_O_natural `(O : ReflectiveSubuniverse) {X Y : pType}
@@ -73,4 +73,4 @@ Defined.
 Definition pequiv_O_inverts `(O : ReflectiveSubuniverse) {X Y : pType}
   (f : X ->* Y) `{O_inverts O f}
   : [O X, _] <~>* [O Y, _]
-  := Build_pEquiv _ _ (O_pfunctor O f) _.
+  := Build_pEquiv (O_pfunctor O f) _.

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -34,7 +34,7 @@ Definition psusp (X : Type) : pType
 (** TODO: make this a displayed functor *)
 Instance is0functor_psusp : Is0Functor psusp
   := Build_Is0Functor _ _ _ _ psusp (fun X Y f
-      => Build_pMap (psusp X) (psusp Y) (functor_susp f) 1).
+      => Build_pMap (functor_susp f) 1).
 
 (** [psusp] is a 1-functor. *)
 Instance is1functor_psusp : Is1Functor psusp.
@@ -125,8 +125,7 @@ End Book_Loop_Susp_Adjunction.
 (** Thus, instead we will construct the adjunction in terms of a unit and counit natural transformation. *)
 
 Definition loop_susp_unit (X : pType) : X ->* loops (psusp X)
-  := Build_pMap X (loops (psusp X))
-      (fun x => merid x @ (merid (point X))^) (concat_pV _).
+  := Build_pMap (fun x => merid x @ (merid (point X))^) (concat_pV _).
 
 (** By Freudenthal, we have that this map is (2n+2)-connected when [X] is (n+1)-connected. *)
 Instance conn_map_loop_susp_unit `{Univalence} (n : trunc_index)
@@ -176,7 +175,7 @@ Proof.
 Defined.
 
 Definition loop_susp_counit (X : pType) : psusp (loops X) ->* X
-  :=  Build_pMap (psusp (loops X)) X (Susp_rec (point X) (point X) idmap) 1.
+  := Build_pMap (Susp_rec (point X) (point X) idmap) 1.
 
 Definition loop_susp_counit_natural {X Y : pType} (f : X ->* Y)
   : f o* loop_susp_counit X

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -21,7 +21,7 @@ Definition pequiv_ptr {n : trunc_index} {A : pType} `{IsTrunc n A}
 (** We could specialize [pO_rec] to give the following result, but since maps induced by truncation-recursion compute on elements of the form [tr _], we can give a better proof of pointedness than the one coming from [pO_rec]. *)
 Definition pTr_rec n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
   : pTr n X ->* Y
-  := Build_pMap (pTr n X) Y (Trunc_rec f) (point_eq f).
+  := Build_pMap (Trunc_rec f) (point_eq f).
 
 (** Note that we get an equality of pointed functions here, without Funext, while [pO_rec_beta] only gives a pointed homotopy. This is because [pTr_rec] computes on elements of the form [tr _]. *)
 Definition pTr_rec_beta_path n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
@@ -29,7 +29,7 @@ Definition pTr_rec_beta_path n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
 Proof.
   unfold pTr_rec, "o*"; cbn.
   (* Since [f] is definitionally equal to [Build_pMap _ _ f (point_eq f)], this works: *)
-  apply (ap (Build_pMap _ _ f)).
+  apply (ap (Build_pMap f)).
   apply concat_1p.
 Defined.
 

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -19,7 +19,7 @@ Class IsSpectrum (E : Prespectrum) :=
 
 Definition equiv_glue (E : Prespectrum) `{IsSpectrum E}
 : forall n, E n <~>* loops (E n.+1)
-  := fun n => Build_pEquiv _ _ (glue E n) _.
+  := fun n => Build_pEquiv (glue E n) _.
 
 Record Spectrum :=
   { to_prespectrum :> Prespectrum


### PR DESCRIPTION
The bidirectionality hint for `Build_pMap` and `Build_pEquiv'` is changed from `& _ _ _ _` to `_ _ & _ _`.  Both work, but the new way expresses the intention more clearly.  The same hint is added to `Build_pEquiv`.

The comments near two of these are updated to be more accurate.  (The third is in the same file as one of the others, so I didn't add a comment there.)

Because these hints work so well, almost every use in the library doesn't need arguments one and two, so they have been made implicit.  (In the case of `Build_pEquiv'`, they had already been declared implicit, but the `Arguments` command accidentally undid this.)