### PR TITLE
Make f and g explicit arguments to isequiv_compose

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -30,7 +30,9 @@ Instance reflexive_equiv : Reflexive Equiv | 0 := @equiv_idmap.
 Arguments reflexive_equiv /.
 
 (** The composition of equivalences is an equivalence. *)
-Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
+Instance isequiv_compose {A B C : Type}
+  (f : A -> B) `{IsEquiv A B f}
+  (g : B -> C) `{IsEquiv B C g}
   : IsEquiv (g o f) | 1000
   := Build_IsEquiv A C (g o f)
     (f^-1 o g^-1)
@@ -46,13 +48,6 @@ Instance isequiv_compose `{IsEquiv A B f} `{IsEquiv B C g}
       ) @
       (ap_compose f g _)^
     ).
-
-(* An alias of [isequiv_compose], with some arguments explicit; often convenient when type class search fails. *)
-Definition isequiv_compose'
-  {A B : Type} (f : A -> B) (_ : IsEquiv f)
-  {C : Type} (g : B -> C) (_ : IsEquiv g)
-  : IsEquiv (g o f)
-  := isequiv_compose.
 
 Definition equiv_compose {A B C : Type} (g : B -> C) (f : A -> B)
   `{IsEquiv B C g} `{IsEquiv A B f}

--- a/theories/Categories/Category/Sigma/Univalent.v
+++ b/theories/Categories/Category/Sigma/Univalent.v
@@ -348,16 +348,17 @@ Section on_both.
       refine ((@Pmor_iso_adjust s0 s1 d1)^-1 o _).
       exact (@Pidtoiso _ _ _). }
     { (* Do this in small steps to make it fast. *)
-      nrefine isequiv_compose. 1:apply isequiv_inverse.
-      nrefine isequiv_compose. 2:apply isequiv_inverse.
+      napply isequiv_compose. 1:apply isequiv_inverse.
+      napply isequiv_compose. 2:apply isequiv_inverse.
       nrefine isequiv_functor_sigma. 1:apply A_cat.
       destruct s, d.
       simpl Overture.pr1.
       intro p; destruct p.
-      eapply @isequiv_compose.
+      eapply isequiv_compose.
       - exact _.
       - eapply @isequiv_inverse. }
     { intro p; apply path_isomorphic; destruct p.
       reflexivity. }
   Defined.
 End on_both.
+

--- a/theories/Classes/categories/ua_category.v
+++ b/theories/Classes/categories/ua_category.v
@@ -74,7 +74,7 @@ Proof.
   intros A B.
   rewrite path_idtoiso_isomorphic_id.
   apply @isequiv_compose.
-  - apply isequiv_compose.
+  - rapply isequiv_compose.
   - apply isequiv_inverse.
 Qed.
 

--- a/theories/Classes/theory/ua_homomorphism.v
+++ b/theories/Classes/theory/ua_homomorphism.v
@@ -274,7 +274,7 @@ Section hom_compose.
     (f : ∀ s, A s → B s) `{IsIsomorphism σ A B f}
     : IsIsomorphism (λ s, g s o f s).
   Proof.
-    intro s. apply isequiv_compose.
+    intro s. rapply isequiv_compose.
   Qed.
 
   Definition hom_compose

--- a/theories/Colimits/Sequential.v
+++ b/theories/Colimits/Sequential.v
@@ -319,7 +319,7 @@ Proof.
       - exact (fun x b => K _ _ _ @ (ap _ (p (x^++) b))).
   + intro n; revert x; induction n as [ | n e].
     * exact (fun _ => isequiv_idmap _).
-    * intro x; exact isequiv_compose.
+    * intro x; rapply isequiv_compose.
 Defined.
 
 (** A fibered type sequence defines a type family; Section 4. *)

--- a/theories/Diagrams/Cocone.v
+++ b/theories/Diagrams/Cocone.v
@@ -242,7 +242,7 @@ Section FunctorialityCocone.
   Proof.
     srapply Build_UniversalCocone; intro.
     rewrite (path_forall _ _ (fun f => cocone_precompose_postcompose m f C)).
-    exact isequiv_compose.
+    rapply isequiv_compose.
   Defined.
 
   #[export] Instance cocone_postcompose_equiv_universality {D: Diagram G} `(f: X <~> Y)
@@ -251,7 +251,7 @@ Section FunctorialityCocone.
   Proof.
     snapply Build_UniversalCocone; intro.
     rewrite <- (path_forall _ _ (fun g => cocone_postcompose_comp f g C)).
-    exact isequiv_compose.
+    rapply isequiv_compose.
   Defined.
 
 End FunctorialityCocone.

--- a/theories/Diagrams/Cone.v
+++ b/theories/Diagrams/Cone.v
@@ -231,7 +231,7 @@ Section FunctorialityCone.
   Proof.
     srapply Build_UniversalCone; intro.
     rewrite (path_forall _ _ (fun f => cone_postcompose_precompose m f C)).
-    exact isequiv_compose.
+    rapply isequiv_compose.
   Defined.
 
   #[export] Instance cone_precompose_equiv_universality {D: Diagram G} `(f: Y <~> X)
@@ -240,7 +240,7 @@ Section FunctorialityCone.
   Proof.
     srapply Build_UniversalCone; intro.
     rewrite <- (path_forall _ _ (fun g => cone_precompose_comp g f C)).
-    exact isequiv_compose.
+    rapply isequiv_compose.
   Defined.
 
 End FunctorialityCone.

--- a/theories/Diagrams/Diagram.v
+++ b/theories/Diagrams/Diagram.v
@@ -205,7 +205,7 @@ Section Diagram.
     napply (Build_diagram_equiv (diagram_comp m2 m1)).
     intros i.
     simpl.
-    apply isequiv_compose'; [apply m1 | apply m2].
+    apply isequiv_compose; [apply m1 | apply m2].
   Defined.
 End Diagram.
 

--- a/theories/HFiber.v
+++ b/theories/HFiber.v
@@ -95,7 +95,7 @@ Instance isequiv_functor_hfiber2 {A B C D}
   : IsEquiv (functor_hfiber2 p q).
 Proof.
   refine (isequiv_functor_sigma (f := h)); intros a.
-  exact (isequiv_compose (f := fun e => (p a)^ @ ap k e) (g := fun e' => e' @ q)).
+  exact (isequiv_compose (fun e => (p a)^ @ ap k e) (fun e' => e' @ q)).
 Defined.
 
 Definition equiv_functor_hfiber2 {A B C D}

--- a/theories/Modalities/Lex.v
+++ b/theories/Modalities/Lex.v
@@ -326,13 +326,12 @@ Section ImpliesLex.
     specialize (H A Unit B Unit (const_tt _) (const_tt _) f idmap _ _ _ _
                   (fun _ => 1)).
     unfold IsPullback, pullback_corec in H.
-    refine (@isequiv_compose _ _ _ H _ (fun x => x.2.1) _).
+    refine (isequiv_compose _ (H:=H) (fun x => x.2.1)).
     unfold Pullback.
-    refine (@isequiv_compose _ {b:Unit & B}
-                             (functor_sigma idmap (fun a => pr1))
-                             _ _ pr2 _).
-    refine (@isequiv_compose _ _ (equiv_sigma_prod0 Unit B)
-                             _ _ snd _).
+    refine (isequiv_compose (B:={b:Unit & B})
+              (functor_sigma idmap (fun a => pr1))
+              pr2).
+    refine (isequiv_compose (equiv_sigma_prod0 Unit B) snd).
     exact (equiv_isequiv (prod_unit_l B)).
   Defined.
 

--- a/theories/Modalities/Meet.v
+++ b/theories/Modalities/Meet.v
@@ -93,7 +93,7 @@ Section RSUMeet.
 
   Definition isequiv_plus_inmeet (X : Type) `{In Meet X} : IsEquiv (to_plus X).
   Proof.
-    apply (@isequiv_compose _ _ (to O X) _ _ (to L (O X))).
+    rapply (isequiv_compose (to O X) (to L (O X))).
     apply isequiv_to_O_inO.
     exact (inO_equiv_inO X (to O X)).
   Defined.

--- a/theories/Modalities/Open.v
+++ b/theories/Modalities/Open.v
@@ -75,8 +75,8 @@ Proof.
       refine (cancelR_isequiv (fun x (u:Unit) => x)).
       exact X_inO.
     + intros ext; specialize (ext tt).
-      refine (isequiv_compose (f := (fun x => unit_name x))
-                              (g := (fun h => h o const_tt U))).
+      refine (isequiv_compose (fun x => unit_name x)
+                              (fun h => h o const_tt U)).
       exact (isequiv_ooextendable (fun _ => X) (const_tt U) ext).
 Defined.
 

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1461,7 +1461,7 @@ Section ConnectedTypes.
              {A : Type} `{IsConnected O A} (C : Type) `{In O C}
   : IsEquiv (@const A C).
   Proof.
-    exact (@isequiv_compose _ _ (fun c u => c) _ _ _
+    exact (@isequiv_compose _ _ _ (fun c u => c) _ _
               (isequiv_ooextendable (fun _ => C) (const_tt A)
                                     (ooextendable_const_isconnected_inO A C))).
   Defined.

--- a/theories/Spectra/Spectrum.v
+++ b/theories/Spectra/Spectrum.v
@@ -33,5 +33,5 @@ Proof.
   - intros n.
     exact ((ptr_loops _ (E n.+1)) o*E (pequiv_ptr_functor _ (equiv_glue E n))).
   - intros n. unfold glue.
-    exact isequiv_compose.
+    rapply isequiv_compose.
 Defined.

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -326,7 +326,7 @@ Definition equiv_concat_r {A : Type} `(p : y = z) (x : A)
 
 Instance isequiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
   : IsEquiv (fun r:x=y => p @ r @ q) | 0
-  := @isequiv_compose _ _ (fun r => p @ r) _ _ (fun r => r @ q) _.
+  := isequiv_compose (fun r => p @ r) (fun r => r @ q).
 
 Definition equiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
   : (x = y) <~> (x' = y')
@@ -411,7 +411,7 @@ Instance isequiv_moveR_Mp
 : IsEquiv (moveR_Mp p q r).
 Proof.
   destruct r.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveR_Mp
@@ -424,7 +424,7 @@ Instance isequiv_moveR_pM
 : IsEquiv (moveR_pM p q r).
 Proof.
   destruct p.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveR_pM
@@ -437,7 +437,7 @@ Instance isequiv_moveR_Vp
 : IsEquiv (moveR_Vp p q r).
 Proof.
   destruct r.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveR_Vp
@@ -450,7 +450,7 @@ Instance isequiv_moveR_pV
 : IsEquiv (moveR_pV p q r).
 Proof.
   destruct p.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveR_pV
@@ -463,7 +463,7 @@ Instance isequiv_moveL_Mp
 : IsEquiv (moveL_Mp p q r).
 Proof.
   destruct r.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveL_Mp
@@ -476,7 +476,7 @@ Definition isequiv_moveL_pM
 : IsEquiv (moveL_pM p q r).
 Proof.
   destruct p.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveL_pM
@@ -489,7 +489,7 @@ Instance isequiv_moveL_Vp
 : IsEquiv (moveL_Vp p q r).
 Proof.
   destruct r.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveL_Vp
@@ -502,7 +502,7 @@ Instance isequiv_moveL_pV
 : IsEquiv (moveL_pV p q r).
 Proof.
   destruct p.
-  exact (isequiv_compose' _ (isequiv_concat_l _ _) _ (isequiv_concat_r _ _)).
+  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
 Defined.
 
 Definition equiv_moveL_pV
@@ -656,7 +656,7 @@ Instance isequiv_moveR_equiv_M `{IsEquiv A B f} (x : A) (y : B)
 : IsEquiv (@moveR_equiv_M A B f _ x y).
 Proof.
   unfold moveR_equiv_M.
-  exact (@isequiv_compose _ _ (ap f) _ _ (fun q => q @ eisretr f y) _).
+  exact (isequiv_compose (ap f) (fun q => q @ eisretr f y)).
 Defined.
 
 Definition equiv_moveR_equiv_M `{IsEquiv A B f} (x : A) (y : B)
@@ -667,7 +667,7 @@ Instance isequiv_moveR_equiv_V `{IsEquiv A B f} (x : B) (y : A)
 : IsEquiv (@moveR_equiv_V A B f _ x y).
 Proof.
   unfold moveR_equiv_V.
-  exact (@isequiv_compose _ _ (ap f^-1) _ _ (fun q => q @ eissect f y) _).
+  exact (isequiv_compose (ap f^-1) (fun q => q @ eissect f y)).
 Defined.
 
 Definition equiv_moveR_equiv_V `{IsEquiv A B f} (x : B) (y : A)
@@ -678,7 +678,7 @@ Instance isequiv_moveL_equiv_M `{IsEquiv A B f} (x : A) (y : B)
 : IsEquiv (@moveL_equiv_M A B f _ x y).
 Proof.
   unfold moveL_equiv_M.
-  exact (@isequiv_compose _ _ (ap f) _ _ (fun q => (eisretr f y)^ @ q) _).
+  exact (isequiv_compose (ap f) (fun q => (eisretr f y)^ @ q)).
 Defined.
 
 Definition equiv_moveL_equiv_M `{IsEquiv A B f} (x : A) (y : B)
@@ -689,7 +689,7 @@ Instance isequiv_moveL_equiv_V `{IsEquiv A B f} (x : B) (y : A)
 : IsEquiv (@moveL_equiv_V A B f _ x y).
 Proof.
   unfold moveL_equiv_V.
-  exact (@isequiv_compose _ _ (ap f^-1) _ _ (fun q => (eissect f y)^ @ q) _).
+  exact (isequiv_compose (ap f^-1) (fun q => (eissect f y)^ @ q)).
 Defined.
 
 Definition equiv_moveL_equiv_V `{IsEquiv A B f} (x : B) (y : A)

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -620,7 +620,7 @@ Definition path_sigma_hprop {A : Type} {P : A -> Type}
 
 Instance isequiv_path_sigma_hprop {A P} `{forall x : A, IsHProp (P x)} {u v : sig P}
   : IsEquiv (@path_sigma_hprop A P _ u v) | 100
-  := isequiv_compose.
+  := isequiv_compose _ _.
 
 #[export]
 Hint Immediate isequiv_path_sigma_hprop : typeclass_instances.

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -625,7 +625,7 @@ Proof.
   intros X Y f g; cbn in *.
   snapply isequiv_homotopic.
   - exact (GpdHom_path o (ap (x:=f) (y:=g) cate_fun)).
-  - exact isequiv_compose.
+  - rapply isequiv_compose.
   - intro p; by induction p.
 Defined.
 


### PR DESCRIPTION
`isequiv_compose` had `f` and `g` as implicit arguments, just because of the way it was defined with implicit generalization of arguments.  That meant that it was often used in an unwieldy `@isequiv_compose` form with lots of underscores.  This PR makes `f` and `g` into explicit arguments, which makes many places cleaner, although it means that `apply` has to change to `rapply` in a few other places.