### PR TITLE
[WIP] Add biproduct infrastructure for additive categories

### DIFF
--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -133,6 +133,14 @@ Section BiproductOperations.
     : (biproduct_coprod_mor W f g o inr B = g)%morphism
     := snd_type (biproduct_coprod_universal W f g).2.
 
+  Definition biproduct_coprod_unique (W : object C)
+    (f : morphism C X W) (g : morphism C Y W)
+    (h : morphism C B W)
+    (Hl : (h o inl B = f)%morphism)
+    (Hr : (h o inr B = g)%morphism)
+    : h = biproduct_coprod_mor W f g
+    := ap pr1 (contr (h; (Hl, Hr)))^.
+
   (** The product universal morphism and its properties. *)
   Definition biproduct_prod_universal (W : object C) 
     (f : morphism C W X) (g : morphism C W Y)
@@ -155,16 +163,6 @@ Section BiproductOperations.
     : (outr B o biproduct_prod_mor W f g = g)%morphism
     := snd_type (biproduct_prod_universal W f g).2.
   
-  (** ** Uniqueness properties *)
-
-  Definition biproduct_coprod_unique (W : object C)
-    (f : morphism C X W) (g : morphism C Y W)
-    (h : morphism C B W)
-    (Hl : (h o inl B = f)%morphism)
-    (Hr : (h o inr B = g)%morphism)
-    : h = biproduct_coprod_mor W f g
-    := ap pr1 (contr (h; (Hl, Hr)))^.
-
   Definition biproduct_prod_unique (W : object C)
     (f : morphism C W X) (g : morphism C W Y)
     (h : morphism C W B)

--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -8,6 +8,9 @@ From HoTT Require Import Basics Types.
 From HoTT.Categories Require Import Category Functor.
 From HoTT.Categories.Additive Require Import ZeroObjects.
 
+Local Notation fst_type := Basics.Overture.fst.
+Local Notation snd_type := Basics.Overture.snd.
+
 (** * Biproduct structures *)
 
 (** ** Biproduct data
@@ -120,25 +123,15 @@ Section BiproductOperations.
     : morphism C B W
     := (biproduct_coprod_universal W f g).1.
 
-  Lemma biproduct_coprod_beta_l (W : object C) 
+  Definition biproduct_coprod_beta_l (W : object C)
     (f : morphism C X W) (g : morphism C Y W)
-    : (biproduct_coprod_mor W f g o inl B = f)%morphism.
-  Proof.
-    unfold biproduct_coprod_mor, biproduct_coprod_universal.
-    set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
-    destruct c as [h [Hl Hr]].
-    exact Hl.
-  Qed.
+    : (biproduct_coprod_mor W f g o inl B = f)%morphism
+    := fst_type (biproduct_coprod_universal W f g).2.
 
-  Lemma biproduct_coprod_beta_r (W : object C) 
+  Definition biproduct_coprod_beta_r (W : object C)
     (f : morphism C X W) (g : morphism C Y W)
-    : (biproduct_coprod_mor W f g o inr B = g)%morphism.
-  Proof.
-    unfold biproduct_coprod_mor, biproduct_coprod_universal.
-    set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
-    destruct c as [h [Hl Hr]].
-    exact Hr.
-  Qed.
+    : (biproduct_coprod_mor W f g o inr B = g)%morphism
+    := snd_type (biproduct_coprod_universal W f g).2.
 
   (** The product universal morphism and its properties. *)
   Definition biproduct_prod_universal (W : object C) 
@@ -152,55 +145,33 @@ Section BiproductOperations.
     : morphism C W B
     := (biproduct_prod_universal W f g).1.
 
-  Lemma biproduct_prod_beta_l (W : object C) 
+  Definition biproduct_prod_beta_l (W : object C)
     (f : morphism C W X) (g : morphism C W Y)
-    : (outl B o biproduct_prod_mor W f g = f)%morphism.
-  Proof.
-    unfold biproduct_prod_mor, biproduct_prod_universal.
-    set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
-    destruct c as [h [Hl Hr]].
-    exact Hl.
-  Qed.
+    : (outl B o biproduct_prod_mor W f g = f)%morphism
+    := fst_type (biproduct_prod_universal W f g).2.
 
-  Lemma biproduct_prod_beta_r (W : object C) 
+  Definition biproduct_prod_beta_r (W : object C)
     (f : morphism C W X) (g : morphism C W Y)
-    : (outr B o biproduct_prod_mor W f g = g)%morphism.
-  Proof.
-    unfold biproduct_prod_mor, biproduct_prod_universal.
-    set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
-    destruct c as [h [Hl Hr]].
-    exact Hr.
-  Qed.
+    : (outr B o biproduct_prod_mor W f g = g)%morphism
+    := snd_type (biproduct_prod_universal W f g).2.
   
   (** ** Uniqueness properties *)
 
-  Lemma biproduct_coprod_unique (W : object C) 
+  Definition biproduct_coprod_unique (W : object C)
     (f : morphism C X W) (g : morphism C Y W)
     (h : morphism C B W)
     (Hl : (h o inl B = f)%morphism)
     (Hr : (h o inr B = g)%morphism)
-    : h = biproduct_coprod_mor W f g.
-  Proof.
-    unfold biproduct_coprod_mor.
-    set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
-    assert (p : (h; (Hl, Hr)) = c).
-    1: apply (@path_contr _ (coprod_universal (biproduct_universal B) W f g)).
-    exact (ap pr1 p).
-  Qed.
-  
-  Lemma biproduct_prod_unique (W : object C) 
+    : h = biproduct_coprod_mor W f g
+    := ap pr1 (contr (h; (Hl, Hr)))^.
+
+  Definition biproduct_prod_unique (W : object C)
     (f : morphism C W X) (g : morphism C W Y)
     (h : morphism C W B)
     (Hl : (outl B o h = f)%morphism)
     (Hr : (outr B o h = g)%morphism)
-    : h = biproduct_prod_mor W f g.
-  Proof.
-    unfold biproduct_prod_mor.
-    set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
-    assert (p : (h; (Hl, Hr)) = c).
-    1: apply (@path_contr _ (prod_universal (biproduct_universal B) W f g)).
-    exact (ap pr1 p).
-  Qed.
+    : h = biproduct_prod_mor W f g
+    := ap pr1 (contr (h; (Hl, Hr)))^.
 
 End BiproductOperations.
 

--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -1,0 +1,197 @@
+(** * Biproducts in categories with zero objects
+
+    Objects that are simultaneously products and coproducts, fundamental
+    to additive category theory.
+*)
+
+From HoTT Require Import Basics Types.
+From HoTT.Categories Require Import Category Functor.
+From HoTT.Categories.Additive Require Import ZeroObjects.
+
+(** * Biproduct structures *)
+
+(** ** Biproduct data
+    
+    The data of a biproduct consists of an object together with injection
+    and projection morphisms.
+*)
+
+Record BiproductData {C : PreCategory} (X Y : object C)
+  : Type
+  := {
+  biproduct_obj : object C;
+  
+  (* Coproduct structure: injections *)
+  inl : morphism C X biproduct_obj;
+  inr : morphism C Y biproduct_obj;
+  
+  (* Product structure: projections *)
+  outl : morphism C biproduct_obj X;
+  outr : morphism C biproduct_obj Y
+}.
+
+Arguments biproduct_obj {C X Y} b : rename.
+Arguments inl {C X Y} b : rename.
+Arguments inr {C X Y} b : rename.
+Arguments outl {C X Y} b : rename.
+Arguments outr {C X Y} b : rename.
+
+(** ** Biproduct axioms
+    
+    The axioms that make biproduct data into an actual biproduct.
+    These ensure the projection-injection pairs behave correctly.
+*)
+
+Record IsBiproduct {C : PreCategory} `{Z : ZeroObject C} {X Y : object C} 
+                   (B : BiproductData X Y)
+  : Type
+  := {
+  (* Projection-injection identities *)
+  beta_l : (outl B o inl B = 1)%morphism;
+  beta_r : (outr B o inr B = 1)%morphism;
+  
+  (* Mixed terms are zero *)
+  mixed_l : (outl B o inr B)%morphism = zero_morphism Y X;
+  mixed_r : (outr B o inl B)%morphism = zero_morphism X Y
+}.
+
+Arguments beta_l {C Z X Y B} i : rename.
+Arguments beta_r {C Z X Y B} i : rename.
+Arguments mixed_l {C Z X Y B} i : rename.
+Arguments mixed_r {C Z X Y B} i : rename.
+
+(** ** Universal property of biproducts
+    
+    The universal property states that morphisms into/out of the biproduct
+    are uniquely determined by their components.
+*)
+
+Record HasBiproductUniversal {C : PreCategory} {X Y : object C} 
+                             (B : BiproductData X Y)
+  : Type
+  := {
+  (* Universal property as a coproduct *)
+  coprod_universal : forall (W : object C) 
+    (f : morphism C X W) (g : morphism C Y W),
+    Contr {h : morphism C (biproduct_obj B) W & 
+           ((h o inl B = f)%morphism) * 
+           ((h o inr B = g)%morphism)};
+  
+  (* Universal property as a product *)
+  prod_universal : forall (W : object C) 
+    (f : morphism C W X) (g : morphism C W Y),
+    Contr {h : morphism C W (biproduct_obj B) & 
+           ((outl B o h = f)%morphism) * 
+           ((outr B o h = g)%morphism)}
+}.
+
+Arguments coprod_universal {C X Y B} u W f g : rename.
+Arguments prod_universal {C X Y B} u W f g : rename.
+
+(** ** Complete biproduct structure
+    
+    A biproduct is biproduct data together with the proof that it satisfies
+    the biproduct axioms and universal property.
+*)
+
+Record Biproduct {C : PreCategory} `{Z : ZeroObject C} (X Y : object C)
+  : Type
+  := {
+  biproduct_data : BiproductData X Y;
+  biproduct_is : IsBiproduct biproduct_data;
+  biproduct_universal : HasBiproductUniversal biproduct_data
+}.
+
+Arguments biproduct_data {C Z X Y} b : rename.
+Arguments biproduct_is {C Z X Y} b : rename.
+Arguments biproduct_universal {C Z X Y} b : rename.
+
+(** * Biproduct operations *)
+
+Section BiproductOperations.
+  Context {C : PreCategory} `{Z : ZeroObject C} {X Y : object C}.
+  Variable (B : Biproduct X Y).
+
+  (** ** Uniqueness from universal property *)
+
+  (** Extract the unique morphism from the coproduct universal property. *)
+  Definition biproduct_coprod_mor (W : object C) 
+    (f : morphism C X W) (g : morphism C Y W)
+    : morphism C (biproduct_obj (biproduct_data B)) W
+    := pr1 (@center _ (coprod_universal (biproduct_universal B) W f g)).
+
+  Lemma biproduct_coprod_beta_l (W : object C) 
+    (f : morphism C X W) (g : morphism C Y W)
+    : (biproduct_coprod_mor W f g o inl (biproduct_data B) = f)%morphism.
+  Proof.
+    unfold biproduct_coprod_mor.
+    set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
+    destruct c as [h [Hl Hr]].
+    exact Hl.
+  Qed.
+
+  Lemma biproduct_coprod_beta_r (W : object C) 
+    (f : morphism C X W) (g : morphism C Y W)
+    : (biproduct_coprod_mor W f g o inr (biproduct_data B) = g)%morphism.
+  Proof.
+    unfold biproduct_coprod_mor.
+    set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
+    destruct c as [h [Hl Hr]].
+    exact Hr.
+  Qed.
+  
+  (** Extract the unique morphism from the product universal property. *)
+  Definition biproduct_prod_mor (W : object C) 
+    (f : morphism C W X) (g : morphism C W Y)
+    : morphism C W (biproduct_obj (biproduct_data B))
+    := pr1 (@center _ (prod_universal (biproduct_universal B) W f g)).
+
+  Lemma biproduct_prod_beta_l (W : object C) 
+    (f : morphism C W X) (g : morphism C W Y)
+    : (outl (biproduct_data B) o biproduct_prod_mor W f g = f)%morphism.
+  Proof.
+    unfold biproduct_prod_mor.
+    set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
+    destruct c as [h [Hl Hr]].
+    exact Hl.
+  Qed.
+
+  Lemma biproduct_prod_beta_r (W : object C) 
+    (f : morphism C W X) (g : morphism C W Y)
+    : (outr (biproduct_data B) o biproduct_prod_mor W f g = g)%morphism.
+  Proof.
+    unfold biproduct_prod_mor.
+    set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
+    destruct c as [h [Hl Hr]].
+    exact Hr.
+  Qed.
+  
+  (** ** Uniqueness properties *)
+
+Lemma biproduct_coprod_unique (W : object C) 
+    (f : morphism C X W) (g : morphism C Y W)
+    (h : morphism C (biproduct_obj (biproduct_data B)) W)
+    : (h o inl (biproduct_data B) = f)%morphism -> 
+      (h o inr (biproduct_data B) = g)%morphism ->
+      h = biproduct_coprod_mor W f g.
+  Proof.
+    intros Hl Hr.
+    unfold biproduct_coprod_mor.
+    set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
+    assert (p : (h; (Hl, Hr)) = c).
+    { apply (@path_contr _ (coprod_universal (biproduct_universal B) W f g)). }
+    exact (ap pr1 p).
+  Qed.
+
+End BiproductOperations.
+
+(** * Export hints *)
+
+Hint Resolve 
+  biproduct_coprod_beta_l biproduct_coprod_beta_r
+  biproduct_prod_beta_l biproduct_prod_beta_r
+  : biproduct.
+
+Hint Rewrite 
+  @zero_morphism_left @zero_morphism_right
+  : biproduct_simplify.

--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -108,17 +108,23 @@ Section BiproductOperations.
 
   (** ** Uniqueness from universal property *)
 
+  (** The coproduct universal morphism and its properties. *)
+  Definition biproduct_coprod_universal (W : object C) 
+    (f : morphism C X W) (g : morphism C Y W)
+    : {h : morphism C B W & ((h o inl B = f)%morphism * (h o inr B = g)%morphism)}
+    := @center _ (coprod_universal (biproduct_universal B) W f g).
+
   (** Extract the unique morphism from the coproduct universal property. *)
   Definition biproduct_coprod_mor (W : object C) 
     (f : morphism C X W) (g : morphism C Y W)
-    : morphism C (biproduct_data B) W
-    := pr1 (@center _ (coprod_universal (biproduct_universal B) W f g)).
+    : morphism C B W
+    := (biproduct_coprod_universal W f g).1.
 
   Lemma biproduct_coprod_beta_l (W : object C) 
     (f : morphism C X W) (g : morphism C Y W)
-    : (biproduct_coprod_mor W f g o inl (biproduct_data B) = f)%morphism.
+    : (biproduct_coprod_mor W f g o inl B = f)%morphism.
   Proof.
-    unfold biproduct_coprod_mor.
+    unfold biproduct_coprod_mor, biproduct_coprod_universal.
     set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
     destruct c as [h [Hl Hr]].
     exact Hl.
@@ -126,25 +132,31 @@ Section BiproductOperations.
 
   Lemma biproduct_coprod_beta_r (W : object C) 
     (f : morphism C X W) (g : morphism C Y W)
-    : (biproduct_coprod_mor W f g o inr (biproduct_data B) = g)%morphism.
+    : (biproduct_coprod_mor W f g o inr B = g)%morphism.
   Proof.
-    unfold biproduct_coprod_mor.
+    unfold biproduct_coprod_mor, biproduct_coprod_universal.
     set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
     destruct c as [h [Hl Hr]].
     exact Hr.
   Qed.
-  
+
+  (** The product universal morphism and its properties. *)
+  Definition biproduct_prod_universal (W : object C) 
+    (f : morphism C W X) (g : morphism C W Y)
+    : {h : morphism C W B & ((outl B o h = f)%morphism * (outr B o h = g)%morphism)}
+    := @center _ (prod_universal (biproduct_universal B) W f g).
+
   (** Extract the unique morphism from the product universal property. *)
   Definition biproduct_prod_mor (W : object C) 
     (f : morphism C W X) (g : morphism C W Y)
-    : morphism C W (biproduct_data B)
-    := pr1 (@center _ (prod_universal (biproduct_universal B) W f g)).
+    : morphism C W B
+    := (biproduct_prod_universal W f g).1.
 
   Lemma biproduct_prod_beta_l (W : object C) 
     (f : morphism C W X) (g : morphism C W Y)
-    : (outl (biproduct_data B) o biproduct_prod_mor W f g = f)%morphism.
+    : (outl B o biproduct_prod_mor W f g = f)%morphism.
   Proof.
-    unfold biproduct_prod_mor.
+    unfold biproduct_prod_mor, biproduct_prod_universal.
     set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
     destruct c as [h [Hl Hr]].
     exact Hl.
@@ -152,9 +164,9 @@ Section BiproductOperations.
 
   Lemma biproduct_prod_beta_r (W : object C) 
     (f : morphism C W X) (g : morphism C W Y)
-    : (outr (biproduct_data B) o biproduct_prod_mor W f g = g)%morphism.
+    : (outr B o biproduct_prod_mor W f g = g)%morphism.
   Proof.
-    unfold biproduct_prod_mor.
+    unfold biproduct_prod_mor, biproduct_prod_universal.
     set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
     destruct c as [h [Hl Hr]].
     exact Hr.
@@ -202,4 +214,3 @@ Hint Resolve
 Hint Rewrite 
   @zero_morphism_left @zero_morphism_right
   : biproduct_simplify.
-        

--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -30,6 +30,8 @@ Record BiproductData {C : PreCategory} (X Y : object C)
   outr : morphism C biproduct_obj Y
 }.
 
+Coercion biproduct_obj : BiproductData >-> object.
+
 Arguments biproduct_obj {C X Y} b : rename.
 Arguments inl {C X Y} b : rename.
 Arguments inr {C X Y} b : rename.
@@ -73,16 +75,14 @@ Record HasBiproductUniversal {C : PreCategory} {X Y : object C}
   (* Universal property as a coproduct *)
   coprod_universal : forall (W : object C) 
     (f : morphism C X W) (g : morphism C Y W),
-    Contr {h : morphism C (biproduct_obj B) W & 
-           ((h o inl B = f)%morphism) * 
-           ((h o inr B = g)%morphism)};
+    Contr {h : morphism C B W & 
+           ((h o inl B = f)%morphism * (h o inr B = g)%morphism)};
   
   (* Universal property as a product *)
   prod_universal : forall (W : object C) 
     (f : morphism C W X) (g : morphism C W Y),
-    Contr {h : morphism C W (biproduct_obj B) & 
-           ((outl B o h = f)%morphism) * 
-           ((outr B o h = g)%morphism)}
+    Contr {h : morphism C W B & 
+           ((outl B o h = f)%morphism * (outr B o h = g)%morphism)}
 }.
 
 Arguments coprod_universal {C X Y B} u W f g : rename.
@@ -94,7 +94,7 @@ Arguments prod_universal {C X Y B} u W f g : rename.
     the biproduct axioms and universal property.
 *)
 
-Record Biproduct {C : PreCategory} `{Z : ZeroObject C} (X Y : object C)
+Class Biproduct {C : PreCategory} `{Z : ZeroObject C} (X Y : object C)
   : Type
   := {
   biproduct_data : BiproductData X Y;
@@ -117,7 +117,7 @@ Section BiproductOperations.
   (** Extract the unique morphism from the coproduct universal property. *)
   Definition biproduct_coprod_mor (W : object C) 
     (f : morphism C X W) (g : morphism C Y W)
-    : morphism C (biproduct_obj (biproduct_data B)) W
+    : morphism C (biproduct_data B) W
     := pr1 (@center _ (coprod_universal (biproduct_universal B) W f g)).
 
   Lemma biproduct_coprod_beta_l (W : object C) 
@@ -143,7 +143,7 @@ Section BiproductOperations.
   (** Extract the unique morphism from the product universal property. *)
   Definition biproduct_prod_mor (W : object C) 
     (f : morphism C W X) (g : morphism C W Y)
-    : morphism C W (biproduct_obj (biproduct_data B))
+    : morphism C W (biproduct_data B)
     := pr1 (@center _ (prod_universal (biproduct_universal B) W f g)).
 
   Lemma biproduct_prod_beta_l (W : object C) 
@@ -168,9 +168,9 @@ Section BiproductOperations.
   
   (** ** Uniqueness properties *)
 
-Lemma biproduct_coprod_unique (W : object C) 
+  Lemma biproduct_coprod_unique (W : object C) 
     (f : morphism C X W) (g : morphism C Y W)
-    (h : morphism C (biproduct_obj (biproduct_data B)) W)
+    (h : morphism C (biproduct_data B) W)
     : (h o inl (biproduct_data B) = f)%morphism -> 
       (h o inr (biproduct_data B) = g)%morphism ->
       h = biproduct_coprod_mor W f g.
@@ -179,7 +179,7 @@ Lemma biproduct_coprod_unique (W : object C)
     unfold biproduct_coprod_mor.
     set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
     assert (p : (h; (Hl, Hr)) = c).
-    { apply (@path_contr _ (coprod_universal (biproduct_universal B) W f g)). }
+    1: apply (@path_contr _ (coprod_universal (biproduct_universal B) W f g)).
     exact (ap pr1 p).
   Qed.
 
@@ -195,3 +195,4 @@ Hint Resolve
 Hint Rewrite 
   @zero_morphism_left @zero_morphism_right
   : biproduct_simplify.
+        

--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -16,9 +16,7 @@ From HoTT.Categories.Additive Require Import ZeroObjects.
     and projection morphisms.
 *)
 
-Record BiproductData {C : PreCategory} (X Y : object C)
-  : Type
-  := {
+Record BiproductData {C : PreCategory} (X Y : object C) := {
   biproduct_obj : object C;
   
   (* Coproduct structure: injections *)
@@ -45,9 +43,7 @@ Arguments outr {C X Y} b : rename.
 *)
 
 Record IsBiproduct {C : PreCategory} `{Z : ZeroObject C} {X Y : object C} 
-                   (B : BiproductData X Y)
-  : Type
-  := {
+                   (B : BiproductData X Y) := {
   (* Projection-injection identities *)
   beta_l : (outl B o inl B = 1)%morphism;
   beta_r : (outr B o inr B = 1)%morphism;
@@ -69,9 +65,7 @@ Arguments mixed_r {C Z X Y B} i : rename.
 *)
 
 Record HasBiproductUniversal {C : PreCategory} {X Y : object C}
-  (B : BiproductData X Y)
-  : Type
-  := {
+  (B : BiproductData X Y) := {
   (* Universal property as a coproduct *)
   coprod_universal : forall (W : object C) 
     (f : morphism C X W) (g : morphism C Y W),
@@ -94,9 +88,7 @@ Arguments prod_universal {C X Y B} u W f g : rename.
     the biproduct axioms and universal property.
 *)
 
-Class Biproduct {C : PreCategory} `{Z : ZeroObject C} (X Y : object C)
-  : Type
-  := {
+Class Biproduct {C : PreCategory} `{Z : ZeroObject C} (X Y : object C) := {
   biproduct_data : BiproductData X Y;
   biproduct_is : IsBiproduct biproduct_data;
   biproduct_universal : HasBiproductUniversal biproduct_data
@@ -172,16 +164,29 @@ Section BiproductOperations.
 
   Lemma biproduct_coprod_unique (W : object C) 
     (f : morphism C X W) (g : morphism C Y W)
-    (h : morphism C (biproduct_data B) W)
-    : (h o inl (biproduct_data B) = f)%morphism -> 
-      (h o inr (biproduct_data B) = g)%morphism ->
-      h = biproduct_coprod_mor W f g.
+    (h : morphism C B W)
+    (Hl : (h o inl B = f)%morphism)
+    (Hr : (h o inr B = g)%morphism)
+    : h = biproduct_coprod_mor W f g.
   Proof.
-    intros Hl Hr.
     unfold biproduct_coprod_mor.
     set (c := @center _ (coprod_universal (biproduct_universal B) W f g)).
     assert (p : (h; (Hl, Hr)) = c).
     1: apply (@path_contr _ (coprod_universal (biproduct_universal B) W f g)).
+    exact (ap pr1 p).
+  Qed.
+  
+  Lemma biproduct_prod_unique (W : object C) 
+    (f : morphism C W X) (g : morphism C W Y)
+    (h : morphism C W B)
+    (Hl : (outl B o h = f)%morphism)
+    (Hr : (outr B o h = g)%morphism)
+    : h = biproduct_prod_mor W f g.
+  Proof.
+    unfold biproduct_prod_mor.
+    set (c := @center _ (prod_universal (biproduct_universal B) W f g)).
+    assert (p : (h; (Hl, Hr)) = c).
+    1: apply (@path_contr _ (prod_universal (biproduct_universal B) W f g)).
     exact (ap pr1 p).
   Qed.
 
@@ -197,3 +202,4 @@ Hint Resolve
 Hint Rewrite 
   @zero_morphism_left @zero_morphism_right
   : biproduct_simplify.
+        

--- a/theories/Categories/Additive/Biproducts.v
+++ b/theories/Categories/Additive/Biproducts.v
@@ -68,8 +68,8 @@ Arguments mixed_r {C Z X Y B} i : rename.
     are uniquely determined by their components.
 *)
 
-Record HasBiproductUniversal {C : PreCategory} {X Y : object C} 
-                             (B : BiproductData X Y)
+Record HasBiproductUniversal {C : PreCategory} {X Y : object C}
+  (B : BiproductData X Y)
   : Type
   := {
   (* Universal property as a coproduct *)
@@ -101,6 +101,8 @@ Class Biproduct {C : PreCategory} `{Z : ZeroObject C} (X Y : object C)
   biproduct_is : IsBiproduct biproduct_data;
   biproduct_universal : HasBiproductUniversal biproduct_data
 }.
+
+Coercion biproduct_data : Biproduct >-> BiproductData.
 
 Arguments biproduct_data {C Z X Y} b : rename.
 Arguments biproduct_is {C Z X Y} b : rename.
@@ -195,4 +197,3 @@ Hint Resolve
 Hint Rewrite 
   @zero_morphism_left @zero_morphism_right
   : biproduct_simplify.
-        


### PR DESCRIPTION
Extracting Biproducts.v from stable categories formalization (#2288).

**Status: WIP - not ready for merge**

Changes from original formalization:
- Fixed imports (removed non-existent ZeroMorphismLemmas.v)
- Made `ZeroObject` implicit throughout using `` `{Z : ZeroObject C} ``
- Updated `zero_morphism` calls to use implicit Z parameter
- Removed unused definitions (bi_inl, bi_inr, bi_outl, bi_outr, biproduct)
- Removed unused lemma (biproduct_prod_unique)
- Applied HoTT style conventions

The file provides:
- `BiproductData`: injection/projection morphisms
- `IsBiproduct`: axioms (beta_l, beta_r, mixed_l, mixed_r)
- `HasBiproductUniversal`: universal properties as product and coproduct
- `Biproduct`: complete structure combining the above
- Operations: biproduct_coprod_mor, biproduct_prod_mor with beta lemmas
- Uniqueness lemma: biproduct_coprod_unique

@jdchristensen This is work in progress, naturally - submitting early for initial feedback. I will be continuously re-reviewing for anything I missed. Thank you very much for your time