### PR TITLE
Improvements to Truncations/Core

### DIFF
--- a/theories/Algebra/Groups/FreeProduct.v
+++ b/theories/Algebra/Groups/FreeProduct.v
@@ -777,8 +777,7 @@ Proof.
   refine (equiv_sigma_prod0 _ _ oE equiv_functor_sigma_id (fun _ => equiv_sigma_contr _)).
   intros f.
   rapply contr_forall.
-  intros []; apply contr_inhab_prop.
-  apply tr.
+  intros []; rapply contr_inhabited_hprop.
   exact (grp_homo_unit _ @ (grp_homo_unit _)^).
 Defined.
 

--- a/theories/Misc/BarInduction.v
+++ b/theories/Misc/BarInduction.v
@@ -138,11 +138,6 @@ Proof.
   intros P dP iP bP.
   apply merely_inhabited_iff_inhabited_stable.
   rapply (pDBI (Tr (-1) o P)).
-  - intro l.
-    destruct (dP l) as [p | np].
-    + left; exact (tr p).
-    + right; intro s.
-      by strip_truncations.
   - intros l q.
     refine (tr (iP _ _)).
     intro a; apply merely_inhabited_iff_inhabited_stable, (q a).

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -200,11 +200,8 @@ Notation "A \/ B" := (hor A B) : hprop_scope.
 
 Definition himage {X Y} (f : X -> Y) := image (Tr (-1)) f.
 
-Definition contr_inhab_prop {A} `{IsHProp A} (ma : merely A) : Contr A.
-Proof.
-  refine (@contr_trunc_conn (Tr (-1)) A _ _); try assumption.
-  exact (contr_inhabited_hprop _ ma).
-Defined.
+Definition contr_merely_inhabited_hprop {A} `{IsHProp A} (ma : merely A) : Contr A
+  := contr_inhabited_hprop _ (tr^-1 ma).
 
 (** A stable type is logically equivalent to its (-1)-truncation. (It follows that this is true for decidable types as well.) *)
 Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -185,15 +185,23 @@ Defined.
 #[export]
 Hint Immediate istruncmap_mapinO_tr : typeclass_instances.
 
-(** A stable type is logically equivalent to its (-1)-truncation. (It follows that this is true for decidable types as well.) *)
-Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
-  : Tr (-1) A <-> A.
+(** ** How stability interacts with truncation *)
+
+(** For [n >= -1], a stable type is logically equivalent to its [n]-truncation. (It follows that this is true for decidable types as well.) *)
+Definition trunc_inhabited_iff_inhabited_stable (n : trunc_index) {A} {A_stable : Stable A}
+  : Tr n.+1 A <-> A.
 Proof.
-  refine (_, tr).
+  nrefine (_, tr).
   intro ma.
   apply stable; intro na.
-  revert ma; rapply Trunc_ind; exact na.
+  strip_truncations.
+  exact (na ma).
 Defined.
+
+(** The most common case involves [Tr (-1)], so we give it its own name. *)
+Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
+  : Tr (-1) A <-> A
+  := trunc_inhabited_iff_inhabited_stable (-2).
 
 (** ** A few special things about the (-2)-truncation *)
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -185,7 +185,7 @@ Defined.
 #[export]
 Hint Immediate istruncmap_mapinO_tr : typeclass_instances.
 
-(** ** How stability interacts with truncation *)
+(** ** How stability and decidability interact with truncation *)
 
 (** For [n >= -1], a stable type is logically equivalent to its [n]-truncation. (It follows that this is true for decidable types as well.) *)
 Definition trunc_inhabited_iff_inhabited_stable (n : trunc_index) {A} {A_stable : Stable A}
@@ -202,6 +202,13 @@ Defined.
 Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
   : Tr (-1) A <-> A
   := trunc_inhabited_iff_inhabited_stable (-2).
+
+Instance decidable_trunc_decidable (n : trunc_index) {A} {A_decidable : Decidable A}
+  : Decidable (Tr n.+1 A).
+Proof.
+  rapply decidable_iff.
+  symmetry; rapply trunc_inhabited_iff_inhabited_stable.
+Defined.
 
 (** ** A few special things about the (-2)-truncation *)
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -341,16 +341,15 @@ Defined.
 (** ** Tactic to remove truncations in hypotheses if possible *)
 
 Ltac strip_truncations :=
-  (** search for truncated hypotheses *)
   progress repeat
     match goal with
     | [ T : _ |- _ ]
       => revert_opaque T;
         refine (@Trunc_ind _ _ _ _ _);
-        (** ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately truncated *)
+        (* Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately truncated: *)
         [];
         intro T
-  end.
+    end.
 
 (** See [strip_reflections] and [strip_modalities] for generalizations to other reflective subuniverses and modalities.  We provide this version because it sometimes needs fewer universes (due to the cumulativity of [Trunc]).  However, that same cumulativity sometimes causes free universe variables.  For a hypothesis of type [Trunc@{i} X], we can use [Trunc_ind@{i j}], but sometimes Coq uses [Trunc_ind@{k j}] with [i <= k] and [k] otherwise free.  In these cases, [strip_reflections] and/or [strip_modalities] may generate fewer universe variables. *)
 

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -200,9 +200,6 @@ Notation "A \/ B" := (hor A B) : hprop_scope.
 
 Definition himage {X Y} (f : X -> Y) := image (Tr (-1)) f.
 
-Definition contr_merely_inhabited_hprop {A} `{IsHProp A} (ma : merely A) : Contr A
-  := contr_inhabited_hprop _ (tr^-1 ma).
-
 (** A stable type is logically equivalent to its (-1)-truncation. (It follows that this is true for decidable types as well.) *)
 Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
   : Tr (-1) A <-> A.

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -50,6 +50,21 @@ Definition Trunc_rec_tr n {A : Type}
   : Trunc_rec (A:=A) (tr (n:=n)) == idmap
   := Trunc_ind _ (fun a => idpath).
 
+(** ** Tactic to remove truncations in hypotheses if possible *)
+
+Ltac strip_truncations :=
+  progress repeat
+    match goal with
+    | [ T : _ |- _ ]
+      => revert_opaque T;
+        refine (@Trunc_ind _ _ _ _ _);
+        (* Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately truncated: *)
+        [];
+        intro T
+    end.
+
+(** See [strip_reflections] and [strip_modalities] for generalizations to other reflective subuniverses and modalities.  We provide this version because it sometimes needs fewer universes (due to the cumulativity of [Trunc]).  However, that same cumulativity sometimes causes free universe variables.  For a hypothesis of type [Trunc@{i} X], we can use [Trunc_ind@{i j}], but sometimes Coq uses [Trunc_ind@{k j}] with [i <= k] and [k] otherwise free.  In these cases, [strip_reflections] and/or [strip_modalities] may generate fewer universe variables. *)
+
 (** ** [Trunc] is a modality *)
 
 Definition Tr (n : trunc_index) : Modality.
@@ -170,6 +185,16 @@ Defined.
 #[export]
 Hint Immediate istruncmap_mapinO_tr : typeclass_instances.
 
+(** A stable type is logically equivalent to its (-1)-truncation. (It follows that this is true for decidable types as well.) *)
+Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
+  : Tr (-1) A <-> A.
+Proof.
+  refine (_, tr).
+  intro ma.
+  apply stable; intro na.
+  revert ma; rapply Trunc_ind; exact na.
+Defined.
+
 (** ** A few special things about the (-2)-truncation *)
 
 (** The type of contractible types is contractible. *)
@@ -199,16 +224,6 @@ Declare Scope hprop_scope.
 Notation "A \/ B" := (hor A B) : hprop_scope.
 
 Definition himage {X Y} (f : X -> Y) := image (Tr (-1)) f.
-
-(** A stable type is logically equivalent to its (-1)-truncation. (It follows that this is true for decidable types as well.) *)
-Definition merely_inhabited_iff_inhabited_stable {A} {A_stable : Stable A}
-  : Tr (-1) A <-> A.
-Proof.
-  refine (_, tr).
-  intro ma.
-  apply stable; intro na.
-  revert ma; rapply Trunc_ind; exact na.
-Defined.
 
 (** ** Surjections *)
 
@@ -337,21 +352,6 @@ Proof.
     intros [].
     reflexivity.
 Defined.
-
-(** ** Tactic to remove truncations in hypotheses if possible *)
-
-Ltac strip_truncations :=
-  progress repeat
-    match goal with
-    | [ T : _ |- _ ]
-      => revert_opaque T;
-        refine (@Trunc_ind _ _ _ _ _);
-        (* Ensure that we didn't generate more than one subgoal, i.e. that the goal was appropriately truncated: *)
-        [];
-        intro T
-    end.
-
-(** See [strip_reflections] and [strip_modalities] for generalizations to other reflective subuniverses and modalities.  We provide this version because it sometimes needs fewer universes (due to the cumulativity of [Trunc]).  However, that same cumulativity sometimes causes free universe variables.  For a hypothesis of type [Trunc@{i} X], we can use [Trunc_ind@{i j}], but sometimes Coq uses [Trunc_ind@{k j}] with [i <= k] and [k] otherwise free.  In these cases, [strip_reflections] and/or [strip_modalities] may generate fewer universe variables. *)
 
 (** ** Iterated truncations *)
 


### PR DESCRIPTION
The makes some changes that were originally in https://github.com/jdchristensen/HoTT/pull/39 but didn't make it into #2274.

The main thing is that `decidable_trunc_decidable` is added (as an instance), which abstracts out something done in BarInduction.v.  One other result is generalized, and a few proofs are simplified.

Since some things get moved around, it's best to read this one commit at a time.  The commits that move things don't make any changes.

@thchatzidiamantis Can you look this over as well?