### PR TITLE
Add and use concat_l, concat_r and concat_lr

### DIFF
--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -62,8 +62,6 @@ Local Open Scope path_scope.
 
 (** ** The 1-dimensional groupoid structure. *)
 
-(** [concat], with arguments flipped. Useful mainly in the idiom [apply (concatR (expression))]. Given as a notation not a definition so that the resultant terms are literally instances of [concat], with no unfolding required. *)
-Notation concatR := (fun p q => concat q p).
 
 (** The identity path is a right unit. *)
 Definition concat_p1 {A : Type} {x y : A} (p : x = y) :

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -76,6 +76,11 @@ Definition concat_lr {A : Type} {w x y z : A} (p : w = x) (r : y = z)
   : (x = y) -> (w = z)
   := fun q => p @ q @ r.
 
+(** The "/" indicates that these should be unfolded by [cbn] and [simpl] when the specified arguments are given. *)
+Arguments concat_l {A x y z} p q /.
+Arguments concat_r {A x y z} q p /.
+Arguments concat_lr {A w x y z} p r q /.
+
 (** The identity path is a right unit. *)
 Definition concat_p1 {A : Type} {x y : A} (p : x = y) :
   p @ 1 = p

--- a/theories/Basics/PathGroupoids.v
+++ b/theories/Basics/PathGroupoids.v
@@ -62,6 +62,19 @@ Local Open Scope path_scope.
 
 (** ** The 1-dimensional groupoid structure. *)
 
+(** Partially applied versions of [concat].  The first is a synonym for [concat p], but we include it to parallel the second one. *)
+Definition concat_l {A : Type} {x y z : A} (p : x = y)
+  : (y = z) -> (x = z)
+  := concat p.
+
+Definition concat_r {A : Type} {x y z : A} (q : y = z)
+  : (x = y) -> (x = z)
+  := fun p => p @ q.
+
+(** The operation of composing a path on two sides. *)
+Definition concat_lr {A : Type} {w x y z : A} (p : w = x) (r : y = z)
+  : (x = y) -> (w = z)
+  := fun q => p @ q @ r.
 
 (** The identity path is a right unit. *)
 Definition concat_p1 {A : Type} {x y : A} (p : x = y) :
@@ -182,112 +195,112 @@ Definition moveR_Mp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   p = r^ @ q -> r @ p = q.
 Proof.
   destruct r.
-  intro h. exact (concat_1p _ @ h @ concat_1p _).
+  exact (concat_lr (concat_1p _) (concat_1p _)).
 Defined.
 
 Definition moveR_pM {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   r = q @ p^ -> r @ p = q.
 Proof.
   destruct p.
-  intro h. exact (concat_p1 _ @ h @ concat_p1 _).
+  exact (concat_lr (concat_p1 _) (concat_p1 _)).
 Defined.
 
 Definition moveR_Vp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y) :
   p = r @ q -> r^ @ p = q.
 Proof.
   destruct r.
-  intro h. exact (concat_1p _ @ h @ concat_1p _).
+  exact (concat_lr (concat_1p _) (concat_1p _)).
 Defined.
 
 Definition moveR_pV {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x) :
   r = q @ p -> r @ p^ = q.
 Proof.
   destruct p.
-  intro h. exact (concat_p1 _ @ h @ concat_p1 _).
+  exact (concat_lr (concat_p1 _) (concat_p1 _)).
 Defined.
 
 Definition moveL_Mp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   r^ @ q = p -> q = r @ p.
 Proof.
   destruct r.
-  intro h. exact ((concat_1p _)^ @ h @ (concat_1p _)^).
+  exact (concat_lr (concat_1p _)^ (concat_1p _)^).
 Defined.
 
 Definition moveL_pM {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x) :
   q @ p^ = r -> q = r @ p.
 Proof.
   destruct p.
-  intro h. exact ((concat_p1 _)^ @ h @ (concat_p1 _)^).
+  exact (concat_lr (concat_p1 _)^ (concat_p1 _)^).
 Defined.
 
 Definition moveL_Vp {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y) :
   r @ q = p -> q = r^ @ p.
 Proof.
   destruct r.
-  intro h. exact ((concat_1p _)^ @ h @ (concat_1p _)^).
+  exact (concat_lr (concat_1p _)^ (concat_1p _)^).
 Defined.
 
 Definition moveL_pV {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x) :
   q @ p = r -> q = r @ p^.
 Proof.
   destruct p.
-  intro h. exact ((concat_p1 _)^ @ h @ (concat_p1 _)^).
+  exact (concat_lr (concat_p1 _)^ (concat_p1 _)^).
 Defined.
 
 Definition moveL_1M {A : Type} {x y : A} (p q : x = y) :
   p @ q^ = 1 -> p = q.
 Proof.
   destruct q.
-  intro h. exact ((concat_p1 _)^ @ h).
+  exact (concat_l (concat_p1 _)^).
 Defined.
 
 Definition moveL_M1 {A : Type} {x y : A} (p q : x = y) :
   q^ @ p = 1 -> p = q.
 Proof.
   destruct q.
-  intro h. exact ((concat_1p _)^ @ h).
+  exact (concat_l (concat_1p _)^).
 Defined.
 
 Definition moveL_1V {A : Type} {x y : A} (p : x = y) (q : y = x) :
   p @ q = 1 -> p = q^.
 Proof.
   destruct q.
-  intro h. exact ((concat_p1 _)^ @ h).
+  exact (concat_l (concat_p1 _)^).
 Defined.
 
 Definition moveL_V1 {A : Type} {x y : A} (p : x = y) (q : y = x) :
   q @ p = 1 -> p = q^.
 Proof.
   destruct q.
-  intro h. exact ((concat_1p _)^ @ h).
+  exact (concat_l (concat_1p _)^).
 Defined.
 
 Definition moveR_M1 {A : Type} {x y : A} (p q : x = y) :
   1 = p^ @ q -> p = q.
 Proof.
   destruct p.
-  intro h. exact (h @ (concat_1p _)).
+  exact (concat_r (concat_1p _)).
 Defined.
 
 Definition moveR_1M {A : Type} {x y : A} (p q : x = y) :
   1 = q @ p^ -> p = q.
 Proof.
   destruct p.
-  intro h. exact (h @ (concat_p1 _)).
+  exact (concat_r (concat_p1 _)).
 Defined.
 
 Definition moveR_1V {A : Type} {x y : A} (p : x = y) (q : y = x) :
   1 = q @ p -> p^ = q.
 Proof.
   destruct p.
-  intro h. exact (h @ (concat_p1 _)).
+  exact (concat_r (concat_p1 _)).
 Defined.
 
 Definition moveR_V1 {A : Type} {x y : A} (p : x = y) (q : y = x) :
   1 = p @ q -> p^ = q.
 Proof.
   destruct p.
-  intro h. exact (h @ (concat_1p _)).
+  exact (concat_r (concat_1p _)).
 Defined.
 
 (* In general, the path we want to move might be arbitrarily deeply nested at the beginning of a long concatenation.  Thus, instead of defining functions such as [moveL_Mp_p], we define a tactical that can repeatedly rewrite with associativity to expose it. *)

--- a/theories/Diagrams/CommutativeSquares.v
+++ b/theories/Diagrams/CommutativeSquares.v
@@ -75,16 +75,21 @@ Lemma comm_square_inverse_is_sect
    = ap f (eissect wA a).
 Proof.
   unfold comm_square_inverse, comm_square_comp; simpl.
-  repeat apply (concat (concat_pp_p _ _ _)). apply moveR_Vp.
+  repeat lhs napply concat_pp_p. apply moveR_Vp.
   transitivity (ap (wB ^-1 o wB) (ap f (eissect wA a)) @ eissect wB (f a)).
-  2: apply (concat (concat_Ap (eissect wB) _)). 2: apply ap, ap_idmap.
-  apply (concat (concat_p_pp _ _ _)), whiskerR.
-  apply (concat (ap_pp (wB ^-1) _ _)^), (concatR (ap_compose wB _ _)^).
-  apply ap, (concat (concat_pp_p _ _ _)), moveR_Vp.
+  2: { lhs napply (concat_Ap (eissect wB)).
+       apply ap, ap_idmap. }
+  lhs napply concat_p_pp.
+  apply whiskerR.
+  lhs_V napply ap_pp.
+  rhs napply ap_compose.
+  apply ap.
+  lhs napply concat_pp_p.
+  apply moveR_Vp.
   path_via (ap (f' o wA) (eissect wA a) @ wf a).
-  - apply whiskerR.  apply (concatR (ap_compose wA f' _)^).
+  - apply whiskerR. rhs napply ap_compose.
     apply ap, eisadj.
-  - apply (concat (concat_Ap wf _)).
+  - lhs napply (concat_Ap wf).
     apply whiskerL, (ap_compose f wB).
 Defined.
 

--- a/theories/Diagrams/Diagram.v
+++ b/theories/Diagrams/Diagram.v
@@ -117,8 +117,8 @@ Section Diagram.
     intros h_comm.
     assert (HH : m1_comm = m2_comm).
     { funext i j f x.
-      apply (concatR (concat_1p _)).
-      apply (concatR (h_comm _ _ _ _)).
+      rhs_V napply concat_1p.
+      rhs_V napply h_comm.
       apply inverse, concat_p1. }
     destruct HH.
     reflexivity.

--- a/theories/HIT/V.v
+++ b/theories/HIT/V.v
@@ -162,7 +162,7 @@ Proof.
     intros [b Rab]. exists b.
     apply tr.
     exists (ap h (spglue R Rab)).
-    apply (concatR (apD H_h (spglue R Rab))).
+    rhs_V napply (apD H_h (spglue R Rab)).
     apply inverse. unfold f, g. apply transport_compose.
   - intros b.
     set (trunca := snd bitot_R b). generalize trunca.
@@ -170,7 +170,7 @@ Proof.
     intros [a Rab]. exists a.
     apply tr.
     exists (ap h (spglue R Rab)).
-    apply (concatR (apD H_h (spglue R Rab))).
+    rhs_V napply (apD H_h (spglue R Rab)).
     apply inverse. unfold f, g. apply transport_compose.
 Defined.
 

--- a/theories/Homotopy/Suspension.v
+++ b/theories/Homotopy/Suspension.v
@@ -556,8 +556,9 @@ Proof.
   intro x. apply moveL_pV.
   transitivity (ap (Susp_rec H_N H_S f) (merid x) @ n.2 South).
   - apply whiskerR, inverse, Susp_rec_beta_merid.
-  - refine (concat_Ap n.2 (merid x) @ _).
-    apply (concatR (concat_p1 _)), whiskerL. apply ap_const.
+  - lhs napply (concat_Ap n.2 (merid x)).
+    rhs_V napply concat_p1.
+    apply whiskerL, ap_const.
 Defined.
 
 (** ** Contractibility of the suspension *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -277,7 +277,7 @@ Proof.
     exists (fun a => pr2 (f_eb a) tt).
     (* The last component is essentially (g' ..2), wrapped in a bit of path-algebra. *)
     apply moveL_Mp.
-    apply (concatR (apD10 (ea_eab ..2) tt)).
+    rhs_V napply (apD10 (ea_eab ..2) tt).
     set (ea := ea_eab ..1). generalize ea; simpl. clear ea_eab ea. intros.
     rewrite transport_arrow. rewrite transport_const. rewrite transport_paths_Fl.
     exact 1%path.

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -301,7 +301,7 @@ Definition equiv_path_inverse {A : Type} (x y : A)
   := Build_Equiv _ _ (@inverse A x y) _.
 
 Instance isequiv_concat_l {A : Type} `(p : x = y:>A) (z : A)
-  : IsEquiv (@transitivity A _ _ x y z p) | 0.
+  : IsEquiv (concat_l (z:=z) p) | 0.
 Proof.
   refine (Build_IsEquiv _ _ _ (concat p^)
                        (concat_p_Vp p) (concat_V_pp p) _).
@@ -310,10 +310,10 @@ Defined.
 
 Definition equiv_concat_l {A : Type} `(p : x = y) (z : A)
   : (y = z) <~> (x = z)
-  := Build_Equiv _ _ (concat p) _.
+  := Build_Equiv _ _ (concat_l p) _.
 
 Instance isequiv_concat_r {A : Type} `(p : y = z) (x : A)
-  : IsEquiv (fun q:x=y => q @ p) | 0.
+  : IsEquiv (concat_r (x:=x) p) | 0.
 Proof.
   refine (Build_IsEquiv _ _ (fun q => q @ p) (fun q => q @ p^)
            (fun q => concat_pV_p q p) (fun q => concat_pp_V q p) _).
@@ -322,15 +322,15 @@ Defined.
 
 Definition equiv_concat_r {A : Type} `(p : y = z) (x : A)
   : (x = y) <~> (x = z)
-  := Build_Equiv _ _ (fun q => q @ p) _.
+  := Build_Equiv _ _ (concat_r p) _.
 
 Instance isequiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
-  : IsEquiv (fun r:x=y => p @ r @ q) | 0
-  := isequiv_compose (fun r => p @ r) (fun r => r @ q).
+  : IsEquiv (concat_lr p q) | 0
+  := isequiv_compose (concat_l p) (concat_r q).
 
 Definition equiv_concat_lr {A : Type} {x x' y y' : A} (p : x' = x) (q : y = y')
   : (x = y) <~> (x' = y')
-  := Build_Equiv _ _ (fun r:x=y => p @ r @ q) _.
+  := Build_Equiv _ _ (concat_lr p q) _.
 
 Definition equiv_p1_1q {A : Type} {x y : A} {p q : x = y}
   : p = q <~> p @ 1 = 1 @ q
@@ -410,8 +410,8 @@ Instance isequiv_moveR_Mp
  {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveR_Mp p q r).
 Proof.
-  destruct r.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct r; apply isequiv_concat_lr.
+  (* [isequiv_concat_lr] is also found by typeclass search, but this is clearer to the reader. *)
 Defined.
 
 Definition equiv_moveR_Mp
@@ -423,8 +423,7 @@ Instance isequiv_moveR_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveR_pM p q r).
 Proof.
-  destruct p.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct p; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveR_pM
@@ -436,8 +435,7 @@ Instance isequiv_moveR_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
 : IsEquiv (moveR_Vp p q r).
 Proof.
-  destruct r.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct r; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveR_Vp
@@ -449,8 +447,7 @@ Instance isequiv_moveR_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
 : IsEquiv (moveR_pV p q r).
 Proof.
-  destruct p.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct p; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveR_pV
@@ -462,8 +459,7 @@ Instance isequiv_moveL_Mp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveL_Mp p q r).
 Proof.
-  destruct r.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct r; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveL_Mp
@@ -475,8 +471,7 @@ Definition isequiv_moveL_pM
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : y = x)
 : IsEquiv (moveL_pM p q r).
 Proof.
-  destruct p.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct p; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveL_pM
@@ -488,8 +483,7 @@ Instance isequiv_moveL_Vp
   {A : Type} {x y z : A} (p : x = z) (q : y = z) (r : x = y)
 : IsEquiv (moveL_Vp p q r).
 Proof.
-  destruct r.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct r; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveL_Vp
@@ -501,8 +495,7 @@ Instance isequiv_moveL_pV
   {A : Type} {x y z : A} (p : z = x) (q : y = z) (r : y = x)
 : IsEquiv (moveL_pV p q r).
 Proof.
-  destruct p.
-  exact (isequiv_compose (equiv_concat_l _ _) (equiv_concat_r _ _)).
+  destruct p; apply isequiv_concat_lr.
 Defined.
 
 Definition equiv_moveL_pV

--- a/theories/Types/Paths.v
+++ b/theories/Types/Paths.v
@@ -722,9 +722,7 @@ Definition dpath_path_lr {A : Type} {x1 x2 : A}
   transport (fun x => x = x) p q = r.
 Proof.
   destruct p; simpl.
-  transitivity (q @ 1 = r).
-  - exact (equiv_concat_r (concat_1p r) (q @ 1)).
-  - exact (equiv_concat_l (concat_p1 q)^ r).
+  symmetry; apply equiv_p1_1q.
 Defined.
 
 Definition dpath_path_Fl {A B : Type} {f : A -> B} {x1 x2 : A} {y : B}
@@ -766,9 +764,7 @@ Definition dpath_path_FFlr {A B : Type} {f : A -> B} {g : B -> A}
   transport (fun x => g (f x) = x) p q = r.
 Proof.
   destruct p; simpl.
-  transitivity (q @ 1 = r).
-  - exact (equiv_concat_r (concat_1p r) (q @ 1)).
-  - exact (equiv_concat_l (concat_p1 q)^ r).
+  symmetry; apply equiv_p1_1q.
 Defined.
 
 Definition dpath_path_lFFr {A B : Type} {f : A -> B} {g : B -> A}
@@ -778,9 +774,7 @@ Definition dpath_path_lFFr {A B : Type} {f : A -> B} {g : B -> A}
   transport (fun x => x = g (f x)) p q = r.
 Proof.
   destruct p; simpl.
-  transitivity (q @ 1 = r).
-  - exact (equiv_concat_r (concat_1p r) (q @ 1)).
-  - exact (equiv_concat_l (concat_p1 q)^ r).
+  symmetry; apply equiv_p1_1q.
 Defined.
 
 Definition dpath_paths2 {A : Type} {x y : A}
@@ -792,8 +786,8 @@ Definition dpath_paths2 {A : Type} {x y : A}
   transport (fun a => idpath a = idpath a) p q = r.
 Proof.
   destruct p. simpl.
-  refine (_ oE (equiv_whiskerR _ _ 1)^-1).
-  refine (_ oE (equiv_whiskerL 1 _ _)^-1).
+  refine (_ oE equiv_cancelR _ _ 1).
+  refine (_ oE equiv_cancelL 1 _ _).
   refine (equiv_concat_lr _ _).
   - symmetry; apply whiskerR_p1_1.
   - apply whiskerL_1p_1.


### PR DESCRIPTION
I noticed that a lot of proofs in Paths.v were essentially reproving isequiv_concat_lr using isequiv_compose.  This PR directly uses isequiv_concat_lr for those results.  While doing this, I thought it would be cleaner to explicitly define concat_l, concat_r and concat_lr (corresponding to equiv_concat_l, equiv_concat_r and equiv_concat_lr).  We already had a notation concatR, but in all of the places it was used, rhs_V worked better.  So the first commit removes concatR, and the next two commits add the new definitions and then use them.

The fourth commit is independent, but similar in spirit.

The library builds after each commit.