### PR TITLE
Add "ghcup install cabal" to work around error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,9 @@ jobs:
           libxml2-dev libxslt1-dev time lua5.1 unzip npm
           # libnode-dev node-gyp
 
-          # The next line will hopefully fix the error:
+          # The next two lines will hopefully fix the error:
           # <repo>/root.json does not have enough signatures signed with the appropriate keys
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
           ghcup install cabal
           cabal update
           cabal install --lib graphviz text fgl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,9 @@ jobs:
           libxml2-dev libxslt1-dev time lua5.1 unzip npm
           # libnode-dev node-gyp
 
+          # The next line will hopefully fix the error:
+          # <repo>/root.json does not have enough signatures signed with the appropriate keys
+          ghcup install cabal
           cabal update
           cabal install --lib graphviz text fgl
           sudo -E npm config set strict-ssl false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,14 +249,14 @@ jobs:
         ocaml_version: ${{ env.ocaml-version }}
         custom_script: |
           sudo apt-get update
-          sudo apt-get install -y ghc cabal-install
+          sudo apt-get install -y ghc
           sudo apt-get install -y --allow-unauthenticated \
           libssl-dev aspcud \
           graphviz xsltproc python3-lxml python-pexpect-doc \
           libxml2-dev libxslt1-dev time lua5.1 unzip npm
           # libnode-dev node-gyp
 
-          # The next three lines will hopefully fix the error:
+          # Installing cabal using ghcup rather than installing cabal-install via apt fixes the error:
           # <repo>/root.json does not have enough signatures signed with the appropriate keys
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_MINIMAL=1 sh
           source ~/.ghcup/env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,9 +256,10 @@ jobs:
           libxml2-dev libxslt1-dev time lua5.1 unzip npm
           # libnode-dev node-gyp
 
-          # The next two lines will hopefully fix the error:
+          # The next three lines will hopefully fix the error:
           # <repo>/root.json does not have enough signatures signed with the appropriate keys
-          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_MINIMAL=1 sh
+          source ~/.ghcup/env
           ghcup install cabal
           cabal update
           cabal install --lib graphviz text fgl


### PR DESCRIPTION
This is an attempt to fix the doc-dep-graphs build, which is failing with:
```
+ (script @ line 12) $ cabal update
Config file path source is default config file.
Config file /home/coq/.cabal/config not found.
Writing default configuration to /home/coq/.cabal/config
<repo>/root.json does not have enough signatures signed with the appropriate keys
```
