### PR TITLE
Generalize lhs and rhs tactics to other relations

### DIFF
--- a/theories/Basics/Tactics.v
+++ b/theories/Basics/Tactics.v
@@ -365,11 +365,16 @@ Tactic Notation "stapply'" uconstr(term)
   := do_with_holes' ltac:(fun x => srefine x) term.
 
 (** Apply a tactic to one side of an equation.  For example, [lhs rapply lemma].  [tac] should produce a path. *)
-
 Tactic Notation "lhs" tactic3(tac) := nrefine (ltac:(tac) @ _).
 Tactic Notation "lhs_V" tactic3(tac) := nrefine (ltac:(tac)^ @ _).
 Tactic Notation "rhs" tactic3(tac) := nrefine (_ @ ltac:(tac)^).
 Tactic Notation "rhs_V" tactic3(tac) := nrefine (_ @ ltac:(tac)).
+
+(** Here are versions that work for a general relation.  The relation needs to be transitive and, in two cases, symmetric.  These versions also work for paths in most cases, but due to slightly different behaviours, don't work quite as well as the previous versions. *)
+Tactic Notation "lhs'" tactic3(tac) := etransitivity; [tac|].
+Tactic Notation "lhs_V'" tactic3(tac) := etransitivity; [symmetry; tac|].
+Tactic Notation "rhs'" tactic3(tac) := etransitivity; [|symmetry; tac].
+Tactic Notation "rhs_V'" tactic3(tac) := etransitivity; [|tac].
 
 (** SSReflect tactics, adapted by Robbert Krebbers *)
 Ltac done :=

--- a/theories/Pointed/pSusp.v
+++ b/theories/Pointed/pSusp.v
@@ -244,22 +244,22 @@ Proof.
               (fun f => fmap loops f o* loop_susp_unit A)
               (fun g => loop_susp_counit B o* fmap psusp g) _ _).
     + intros g. apply path_pforall.
-      refine (pmap_prewhisker _ (fmap_comp loops _ _) @* _).
-      refine (pmap_compose_assoc _ _ _ @* _).
-      refine (pmap_postwhisker _ (loop_susp_unit_natural g)^* @* _).
-      refine ((pmap_compose_assoc _ _ _)^* @* _).
-      refine (pmap_prewhisker g (loop_susp_triangle1 B) @* _).
+      lhs' exact (pmap_prewhisker _ (fmap_comp loops _ _)).
+      lhs' apply pmap_compose_assoc.
+      lhs' exact (pmap_postwhisker _ (loop_susp_unit_natural g)^* ).
+      lhs_V' apply pmap_compose_assoc.
+      lhs' exact (pmap_prewhisker g (loop_susp_triangle1 B)).
       apply pmap_postcompose_idmap.
     + intros f. apply path_pforall.
-      refine (pmap_postwhisker _ (fmap_comp psusp _ _) @* _).
-      refine ((pmap_compose_assoc _ _ _)^* @* _).
-      refine (pmap_prewhisker _ (loop_susp_counit_natural f)^* @* _).
-      refine (pmap_compose_assoc _ _ _ @* _).
-      refine (pmap_postwhisker f (loop_susp_triangle2 A) @* _).
+      lhs' exact (pmap_postwhisker _ (fmap_comp psusp _ _)).
+      lhs_V' apply pmap_compose_assoc.
+      lhs' exact (pmap_prewhisker _ (loop_susp_counit_natural f)^* ).
+      lhs' apply pmap_compose_assoc.
+      lhs' exact (pmap_postwhisker f (loop_susp_triangle2 A)).
       apply pmap_precompose_idmap.
   - apply path_pforall.
     unfold equiv_adjointify, equiv_fun.
-    napply (pmap_prewhisker _ fmap_loops_pconst @* _).
+    lhs' exact (pmap_prewhisker _ fmap_loops_pconst).
     tapply cat_zero_l.
 Defined.
 
@@ -270,7 +270,7 @@ Definition loop_susp_adjoint_nat_r `{Funext} (A B B' : pType)
   ==* fmap loops g o* loop_susp_adjoint A B f.
 Proof.
   cbn.
-  refine (_ @* pmap_compose_assoc _ _ _).
+  rhs_V' apply pmap_compose_assoc.
   apply pmap_prewhisker.
   exact (fmap_comp loops f g).
 Defined.
@@ -280,7 +280,7 @@ Definition loop_susp_adjoint_nat_l `{Funext} (A A' B : pType)
   ==* (loop_susp_adjoint A B)^-1 f o* fmap psusp g.
 Proof.
   cbn.
-  refine (_ @* (pmap_compose_assoc _ _ _)^*).
+  rhs' apply pmap_compose_assoc.
   apply pmap_postwhisker.
   exact (fmap_comp psusp g f).
 Defined.
@@ -291,7 +291,7 @@ Instance is1natural_loop_susp_adjoint_r `{Funext} (A : pType)
 Proof.
   snapply Build_Is1Natural.
   intros B B' g f.
-  refine ( _ @ cat_assoc_strong _ _ _).
+  rhs_V rapply cat_assoc_strong.
   refine (ap (fun x => x o* loop_susp_unit A) _).
   apply path_pforall.
   tapply (fmap_comp loops).

--- a/theories/WildCat/Core.v
+++ b/theories/WildCat/Core.v
@@ -356,7 +356,7 @@ Proof.
   - intros a b f g p; exact (fmap2 G (fmap2 F p)).
   - intros a; exact (fmap2 G (fmap_id F a) $@ fmap_id G (F a)).
   - intros a b c f g.
-    refine (fmap2 G (fmap_comp F f g) $@ _).
+    lhs' rapply (fmap2 G (fmap_comp F f g)).
     exact (fmap_comp G (fmap F f) (fmap F g)).
 Defined.
 
@@ -401,21 +401,21 @@ Definition gpd_hV_h {A} `{Is1Gpd A} {a b c : A} (f : b $-> c) (g : b $-> a)
 Definition gpd_moveL_1M {A} `{Is1Gpd A} {x y : A} {p q : x $-> y}
   (r : p $o q^$ $== Id _) : p $== q.
 Proof.
-  refine ((cat_idr p)^$ $@ (p $@L (gpd_issect q)^$) $@ (cat_assoc _ _ _)^$ $@ _).
+  lhs' exact ((cat_idr p)^$ $@ (p $@L (gpd_issect q)^$) $@ (cat_assoc _ _ _)^$).
   exact ((r $@R q) $@ cat_idl q).
 Defined.
 
 Definition gpd_moveR_V1 {A} `{Is1Gpd A} {x y : A} {p : x $-> y}
   {q : y $-> x} (r : Id _ $== p $o q) : p^$ $== q.
 Proof.
-  refine ((cat_idr p^$)^$ $@ (p^$ $@L r) $@ _).
+  lhs' exact ((cat_idr p^$)^$ $@ (p^$ $@L r)).
   apply gpd_V_hh.
 Defined.
 
 Definition gpd_moveR_M1 {A : Type} `{Is1Gpd A} {x y : A} {p q : x $-> y}
   (r : Id _ $== p^$ $o q) : p $== q.
 Proof.
-  refine (_ $@ (cat_assoc _ _ _)^$ $@ ((gpd_isretr p) $@R q) $@ (cat_idl q)).
+  rhs_V' exact ((cat_assoc _ _ _)^$ $@ (gpd_isretr p $@R q) $@ cat_idl q).
   exact ((cat_idr p)^$ $@ (p $@L r)).
 Defined.
 
@@ -430,8 +430,8 @@ Defined.
 Definition gpd_moveL_1V {A : Type} `{Is1Gpd A} {x y : A} {p : x $-> y}
   {q : y $-> x} (r : p $o q $== Id _) : p $== q^$.
 Proof.
-  refine (_ $@ (cat_idl q^$)).
-  refine (_ $@ (r $@R q^$)).
+  rhs_V' apply cat_idl.
+  rhs_V' exact (r $@R q^$).
   exact (gpd_hh_V _ _)^$.
 Defined.
 
@@ -475,17 +475,16 @@ Definition gpd_rev_pp {A} `{Is1Gpd A} {a b c : A} (f : b $-> c) (g : a $-> b)
   : (f $o g)^$ $== g^$ $o f^$.
 Proof.
   apply gpd_moveR_V1.
-  refine (_ $@ cat_assoc _ _ _).
+  rhs_V' napply cat_assoc.
   apply gpd_moveL_hV.
-  refine (cat_idl _ $@ _).
+  lhs' napply cat_idl.
   exact (gpd_hh_V _ _)^$.
 Defined.
 
 Definition gpd_rev_1 {A} `{Is1Gpd A} {a : A} : (Id a)^$ $== Id a.
 Proof.
-  refine ((gpd_rev2 (gpd_issect (Id a)))^$ $@ _).
-  refine (gpd_rev_pp _ _ $@ _).
-  apply gpd_isretr.
+  rhs_V' exact (gpd_isretr (Id a)).
+  symmetry; apply cat_idl.
 Defined.
 
 Definition gpd_rev_rev {A} `{Is1Gpd A} {a0 a1 : A} (g : a0 $== a1)


### PR DESCRIPTION
I created `lhs'`, `rhs'`, `lhs_V'` and `rhs_V'` which are like the unprimed versions, but work for any transitive relation.  (Symmetry is also needed in two cases.)  The main use case is for reasoning in a wild category or with homotopies of (pointed) functions, as demonstrated in the second and third commits.

Since `paths' is a transitive and symmetric relation, these also work for paths.  If the existing tactics are replaced with these, then almost all of the library builds fine, with just a few lines failing.  I tried very hard to tweak these so that they could completely replace the existing tactics, but I couldn't find a way to make them as robust, so I decided to create these primed versions.

The core issue is that we start with `@transitivity A R _`, which is different from `@concat A`.  We apply `cbn` to what we have, which does reduce it to `@concat A'`, but in some cases `A'` is different from `A`, which causes issues.  I tried many things but had no luck.