### PR TITLE
build: migrate Dune integration to Rocq

### DIFF
--- a/contrib/dune
+++ b/contrib/dune
@@ -1,4 +1,4 @@
-(coq.theory
+(rocq.theory
  (name HoTT.Contrib)
  (package coq-hott)
  (theories HoTT))

--- a/coq-hott.opam
+++ b/coq-hott.opam
@@ -30,6 +30,7 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/HoTT/HoTT.git"
+x-maintenance-intent: ["(latest)"]
 depends: [
   "dune" {>= "3.13"}
   ("rocq-core" {>= "9.0"} & "coq-core" {>= "9.0"})

--- a/dune
+++ b/dune
@@ -26,7 +26,8 @@
   (glob_files_rec ./*.vo))
  (action
   (run
-   coqchk
+   rocq
+   check
    -R
    ./theories
    HoTT
@@ -63,12 +64,12 @@
  (action
   (run etc/emacs/run-etags.sh %{vfile})))
 
-; Common flags for Coq
+; Common flags for Rocq
 
 (env
  (dev
-  (coq
-   (coqdoc_flags
+  (rocq
+   (rocqdoc_flags
     :standard
     --interpolate
     --utf8
@@ -76,8 +77,8 @@
     --parse-comments)
    (flags -noinit -indices-matter -color on)))
  (_
-  (coq
-   (coqdoc_flags
+  (rocq
+   (rocqdoc_flags
     :standard
     --interpolate
     --utf8
@@ -116,7 +117,7 @@
      (copy %{file} benched_file.v)
      (run
       %{bin:hyperfine}
-      "%{bin:coqc} -R %{project_root}/theories HoTT -noinit -indices-matter benched_file.v")))
+      "%{bin:rocq} compile -R %{project_root}/theories HoTT -noinit -indices-matter benched_file.v")))
    (echo "Bench finished, report at %{target}:\n\n")
    (cat %{target}))))
 

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
-(lang dune 3.13)
+(lang dune 3.22)
 
-(using coq 0.8)
+(using rocq 0.12)
 
 (name coq-hott)
 

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,4 @@
-(coq.theory
+(rocq.theory
  (name HoTT.Tests)
  (theories HoTT Ltac2))
 

--- a/theories/dune
+++ b/theories/dune
@@ -4,7 +4,7 @@
 
 ; Main theory stanza telling dune how the HoTT library is compiled
 
-(coq.theory
+(rocq.theory
  (name HoTT)
  (package coq-hott)
  (theories Ltac2))


### PR DESCRIPTION
Migrate from Dune's deprecated Coq integration to `(using rocq 0.11)` and `rocq.*` stanzas.

3.21 is the version of dune pinned ( :cry: ) in the docker images, so it's worth keeping as the lower bound for now. I could unpin it but that messes with the opam CI too much.