### PR TITLE
generate_coqproject: avoid Program.Basics and HoTT.Basics conflict

### DIFF
--- a/etc/generate_coqproject.sh
+++ b/etc/generate_coqproject.sh
@@ -31,6 +31,10 @@ COQPROJECT_HEADER=\
 -arg -noinit
 -arg -indices-matter
 -arg -native-compiler -arg no
+# This is a hack to avoid conflicts between HoTT.Basics and Program.Basics.
+# It would be better if we could more precisely exclude Coq.Program, and
+# even better if we could exclude all or most of the Coq namespace.
+-arg -exclude-dir -arg Program
 "
 
 ## Add additional lines when building with dune


### PR DESCRIPTION
This is a temporary solution to #2290.

Feel free to suggest other solutions.  I will merge this if I don't hear about any other options soon, as it is annoying that our CI is always giving errors.
