### PR TITLE
Add repository agent guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# GitHub Copilot Instructions
+
+Follow [AGENTS.md](../AGENTS.md).
+
+## Environment Setup
+
+The Nix development shell is not activated automatically, so prefix project
+commands with `nix develop -c`:
+
+```sh
+nix develop -c dune build
+nix develop -c dune test
+```

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,38 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # This job name is required by Copilot coding agent.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v35
+
+      - name: Restore Nix cache
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 2G
+          save: false
+
+      - name: Enter Nix development shell
+        run: nix develop -c true

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,9 @@ nix/profiles/
 
 # Ignore the file to bench
 file_to_bench
+
+# Local AI assistant state
+/.agents/
+/.claude/
+/.codex/
+/.pi/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md
+
+Repository-wide guidance for coding agents. A more specific `AGENTS.md` in a
+subdirectory takes precedence for files below it.
+
+## Project
+
+HoTT is a Rocq (formerly Coq) library for homotopy type theory. Library sources
+live in `theories/`, additional developments in `contrib/`, tests in `test/`,
+and developer tooling in `etc/`.
+
+- Preserve the required `-noinit` and `-indices-matter` flags by using the
+  project build rather than invoking Rocq with ad-hoc arguments.
+- Treat the matrices in `.github/workflows/ci.yml` as the source of truth for
+  supported Rocq versions; avoid unnecessary version-specific features.
+
+## Proof Development
+
+- Read `STYLE.md` before changing `.v` files and match the surrounding style.
+  In particular, do not hard-wrap prose in Rocq comments.
+- Prove results at their natural level of generality: consider arbitrary
+  truncation levels, modalities, or reflective subuniverses when appropriate.
+- Prefer reusable lemmas over long proofs, and keep intermediate goals readable
+  enough for a human to follow. Useful project tactics include `napply`,
+  `rapply`, `snapply`, and `srapply`, plus the `lhs`, `lhs_V`, `rhs`, and
+  `rhs_V` tacticals (and primed variants) described in `STYLE.md`.
+- Preserve intended universe polymorphism while avoiding unnecessary universe
+  parameters and constraints. Inspect universe-sensitive definitions with
+  `About` or `Print` and `Set Printing Universes.`; add regression checks under
+  `test/` when appropriate.
+
+## Working Rules
+
+- Keep changes focused and avoid unrelated formatting or refactoring.
+- Do not introduce `Admitted`, `admit`, or new axioms to finish a proof. Follow
+  the axiom conventions in `STYLE.md` when axioms are genuinely in scope.
+- Do not edit generated files or build products such as `_CoqProject`,
+  `Makefile.coq`, `*.vo`, or `_build/`.
+- Wire new library files into the existing exports and build structure, usually
+  `theories/HoTT.v` and the relevant `dune` stanza.
+- Keep commits atomic and self-contained, with tests and implementation grouped
+  so that each commit is independently valid.
+- Do not stage, commit, or rewrite repository history unless explicitly asked.
+
+## Build and Test
+
+Prefer Dune. Use `dune build` for fast feedback while iterating:
+
+```sh
+dune build
+```
+
+Before each commit, run the complete validation target; it subsumes the build:
+
+```sh
+dune test
+```
+
+Use `make -j2` only when a task specifically concerns the Make build or needs
+to reproduce that CI path. Finish with `git diff --check` and report what was
+and was not validated.
+
+## Rocq MCP
+
+When a Rocq MCP server is available, use it for quick proof inspection and
+iteration. Treat it as optional fast feedback and validate final edits with the
+normal Dune build and tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ and developer tooling in `etc/`.
 - Note that `Basics` (especially `Basics.Overture`) provides many of the
   things usually provided by `Init` in standard Rocq developments.
 - Look up the supported Rocq versions in the CI matrices
-  (`.github/workflows/ci.yml`) rather than hard-coding them here; avoid
+  (`.github/workflows/ci.yml`); avoid
   unnecessary version-specific features.
 
 ## Proof Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,36 +11,51 @@ and developer tooling in `etc/`.
 
 - Preserve the required `-noinit` and `-indices-matter` flags by using the
   project build rather than invoking Rocq with ad-hoc arguments.
-- Treat the matrices in `.github/workflows/ci.yml` as the source of truth for
-  supported Rocq versions; avoid unnecessary version-specific features.
+- Note that `Basics` (especially `Basics.Overture`) provides many of the
+  things usually provided by `Init` in standard Rocq developments.
+- Look up the supported Rocq versions in the CI matrices
+  (`.github/workflows/ci.yml`) rather than hard-coding them here; avoid
+  unnecessary version-specific features.
 
 ## Proof Development
 
-- Read `STYLE.md` before changing `.v` files and match the surrounding style.
+- Read `doc/STYLE.md` before changing `.v` files and match the surrounding style.
   In particular, do not hard-wrap prose in Rocq comments.
 - Prove results at their natural level of generality: consider arbitrary
   truncation levels, modalities, or reflective subuniverses when appropriate.
 - Prefer reusable lemmas over long proofs, and keep intermediate goals readable
-  enough for a human to follow. Useful project tactics include `napply`,
-  `rapply`, `snapply`, and `srapply`, plus the `lhs`, `lhs_V`, `rhs`, and
-  `rhs_V` tacticals (and primed variants) described in `STYLE.md`.
+  enough for a human to follow.
+- Useful project tactics include `napply`, `snapply`, `rapply`, `srapply`,
+  `tapply`, `stapply`, and the `lhs`, `lhs_V`, `rhs`, and `rhs_V` tacticals
+  (and primed variants) described in `doc/STYLE.md`.
 - Preserve intended universe polymorphism while avoiding unnecessary universe
   parameters and constraints. Inspect universe-sensitive definitions with
-  `About` or `Print` and `Set Printing Universes.`; add regression checks under
-  `test/` when appropriate.
+  `About` or `Print` and `Set Printing Universes.`
+- Add regression checks under `test/` when appropriate.
+- Before stating a lemma, search `theories/` for an existing or more general
+  form; if a close variant exists, generalize it in place rather than adding
+  a new one.
+- Do not add definitions that merely rename, specialize, or compose existing
+  lemmas in one step; use the existing lemmas directly.
+- Make arguments implicit when inferable from later arguments (objects from
+  morphisms, groups from homomorphisms), and declare instances with
+  `Instance` at the definition rather than wrapping them later.
 
 ## Working Rules
 
 - Keep changes focused and avoid unrelated formatting or refactoring.
 - Do not introduce `Admitted`, `admit`, or new axioms to finish a proof. Follow
-  the axiom conventions in `STYLE.md` when axioms are genuinely in scope.
+  the axiom conventions in `doc/STYLE.md` when axioms are genuinely in scope.
 - Do not edit generated files or build products such as `_CoqProject`,
   `Makefile.coq`, `*.vo`, or `_build/`.
-- Wire new library files into the existing exports and build structure, usually
-  `theories/HoTT.v` and the relevant `dune` stanza.
-- Keep commits atomic and self-contained, with tests and implementation grouped
-  so that each commit is independently valid.
+- Require exactly what the file uses: no reliance on transitive imports, and
+  no meta-file imports (`Categories`, `Basics`) from within their own
+  subtrees.
+- Add new library files to the closest meta-file above them in the folder
+  structure, such as `theories/WildCat.v` or `theories/HoTT.v`.
 - Do not stage, commit, or rewrite repository history unless explicitly asked.
+- When asked to commit, keep commits atomic and self-contained, with tests
+  and implementation grouped so that each commit is independently valid.
 
 ## Build and Test
 
@@ -50,15 +65,18 @@ Prefer Dune. Use `dune build` for fast feedback while iterating:
 dune build
 ```
 
-Before each commit, run the complete validation target; it subsumes the build:
+Before each commit, run the tests with `dune build test/` for fast feedback.
+When the whole task is complete, run the full validation target `dune test`
+(equivalent to `dune runtest`), which additionally runs `coqchk`:
 
 ```sh
 dune test
 ```
 
 Use `make -j2` only when a task specifically concerns the Make build or needs
-to reproduce that CI path. Finish with `git diff --check` and report what was
-and was not validated.
+to reproduce that CI path. Note that `make` will only build a file if `git add`
+has been run on it, so you may stage files with `git add` for this purpose.
+Finish with `git diff --check` and report what was and was not validated.
 
 ## Rocq MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/doc/STYLE.md
+++ b/doc/STYLE.md
@@ -896,14 +896,14 @@ have defined something with a given type, you can construct it with
 tactics and end the proof with `Qed.` The latter makes the term
 "opaque" so that it doesn't "compute".
 
-If something _can_ be made opaque, it is generally preferable to do
-so, for performance reasons. However, many things which a traditional
-type theorist would make opaque cannot be opaque in homotopy type
-theory. For instance, none of the higher-groupoid structure in
-PathGroupoids can be made opaque, not even the "coherence laws". If
-you doubt this, try making some of it opaque and you will find that
-the "higher coherences" such as `pentagon` and `eckmann_hilton` will
-fail to typecheck.
+In practice, we end most proofs with `Defined`, unless there is a
+specific performance reason to use `Qed.` Many things which a
+traditional type theorist would make opaque cannot be opaque in
+homotopy type theory. For instance, none of the higher-groupoid
+structure in PathGroupoids can be made opaque, not even the "coherence
+laws". If you doubt this, try making some of it opaque and you will
+find that the "higher coherences" such as `pentagon` and
+`eckmann_hilton` will fail to typecheck.
 
 In general, it is okay to construct something transparent using
 tactics; it's often a matter of aesthetics whether an explicit proof
@@ -1253,7 +1253,9 @@ reflexivity. Qed.`
 
 - `lhs`, `lhs_V`, `rhs`, `rhs_V`: Defined in `Basics/Tactics`.
   These are tacticals that apply a specified tactic to one side
-  of an equality. E.g. `lhs napply concat_1p.`
+  of an equality. E.g. `lhs napply concat_1p.` Primed variants
+  (`lhs'`, etc) exist which apply a specified tactic to one side of
+  any symmetric, transitive relation (such as `==*` or `<~>`).
 
 - `transparent assert`: Defined in `Basics/Overture`, this tactic is
   like `assert` but produces a transparent subterm rather than an


### PR DESCRIPTION
## Summary

- add concise repository-wide guidance for coding agents
- expose the same guidance to Claude and GitHub Copilot
- prepare Copilot's Nix development environment before agent sessions
- ignore local state created by common coding agents

## Motivation

Give coding agents one project-specific source of truth for Rocq development,
build validation, and repository conventions while keeping environment-specific
Copilot setup separate.
