### PR TITLE
Connectivity

### DIFF
--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -211,13 +211,10 @@ Section GBM.
         Definition equiv_Ocodeleft2
           : O (Pushout Ocodeleft2ab Ocodeleft2ac) <~> O codeleft2.
         Proof.
-          refine ((equiv_O_functor O (equiv_sigma_contr
-                  (fun yqqu : codeleft2 =>
-                     O (Join ((x0; codeleft2_q00 yqqu) = (x1; codeleft2_q10 yqqu))
-                             ((codeleft2_y0 yqqu ; codeleft2_q10 yqqu) = (y1; q11)))))) oE _).
-          refine ((equiv_O_sigma_O O _)^-1 oE _).
+          refine (_ oE equiv_O_functor O equiv_Ocodeleft2plus).
+          refine (_ oE (equiv_O_sigma_O O _)^-1).
           apply equiv_O_functor.
-          exact equiv_Ocodeleft2plus.
+          rapply equiv_sigma_contr.
         Defined.
 
         (** The next step is to reassociate the resulting double-pushout and "contract" both of them, one after the other, because they are pushouts along equivalences.  In order to do this, we need first of all to know that the resulting map from [codeleft0] to the above pushout factors through [Ocodeleft2b] via an equivalence.  Here's the equivalence: *)

--- a/theories/Homotopy/Join/Core.v
+++ b/theories/Homotopy/Join/Core.v
@@ -871,33 +871,24 @@ Section JoinTrunc.
     : IsConnected (m +2+ n) (Join A B).
   Proof.
     apply isconnected_from_elim; intros C ? k.
-    pose @istrunc_inO_tr.
-    pose proof (istrunc_extension_along_conn
-                  (fun b:B => tt) (fun _ => C) (k o joinr)).
-    unfold ExtensionAlong in *.
     transparent assert (f : (A -> {s : Unit -> C &
                                    forall x, s tt = k (joinr x)})).
     { intros a; exists (fun _ => k (joinl a)); intros b.
       exact (ap k (jglue a b)). }
-    assert (h := isconnected_elim
-                   m {s : Unit -> C & forall x : B, s tt = k (joinr x)} f).
+    assert (h : NullHomotopy f).
+    { rapply (isconnected_elim m).
+      rapply (istrunc_extension_along_conn (n:=n)). }
     unfold NullHomotopy in *; destruct h as [[c g] h].
     exists (c tt).
     snapply Join_ind.
-    - intros a; cbn. exact (ap10 (h a)..1 tt).
-    - intros b; cbn. exact ((g b)^).
+    - intros a; cbn beta. exact (ap10 (h a)..1 tt).
+    - intros b; cbn beta. exact (g b)^.
     - intros a b.
-      rewrite transport_paths_FlFr, ap_const, concat_p1; cbn.
-      subst f; set (ha := h a); clearbody ha; clear h;
-      assert (ha2 := ha..2); set (ha1 := ha..1) in *;
-      clearbody ha1; clear ha; cbn in *.
-      rewrite <- (inv_V (ap10 ha1 tt)).
-      rewrite <- inv_pp.
-      apply inverse2.
-      refine (_ @ apD10 ha2 b); clear ha2.
-      rewrite transport_forall_constant, transport_paths_FlFr.
-      rewrite ap_const, concat_p1.
-      reflexivity.
+      transport_paths Fl.
+      apply moveL_pV, moveR_Mp.
+      lhs_V napply (apD10 (h a)..2 b); simpl.
+      lhs napply transport_forall_constant.
+      napply transport_paths_Fl.
   Defined.
 
 End JoinTrunc.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -146,6 +146,20 @@ Proof.
   exact (isconnected_pred_add n m _).
 Defined.
 
+(** ** (-2)-connectedness *)
+
+(** Every type is (-2)-connected. *)
+Definition isconnected_minus_two A : IsConnected (-2) A
+  := istrunc_truncation (-2) A.
+
+(** Every map is (-2)-connected. *)
+Definition isconnmap_minus_two {A B : Type} (f : A -> B)
+  : IsConnMap (-2) f
+  := fun b => isconnected_minus_two _.
+
+Hint Immediate isconnected_minus_two : typeclass_instances.
+Hint Immediate isconnmap_minus_two : typeclass_instances.
+
 (** ** 0-connectedness *)
 
 (** To be 0-connected is the same as to be (-1)-connected and that any two points are merely equal.  TODO: This should also be generalized to separated subuniverses (CORS Remark 2.35).  *)

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -64,11 +64,11 @@ Defined.
 
 (** The connectivity of a pointed type and (the inclusion of) its point are intimately connected. *)
 
-(** We can't make both of these [Instance]s, as that would result in infinite loops. *)
+(** We can't make both of these [Instance]s, as that would result in infinite loops. And the first one is not likely to be useful as an instance, as it requires guessing the point [a0]. *)
 
-Instance conn_pointed_type@{u} {n : trunc_index} {A : Type@{u}} (a0:A)
-  `{IsConnMap n _ _ (unit_name a0)}
-  : IsConnected n.+1 A | 1000.
+Definition conn_pointed_type@{u} {n : trunc_index} {A : Type@{u}} (a0:A)
+  `{IsConnMap@{u} n _ _ (unit_name a0)}
+  : IsConnected n.+1 A.
 Proof.
   apply isconnected_conn_map_to_unit.
   exact (OO_cancelR_conn_map (Tr n.+1) (Tr n) (unit_name a0) (const_tt A)).
@@ -82,6 +82,7 @@ Proof.
   apply O_lex_leq_Tr.
 Defined.
 
+(** [conn_point_incl] can be made an instance, but at the time of writing, this doesn't cause any additional goals to be solved compared to making it an immediate hint, so we do the latter. *)
 #[export] Hint Immediate conn_point_incl : typeclass_instances.
 
 (** Note that [OO_cancelR_conn_map] and [OO_cancelL_conn_map] (Proposition 2.31 of CORS) generalize the above statements to 2/3 of a 2-out-of-3 property for connected maps, for any reflective subuniverse and its subuniverse of separated types.  If useful, we could specialize that more general form explicitly to truncations. *)

--- a/theories/Truncations/Core.v
+++ b/theories/Truncations/Core.v
@@ -165,7 +165,7 @@ Defined.
 Hint Extern 1000 (IsTrunc _ _) => simple apply istrunc_inO_tr; solve [ trivial ] : typeclass_instances.
 (** This doesn't seem to be quite the same as [Hint Immediate] with a different cost either, though.  *)
 
-(** Unfortunately, this isn't perfect; Coq still can't always find [In n] hypotheses in the context when it wants [IsTrunc].  You can always apply [istrunc_inO_tr] explicitly, but sometimes it also works to just [pose] it into the context. *)
+(** Unfortunately, this isn't perfect; Coq still can't always find [In n] hypotheses in the context when it wants [IsTrunc].  You can always apply [istrunc_inO_tr] explicitly, but sometimes it also works to just [pose] it into the context (at the risk of causing loops in typeclass search). *)
 
 (** We do the same for [IsTruncMap n] and [MapIn (Tr n)]. *)
 Instance mapinO_tr_istruncmap {n : trunc_index} {A B : Type}


### PR DESCRIPTION
Some things related to connectivity, in preparation for some work on cofibres.

The first commit removes an unused instance.  This frees up the reverse implication to be an instance, but it turned out that that didn't help anything, so I left it as an immediate hint.

The second commit simplifies the proof of isconnected_join.  I started looking at this because the third commit caused this proof to fail.  The old proof posed `istrunc_inO_tr` into the context, but since the reverse implication is an instance, this makes loops possible.  The old proof got lucky, but this was fragile, so I refactored the proof.  In the end, it's much cleaner.

The third commit adds new instances saying that all types and maps are (-2)-connected.

The fourth commit isn't directly related, but while working on this I noticed that one of the lemmas leading up to Blakers-Massey can have a simpler proof.