### PR TITLE
Bicategory pre post

### DIFF
--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -289,8 +289,7 @@ Defined.
 Instance is1gpd_abses {A B : AbGroup@{u}}
   : Is1Gpd (AbSES B A).
 Proof.
-  rapply Build_Is1Gpd;
-    intros E F p e; cbn.
+  intros E F p; constructor.
   - apply eissect.
   - apply eisretr.
 Defined.

--- a/theories/Basics/Notations.v
+++ b/theories/Basics/Notations.v
@@ -156,6 +156,7 @@ Reserved Infix "$oE" (at level 40, left associativity).
 Reserved Infix "$==" (at level 70).
 Reserved Infix "$o@" (at level 30).
 Reserved Infix "$@" (at level 30).
+Reserved Infix "$|" (at level 30).
 Reserved Infix "$@L" (at level 30).
 Reserved Infix "$@R" (at level 30).
 Reserved Infix "$@@" (at level 30).

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -101,6 +101,26 @@ Definition concat_pp_p {A : Type} {x y z t : A} (p : x = y) (q : y = z) (r : z =
       match p with idpath => 1
       end end end.
 
+Theorem concat_assoc_inv {A : Type} {x y z t : A} (p : x = y) (q : y = z) (r : z = t) :
+  concat_p_pp p q r @ concat_pp_p p q r = 1.
+Proof.
+  unfold concat_pp_p, concat_p_pp.
+  refine (match r with idpath => _ end).
+  refine (match q with idpath => _ end).
+  refine (match p with idpath => _ end).
+  exact idpath.
+Defined.
+
+Theorem concat_assoc_inv' {A : Type} {x y z t : A} (p : x = y) (q : y = z) (r : z = t) :
+  concat_pp_p p q r @ concat_p_pp p q r = 1.
+Proof.
+  unfold concat_pp_p, concat_p_pp.
+  refine (match r with idpath => _ end).
+  refine (match q with idpath => _ end).
+  refine (match p with idpath => _ end).
+  exact idpath.
+Defined.
+
 (** The left inverse law. *)
 Definition concat_pV {A : Type} {x y : A} (p : x = y) :
   p @ p^ = 1

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -582,6 +582,25 @@ Proof.
   - intros ? ? f; exact (pmap_precompose_idmap f).
 Defined.
 
+(** [pType] is a 1-coherent bicategory *)
+Instance is1bicat_ptype : Is1Bicat pType.
+Proof.
+  snapply Build_Is1Bicat.
+  - exact _.
+  - intros A B C h; rapply Build_Is0Functor.
+    intros f g p; cbn.
+    apply pmap_postwhisker; assumption.
+  - intros A B C h; rapply Build_Is0Functor.
+    intros f g p; cbn.
+    apply pmap_prewhisker; assumption.
+  - intros ? ? ? ? f g h; exact (pmap_compose_assoc h g f).
+  - intros ? ? ? ? f g h; exact ((pmap_compose_assoc h g f)^* ).
+  - intros ? ? f; exact (pmap_postcompose_idmap f).
+  - intros ? ? f; exact ((pmap_postcompose_idmap f)^* ).
+  - intros ? ? f; exact (pmap_precompose_idmap f).
+  - intros ? ? f; exact ((pmap_precompose_idmap f)^* ).
+Defined.
+
 (** [pType] is a pointed category *)
 Instance ispointedcat_ptype : IsPointedCat pType.
 Proof.
@@ -624,10 +643,12 @@ Defined.
 Instance is3graph_ptype : Is3Graph pType
   := fun f g => is2graph_pforall _ _.
 
-Instance is21cat_ptype : Is21Cat pType.
+Instance isbicat_ptype : IsBicat pType.
 Proof.
-  unshelve econstructor.
-  - exact _.
+  econstructor.
+  5-7: intros; constructor; [
+          apply phomotopy_compose_pV
+        | apply phomotopy_compose_Vp].
   - intros A B C f; napply Build_Is1Functor.
     + intros g h p q r.
       srapply Build_pHomotopy.
@@ -659,45 +680,37 @@ Proof.
     + intros x.
       exact (concat_Ap q _)^.
     + by pelim p f g q h k.
-  - intros A B C D f g.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
-    by pelim f g s1 r1 r2.
-  - intros A B C D f g.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
-    by pelim f s1 r1 r2 g.
-  - intros A B C D f g.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: cbn; exact (fun _ => concat_p1 _ @ ap_compose _ _ _ @ (concat_1p _)^).
-    by pelim s1 r1 r2 f g.
-  - intros A B.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ ap_idmap _ @ (concat_1p _)^).
-    by pelim s1 r1 r2.
-  - intros A B.
-    snapply Build_Is1Natural.
-    intros r1 r2 s1.
-    srapply Build_pHomotopy.
-    1: exact (fun _ => concat_p1 _ @ (concat_1p _)^).
-    simpl; by pelim s1 r1 r2.
-  - intros A B C D E f g h j.
-    srapply Build_pHomotopy.
-    1: reflexivity.
-    by pelim f g h j.
-  - intros A B C f g.
-    srapply Build_pHomotopy.
-    1: reflexivity.
-    by pelim f g.
+  - intros A B C D; snapply Build_Is1Natural.
+    (* TODO: It would be nice if this naturality proof could reuse the proof in the
+       definition of the bicategory Type. *)
+    intros [[f g] h] [[f' g'] h'] [[p q] r]; simpl in *.
+    snapply Build_pHomotopy.
+    + intro x; apply (Type_associator_natural A B C D).
+    + unfold Type_associator_natural.
+      pelim p f f' q g g' r; pelim h h'.
+      exact idpath.
+  - intros A B. snapply Build_Is1Natural.
+    intros f g p; srapply Build_pHomotopy.
+    + (* The proof is very simple, but it seems preferable to explicitly link it to the corresponding construction in Type. *)
+      exact (isnat _ (alnat:=isnatural_bicat_idl (A:=Type)) p).
+    + by pelim p f g.
+  - intros A B. snapply Build_Is1Natural.
+    intros f g p; srapply Build_pHomotopy.
+    + (* Same comment as above. *)
+      exact (isnat _ (alnat:=isnatural_bicat_idr (A:=Type)) p).
+    + simpl; unfold Type_right_unitor_natural.
+      by pelim p f g.
+  - intros A B C D E f g h k. simpl.
+    snapply Build_pHomotopy.
+    + exact (bicat_pentagon (A:=Type) f g h k).
+    + by pelim f g h k.
+  - intros A B C f g. snapply Build_pHomotopy.
+    + exact (bicat_tril (A:=Type) f g).
+    + by pelim f g.
 Defined.
+
+Instance Is21Cat_ptype : Is21Cat pType
+  := Build_Is21Cat _ _ _ _ _ _ _ _ _ .
 
 (** The forgetful map from [pType] to [Type] is a 0-functor *)
 Instance is0functor_pointed_type : Is0Functor pointed_type.

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -635,9 +635,9 @@ Defined.
 (** [pForall] is a 1-groupoid *)
 Instance is1gpd_pforall (A : pType) (P : pFam A) : Is1Gpd (pForall A P) | 10.
 Proof.
-  econstructor.
-  + intros ? ? p. exact (phomotopy_compose_pV p).
-  + intros ? ? p. exact (phomotopy_compose_Vp p).
+  intros ? ? p; constructor.
+  + exact (phomotopy_compose_pV p).
+  + exact (phomotopy_compose_Vp p).
 Defined.
 
 Instance is3graph_ptype : Is3Graph pType

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -173,6 +173,12 @@ Record RetractionOf {A} `{Is1Cat A} {a b : A} (f : a $-> b) :=
     is_retraction : comp_left_inverse $o f $== Id a
   }.
 
+Class AreInverse {A} `{Is1Cat A} {a b : A} (f : a $-> b) (g : b $-> a) :=
+  {
+    inv_issect : g $o f $== Id a;
+    inv_isretr : f $o g $== Id b;
+  }.
+
 (** Often, the coherences are actually equalities rather than homotopies. *)
 Class Is1Cat_Strong (A : Type)`{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
 {

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -386,10 +386,13 @@ Arguments is1functor_compose {A B C}
 (** ** Wild 1-groupoids *)
 
 Class Is1Gpd (A : Type) `{Is1Cat A, !Is0Gpd A} :=
-{
-  gpd_issect : forall {a b : A} (f : a $-> b), f^$ $o f $== Id a ;
-  gpd_isretr : forall {a b : A} (f : a $-> b), f $o f^$ $== Id b ;
-}.
+  is1gpd :: forall {a b : A} (f : a $-> b), AreInverse f f^$.
+
+Definition gpd_issect {A : Type} `{Is1Gpd A} {a b : A} (f : a $-> b) :=
+  inv_issect (f:=f) (g:=f^$).
+
+Definition gpd_isretr {A : Type} `{Is1Gpd A} {a b : A} (f : a $-> b) :=
+  inv_isretr (f:=f) (g:=f^$).
 
 (** Some more convenient equalities for morphisms in a 1-groupoid. The naming scheme is similar to [PathGroupoids.v].*)
 

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -592,7 +592,7 @@ Defined.
 Instance is1gpd_core {A : Type} `{HasEquivs A}
   : Is1Gpd (core A).
 Proof.
-  apply Build_Is1Gpd; cbn ; intros a b f;
+  intros a b f; constructor;
     refine (compose_cate_fun _ _ $@ _ $@ (id_cate_fun _)^$).
   - apply cate_issect.
   - apply cate_isretr.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -48,6 +48,21 @@ Proof.
   exact (@ap _ _ (cat_precomp c f)).
 Defined.
 
+(** Any type is a 1-bicategory with n-morphisms given by paths. *)
+Instance is1bicat_paths {A : Type} : Is1Bicat A.
+Proof.
+  snapply Build_Is1Bicat.
+  - exact _.
+  - exact _.
+  - exact _.
+  - exact (@concat_p_pp A).
+  - exact (@concat_pp_p A).
+  - exact (@concat_p1 A).
+  - intros a b f. exact ((@concat_p1 A _ _ f)^).
+  - exact (@concat_1p A).
+  - intros a b f. exact ((@concat_1p A _ _ f)^).
+Defined.
+
 (** Any type is a 1-category with n-morphisms given by paths. *)
 Instance is1cat_paths {A : Type} : Is1Cat A.
 Proof.
@@ -71,10 +86,10 @@ Proof.
 Defined.
 
 (** Any type is a 2-category with higher morphisms given by paths. *)
-Instance is21cat_paths {A : Type} : Is21Cat A.
+
+Instance isbicat_paths {A : Type} : IsBicat A.
 Proof.
-  snapply Build_Is21Cat.
-  - exact _.
+  snapply Build_IsBicat.
   - exact _.
   - intros x y z p.
     snapply Build_Is1Functor.
@@ -92,30 +107,27 @@ Proof.
       exact (whiskerL_pp p).
   - intros a b c q r s t h g.
     exact (concat_whisker q r s t h g)^.
-  - intros a b c d q r.
+  - intros a b c d.
     snapply Build_Is1Natural.
-    intros s t h.
-    apply concat_p_pp_nat_r.
-  - intros a b c d q r.
-    snapply Build_Is1Natural.
-    intros s t h.
-    apply concat_p_pp_nat_m.
-  - intros a b c d q r.
-    snapply Build_Is1Natural.
-    intros s t h.
-    apply concat_p_pp_nat_l.
+    intros [[f g] h] [[f' g'] h'] [[p q] r]; simpl in *.
+    unfold Bifunctor.fmap11, Prod.fmap_pair; simpl.
+    unfold cat_precomp; simpl in p, q, r.
+    destruct r, q, p. simpl. exact (concat_1p_p1 _ ).
+  - intros a b c d f g h; constructor.
+    + exact (concat_assoc_inv f g h).
+    + exact (concat_assoc_inv' f g h).
+  - intros a b f; constructor.
+    + exact (concat_pV _).
+    + exact (concat_Vp _).
+  - intros a b f; constructor.
+    + exact (concat_pV _).
+    + exact (concat_Vp _).
   - intros a b.
     snapply Build_Is1Natural.
-    intros p q h; cbn.
-    apply moveL_Mp.
-    lhs napply concat_p_pp.
-    exact (whiskerR_p1 h).
+    apply concat_A1p.
   - intros a b.
     snapply Build_Is1Natural.
-    intros p q h.
-    apply moveL_Mp.
-    lhs rapply concat_p_pp.
-    exact (whiskerL_1p h).
+    apply concat_A1p.
   - intros a b c d e p q r s.
     lhs napply concat_p_pp.
     exact (pentagon p q r s).

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -64,18 +64,8 @@ Proof.
 Defined.
 
 (** Any type is a 1-category with n-morphisms given by paths. *)
-Instance is1cat_paths {A : Type} : Is1Cat A.
-Proof.
-  snapply Build_Is1Cat.
-  - exact _.
-  - exact _.
-  - exact _.
-  - exact _.
-  - exact (@concat_p_pp A).
-  - exact (@concat_pp_p A).
-  - exact (@concat_p1 A).
-  - exact (@concat_1p A).
-Defined.
+Instance is1cat_paths {A : Type} : Is1Cat A
+  := is1cat_is1bicat A _.
 
 (** Any type is a 1-groupoid with morphisms given by paths. *)
 Instance is1gpd_paths {A : Type} : Is1Gpd A.

--- a/theories/WildCat/Paths.v
+++ b/theories/WildCat/Paths.v
@@ -70,9 +70,9 @@ Instance is1cat_paths {A : Type} : Is1Cat A
 (** Any type is a 1-groupoid with morphisms given by paths. *)
 Instance is1gpd_paths {A : Type} : Is1Gpd A.
 Proof.
-  snapply Build_Is1Gpd.
-  - exact (@concat_pV A).
-  - exact (@concat_Vp A).
+  intros a b f; constructor.
+  - exact (@concat_pV A _ _ _).
+  - exact (@concat_Vp A _ _ _).
 Defined.
 
 (** Any type is a 2-category with higher morphisms given by paths. *)

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -1,93 +1,131 @@
 Require Import Basics.Overture Basics.Tactics.
 Require Import WildCat.Core.
 Require Import WildCat.NatTrans.
+Require Import WildCat.Prod.
+Require Import WildCat.Bifunctor.
+
+Declare Scope twocat.
+Notation "f $=> g" := (Hom (A:=Hom _ _) f g) : twocat.
+Local Open Scope twocat.
 
 (** * Wild (2,1)-categories *)
 
-Class Is21Cat (A : Type) `{Is1Cat A, !Is3Graph A} :=
+(** ** Wild 1-categorical structures *)
+Class Is1Bicat (A : Type) `{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
 {
-  is1cat_hom : forall (a b : A), Is1Cat (a $-> b) ;
-  is1gpd_hom : forall (a b : A), Is1Gpd (a $-> b) ;
-  is1functor_postcomp : forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) ;
-  is1functor_precomp : forall (a b c : A) (f : a $-> b), Is1Functor (cat_precomp c f) ;
+  is01bicat_hom :: forall (a b : A), Is01Cat (a $-> b) ;
+  is0functor_bicat_postcomp :: forall (a b c : A) (g : b $-> c), Is0Functor (cat_postcomp a g) ;
+  is0functor_bicat_precomp :: forall (a b c : A) (f : a $-> b), Is0Functor (cat_precomp c f) ;
+  bicat_assoc : forall {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    (h $o g) $o f $=> h $o (g $o f);
+  bicat_assoc_opp : forall {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    h $o (g $o f) $=> (h $o g) $o f;
+  bicat_idl : forall {a b : A} (f : a $-> b), Id b $o f $=> f;
+  bicat_idl_opp : forall {a b : A} (f : a $-> b), f $=> Id b $o f;
+  bicat_idr : forall {a b : A} (f : a $-> b), f $o Id a $=> f;
+  bicat_idr_opp : forall {a b : A} (f : a $-> b), f $=> f $o Id a;
+}.
+Notation "p $@R h" := (fmap (cat_precomp _ h) p) : twocat.
+Notation "h $@L p" := (fmap (cat_postcomp _ h) p) : twocat.
+Notation "a $| b" := (cat_comp (A:=Hom _ _) b a) : twocat.
+
+Instance is0bifunctor_bicat_comp (A : Type) `{Is1Bicat A} (a b c : A)
+  : Is0Bifunctor (cat_comp (a:=a) (b:=b) (c:=c))
+  := Build_Is0Bifunctor'' _.
+
+Instance Is0Functor_swap (A: Type) `{Is1Bicat A} (a b c : A)
+  : Is0Functor (fun '(f,g) => cat_comp (a:=a) (b:=b) (c:=c) g f).
+Proof.
+  change (fun p => snd p $o fst p) with (fun p => (Types.Forall.flip (cat_comp (a:=a) (b:=b) (c:=c)) (fst p) (snd p))).
+  rapply (is0functor_bifunctor_uncurried (Forall.flip (cat_comp))).
+  rapply is0bifunctor_flip.
+Defined.
+
+Notation "alpha $@@ beta" := (fmap11 cat_comp beta alpha) : twocat.
+
+Instance Is0Functor_left_assoc (A: Type) `{Is1Bicat A} (a b c d : A):
+  Is0Functor (fun p : (a $-> b) * (b $-> c) * (c $-> d) =>
+                let '(f,g,h) := p in (h $o g) $o f).
+Proof.
+  simpl.
+  constructor.
+  intros ? ? [[alpha beta] gamma].
+  exact (alpha $@@ (beta $@@ gamma)).
+Defined.
+
+Instance Is0Functor_right_assoc (A: Type) `{Is1Bicat A} (a b c d : A):
+  Is0Functor (fun p : (a $-> b) * (b $-> c) * (c $-> d) =>
+                let '(f,g,h) := p in h $o (g $o f)).
+Proof.
+  simpl.
+  constructor.
+  intros ? ? [[alpha beta] gamma].
+  exact ((alpha $@@ beta) $@@ gamma).
+Defined.
+
+Class IsBicat (A : Type) `{H: Is1Bicat A} `{!Is3Graph A} :=
+{
+  is1cat_hom :: forall (a b : A), Is1Cat (a $-> b) ;
+  is1functor_postcomp :: forall (a b c : A) (g : b $-> c), Is1Functor (cat_postcomp a g) ;
+  is1functor_precomp :: forall (a b c : A) (f : a $-> b), Is1Functor (cat_precomp c f) ;
   bifunctor_coh_comp : forall {a b c : A} {f f' : a $-> b}  {g g' : b $-> c}
-    (p : f $== f') (p' : g $== g'),
-    (p' $@R f) $@ (g' $@L p) $== (g $@L p) $@ (p' $@R f') ;
-
-  (** Naturality of the associator in each variable separately *)
-  is1natural_cat_assoc_l : forall (a b c d : A) (f : a $-> b) (g : b $-> c),
-      Is1Natural (cat_precomp d f o cat_precomp d g) (cat_precomp d (g $o f))
-                 (cat_assoc f g);
-  is1natural_cat_assoc_m : forall (a b c d : A) (f : a $-> b) (h : c $-> d),
-      Is1Natural (cat_precomp d f o cat_postcomp b h) (cat_postcomp a h o cat_precomp c f)
-                 (fun g => cat_assoc f g h);
-  is1natural_cat_assoc_r : forall (a b c d : A) (g : b $-> c) (h : c $-> d),
-      Is1Natural (cat_postcomp a (h $o g)) (cat_postcomp a h o cat_postcomp a g)
-                 (fun f => cat_assoc f g h);
-
-  (** Naturality of the unitors *)
-  is1natural_cat_idl : forall (a b : A),
-      Is1Natural (cat_postcomp a (Id b)) idmap
-                 cat_idl ;
-
-  is1natural_cat_idr : forall (a b : A),
-      Is1Natural (cat_precomp b (Id a)) idmap
-                 cat_idr;
-
-  (** Coherence *)
-  cat_pentagon : forall (a b c d e : A)
-                        (f : a $-> b) (g : b $-> c) (h : c $-> d) (k : d $-> e),
-      (k $@L cat_assoc f g h) $o (cat_assoc f (h $o g) k) $o (cat_assoc g h k $@R f)
-      $== (cat_assoc (g $o f) h k) $o (cat_assoc f g (k $o h)) ;
-
-  cat_tril : forall (a b c : A) (f : a $-> b) (g : b $-> c),
-      (g $@L cat_idl f) $o (cat_assoc f (Id b) g) $== (cat_idr g $@R f)
+    (p : f $=> f') (p' : g $=> g'),
+    (p' $@R f) $| (g' $@L p) $== (g $@L p) $| (p' $@R f');
+  isnatural_bicat_assoc :: forall {a b c d : A},
+    Is1Natural
+      (fun '(f,g,h) => (h $o g) $o f)
+      (fun '(f,g,h) => h $o (g $o f))
+      (fun '(f,g,h) => bicat_assoc (Is1Bicat:=H) (a:=a) (b:=b) (c:=c) (d:=d) f g h);
+  areinv_bicat_assoc :: forall {a b c d : A} (f : a $-> b) (g : b $-> c) (h : c $-> d),
+    AreInverse (bicat_assoc f g h) (bicat_assoc_opp f g h);
+  areinv_bicat_idl :: forall {a b : A} (f : a $-> b),
+    AreInverse (bicat_idl f) (bicat_idl_opp f);
+  areinv_bicat_idr :: forall {a b : A} (f : a $-> b),
+    AreInverse (bicat_idr f) (bicat_idr_opp f);
+  isnatural_bicat_idl :: forall {a b : A}, Is1Natural _ _ (bicat_idl (a:=a) (b:=b));
+  isnatural_bicat_idr :: forall {a b : A}, Is1Natural _ _ (bicat_idr (a:=a) (b:=b));
+  bicat_pentagon : forall {a b c d e : A}
+                     (f : a $-> b) (g : b $-> c) (h : c $-> d) (k : d $-> e),
+      (k $@L bicat_assoc f g h) $o (bicat_assoc f (h $o g) k) $o (bicat_assoc g h k $@R f)
+      $== (bicat_assoc (g $o f) h k) $o (bicat_assoc f g (k $o h)) ;
+  bicat_tril : forall {a b c : A} (f : a $-> b) (g : b $-> c),
+      (g $@L bicat_idl f) $o (bicat_assoc f (Id b) g) $== (bicat_idr g $@R f)
 }.
 
-Existing Instance is1cat_hom.
-Existing Instance is1gpd_hom.
-Existing Instance is1functor_precomp.
-Existing Instance is1functor_postcomp.
-Existing Instance is1natural_cat_assoc_l.
-Existing Instance is1natural_cat_assoc_m.
-Existing Instance is1natural_cat_assoc_r.
-Existing Instance is1natural_cat_idl.
-Existing Instance is1natural_cat_idr.
+Class Is21Cat (A : Type) `{IsBicat A} :=
+{
+  is0gpd_hom :: forall (a b : A), Is0Gpd (a $-> b) ;
+  is1gpd_hom :: forall (a b : A), Is1Gpd (a $-> b) ;
+}.
 
 (** *** Whiskering functoriality *)
 
-Definition cat_postwhisker_pp {A} `{Is21Cat A} {a b c : A}
-  {f g h : a $-> b} (k : b $-> c) (p : f $== g) (q : g $== h)
-  : k $@L (p $@ q) $== (k $@L p) $@ (k $@L q).
+Definition cat_postwhisker_pp {A} `{IsBicat A} {a b c : A}
+  {f g h : a $-> b} (k : b $-> c) (p : f $=> g) (q : g $=> h)
+  : k $@L (p $| q) $== (k $@L p) $| (k $@L q).
 Proof.
   rapply fmap_comp.
 Defined.
 
-Definition cat_prewhisker_pp {A} `{Is21Cat A} {a b c : A}
-  {f g h : b $-> c} (k : a $-> b) (p : f $== g) (q : g $== h)
-  : (p $@ q) $@R k $== (p $@R k) $@ (q $@R k).
+Definition cat_prewhisker_pp {A} `{IsBicat A} {a b c : A}
+  {f g h : b $-> c} (k : a $-> b) (p : f $=> g) (q : g $=> h)
+  : (p $| q) $@R k $== (p $@R k) $| (q $@R k).
 Proof.
   rapply fmap_comp.
+Defined.
+
+Instance is1bifunctor_bicat_comp {A: Type} `{IsBicat A} {a b c : A} :
+  Is1Bifunctor (cat_comp (a:=a) (b:=b) (c:=c)).
+Proof.
+  rapply Build_Is1Bifunctor''.
+  intros.
+  apply bifunctor_coh_comp.
 Defined.
 
 (** *** Exchange law *)
 
-Definition cat_exchange {A : Type} `{Is21Cat A} {a b c : A}
+Definition cat_exchange {A : Type} `{IsBicat A} {a b c : A}
   {f f' f'' : a $-> b} {g g' g'' : b $-> c}
-  (p : f $== f') (q : f' $== f'') (r : g $== g') (s : g' $== g'')
-  : (p $@ q) $@@ (r $@ s) $== (p $@@ r) $@ (q $@@ s).
-Proof.
-  unfold "$@@".
-  (** We use the distributivity of [$@R] and [$@L] in a (2,1)-category (since they are functors) to see that we have the same data on both sides of the 3-morphism. *)
-  nrefine ((_ $@L cat_prewhisker_pp _ _ _ ) $@ _).
-  nrefine ((cat_postwhisker_pp _ _ _ $@R _) $@ _).
-  (** Now we reassociate and whisker on the left and right. *)
-  nrefine (cat_assoc _ _ _ $@ _).
-  refine (_ $@ (cat_assoc _ _ _)^$).
-  nrefine (_ $@L _).
-  refine (_ $@ cat_assoc _ _ _).
-  refine ((cat_assoc _ _ _)^$ $@ _).
-  nrefine (_ $@R _).
-  (** Finally we are left with the bifunctoriality condition for left and right whiskering which is part of the data of the (2,1)-cat. *)
-  apply bifunctor_coh_comp.
-Defined.
+  (p : f $=> f') (q : f' $=> f'') (r : g $=> g') (s : g' $=> g'')
+  : (p $| q) $@@ (r $| s) $== (p $@@ r) $| (q $@@ s)
+  := fmap11_comp _ _ _ _ _.

--- a/theories/WildCat/TwoOneCat.v
+++ b/theories/WildCat/TwoOneCat.v
@@ -25,6 +25,18 @@ Class Is1Bicat (A : Type) `{!IsGraph A, !Is2Graph A, !Is01Cat A} :=
   bicat_idr : forall {a b : A} (f : a $-> b), f $o Id a $=> f;
   bicat_idr_opp : forall {a b : A} (f : a $-> b), f $=> f $o Id a;
 }.
+
+Definition is1cat_is1bicat (A : Type) `{Is1Bicat A}
+  (p : forall a b : A, Is0Gpd (Hom a b))
+  : Is1Cat A.
+Proof.
+  rapply Build_Is1Cat.
+  - exact (@bicat_assoc _ _ _ _ _).
+  - exact (@bicat_assoc_opp _ _ _ _ _).
+  - exact (@bicat_idl _ _ _ _ _).
+  - exact (@bicat_idr _ _ _ _ _).
+Defined.
+
 Notation "p $@R h" := (fmap (cat_precomp _ h) p) : twocat.
 Notation "h $@L p" := (fmap (cat_postcomp _ h) p) : twocat.
 Notation "a $| b" := (cat_comp (A:=Hom _ _) b a) : twocat.

--- a/theories/WildCat/Universe.v
+++ b/theories/WildCat/Universe.v
@@ -134,9 +134,9 @@ Defined.
 
 Instance is1gpd_type_hom (A B : Type) : Is1Gpd (A $-> B).
 Proof.
-  repeat unshelve esplit.
-  - intros ? ? ? ?; apply concat_pV.
-  - intros ? ? ? ?; apply concat_Vp.
+  intros ? ? ?; constructor.
+  - intro; apply concat_pV.
+  - intro; apply concat_Vp.
 Defined.
 
 Instance is1functor_cat_postcomp {A B C : Type} (g : B $-> C)


### PR DESCRIPTION
This PR defines a wild bicategory. This is a rewrite of the previous PR, because my original definition of a `1Bicat` was too far from the definition of a `1Cat`, making it a lot of work to port work using `1Cat`s to use `1Bicat`s instead. 
Also, with my original definition using `Is0Bifunctor` there are two different ways to whisker a 2-cell with a 1-cell that are not in any way related, and this seems like a potential pitfall.

On the other hand, the definition of a `Bicategory` is more of a departure from the current definition of a `(2,1)`-category, in that it assumes that the associator is natural as a functor on `(a $-> b) * (b $-> c) * (c $-> d)$` rather than being natural in each argument separately. This definition is more complex because it uses products and uncurrying, but I preferred the style, and there's not as much material in the library for (2,1)-cats as there is for 1-cats so refactoring is not as much of an issue.

- The first commit defines a 1-bicategory (which is a wild 1-category without the requirement that 2-cells are invertible) and a bicategory; it refactors the definition of (2,1)-category to extend bicategory; all (2,1)-categories (the path groupoid of a type, the universe Type, pType) are rewritten as bicategories. While writing the proofs that pType is a bicategory I took care to try and reuse the same proofs for Type in many places. A few helper lemmas in constructing the (2,1)-category of paths are extracted and put in `PathGroupoid.v`. Notation is introduced for vertical pasting.
- In the second commit, a definition is given to upgrade a 1-bicategory to a 1-category when 2-cells are invertible; all near-duplicate definitions from the first commit are deduplicated.
- The third commit better integrates `AreInverse` into the library by rewriting `Is1Gpd` to depend on `AreInverse`.