### PR TITLE
Miscellaneous improvements

### DIFF
--- a/theories/Basics/Equivalences.v
+++ b/theories/Basics/Equivalences.v
@@ -33,21 +33,22 @@ Arguments reflexive_equiv /.
 Instance isequiv_compose {A B C : Type}
   (f : A -> B) `{IsEquiv A B f}
   (g : B -> C) `{IsEquiv B C g}
-  : IsEquiv (g o f) | 1000
-  := Build_IsEquiv A C (g o f)
-    (f^-1 o g^-1)
-    (fun c => ap g (eisretr f (g^-1 c)) @ eisretr g c)
-    (fun a => ap (f^-1) (eissect g (f a)) @ eissect f a)
-    (fun a =>
-      (whiskerL _ (eisadj g (f a))) @
-      (ap_pp g _ _)^ @
-      ap02 g
-      ( (concat_A1p (eisretr f) (eissect g (f a)))^ @
-        (ap_compose f^-1 f _ @@ eisadj f a) @
-        (ap_pp f _ _)^
-      ) @
-      (ap_compose f g _)^
-    ).
+  : IsEquiv (g o f) | 1000.
+Proof.
+  snapply Build_IsEquiv.
+  - exact (f^-1 o g^-1).
+  - intro c. exact (ap g (eisretr f (g^-1 c)) @ eisretr g c).
+  - intro a. exact (ap (f^-1) (eissect g (f a)) @ eissect f a).
+  - intro a; cbn.
+    lhs napply (1 @@ eisadj g _).
+    symmetry.
+    lhs napply (ap_compose f).
+    rhs_V napply ap_pp.
+    apply ap02.
+    lhs napply ap_pp.
+    rhs_V napply (concat_A1p (eisretr f) (eissect g (f a))).
+    exact (ap_compose f^-1 f _ @@ eisadj f a)^.
+Defined.
 
 Definition equiv_compose {A B C : Type} (g : B -> C) (f : A -> B)
   `{IsEquiv B C g} `{IsEquiv A B f}

--- a/theories/Modalities/ReflectiveSubuniverse.v
+++ b/theories/Modalities/ReflectiveSubuniverse.v
@@ -1652,6 +1652,15 @@ Section ConnectedMaps.
     exact istrunc_forall.
   Defined.
 
+  (** A map which is both connected and modal is an equivalence. *)
+  Definition isequiv_conn_ino_map {A B : Type} (f : A -> B)
+             `{IsConnMap O _ _ f} `{MapIn O _ _ f}
+  : IsEquiv f.
+  Proof.
+    apply isequiv_contr_map. intros b.
+    exact (contr_trunc_conn O).
+  Defined.
+
   (** Connected maps are orthogonal to modal maps (i.e. families of modal types). *)
   Definition conn_map_elim
              {A B : Type} (f : A -> B) `{IsConnMap O _ _ f}
@@ -1677,15 +1686,6 @@ Section ConnectedMaps.
     destruct (isconnected_elim O (P (f a)) fibermap) as [x e].
     change (d a) with (fibermap (a;1)).
     apply inverse, e.
-  Defined.
-
-  (** A map which is both connected and modal is an equivalence. *)
-  Definition isequiv_conn_ino_map {A B : Type} (f : A -> B)
-             `{IsConnMap O _ _ f} `{MapIn O _ _ f}
-  : IsEquiv f.
-  Proof.
-    apply isequiv_contr_map. intros b.
-    exact (contr_trunc_conn O).
   Defined.
 
   (** We can re-express this in terms of extensions. *)

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -100,8 +100,8 @@ Definition finite_decidable_hprop X `{IsHProp X} `{Decidable X}
 : Finite X.
 Proof.
   destruct (dec X) as [x|nx].
-  - assert (Contr X) by exact (contr_inhabited_hprop X x).
-    exact _.
+  - apply finite_contr.
+    by apply contr_inhabited_hprop.
   - refine (finite_equiv Empty nx^-1 _).
 Defined.
 

--- a/theories/Spaces/Finite/Finite.v
+++ b/theories/Spaces/Finite/Finite.v
@@ -171,11 +171,9 @@ Proof.
 Defined.
 
 (** It follows that if [X] is finite, then its propositional truncation is decidable. *)
-Instance decidable_merely_finite X {fX : Finite X}
-: Decidable (merely X).
-Proof.
-  exact _.
-Defined.
+Definition decidable_merely_finite X {fX : Finite X}
+  : Decidable (merely X)
+  := _.
 
 (** From this, it follows that any finite set is *merely* decidable. *)
 Definition merely_decidable_finite X `{Finite X}

--- a/theories/Universes/BAut.v
+++ b/theories/Universes/BAut.v
@@ -218,12 +218,11 @@ Section Center2BAut.
     apply path_forall; intros Z.
     assert (IsHSet (idpath Z.1 = idpath Z.1)) by exact _.
     baut_reduce.
-    cbn. unfold functor_forall, sig_rect, merely_rec_hset. cbn.
+    cbn.
     rewrite equiv_path2_universe_1.
-    rewrite !concat_p1, !concat_Vp.
-    simpl.
-    rewrite !concat_p1, !concat_Vp.
-    reflexivity.
+    rewrite concat_p1, concat_Vp.
+    cbn.
+    rewrite concat_p1; apply concat_Vp.
   Defined.
 
 End Center2BAut.

--- a/theories/WildCat/Opposite.v
+++ b/theories/WildCat/Opposite.v
@@ -12,73 +12,64 @@ Notation "A ^op" := (op A).
 Instance isgraph_op {A : Type} `{IsGraph A}
   : IsGraph A^op.
 Proof.
-  apply Build_IsGraph.
-  unfold op; exact (fun a b => b $-> a).
+  apply Build_IsGraph; cbv.
+  intros a b; exact (Hom b a).
 Defined.
 
 Instance is01cat_op {A : Type} `{Is01Cat A} : Is01Cat A^op.
 Proof.
-  apply Build_Is01Cat.
-  + cbv; exact Id.
-  + cbv; exact (fun a b c g f => f $o g).
+  apply Build_Is01Cat; cbv.
+  + exact Id.
+  + intros a b c f g; exact (cat_comp g f).
 Defined.
 
 (** We don't invert 2-cells as this is op on the first level. *)
 Instance is2graph_op {A : Type} `{Is2Graph A} : Is2Graph A^op.
 Proof.
-  intros a b; unfold op in *; cbn; exact _.
+  cbv.
+  intros a b; exact (isgraph_hom b a).
 Defined.
 
 Instance is1cat_op {A : Type} `{Is1Cat A} : Is1Cat A^op.
 Proof.
-  snapply Build_Is1Cat; unfold op in *; cbv in *.
-  - intros a b.
-    apply is01cat_hom.
-  - intros a b.
-    apply is0gpd_hom.
-  - intros a b c h.
-    srapply Build_Is0Functor.
-    intros f g p.
-    cbn in *.
-    exact (p $@R h).
-  - intros a b c h.
-    srapply Build_Is0Functor.
-    intros f g p.
-    cbn in *.
-    exact (h $@L p).
+  snapply Build_Is1Cat; cbv.
+  - intros a b; exact (is01cat_hom b a).
+  - intros a b; exact (is0gpd_hom b a).
+  - intros a b c; exact (is0functor_precomp c b a).
+  - intros a b c; exact (is0functor_postcomp c b a).
   - intros a b c d f g h; exact (cat_assoc_opp h g f).
   - intros a b c d f g h; exact (cat_assoc h g f).
-  - intros a b f; exact (cat_idr f).
-  - intros a b f; exact (cat_idl f).
+  - intros a b; exact cat_idr.
+  - intros a b; exact cat_idl.
 Defined.
 
 Instance is1cat_strong_op A `{Is1Cat_Strong A}
   : Is1Cat_Strong (A ^op).
 Proof.
-  snapply Build_Is1Cat_Strong.
-  1-4: exact _.
-  all: cbn.
+  snapply Build_Is1Cat_Strong; cbv.
+  - intros a b; exact (is01cat_hom_strong b a).
+  - intros a b; exact (is0gpd_hom_strong b a).
+  - intros a b c; exact (is0functor_precomp_strong c b a).
+  - intros a b c; exact (is0functor_postcomp_strong c b a).
   - intros a b c d f g h; exact (cat_assoc_opp_strong h g f).
   - intros a b c d f g h; exact (cat_assoc_strong h g f).
-  - intros a b f.
-    apply cat_idr_strong.
-  - intros a b f.
-    apply cat_idl_strong.
+  - intros a b; exact cat_idr_strong.
+  - intros a b; exact cat_idl_strong.
 Defined.
 
 (** Opposite groupoids *)
 
 Instance is0gpd_op A `{Is0Gpd A} : Is0Gpd (A^op).
 Proof.
-  srapply Build_Is0Gpd; unfold op in *; cbn in *.
+  srapply Build_Is0Gpd; cbv.
   intros a b.
   exact gpd_rev.
 Defined.
 
 Instance op0gpd_fun A `{Is0Gpd A} :
-  Is0Functor( (fun x => x) : A^op -> A).
+  Is0Functor((fun x => x) : A^op -> A).
 Proof.
-  srapply Build_Is0Functor; unfold op in *; cbn.
+  srapply Build_Is0Functor; cbv.
   intros a b.
   exact (fun f => f^$).
 Defined.
@@ -89,18 +80,16 @@ Instance is0functor_op A B (F : A -> B)
   `{IsGraph A, IsGraph B, x : !Is0Functor F}
   : Is0Functor (F : A^op -> B^op).
 Proof.
-  apply Build_Is0Functor.
-  intros a b; cbn.
-  apply fmap.
-  assumption.
+  apply Build_Is0Functor; cbv.
+  intros a b; exact (fmap F).
 Defined.
 
 Instance is1functor_op A B (F : A -> B)
   `{Is1Cat A, Is1Cat B, !Is0Functor F, !Is1Functor F}
   : Is1Functor (F : A^op -> B^op).
 Proof.
-  apply Build_Is1Functor; cbn.
-  - intros a b; rapply fmap2.
+  apply Build_Is1Functor; cbv.
+  - intros a b f g; exact (fmap2 F).
   - exact (fmap_id F).
   - intros a b c f g; exact (fmap_comp F g f).
 Defined.
@@ -120,8 +109,8 @@ Instance is1functor_op' A B (F : A^op -> B^op)
 Instance hasmorext_op {A : Type} `{H0 : HasMorExt A}
   : HasMorExt A^op.
 Proof.
-  intros a b f g.
-  exact (@isequiv_Htpy_path _ _ _ _ _ H0 b a f g).
+  unfold op.
+  intros a b; exact (isequiv_Htpy_path b a).
 Defined.
 
 Instance isinitial_op_isterminal {A : Type} `{Is1Cat A} (x : A)


### PR DESCRIPTION
Each commit is independent, and the library builds after each commit.

The fifth commit, changing Connectedness.v, is the only one with any substance.  I noticed that `is0connected_merely_allpaths` can be generalized to any truncation level.  I also added an `isconnmap` version of this and also of the converse statement.

The first commit moves a result that was in a strange place, interrupting the flow of other related results.

The others are pretty self-explanatory; see the commit messages.