### PR TITLE
Cofiber: add isconnmap_isconnected_cofiber, converse of isconnected_cofiber

### DIFF
--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -45,7 +45,7 @@ Defined.
 Section GBM.
     Context {X Y : Type} (Q : X -> Y -> Type).
 
-    (** Here's the hypothesis of ABFJ's generalized Blakers-Massey.  It works for any reflective subuniverse, not only modalities! *)
+    (** Here's the hypothesis of ABFJ's generalized Blakers-Massey theorem.  It works for any reflective subuniverse, not only modalities!  In the application, [O] will be [Tr (n +2+ m)] and we'll use [isconnected_join] to verify [isconnected_cogap]. *)
     Context (O : ReflectiveSubuniverse).
     Context
       (isconnected_cogap :
@@ -571,7 +571,7 @@ Definition blakers_massey_po `{Univalence} (m n : trunc_index)
   `{H1 : !IsConnMap m.+1 f} `{H2 : !IsConnMap n g}
   : IsConnMap (n +2+ m).-1 (pullback_corec (pglue (f:=f) (g:=g))).
 Proof.
-  (** We postcompose our map with an equivalence from the the pullback of the pushout of [f] and [g] to the pullback of an equivalent [SPushout] over a family [Q]. *)
+  (** We postcompose our map with an equivalence from the pullback of the pushout of [f] and [g] to the pullback of an equivalent [SPushout] over a family [Q]. *)
   pose (Q := fun y z => {x : X & f x = y /\ g x = z}).
   snapply cancelL_equiv_conn_map.
   1: exact (Pullback (spushl Q) (spushr Q)).

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -525,32 +525,51 @@ End GBM.
 
 (** ** The classical Blakers-Massey Theorem *)
 
-Instance blakers_massey `{Univalence} (m n : trunc_index)
-  {X Y : Type} (Q : X -> Y -> Type)
-  `{forall x, IsConnected m.+1 { y : Y & Q x y } }
-  `{forall y, IsConnected n.+1 { x : X & Q x y } }
+(** We first state a version that gracefully extends to the bottom by assuming that path types in [{ x : X & Q x y }] are connected rather than the types themselves. *)
+Definition blakers_massey_connected_paths `{Univalence}
+  (m n : trunc_index) {X Y : Type} (Q : X -> Y -> Type)
+  `{forall x, IsConnected m.+1 { y : Y & Q x y }}
+  `{forall y x1 qx1y x2 qx2y, IsConnected n ((x1; qx1y) = (x2; qx2y) :> { x : X & Q x y })}
   (x : X) (y : Y)
-  : IsConnMap (n +2+ m) (@spglue X Y Q x y).
+  : IsConnMap (n +2+ m) (@spglue X Y Q x y)
+  := contr_code_inhab Q (n +2+ m) _ x (merely_isconnected m _) (spushr Q y).
+  (* Typeclass search finds [isconnected_join]. *)
+
+(** Here is the classical statement where we instead assume that the types are connected.  [m] and [n] here match the usage in the previous result. *)
+Instance blakers_massey `{Univalence}
+  (m n : trunc_index) {X Y : Type} (Q : X -> Y -> Type)
+  `{forall x, IsConnected m.+1 { y : Y & Q x y }}
+  `{forall y, IsConnected n.+1 { x : X & Q x y }}
+  (x : X) (y : Y)
+  : IsConnMap (n +2+ m) (@spglue X Y Q x y)
+  := blakers_massey_connected_paths m n Q x y.
+
+(** We can in fact reduce [m] by one in both the statement and the conclusion.  When [m] is [-2], this is one step weaker than what [blakers_massey_connected_paths] gives, but it is convenient to have this uniform statement.  We'll use this convention for the later results as well. *)
+Instance blakers_massey' `{Univalence}
+  (m n : trunc_index) {X Y : Type} (Q : X -> Y -> Type)
+  `{forall x, IsConnected m.+1 { y : Y & Q x y }}
+  `{forall y, IsConnected n { x : X & Q x y }}
+  (x : X) (y : Y)
+  : IsConnMap (n +2+ m).-1 (@spglue X Y Q x y).
 Proof.
-  intros r.
-  snrefine (contr_code_inhab Q (n +2+ m) _ x
-                            (merely_isconnected m _) (spushr Q y) r).
-  1: intros; apply isconnected_join.
-  all: exact _.
+  destruct n.
+  - apply isconnmap_pred'.
+    rapply blakers_massey_connected_paths.
+  - rapply blakers_massey_connected_paths.
 Defined.
 
 (** A sigma functor is connected if its fibers are, so we have the following. *)
 Definition blakers_massey_total_map `{Univalence} (m n : trunc_index)
   {X Y : Type} (Q : X -> Y -> Type)
   `{forall x, IsConnected m.+1 { y : Y & Q x y } }
-  `{forall y, IsConnected n.+1 { x : X & Q x y } }
-  : IsConnMap (Tr (n +2+ m)) (spushout_sjoin_map Q)
+  `{forall y, IsConnected n { x : X & Q x y } }
+  : IsConnMap (Tr (n +2+ m).-1) (spushout_sjoin_map Q)
   := _.
 
 Definition blakers_massey_po `{Univalence} (m n : trunc_index)
   {X Y Z : Type} (f : X -> Y) (g : X -> Z)
-  `{H1 : !IsConnMap m.+1 f} `{H2 : !IsConnMap n.+1 g}
-  : IsConnMap (n +2+ m) (pullback_corec (pglue (f:=f) (g:=g))).
+  `{H1 : !IsConnMap m.+1 f} `{H2 : !IsConnMap n g}
+  : IsConnMap (n +2+ m).-1 (pullback_corec (pglue (f:=f) (g:=g))).
 Proof.
   (** We postcompose our map with an equivalence from the the pullback of the pushout of [f] and [g] to the pullback of an equivalent [SPushout] over a family [Q]. *)
   pose (Q := fun y z => {x : X & f x = y /\ g x = z}).
@@ -587,5 +606,5 @@ Instance freudenthal `{Univalence} (n : trunc_index)
 Proof.
   (* If we post-compose [merid : X -> North = South] with an equivalence [North = South <~> P], where [P] is the pullback of the inclusions [Unit -> Susp X] hitting [North] and [South], we get the canonical comparison map [X -> P] whose connectivity follows from the Blakers-Massey theorem. *)
   rapply (cancelL_equiv_conn_map _ _ (equiv_pullback_unit_unit_paths _ _)^-1%equiv).
-  rapply blakers_massey_po.
+  rapply (blakers_massey_po n n.+1).
 Defined.

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -527,14 +527,14 @@ End GBM.
 
 Instance blakers_massey `{Univalence} (m n : trunc_index)
   {X Y : Type} (Q : X -> Y -> Type)
-  `{forall y, IsConnected m.+1 { x : X & Q x y } }
-  `{forall x, IsConnected n.+1 { y : Y & Q x y } }
+  `{forall x, IsConnected m.+1 { y : Y & Q x y } }
+  `{forall y, IsConnected n.+1 { x : X & Q x y } }
   (x : X) (y : Y)
-  : IsConnMap (m +2+ n) (@spglue X Y Q x y).
+  : IsConnMap (n +2+ m) (@spglue X Y Q x y).
 Proof.
   intros r.
-  snrefine (contr_code_inhab Q (m +2+ n) _ x
-                            (merely_isconnected n _) (spushr Q y) r).
+  snrefine (contr_code_inhab Q (n +2+ m) _ x
+                            (merely_isconnected m _) (spushr Q y) r).
   1: intros; apply isconnected_join.
   all: exact _.
 Defined.
@@ -542,15 +542,15 @@ Defined.
 (** A sigma functor is connected if its fibers are, so we have the following. *)
 Definition blakers_massey_total_map `{Univalence} (m n : trunc_index)
   {X Y : Type} (Q : X -> Y -> Type)
-  `{forall y, IsConnected m.+1 { x : X & Q x y } }
-  `{forall x, IsConnected n.+1 { y : Y & Q x y } }
-  : IsConnMap (Tr (m +2+ n)) (spushout_sjoin_map Q)
+  `{forall x, IsConnected m.+1 { y : Y & Q x y } }
+  `{forall y, IsConnected n.+1 { x : X & Q x y } }
+  : IsConnMap (Tr (n +2+ m)) (spushout_sjoin_map Q)
   := _.
 
 Definition blakers_massey_po `{Univalence} (m n : trunc_index)
   {X Y Z : Type} (f : X -> Y) (g : X -> Z)
-  `{H1 : !IsConnMap n.+1 f} `{H2 : !IsConnMap m.+1 g}
-  : IsConnMap (m +2+ n) (pullback_corec (pglue (f:=f) (g:=g))).
+  `{H1 : !IsConnMap m.+1 f} `{H2 : !IsConnMap n.+1 g}
+  : IsConnMap (n +2+ m) (pullback_corec (pglue (f:=f) (g:=g))).
 Proof.
   (** We postcompose our map with an equivalence from the the pullback of the pushout of [f] and [g] to the pullback of an equivalent [SPushout] over a family [Q]. *)
   pose (Q := fun y z => {x : X & f x = y /\ g x = z}).
@@ -570,11 +570,11 @@ Proof.
     napply concat_1p. }
   rapply blakers_massey_total_map.
   (** What's left is to check that the partial total spaces of [Q] are connected, which we get since [f] and [g] are connected maps. We just have to strip off the irrelevant parts of [Q] to get the hfiber in each case. *)
-  - intros z.
-    nrefine (isconnected_equiv' _ _ _ (H2 z)).
-    make_equiv_contr_basedpaths.
   - intros y.
     nrefine (isconnected_equiv' _ _ _ (H1 y)).
+    make_equiv_contr_basedpaths.
+  - intros z.
+    nrefine (isconnected_equiv' _ _ _ (H2 z)).
     make_equiv_contr_basedpaths.
 Defined.
 

--- a/theories/Homotopy/BlakersMassey.v
+++ b/theories/Homotopy/BlakersMassey.v
@@ -597,6 +597,30 @@ Proof.
     make_equiv_contr_basedpaths.
 Defined.
 
+(** A version that requires [g] to be surjective instead of [f]. *)
+Definition blakers_massey_po' `{Univalence} (m n : trunc_index)
+  {X Y Z : Type} (f : X -> Y) (g : X -> Z)
+  `{H1 : !IsConnMap m f} `{H2 : !IsConnMap n.+1 g}
+  : IsConnMap (n +2+ m).-1 (pullback_corec (pglue (f:=f) (g:=g))).
+Proof.
+  rewrite trunc_index_add_comm.
+  (* We will postcompose with an equivalence to the symmetrical pullback. *)
+  snapply cancelL_equiv_conn_map.
+  (* And we'll show that the composite is homotopic to the symmetrical [pullback_corec] map, which we already know is connected. *)
+  3: rapply (conn_map_homotopic _ _ _ _ (blakers_massey_po n m g f)).
+  - (* We give the equivalence between the pullbacks. *)
+    refine (_ oE equiv_pullback_symm _ _).
+    snapply (equiv_pullback pushout_sym equiv_idmap equiv_idmap (fun _ => 1) (fun _ => 1)).
+  - (* We show that the composite is homotopic to the symmetrical [pullback_corec] map. *)
+    intro x; cbn; unfold pullback_corec, functor_sigma; cbn.
+    apply (ap (fun w => (g x; f x; w))).
+    symmetry; lhs napply concat_1p; lhs napply concat_p1.
+    lhs napply (ap_V pushout_sym_map (pglue x)).
+    rhs_V napply inv_V.
+    apply inverse2.
+    napply Pushout_rec_beta_pglue.
+Defined.
+
 (** ** The Freudenthal Suspension Theorem *)
 
 (** The Freudenthal suspension theorem is a fairly trivial corollary of the Blakers-Massey theorem.  It says that [merid : X -> North = South] is highly connected. *)

--- a/theories/Homotopy/Cofiber.v
+++ b/theories/Homotopy/Cofiber.v
@@ -98,21 +98,20 @@ Local Open Scope trunc_scope.
 (** ** Connectivity of cofibers *)
 
 (** The cofiber of an [n]-connected map is [n.+1]-connected. *)
-Definition isconnnected_cofiber (n : trunc_index) {X Y : Type} (f : X -> Y)
+Definition isconnected_cofiber (n : trunc_index) {X Y : Type} (f : X -> Y)
   {fc : IsConnMap n f}
   : IsConnected n.+1 (Cofiber f).
 Proof.
   apply isconnected_from_elim.
   intros C H' g.
   exists (g (cf_apex _)).
-  snapply cofiber_ind.
+  snapply cofiber_ind; cbn beta.
   - rapply (conn_map_elim n f).
     intros x.
     exact (ap g (cfglue f x)).
   - exists idpath.
     intros x.
-    lhs snapply transport_paths_Fl.
-    apply moveR_Vp.
+    transport_paths Fl.
     rhs napply concat_p1.
     napply conn_map_comp.
 Defined.

--- a/theories/Homotopy/Cofiber.v
+++ b/theories/Homotopy/Cofiber.v
@@ -127,11 +127,11 @@ Proof.
   apply cfglue.
 Defined.
 
-(** Blakers-Massey implies that the comparison map is highly connected. *)
+(** Blakers-Massey implies that the comparison map is highly connected.  Here we assume that [X] is merely inhabited.  There is a variant that instead assumes that [f] is surjective, with the same proof except that [blakers_massey_po] is used. *)
 Definition isconnected_fiber_to_cofiber `{Univalence}
   (n m : trunc_index) {X Y : Type} {ac : IsConnected m.+1 X}
-  (f : X -> Y) {fc : IsConnMap n.+1 f} (y : Y)
-  : IsConnMap (m +2+ n) (fiber_to_path_cofiber f y).
+  (f : X -> Y) {fc : IsConnMap n f} (y : Y)
+  : IsConnMap (m +2+ n).-1 (fiber_to_path_cofiber f y).
 Proof.
   (* It's enough to check the connectivity of [functor_sigma idmap (fiber_to_path_cofiber f)]. *)
   revert y; snapply conn_map_fiber.
@@ -141,10 +141,23 @@ Proof.
   snapply (cancelL_equiv_conn_map _ _ (equiv_pullback_unit_hfiber _ _)^-1%equiv).
   (* The composite is homotopic to the map from [blakers_massey_po], with the only difference being an extra [1 @ _]. *)
   snapply conn_map_homotopic.
-  3: rapply (blakers_massey_po n m.+1).
+  3: rapply blakers_massey_po'.
   (* Use [compute.] to see the details of the goal. *)
   intros x.
   apply (ap (fun z => (f x; tt; z))).
   unfold fiber_to_path_cofiber; simpl.
   symmetry; apply concat_1p.
+Defined.
+
+(** This lets us prove a converse to [isconnected_cofiber] when [X] is 1-connected. *)
+Definition isconnmap_isconnected_cofiber `{Univalence}
+  (n : trunc_index) {X Y : Type} `{IsConnected 1 X}
+  (f : X -> Y) `{IsConnected n.+1 (Cofiber f)}
+  : IsConnMap n f.
+Proof.
+  simple_induction n n IHn.
+  - exact _.
+  - intros conn_cof y.
+    rapply (isconnected_conn_map_isconnected (n.+1) (fiber_to_path_cofiber f y)).
+    rapply (isconnected_fiber_to_cofiber n 0).
 Defined.

--- a/theories/Homotopy/Cofiber.v
+++ b/theories/Homotopy/Cofiber.v
@@ -141,7 +141,7 @@ Proof.
   snapply (cancelL_equiv_conn_map _ _ (equiv_pullback_unit_hfiber _ _)^-1%equiv).
   (* The composite is homotopic to the map from [blakers_massey_po], with the only difference being an extra [1 @ _]. *)
   snapply conn_map_homotopic.
-  3: rapply blakers_massey_po.
+  3: rapply (blakers_massey_po n m.+1).
   (* Use [compute.] to see the details of the goal. *)
   intros x.
   apply (ap (fun z => (f x; tt; z))).

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -515,7 +515,7 @@ Section Reflective_Subuniverse.
     : IsEquiv (to O T) -> In O T
     := fun _ => inO_equiv_inO (O T) (to O T)^-1.
 
-    (** We don't make this an ordinary instance, but we allow it to solve [In O] constraints if we already have [IsEquiv] as a hypothesis.  *)
+    (** We don't make this an ordinary instance, but we allow it to solve [In O] constraints if we already have [IsEquiv] as a hypothesis. [Hint Immediate] doesn't support #[export] in Sections, so we repeat this at the end of the file. *)
     #[local]
     Hint Immediate inO_isequiv_to_O : typeclass_instances.
 
@@ -1838,6 +1838,15 @@ Section ConnectedMaps.
               (equiv_sigma_contr _)^-1 _).
   Defined.
 
+ (** Combining the above, we see that if [f] is a connected map with connected codomain, then the domain is connected. *)
+ Instance isconnected_conn_map_isconnected {A B : Type} (f : A -> B)
+         `{IsConnMap O _ _ f} `{IsConnected O B}
+   : IsConnected O A.
+ Proof.
+   rapply isconnected_conn_map_to_unit.
+   rapply conn_map_compose.
+ Defined.
+
   (* Lemma 7.5.10: A map to a type in [O] exhibits its codomain as the [O]-reflection of its domain if it is [O]-connected.  (The converse is true if and only if [O] is a modality.) *)
   Definition isequiv_O_rec_conn_map {A B : Type} `{In O B}
              (f : A -> B) `{IsConnMap O _ _ f}
@@ -2187,6 +2196,6 @@ Proof.
     intros; rapply ooextendable_conn_map_inO.
 Defined.
 
-#[export] Hint Immediate inO_isequiv_to_O : typeclass_instances.
-#[export] Hint Immediate inO_unsigma : typeclass_instances.
-#[export] Hint Immediate isconnected_conn_map_to_unit : typeclass_instances.
+Hint Immediate inO_isequiv_to_O : typeclass_instances.
+Hint Immediate inO_unsigma : typeclass_instances.
+Hint Immediate isconnected_conn_map_to_unit : typeclass_instances.

--- a/theories/Truncations/Connectedness.v
+++ b/theories/Truncations/Connectedness.v
@@ -102,12 +102,24 @@ Defined.
 
 (** ** Decreasing connectedness *)
 
-(** An [n.+1]-connected type is also [n]-connected.  This obviously can't be an [Instance]! *)
+(** An [n.+1]-connected type is also [n]-connected. *)
 Definition isconnected_pred n A `{IsConnected n.+1 A}
   : IsConnected n A.
 Proof.
   apply isconnected_from_elim; intros C ? f.
   exact (isconnected_elim n.+1 C f).
+Defined.
+
+(* As an instance, this would cause loops, but it can be added as an immediate hint. *)
+Hint Immediate isconnected_pred : typeclass_instances.
+
+(** A version explicitly using the predecessor function. *)
+Definition isconnected_pred' (n : trunc_index) (A : Type) `{IsConnected n A}
+  : IsConnected n.-1 A.
+Proof.
+  destruct n.
+  1: unfold IsConnected; simpl; apply istrunc_truncation.
+  by apply isconnected_pred.
 Defined.
 
 (** A [k]-connected type is [n]-connected, when [k >= n].  We constrain [k] by making it of the form [n +2+ m], which makes the induction go through smoothly. *)
@@ -116,9 +128,7 @@ Definition isconnected_pred_add n m A `{H : IsConnected (n +2+ m) A}
 Proof.
   induction n.
   1: assumption.
-  apply IHn.
-  apply isconnected_pred.
-  assumption.
+  rapply IHn.
 Defined.
 
 (** A version with the order of summands swapped, which is sometimes handy, e.g. in the next two results. *)
@@ -138,6 +148,11 @@ Definition merely_isconnected n A `{IsConnected n.+1 A}
 Definition is0connected_isconnected (n : trunc_index) A `{IsConnected n.+2 A}
   : IsConnected 0 A
   := isconnected_pred_add' n 0 A.
+
+Definition isconnmap_pred' (n : trunc_index) {A B : Type} (f : A -> B)
+  `{IsConnMap n _ _ f}
+  : IsConnMap n.-1 f
+  := fun b => isconnected_pred' n _.
 
 Definition isconnmap_pred_add n m A B (f : A -> B) `{IsConnMap (n +2+ m) _ _ f}
   : IsConnMap m f.


### PR DESCRIPTION
The main goal here is in the last commit, which adds a result saying that if `f : X -> Y` is a map with 1-connected domain whose cofibre is n.+1 connected, then f is n-connected.  To make this go through smoothly, I tweaked many things in the library.  The two biggest changes are in BlakersMassey:

- In the results about pushouts, instead of assuming that both maps are surjective, I only assume that `g` is.  I needed this to handle the inductive step uniformly.

- Unfortunately, the way it worked out for cofibres, I needed the opposite case, where only `f` is assumed to be surjective.  I could have reversed the pushout that defines the cofibre to make this work out, but it does seem slightly more natural in the current form, so instead I also added the result about the flipped pushout, using symmetry of pushouts and pullbacks.

Since some of the commits to BlakersMassey.v overlap, it might be easiest to read them separately.  The library builds after each commit.

This all builds on Ali's nice work in #2171.