### PR TITLE
Add results on compact and searchable types (mostly following Escardo), lemmas for HProps

### DIFF
--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -173,6 +173,34 @@ Proof.
   apply merely_inhabited_iff_inhabited_stable, s.2, tr, h.
 Defined.
 
+(** A type is searchable if and only if it is compact and inhabited. *)
+
+Definition issearchable_iscompact_inhabited {A : Type}
+  : IsCompact A -> A -> IsSearchable A.
+Proof.
+  intros c a P dP.
+  induction (c P _) as [l|r].
+  - exists l.1.
+    intro h; contradiction (l.2 h).
+  - exact (a; fun _ => r).
+Defined.
+
+Definition iscompact_issearchable {A : Type} : IsSearchable A -> IsCompact A.
+Proof.
+  intros h P dP.
+  set (w := (h P dP).1).
+  destruct (dP w) as [x|y].
+  - exact (inr ((h P dP).2 x)).
+  - exact (inl (w; y)).
+Defined.
+
+Definition inhabited_issearchable {A : Type} : IsSearchable A -> A
+  := fun s => (s (fun a => Unit) _).1.
+
+Definition searchable_iff {A : Type} : IsSearchable A <-> A * (IsCompact A)
+  := (fun s => (inhabited_issearchable s, iscompact_issearchable s),
+        fun c => issearchable_iscompact_inhabited (snd c) (fst c)).
+
 (** ** Examples of searchable and compact types.  *)
 
 Definition issearchable_contr {A} (c : Contr A) : IsSearchable A.
@@ -215,34 +243,6 @@ Proof.
     + by apply inhabited_dtype_bool_encoding_true in r.
   - contradiction (ninhabited_dtype_bool_encoding_false _ r x).
 Defined.
-
-(** A type is searchable if and only if it is compact and inhabited. *)
-
-Definition issearchable_iscompact_inhabited {A : Type}
-  : IsCompact A -> A -> IsSearchable A.
-Proof.
-  intros c a P dP.
-  induction (c P _) as [l|r].
-  - exists l.1.
-    intro h; contradiction (l.2 h).
-  - exact (a; fun _ => r).
-Defined.
-
-Definition iscompact_issearchable {A : Type} : IsSearchable A -> IsCompact A.
-Proof.
-  intros h P dP.
-  set (w := (h P dP).1).
-  destruct (dP w) as [x|y].
-  - exact (inr ((h P dP).2 x)).
-  - exact (inl (w; y)).
-Defined.
-
-Definition inhabited_issearchable {A : Type} : IsSearchable A -> A
-  := fun s => (s (fun a => Unit) _).1.
-
-Definition searchable_iff {A : Type} : IsSearchable A <-> A * (IsCompact A)
-  := (fun s => (inhabited_issearchable s, iscompact_issearchable s),
-        fun c => issearchable_iscompact_inhabited (snd c) (fst c)).
 
 (** The empty type is trivially compact. *)
 Definition iscompact_empty : IsCompact Empty

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -1,0 +1,405 @@
+(** * Properties of compact and searchable types. *)
+
+Require Import Basics Types.
+Require Import Truncations.Core Truncations.Connectedness.
+Require Import Spaces.Nat.Core.
+Require Import Misc.UStructures.
+Require Import Spaces.NatSeq.Core Spaces.NatSeq.UStructure.
+Require Import Homotopy.Suspension.
+Require Import Pointed.Core.
+Require Import Universes.TruncType.
+Require Import Idempotents.
+
+Local Open Scope nat_scope.
+Local Open Scope pointed_scope.
+
+(** ** Basic definitions of compact types. *)
+
+(** A type is compact if for every decidable predicate we can decide whether it is always true or not. *)
+Definition IsCompact (A : Type) : Type
+  := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
+                              {a : A & ~ P a} + (forall a : A, P a).
+
+(** Equivalently, we can assume the same for [HProp]-valued decidable predicates. *)
+Definition IsPropCompact (A : Type) : Type
+  := forall P : A -> HProp, (forall a : A, Decidable (P a)) ->
+                              {a : A & ~ P a} + (forall a : A, P a).
+
+Definition iscompact_ispropcompact {A} (c : IsPropCompact A) : IsCompact A.
+Proof.
+  intros P dP.
+  destruct (c (merely o P) _) as [l|r].
+  - exact (inl (l.1; fun p => l.2 (tr p))).
+  - right.
+    intro a.
+    specialize (r a).
+    rapply stable_decidable.
+    intro n.
+    strip_truncations.
+    exact (n r).
+Defined.
+
+(** Any compact type is decidable. *)
+Definition decidable_iscompact {A : Type} (c : IsCompact A) : Decidable A.
+Proof.
+  destruct (c (fun (_ : A) => Empty) _) as [c1|c2].
+  - exact (inl c1.1).
+  - exact (inr c2).
+Defined.
+
+(** Equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
+Definition IsSigCompact (A : Type) : Type
+  := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
+
+Definition issigcompact_iscompact {A : Type} (c : IsCompact A)
+  : IsSigCompact A.
+Proof.
+  intros P dP.
+  destruct (c (fun a => ~ P a) _) as [l|r].
+  - left; exists l.1.
+    exact (stable_decidable (P l.1) l.2).
+  - right; exact (fun x => (r x.1) x.2).
+Defined.
+
+Definition iscompact_issigcompact {A : Type} (c : IsSigCompact A)
+  : IsCompact A.
+Proof.
+  intros P dP.
+  destruct (c (fun a => ~ P a) _) as [l|r].
+  - exact (inl l).
+  - right; intro a.
+    apply (stable_decidable (P a) (fun h => r (a; h))).
+Defined.
+
+(** Again, it is enough to consider [HProp]-valued families. *)
+Definition IsSigCompact_prop (A : Type) : Type
+  := forall P : A -> HProp,
+      (forall a : A, Decidable (P a)) -> Decidable (sig P).
+
+Definition issigcompact_prop_issigcompact {A : Type}
+  (h : IsSigCompact A)
+  : IsSigCompact_prop A
+  := fun P hP => h P hP.
+
+Definition sigma_iff_prop_truncation_decidable {A : Type} {P : A -> Type}
+  (dP : forall a : A, Decidable (P a))
+  : {x : A & Tr (-1) (P x)} -> {x : A & P x}.
+Proof.
+  intros [x hx].
+  exact (x; fst (@merely_inhabited_iff_inhabited_stable (P x) _) hx).
+Defined.
+
+Definition issigcompact_issigcompact_prop {A : Type}
+  (h : IsSigCompact_prop A)
+  : IsSigCompact A.
+Proof.
+  intros P hP.
+  destruct (h (merely o P) _) as [[l k]|r].
+  - exact (inl (sigma_iff_prop_truncation_decidable hP (l; k))).
+  - right.
+    intros [x z].
+    exact (r (x; tr z)).
+Defined.
+
+(** A weaker definition: for any decidable family, the dependent function type is decidable. *)
+Definition IsPiCompact (A : Type)
+  := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
+      Decidable (forall a : A, P a).
+
+Definition ispicompact_issigcompact {A : Type} (c : IsSigCompact A)
+  : IsPiCompact A.
+Proof.
+  intros P dP.
+  destruct (c (fun a => ~(P a)) _) as [l|r].
+  - right; exact (fun f => l.2 (f l.1)).
+  - left.
+    intro a.
+    apply (stable_decidable (P a)).
+    exact (fun u => r (a; u)).
+Defined.
+
+(** ** Basic definitions of searchable types. *)
+
+(** Second notion of compactness, also called searchability: for every predicate we can find a witness for whether it is always true or not. *)
+Definition IsSearchable (A : Type) : Type
+  := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
+      {x : A & P x -> forall a : A, P a}.
+
+Definition universal_witness {A : Type}
+  : IsSearchable A
+      -> forall (P : A -> Type) (dP : forall a : A, Decidable (P a)), A
+  := fun w P dP => (w P dP).1.
+
+Definition witness_universality {A : Type}
+  (s : IsSearchable A) (P : A -> Type) (dP : forall a : A, Decidable (P a))
+  : P (universal_witness s P dP) -> forall a : A, P a
+  := (s P dP).2.
+
+Definition IsSearchable_prop (A : Type) : Type
+  := forall (P : A -> HProp) (dP : forall a : A, Decidable (P a)),
+      {x : A & P x -> forall a : A, P a}.
+
+Definition issearchable_issearchable_prop {A : Type} (s : IsSearchable_prop A)
+  : IsSearchable A.
+Proof.
+  intros P dP.
+  exists (s (merely o P) _).1.
+  intros h a.
+  exact ((fst merely_inhabited_iff_inhabited_stable)
+            ((s (merely o P) _).2 (tr h) a)).
+Defined.
+
+(** ** Examples of searchable and compact types.  *)
+
+Definition issearchable_contr {A} (c : Contr A) : IsSearchable A.
+Proof.
+  intros P dP.
+  exists (center A).
+  intros p a.
+  by induction (contr a).
+Defined.
+
+Definition dtype_bool_encoding (A : Type) {d : Decidable A} : Bool
+  := if d then true else false.
+
+Definition inhabited_dtype_bool_encoding_true (A : Type) {d : Decidable A}
+  (t : dtype_bool_encoding A = true)
+  : A.
+Proof.
+  induction d as [a|].
+  - exact a.
+  - contradiction (false_ne_true t).
+Defined.
+
+Definition ninhabited_dtype_bool_encoding_false (A : Type) {d : Decidable A}
+  (t : dtype_bool_encoding A = false)
+  : ~ A.
+Proof.
+  induction d as [|x].
+  - contradiction (false_ne_true t^).
+  - exact x.
+Defined.
+
+Definition issearchable_Bool : IsSearchable Bool.
+Proof.
+  intros P dP.
+  exists (dtype_bool_encoding (P false)).
+  intro x.
+  remember (dtype_bool_encoding (P false)) as b eqn:r; induction b.
+  - destruct a.
+    + assumption.
+    + by apply inhabited_dtype_bool_encoding_true in r.
+  - contradiction (ninhabited_dtype_bool_encoding_false _ r x).
+Defined.
+
+(** We prove that a type is searchable if and only if it is compact and inhabited. *)
+
+Definition issearchable_iscompact_inhabited {A : Type}
+  : IsCompact A -> A -> IsSearchable A.
+Proof.
+  intros c a P dP.
+  induction (c P _) as [l|r].
+  - exists l.1.
+    intro h; contradiction (l.2 h).
+  - exact (a; fun a => r).
+Defined.
+
+Definition iscompact_issearchable {A : Type} : IsSearchable A -> IsCompact A.
+Proof.
+  intros h P dP.
+  destruct (dP (h P dP).1) as [x|y].
+  - exact (inr ((h P dP).2 x)).
+  - left.
+    exists (h P dP).1; exact y.
+Defined.
+
+Definition inhabited_issearchable {A : Type} : IsSearchable A -> A
+  := fun h => (h (fun a => Unit) _).1.
+
+Definition searchable_iff {A : Type} : IsSearchable A <-> A * (IsCompact A)
+  := (fun s => (inhabited_issearchable s, iscompact_issearchable s),
+        fun c => issearchable_iscompact_inhabited (snd c) (fst c)).
+
+(** The empty type is trivially compact. *)
+Definition iscompact_empty : IsCompact Empty
+  := fun P dP => inr (fun a => Empty_rec a).
+
+Definition iscompact_empty' {A : Type} (not : ~A) : IsCompact A
+  := fun p dP => inr (fun a => Empty_rec (not a)).
+
+Definition iscompact_iff_not_or_issearchable {A : Type} :
+  IsCompact A <-> (~ A) + IsSearchable A.
+Proof.
+  constructor.
+  - intro h.
+    destruct (decidable_iscompact h) as [l|r].
+    + exact (inr (issearchable_iscompact_inhabited h l)).
+    + exact (inl r).
+  - intros [l|r].
+    + exact (iscompact_empty' l).
+    + exact (iscompact_issearchable r).
+Defined.
+
+(** Compact types are closed under retracts. *)
+Definition iscompact_retract {A : Type} (R : RetractOf A) (c : IsCompact A)
+  : IsCompact (retract_type R).
+Proof.
+  intros P dP; destruct (c (P o (retract_retr R)) _) as [l|r].
+  - exact (inl ((retract_retr R) l.1; l.2)).
+  - exact (inr (fun a =>  ((retract_issect R) a) # r ((retract_sect R) a))).
+Defined.
+
+Definition iscompact_retract' {A R : Type} {f : A -> R} {g : R -> A}
+  (s : forall a, (f o g) a = a) (c : IsCompact A)
+  : IsCompact R.
+Proof.
+  intros P dP. destruct (c (P o f) _) as [l|r].
+  - exact (inl (f l.1; l.2)).
+  - exact (inr (fun a => (s a) # r (g a))).
+Defined.
+
+(** Assuming the set truncation map has a section, a type is compact if and only if its set truncation is compact. *)
+Definition compact_set_trunc_compact `{Univalence} {A : Type} {n : nat}
+  (f : (Tr 0 A) -> A) (s : forall a, (tr o f) a = a)
+  : IsCompact A <-> IsCompact (Tr 0 A).
+Proof.
+  constructor.
+  1: exact (iscompact_retract' s).
+  intro cpt; rapply iscompact_ispropcompact.
+  intros P dP.
+  destruct (cpt (Trunc_rec P)) as [l|r].
+  - intro a; strip_truncations.
+    exact _.
+  - exact (inl (f l.1; fun x => l.2 (ap (Trunc_rec P) (s l.1) # x))).
+  - exact (inr (fun a => r (tr a))).
+Defined.
+
+(** Assuming univalence, the type of propositions is searchable. *)
+Definition issearchable_HProp `{Univalence} : IsSearchable HProp.
+Proof.
+  apply issearchable_issearchable_prop.
+  intros P dP.
+  destruct (dP Unit_hp) as [t|f].
+  - exists False_hp; intros p a.
+    exact (@stable_decidable (P a) _ (not_not_constant_family_hprop P t p a)).
+  - exact (Unit_hp; fun h => Empty_rec (f h)).
+Defined.
+
+(** Assuming univalence, if the domain of a surjective map is searchable, then so is its codomain. *)
+
+Definition ispropsearchable_image `{Univalence} (A B : Type)
+  (s : IsSearchable_prop A)
+  (f : A -> B) (surj : IsSurjection f)
+  : IsSearchable_prop B.
+Proof.
+  intros P dP.
+  specialize (s (P o f) _).
+  exact (f s.1; fun t => conn_map_elim _ f _ (s.2 t)).
+Defined.
+
+Definition issearchable_image `{Univalence} (A B : Type)
+  (s : IsSearchable A)
+  (f : A -> B) (surj : IsSurjection f)
+  : IsSearchable B
+  := issearchable_issearchable_prop (ispropsearchable_image A B s f surj).
+
+(** Assuming univalence, every connected pointed type is searchable. *)
+Definition issearchable_isconnected_ptype `{Univalence} (A : pType)
+  (c : IsConnected (0 : trunc_index) A)
+  : IsSearchable A
+  := (issearchable_image Unit A (issearchable_contr _) (fun _ => pt) _).
+
+(** Assuming univalence, the suspension of any type is searchable. *)
+Definition issearchable_suspension `{Univalence} (A : Type)
+  : IsSearchable (Susp A).
+Proof.
+  unshelve nrefine (issearchable_image Bool (Susp A) issearchable_Bool _ _).
+  - exact (fun b => if b then North else South).
+  - unshelve nrefine (Susp_ind _ _ _ _).
+    1,2: rapply contr_inhabited_hprop.
+    1:  exact (tr (true; idpath)).
+    1:  exact (tr (false; idpath)).
+    + intro x; by apply path_ishprop.
+Defined.
+
+Definition iscompact_image `{Univalence} (A B : Type)
+  (c : IsCompact A)
+  (f : A -> B) (surj : IsSurjection f)
+  : IsCompact B.
+Proof.
+  apply iscompact_iff_not_or_issearchable.
+  destruct ((fst iscompact_iff_not_or_issearchable) c) as [n|s].
+  - left; intro b.
+    rapply (conn_map_elim _ f _ n b).
+  - right; exact (issearchable_image A B s f surj).
+Defined.
+
+Section Uniform_Search.
+
+  (** ** Following https://www.cs.bham.ac.uk/~mhe/TypeTopology/TypeTopology.UniformSearch.html, we prove that if [A] is searchable then [nat -> A] is uniformly IsSearchable. *)
+
+  (** A type with a uniform structure is uniformly searchable if it is searchable over uniformly continuous predicates. *)
+  Definition uniformly_searchable (A : Type) {usA : UStructure A}
+    := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
+        uniformly_continuous P -> exists w0 : A, (P w0 -> forall u : A, P u).
+
+  Context {A : Type} (issearchable_A : IsSearchable A).
+
+  (** The witness function for predicates on [nat -> A] (no uniform continuity required in the construction). *)
+  Definition witness_nat (n : nat) (P : (nat -> A) -> Type)
+  (dP : forall f : (nat -> A), Decidable (P f))
+  : (nat -> A).
+  Proof.
+    induction n in P, dP.
+    - exact (fun _ => inhabited_issearchable issearchable_A).
+    - pose (g Q dQ := Q (IHn Q dQ)).
+      pose (y0 := universal_witness
+                    issearchable_A
+                    (fun x => g (P o (seq_cons x)) _) _).
+      exact (seq_cons y0 (IHn (P o seq_cons y0) _)).
+  Defined.
+
+  Definition uniformsearch_witness (n : nat) := fun P dP =>
+                                                  P (witness_nat n P dP).
+
+  (** The desired property of the witness function. *)
+  Definition uniformsearch_witness_spec {n : nat}
+    (P : (nat -> A) -> Type)
+    (dP : forall f : (nat -> A), Decidable (P f))
+    (is_mod : is_modulus_of_uniform_continuity n P)
+    (h : uniformsearch_witness n P dP)
+    : forall u : nat -> A, P u.
+  Proof.
+    induction n in P, dP, is_mod, h |- *.
+    - intro u.
+      by induction (is_mod u (fun _ => inhabited_issearchable issearchable_A)
+                     (sequence_type_us_zero _ _))^.
+    - intro u.
+      pose (x1 := universal_witness
+                    issearchable_A
+                    (fun y => uniformsearch_witness n (P o (seq_cons y)) _) _).
+      assert (consprop : forall x : A,
+                          uniformsearch_witness n (P o (seq_cons x)) _
+                            -> forall v : nat -> A, P (seq_cons x v)).
+      + exact (fun _ k => IHn (P o (seq_cons _)) _
+                              (cons_decreases_modulus P n _ is_mod) k).
+      + assert (x1prop : uniformsearch_witness n (P o (seq_cons x1)) _
+                          -> forall x : A,
+                              uniformsearch_witness n (P o (seq_cons x)) _).
+        * exact (fun l x =>
+                  witness_universality issearchable_A
+                    (fun y =>
+                      uniformsearch_witness n (P o (seq_cons y)) _) _ l x).
+        * induction (@uniformly_continuous_extensionality _ _ _ P 0
+                    (uniformly_continuous_has_modulus is_mod)
+                      _ _ (seq_cons_head_tail u)).
+          exact (consprop (u 0) (x1prop h (u 0)) (seq_tail u)).
+  Defined.
+
+  Definition has_uniformly_searchable_seq_issearchable
+    : uniformly_searchable (nat -> A)
+    := fun P dP contP
+        => (witness_nat (contP 1).1 P dP;
+            fun r => uniformsearch_witness_spec P dP (contP 1).2 r).
+
+End Uniform_Search.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -149,16 +149,6 @@ Definition IsSearchable (A : Type)
   := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
       {x : A & P x -> forall a : A, P a}.
 
-Definition universal_witness {A : Type}
-  (s : IsSearchable A) (P : A -> Type) (dP : forall a : A, Decidable (P a))
-  : A
-  := (s P dP).1.
-
-Definition witness_universality {A : Type}
-  (s : IsSearchable A) (P : A -> Type) (dP : forall a : A, Decidable (P a))
-  : P (universal_witness s P dP) -> forall a : A, P a
-  := (s P dP).2.
-
 Definition IsSearchableProps (A : Type)
   := forall (P : A -> HProp) (dP : forall a : A, Decidable (P a)),
       {x : A & P x -> forall a : A, P a}.
@@ -309,7 +299,7 @@ Section Uniform_Search.
 
   Context {A : Type} (issearchable_A : IsSearchable A).
 
-  (** The witness function for predicates on [nat -> A] (no uniform continuity required in the construction). *)
+  (** The witness function for uniformly continuous predicates on [nat -> A]. The first argument [n : nat] will be the modulus of uniform continuity, but we do not use the property in this definition. *)
   Definition witness_nat (n : nat) (P : (nat -> A) -> Type)
     (dP : forall (f : nat -> A), Decidable (P f))
     : nat -> A.
@@ -317,9 +307,7 @@ Section Uniform_Search.
     induction n in P, dP.
     - exact (fun _ => inhabited_issearchable issearchable_A).
     - pose (g Q dQ := Q (IHn Q dQ)).
-      pose (y0 := universal_witness
-                    issearchable_A
-                    (fun x => g (P o (seq_cons x)) _) _).
+      pose (y0 := (issearchable_A (fun x => g (P o (seq_cons x)) _) _).1).
       exact (seq_cons y0 (IHn (P o seq_cons y0) _)).
   Defined.
 
@@ -339,9 +327,9 @@ Section Uniform_Search.
       by induction (is_mod u (fun _ => inhabited_issearchable issearchable_A)
                      (sequence_type_us_zero _ _))^.
     - intro u.
-      pose (x1 := universal_witness
-                    issearchable_A
-                    (fun y => uniformsearch_witness n (P o (seq_cons y)) _) _).
+      pose (x1 := (issearchable_A
+                    (fun y => uniformsearch_witness
+                                n (P o (seq_cons y)) _) _).1).
       assert (consprop : forall x : A,
                           uniformsearch_witness n (P o (seq_cons x)) _
                             -> forall v : nat -> A, P (seq_cons x v)).
@@ -351,9 +339,9 @@ Section Uniform_Search.
                           -> forall x : A,
                               uniformsearch_witness n (P o (seq_cons x)) _).
         * exact (fun l x =>
-                  witness_universality issearchable_A
-                    (fun y =>
-                      uniformsearch_witness n (P o (seq_cons y)) _) _ l x).
+                  (issearchable_A
+                    (fun y => uniformsearch_witness n (P o (seq_cons y)) _) _).2
+                  l x).
         * induction (@uniformly_continuous_extensionality _ _ _ P 0
                     (uniformly_continuous_has_modulus is_mod)
                       _ _ (seq_cons_head_tail u)).

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -15,8 +15,8 @@ Local Open Scope pointed_scope.
 
 (** ** Basic definitions of compact types. *)
 
-(** A type is compact if for every decidable predicate we can decide whether it is always true or not. *)
-Definition IsCompact (A : Type) : Type
+(** A type [A] is compact if for every decidable predicate [P] on [A] we can either find an element of [A] making [P] false or we can show that [P a] always holds. *)
+Definition IsCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
                               {a : A & ~ P a} + (forall a : A, P a).
 
@@ -32,11 +32,7 @@ Proof.
   - exact (inl (l.1; fun p => l.2 (tr p))).
   - right.
     intro a.
-    specialize (r a).
-    rapply stable_decidable.
-    intro n.
-    strip_truncations.
-    exact (n r).
+    apply merely_inhabited_iff_inhabited_stable, r.
 Defined.
 
 (** Any compact type is decidable. *)
@@ -275,7 +271,7 @@ Proof.
 Defined.
 
 (** Assuming univalence, the type of propositions is searchable. *)
-Definition issearchable_HProp `{Univalence} : IsSearchable HProp.
+Definition issearchable_hprop `{Univalence} : IsSearchable HProp.
 Proof.
   apply issearchable_issearchable_prop.
   intros P dP.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -292,7 +292,7 @@ Section Uniform_Search.
 
   (** ** Following https://www.cs.bham.ac.uk/~mhe/TypeTopology/TypeTopology.UniformSearch.html, we prove that if [A] is searchable then [nat -> A] is uniformly searchable. *)
 
-  (** A type with a uniform structure is uniformly searchable if it is searchable over uniformly continuous predicates. *)
+  (** A type with a uniform structure is uniformly searchable if it is searchable over uniformly continuous predicates. Here the uniform structure on [Type] is the trivial one [trivial_us] involving the identity types at each level. *)
   Definition uniformly_searchable (A : Type) {usA : UStructure A}
     := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
         uniformly_continuous P -> exists w0 : A, (P w0 -> forall u : A, P u).
@@ -312,12 +312,12 @@ Section Uniform_Search.
   Defined.
 
   (** We often need to apply [P] to [uniformsearch_witness n P dP], and this saves repeating [P]. *)
-  Local Definition pred_uniformsearch_witness (n : nat) := fun P dP =>
-                                                  P (uniformsearch_witness n P dP).
+  Local Definition pred_uniformsearch_witness (n : nat) (P : (nat -> A) -> Type)
+    (dP : forall (f : nat -> A), Decidable (P f))
+    := P (uniformsearch_witness n P dP).
 
   (** The desired property of the witness function. *)
-  Definition uniformsearch_witness_spec {n : nat}
-    (P : (nat -> A) -> Type)
+  Definition uniformsearch_witness_spec {n : nat} (P : (nat -> A) -> Type)
     (dP : forall f : (nat -> A), Decidable (P f))
     (is_mod : is_modulus_of_uniform_continuity n P)
     (h : pred_uniformsearch_witness n P dP)
@@ -350,9 +350,11 @@ Section Uniform_Search.
   Defined.
 
   Definition has_uniformly_searchable_seq_issearchable
-    : uniformly_searchable (nat -> A)
-    := fun P dP contP
-        => (uniformsearch_witness (contP 1).1 P dP;
-            fun r => uniformsearch_witness_spec P dP (contP 1).2 r).
+    : uniformly_searchable (nat -> A).
+  Proof.
+    intros P dP contP.
+    exists (uniformsearch_witness (contP 1).1 P dP).
+    apply uniformsearch_witness_spec; exact (contP 1).2.
+  Defined.
 
 End Uniform_Search.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -211,37 +211,11 @@ Proof.
   by induction (contr a).
 Defined.
 
-Definition dtype_bool_encoding (A : Type) {d : Decidable A} : Bool
-  := if d then true else false.
-
-Definition inhabited_dtype_bool_encoding_true (A : Type) {d : Decidable A}
-  (t : dtype_bool_encoding A = true)
-  : A.
-Proof.
-  induction d as [a|na].
-  - exact a.
-  - cbn in t. contradiction (false_ne_true t).
-Defined.
-
-Definition ninhabited_dtype_bool_encoding_false (A : Type) {d : Decidable A}
-  (t : dtype_bool_encoding A = false)
-  : ~ A.
-Proof.
-  induction d as [a|na].
-  - cbn in t. contradiction (false_ne_true t^).
-  - exact na.
-Defined.
-
 Definition issearchable_Bool : IsSearchable Bool.
 Proof.
   intros P dP.
-  exists (dtype_bool_encoding (P false)).
-  intro x.
-  remember (dtype_bool_encoding (P false)) as b eqn:r; induction b.
-  - intros [].
-    + assumption.
-    + by apply inhabited_dtype_bool_encoding_true in r.
-  - contradiction (ninhabited_dtype_bool_encoding_false _ r x).
+  induction (dP false) as [p | np]; [exists true | exists false].
+  all: by intros p' [].
 Defined.
 
 (** The empty type is trivially compact. *)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -345,8 +345,8 @@ Section Uniform_Search.
     : uniformly_searchable (nat -> A).
   Proof.
     intros P dP contP.
-    exists (uniformsearch_witness (contP 1).1 P dP).
-    apply uniformsearch_witness_spec; exact (contP 1).2.
+    exists (uniformsearch_witness (contP 0).1 P dP).
+    apply uniformsearch_witness_spec; exact (contP 0).2.
   Defined.
 
 End Uniform_Search.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -29,7 +29,7 @@ Proof.
 Defined.
 
 (** Compactness is equivalent to assuming the same for [HProp]-valued decidable predicates. *)
-Definition IsPropCompact (A : Type) : Type
+Definition IsPropCompact (A : Type)
   := forall P : A -> HProp, (forall a : A, Decidable (P a)) ->
                               {a : A & ~ P a} + (forall a : A, P a).
 
@@ -62,7 +62,7 @@ Proof.
 Defined.
 
 (** Another equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
-Definition IsSigCompact (A : Type) : Type
+Definition IsSigCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
 
 Definition equiv_iscompact'_issigcompact {A : Type}
@@ -76,7 +76,7 @@ Proof.
 Defined.
 
 (** Again, it is enough to consider [HProp]-valued families. *)
-Definition IsSigCompact_prop (A : Type) : Type
+Definition IsSigCompact_prop (A : Type)
   := forall P : A -> HProp,
       (forall a : A, Decidable (P a)) -> Decidable (sig P).
 
@@ -125,7 +125,7 @@ Defined.
 (** ** Basic definitions of searchable types. *)
 
 (** Second notion of compactness, also called searchability: for every predicate we can find a witness for whether it is always true or not. *)
-Definition IsSearchable (A : Type) : Type
+Definition IsSearchable (A : Type)
   := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
       {x : A & P x -> forall a : A, P a}.
 
@@ -139,7 +139,7 @@ Definition witness_universality {A : Type}
   : P (universal_witness s P dP) -> forall a : A, P a
   := (s P dP).2.
 
-Definition IsSearchable_prop (A : Type) : Type
+Definition IsSearchable_prop (A : Type)
   := forall (P : A -> HProp) (dP : forall a : A, Decidable (P a)),
       {x : A & P x -> forall a : A, P a}.
 

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -29,11 +29,11 @@ Proof.
 Defined.
 
 (** Compactness is equivalent to assuming the same for [HProp]-valued decidable predicates. *)
-Definition IsPropCompact (A : Type)
+Definition IsCompactProps (A : Type)
   := forall P : A -> HProp, (forall a : A, Decidable (P a)) ->
                               {a : A & ~ P a} + (forall a : A, P a).
 
-Definition iscompact_ispropcompact {A} (c : IsPropCompact A) : IsCompact A.
+Definition iscompact_iscompactprops {A} (c : IsCompactProps A) : IsCompact A.
 Proof.
   intros P dP.
   destruct (c (merely o P) _) as [l|r].
@@ -62,11 +62,11 @@ Proof.
 Defined.
 
 (** Another equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
-Definition IsSigCompact (A : Type)
+Definition IsSigmaCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
 
-Definition equiv_iscompact'_issigcompact {A : Type}
-  : IsCompact' A <-> IsSigCompact A.
+Definition equiv_iscompact'_issigmacompact {A : Type}
+  : IsCompact' A <-> IsSigmaCompact A.
 Proof.
   apply iff_functor_forall; intro P.
   apply iff_functor_forall; intro dP.
@@ -76,13 +76,13 @@ Proof.
 Defined.
 
 (** Again, it is enough to consider [HProp]-valued families. *)
-Definition IsSigCompact_prop (A : Type)
+Definition IsSigmaCompactProps (A : Type)
   := forall P : A -> HProp,
       (forall a : A, Decidable (P a)) -> Decidable (sig P).
 
-Definition issigcompact_prop_issigcompact {A : Type}
-  (h : IsSigCompact A)
-  : IsSigCompact_prop A
+Definition issigmacompactprops_issigmacompact {A : Type}
+  (h : IsSigmaCompact A)
+  : IsSigmaCompactProps A
   := fun P hP => h P hP.
 
 Definition sigma_iff_prop_truncation_decidable {A : Type} {P : A -> Type}
@@ -93,9 +93,9 @@ Proof.
   exact (x; fst (@merely_inhabited_iff_inhabited_stable (P x) _) hx).
 Defined.
 
-Definition issigcompact_issigcompact_prop {A : Type}
-  (h : IsSigCompact_prop A)
-  : IsSigCompact A.
+Definition issigmacompact_issigmacompactprops {A : Type}
+  (h : IsSigmaCompactProps A)
+  : IsSigmaCompact A.
 Proof.
   intros P hP.
   destruct (h (merely o P) _) as [[l k]|r].
@@ -110,7 +110,7 @@ Definition IsPiCompact (A : Type)
   := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
       Decidable (forall a : A, P a).
 
-Definition ispicompact_issigcompact {A : Type} (c : IsSigCompact A)
+Definition ispicompact_issigmacompact {A : Type} (c : IsSigmaCompact A)
   : IsPiCompact A.
 Proof.
   intros P dP.
@@ -139,11 +139,11 @@ Definition witness_universality {A : Type}
   : P (universal_witness s P dP) -> forall a : A, P a
   := (s P dP).2.
 
-Definition IsSearchable_prop (A : Type)
+Definition IsSearchableProps (A : Type)
   := forall (P : A -> HProp) (dP : forall a : A, Decidable (P a)),
       {x : A & P x -> forall a : A, P a}.
 
-Definition issearchable_issearchable_prop {A : Type} (s : IsSearchable_prop A)
+Definition issearchable_issearchableprops {A : Type} (s : IsSearchableProps A)
   : IsSearchable A.
 Proof.
   intros P dP.
@@ -269,7 +269,7 @@ Definition compact_set_trunc_compact `{Univalence} {A : Type} {n : nat}
 Proof.
   constructor.
   1: exact (iscompact_retract' s).
-  intro cpt; rapply iscompact_ispropcompact.
+  intro cpt; rapply iscompact_iscompactprops.
   intros P dP.
   destruct (cpt (Trunc_rec P)) as [l|r].
   - intro a; strip_truncations.
@@ -281,7 +281,7 @@ Defined.
 (** Assuming univalence, the type of propositions is searchable. *)
 Definition issearchable_hprop `{Univalence} : IsSearchable HProp.
 Proof.
-  apply issearchable_issearchable_prop.
+  apply issearchable_issearchableprops.
   intros P dP.
   destruct (dP Unit_hp) as [t|f].
   - exists False_hp; intros p a.
@@ -291,10 +291,10 @@ Defined.
 
 (** Assuming univalence, if the domain of a surjective map is searchable, then so is its codomain. *)
 
-Definition ispropsearchable_image `{Univalence} (A B : Type)
-  (s : IsSearchable_prop A)
+Definition issearchableprops_image `{Univalence} (A B : Type)
+  (s : IsSearchableProps A)
   (f : A -> B) (surj : IsSurjection f)
-  : IsSearchable_prop B.
+  : IsSearchableProps B.
 Proof.
   intros P dP.
   specialize (s (P o f) _).
@@ -305,7 +305,7 @@ Definition issearchable_image `{Univalence} (A B : Type)
   (s : IsSearchable A)
   (f : A -> B) (surj : IsSurjection f)
   : IsSearchable B
-  := issearchable_issearchable_prop (ispropsearchable_image A B s f surj).
+  := issearchable_issearchableprops (issearchableprops_image A B s f surj).
 
 (** Assuming univalence, every connected pointed type is searchable. *)
 Definition issearchable_isconnected_ptype `{Univalence} (A : pType)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -43,28 +43,36 @@ Proof.
   - exact (inr c2).
 Defined.
 
-(** Equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
+(** Since decidable types are stable, it's also equivalent to negate [P] in the definition. *)
+Definition IsCompact' (A : Type)
+  := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
+                              {a : A & P a} + (forall a : A, ~ P a).
+
+Definition iff_iscompact_iscompact' (A : Type)
+  : IsCompact A <-> IsCompact' A.
+Proof.
+  split;
+    napply (functor_forall (fun P => (fun a => ~ P a))); intro P;
+    rapply functor_forall; intro dP;
+    apply functor_sum.
+  2,3: exact idmap.
+  1: apply (functor_sigma idmap).
+  2: apply (functor_forall idmap).
+  all: intro a; by apply stable_decidable.
+Defined.
+
+(** Another equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
 Definition IsSigCompact (A : Type) : Type
   := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
 
-Definition issigcompact_iscompact {A : Type} (c : IsCompact A)
-  : IsSigCompact A.
+Definition equiv_iscompact'_issigcompact {A : Type}
+  : IsCompact' A <-> IsSigCompact A.
 Proof.
-  intros P dP.
-  destruct (c (fun a => ~ P a) _) as [l|r].
-  - left; exists l.1.
-    exact (stable_decidable (P l.1) l.2).
-  - right; exact (fun x => (r x.1) x.2).
-Defined.
-
-Definition iscompact_issigcompact {A : Type} (c : IsSigCompact A)
-  : IsCompact A.
-Proof.
-  intros P dP.
-  destruct (c (fun a => ~ P a) _) as [l|r].
-  - exact (inl l).
-  - right; intro a.
-    apply (stable_decidable (P a) (fun h => r (a; h))).
+  apply iff_functor_forall; intro P.
+  apply iff_functor_forall; intro dP.
+  apply iff_equiv.
+  apply (equiv_functor_sum' equiv_idmap).
+  napply equiv_sig_ind.
 Defined.
 
 (** Again, it is enough to consider [HProp]-valued families. *)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -1,4 +1,4 @@
-(** * Properties of compact and searchable types. *)
+(** * Properties of compact and searchable types *)
 
 Require Import Basics Types.
 Require Import Truncations.Core Truncations.Connectedness.
@@ -13,7 +13,7 @@ Require Import Idempotents.
 Local Open Scope nat_scope.
 Local Open Scope pointed_scope.
 
-(** ** Basic definitions of compact types. *)
+(** ** Basic definitions of compact types *)
 
 (** A type [A] is compact if for every decidable predicate [P] on [A] we can either find an element of [A] making [P] false or we can show that [P a] always holds. *)
 Definition IsCompact (A : Type)
@@ -142,7 +142,7 @@ Proof.
   - exact (inr (fun a => r (tr a))).
 Defined.
 
-(** ** Basic definitions of searchable types. *)
+(** ** Basic definitions of searchable types *)
 
 (** A type is searchable if for every decidable predicate we can find a "universal witness" for whether the predicate is always true or not. *)
 Definition IsSearchable (A : Type)
@@ -191,7 +191,7 @@ Definition searchable_iff {A : Type} : IsSearchable A <-> A * (IsCompact A)
   := (fun s => (inhabited_issearchable s, iscompact_issearchable s),
         fun c => issearchable_iscompact_inhabited (snd c) (fst c)).
 
-(** ** Examples of searchable and compact types.  *)
+(** ** Examples of searchable and compact types  *)
 
 Definition issearchable_contr {A} (c : Contr A) : IsSearchable A.
 Proof.
@@ -290,7 +290,9 @@ Defined.
 
 Section Uniform_Search.
 
-  (** ** Following https://www.cs.bham.ac.uk/~mhe/TypeTopology/TypeTopology.UniformSearch.html, we prove that if [A] is searchable then [nat -> A] is uniformly searchable. *)
+  (** ** Searchability of [nat -> A] *)
+
+  (** Following https://www.cs.bham.ac.uk/~mhe/TypeTopology/TypeTopology.UniformSearch.html, we prove that if [A] is searchable then [nat -> A] is uniformly searchable. *)
 
   (** A type with a uniform structure is uniformly searchable if it is searchable over uniformly continuous predicates. Here the uniform structure on [Type] is the trivial one [trivial_us] involving the identity types at each level. *)
   Definition uniformly_searchable (A : Type) {usA : UStructure A}

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -323,30 +323,22 @@ Section Uniform_Search.
     (h : pred_uniformsearch_witness n P dP)
     : forall u : nat -> A, P u.
   Proof.
-    induction n in P, dP, is_mod, h |- *.
+    induction n in P, dP, is_mod, h.
     - intro u.
-      by induction (is_mod u (fun _ => inhabited_issearchable issearchable_A)
-                     (sequence_type_us_zero _ _))^.
+      refine (transport idmap _ h).
+      (* For [n = 0], [is_mod u1 u2] says that [P u1 = P u2]. *)
+      apply is_mod, sequence_type_us_zero.
     - intro u.
-      pose (wA := (issearchable_A
-                    (fun y => pred_uniformsearch_witness
-                                n (P o (seq_cons y)) _) _).1).
-      assert (consprop : forall x : A,
-                          pred_uniformsearch_witness n (P o (seq_cons x)) _
-                            -> forall v : nat -> A, P (seq_cons x v)).
-      + exact (fun _ k => IHn (P o (seq_cons _)) _
-                              (cons_decreases_modulus P n _ is_mod) k).
-      + assert (wAprop : pred_uniformsearch_witness n (P o (seq_cons wA)) _
-                          -> forall x : A,
-                              pred_uniformsearch_witness n (P o (seq_cons x)) _).
-        * exact (fun l x =>
-                  (issearchable_A
-                    (fun y => pred_uniformsearch_witness n (P o (seq_cons y)) _) _).2
-                  l x).
-        * induction (@uniformly_continuous_extensionality _ _ _ P 0
-                    (uniformly_continuous_has_modulus is_mod)
-                      _ _ (seq_cons_head_tail u)).
-          exact (consprop (u 0) (wAprop h (u 0)) (seq_tail u)).
+      refine (transport idmap _ _).
+      1: exact (uniformly_continuous_extensionality P (m:=0)
+                  (uniformly_continuous_has_modulus is_mod)
+                  (seq_cons_head_tail u)).
+      rapply (IHn (P o (seq_cons (u 0)))).
+      1: apply cons_decreases_modulus, is_mod.
+      (* The universality of [uniformsearch_witness] says that it is enough to check this statement with [u 0] replaced with [wA] above, and that is exactly what [h] proves, by the inductive step. *)
+      refine ((issearchable_A
+                 (fun y => pred_uniformsearch_witness n (P o (seq_cons y)) _) _).2
+                h (u 0)).
   Defined.
 
   Definition has_uniformly_searchable_seq_issearchable

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -92,7 +92,7 @@ Proof.
   intros P hP.
   refine (decidable_iff _ (h (merely o P) _)).
   apply iff_functor_sigma; intro a.
-  apply merely_inhabited_iff_inhabited_stable.
+  exact merely_inhabited_iff_inhabited_stable.
 Defined.
 
 (** A weaker definition: for any decidable family, the dependent function type is decidable. *)
@@ -338,7 +338,7 @@ Section Uniform_Search.
       rapply (IHn (P o (seq_cons (u 0)))).
       1: apply cons_decreases_modulus, is_mod.
       (* The universality of [uniformsearch_witness] says that it is enough to check this statement with [u 0] replaced with [wA] above, and that is exactly what [h] proves, by the inductive step. *)
-      refine ((issearchable_A
+      exact ((issearchable_A
                  (fun y => pred_uniformsearch_witness n (P o (seq_cons y)) _) _).2
                 h (u 0)).
   Defined.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -112,6 +112,36 @@ Proof.
     exact (fun u => r (a; u)).
 Defined.
 
+(** Compact types are closed under retracts. *)
+Definition iscompact_retract {A : Type} (R : RetractOf A) (c : IsCompact A)
+  : IsCompact (retract_type R).
+Proof.
+  intros P dP; destruct (c (P o (retract_retr R)) _) as [l|r].
+  - exact (inl ((retract_retr R) l.1; l.2)).
+  - exact (inr (fun a =>  ((retract_issect R) a) # r ((retract_sect R) a))).
+Defined.
+
+Definition iscompact_retract' {A R : Type} {f : A -> R} {g : R -> A}
+  (s : f o g == idmap) (c : IsCompact A)
+  : IsCompact R
+  := iscompact_retract (Build_RetractOf A R f g s) c.
+
+(** Assuming the set truncation map has a section, a type is compact if and only if its set truncation is compact. *)
+Definition compact_set_trunc_compact `{Univalence} {A : Type}
+  (f : (Tr 0 A) -> A) (s : tr o f == idmap)
+  : IsCompact A <-> IsCompact (Tr 0 A).
+Proof.
+  constructor.
+  1: exact (iscompact_retract' s).
+  intro cpt; rapply iscompact_iscompactprops.
+  intros P dP.
+  destruct (cpt (Trunc_rec P)) as [l|r].
+  - intro a; strip_truncations.
+    exact (dP a).
+  - exact (inl (f l.1; fun x => l.2 (ap (Trunc_rec P) (s l.1) # x))).
+  - exact (inr (fun a => r (tr a))).
+Defined.
+
 (** ** Basic definitions of searchable types. *)
 
 (** A type is searchable if for every decidable predicate we can find a "universal witness" for whether the predicate is always true or not. *)
@@ -232,36 +262,6 @@ Proof.
   - intros [l|r].
     + exact (iscompact_empty' l).
     + exact (iscompact_issearchable r).
-Defined.
-
-(** Compact types are closed under retracts. *)
-Definition iscompact_retract {A : Type} (R : RetractOf A) (c : IsCompact A)
-  : IsCompact (retract_type R).
-Proof.
-  intros P dP; destruct (c (P o (retract_retr R)) _) as [l|r].
-  - exact (inl ((retract_retr R) l.1; l.2)).
-  - exact (inr (fun a =>  ((retract_issect R) a) # r ((retract_sect R) a))).
-Defined.
-
-Definition iscompact_retract' {A R : Type} {f : A -> R} {g : R -> A}
-  (s : f o g == idmap) (c : IsCompact A)
-  : IsCompact R
-  := iscompact_retract (Build_RetractOf A R f g s) c.
-
-(** Assuming the set truncation map has a section, a type is compact if and only if its set truncation is compact. *)
-Definition compact_set_trunc_compact `{Univalence} {A : Type}
-  (f : (Tr 0 A) -> A) (s : tr o f == idmap)
-  : IsCompact A <-> IsCompact (Tr 0 A).
-Proof.
-  constructor.
-  1: exact (iscompact_retract' s).
-  intro cpt; rapply iscompact_iscompactprops.
-  intros P dP.
-  destruct (cpt (Trunc_rec P)) as [l|r].
-  - intro a; strip_truncations.
-    exact (dP a).
-  - exact (inl (f l.1; fun x => l.2 (ap (Trunc_rec P) (s l.1) # x))).
-  - exact (inr (fun a => r (tr a))).
 Defined.
 
 (** Assuming univalence, the type of propositions is searchable. *)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -20,7 +20,15 @@ Definition IsCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
                               {a : A & ~ P a} + (forall a : A, P a).
 
-(** Equivalently, we can assume the same for [HProp]-valued decidable predicates. *)
+(** Any compact type is decidable. *)
+Definition decidable_iscompact {A : Type} (c : IsCompact A) : Decidable A.
+Proof.
+  destruct (c (fun (_ : A) => Empty) _) as [c1|c2].
+  - exact (inl c1.1).
+  - exact (inr c2).
+Defined.
+
+(** Compactness is equivalent to assuming the same for [HProp]-valued decidable predicates. *)
 Definition IsPropCompact (A : Type) : Type
   := forall P : A -> HProp, (forall a : A, Decidable (P a)) ->
                               {a : A & ~ P a} + (forall a : A, P a).
@@ -33,14 +41,6 @@ Proof.
   - right.
     intro a.
     apply merely_inhabited_iff_inhabited_stable, r.
-Defined.
-
-(** Any compact type is decidable. *)
-Definition decidable_iscompact {A : Type} (c : IsCompact A) : Decidable A.
-Proof.
-  destruct (c (fun (_ : A) => Empty) _) as [c1|c2].
-  - exact (inl c1.1).
-  - exact (inr c2).
 Defined.
 
 (** Since decidable types are stable, it's also equivalent to negate [P] in the definition. *)

--- a/theories/Types/Sigma.v
+++ b/theories/Types/Sigma.v
@@ -436,6 +436,15 @@ Definition equiv_functor_sigma_pb {A B : Type} {Q : B -> Type}
   : sig (Q o f) <~> sig Q
   := equiv_functor_sigma f (fun a => 1%equiv).
 
+(** ** Functoriality on logical equivalences *)
+
+(** At least over a fixed base *)
+Definition iff_functor_sigma {A : Type} {P Q : A -> Type}
+           (f : forall a, P a <-> Q a)
+  : sig P <-> sig Q
+  := (functor_sigma idmap (fun a => fst (f a)),
+    functor_sigma idmap (fun a => snd (f a))).
+
 (** Lemma 3.11.9(i): Summing up a contractible family of types does nothing. *)
 Instance isequiv_pr1_contr {A} {P : A -> Type}
   `{forall a, Contr (P a)}

--- a/theories/Universes/TruncType.v
+++ b/theories/Universes/TruncType.v
@@ -170,17 +170,17 @@ Section TruncType.
   Defined.
 
   (** An [HProp] cannot be not equal to [Unit_hp] and not equal to [False_hp]. *)
-  Definition not_not_unit_and_not_empty_hprop `{Univalence} (P : HProp)
+  Definition not_not_unit_and_not_empty_hprop (P : HProp)
     : ~ ((P <> Unit_hp) * (P <> False_hp)).
   Proof.
     intros [h1 h2].
     apply (iff_contradiction (~ P)); constructor.
-    - intro p. apply h1. exact (equiv_path_iff_hprop (fun _ => tt, fun _ => p)).
-    - intro q. apply h2. exact (equiv_path_iff_hprop (q, Empty_rec)).
+    - intro p. apply h1. exact (path_iff_hprop (fun _ => tt) (fun _ => p)).
+    - intro q. apply h2. exact (path_iff_hprop q Empty_rec).
   Defined.
 
   (** Any map from [HProp] to a type with [~~]-stable paths that maps [Unit_hp] and [False_hp] to equal terms is weakly constant. *)
-  Definition WeaklyConstant_HProp_to_stable_paths {A : Type}
+  Definition weaklyconstant_hprop_to_stable_paths' {A : Type}
     (F : HProp -> A) (s : forall x y : HProp, Stable (F x = F y))
     (h1 : F Unit_hp = F False_hp)
     : forall (B : HProp), F B = F Unit_hp.
@@ -193,20 +193,20 @@ Section TruncType.
     - exact (ap F p @ h1^).
   Defined.
 
-  Definition WeaklyConstant_HProp_to_stable_paths' {A : Type}
+  Definition weaklyconstant_hprop_to_stable_paths {A : Type}
     (F : HProp -> A) (s : forall x y : HProp, Stable (F x = F y))
     (h1 : F Unit_hp = F False_hp)
     : WeaklyConstant F
-    := fun B C => WeaklyConstant_HProp_to_stable_paths F s h1 B
-                  @ (WeaklyConstant_HProp_to_stable_paths F s h1 C)^.
+    := fun B C => weaklyconstant_hprop_to_stable_paths' F s h1 B
+                  @ (weaklyconstant_hprop_to_stable_paths' F s h1 C)^.
 
   Definition not_not_constant_family_hprop (P : HProp -> Type)
     (p : P Unit_hp) (p' : P False_hp) (x : HProp)
     : ~~P x.
   Proof.
     intro f.
-    contradiction (not_not_unit_and_not_empty_hprop x); constructor.
-    1,2: intro h; apply f.
+    apply (not_not_unit_and_not_empty_hprop x).
+    split; intro h; apply f.
     - exact (h^ # p).
     - exact (h^ # p').
   Defined.

--- a/theories/Universes/TruncType.v
+++ b/theories/Universes/TruncType.v
@@ -169,4 +169,46 @@ Section TruncType.
     exact (equiv_path_trunctype' _ _ oE equiv_path_iff_ishprop).
   Defined.
 
+  (** An [HProp] cannot be not equal to [Unit_hp] and not equal to [False_hp]. *)
+  Definition not_not_unit_and_not_empty_hprop `{Univalence} (P : HProp)
+    : ~ ((P <> Unit_hp) * (P <> False_hp)).
+  Proof.
+    intros [h1 h2].
+    apply (iff_contradiction (~ P)); constructor.
+    - intro p. apply h1. exact (equiv_path_iff_hprop (fun _ => tt, fun _ => p)).
+    - intro q. apply h2. exact (equiv_path_iff_hprop (q, Empty_rec)).
+  Defined.
+
+  (** Any map from [HProp] to a type with [~~]-stable paths that maps [Unit_hp] and [False_hp] to equal terms is weakly constant. *)
+  Definition WeaklyConstant_HProp_to_stable_paths {A : Type}
+    (F : HProp -> A) (s : forall x y : HProp, Stable (F x = F y))
+    (h1 : F Unit_hp = F False_hp)
+    : forall (B : HProp), F B = F Unit_hp.
+  Proof.
+    intros B.
+    apply (s B Unit_hp); intro h'.
+    apply (not_not_unit_and_not_empty_hprop B).
+    split; intro p; apply h'.
+    - exact (ap F p).
+    - exact (ap F p @ h1^).
+  Defined.
+
+  Definition WeaklyConstant_HProp_to_stable_paths' {A : Type}
+    (F : HProp -> A) (s : forall x y : HProp, Stable (F x = F y))
+    (h1 : F Unit_hp = F False_hp)
+    : WeaklyConstant F
+    := fun B C => WeaklyConstant_HProp_to_stable_paths F s h1 B
+                  @ (WeaklyConstant_HProp_to_stable_paths F s h1 C)^.
+
+  Definition not_not_constant_family_hprop (P : HProp -> Type)
+    (p : P Unit_hp) (p' : P False_hp) (x : HProp)
+    : ~~P x.
+  Proof.
+    intro f.
+    contradiction (not_not_unit_and_not_empty_hprop x); constructor.
+    1,2: intro h; apply f.
+    - exact (h^ # p).
+    - exact (h^ # p').
+  Defined.
+
 End TruncType.


### PR DESCRIPTION
We add definitions and basic facts about compact and searchable types, including some examples and characterisations. We prove that the type `nat->X` is uniformly searchable if `X` is searchable. Useful lemmas about propositions and Σ-types are added to `TruncType` and `Sigma` respectively.