### PR TITLE
Compact types: Change of main definition, compactness of Σ-types

### DIFF
--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -200,7 +200,7 @@ Proof.
     + exact (inr (issearchable_issigmacompact_inhabited c l)).
     + exact (inl r).
   - intros [l|r].
-    + exact (fun P dP => inr (l o  pr1)).
+    + exact (fun P dP => inr (l o pr1)).
     + exact (issigmacompact_issearchable r).
 Defined.
 
@@ -237,6 +237,17 @@ Definition issigmacompact_bool : IsSigmaCompact Bool
 (** The empty type is trivially compact. *)
 Definition issigmacompact_empty : IsSigmaCompact Empty
   := fun P dP => inr pr1.
+
+(** Any decidable proposition is compact. *)
+Definition issigmacompact_decidable_hprop {A : HProp} (dA : Decidable A)
+  : IsSigmaCompact A.
+Proof.
+  destruct (equiv_decidable_hprop A) as [e1|e2].
+  - apply (issigmacompact_equiv e1).
+    rapply issigmacompact_contr.
+  - apply (issigmacompact_equiv e2).
+    exact (fun P dP => inr proj1).
+Defined.
 
 (** Assuming univalence, the type of propositions is searchable. *)
 Definition issearchable_hprop `{Univalence} : IsSearchable HProp.
@@ -354,11 +365,7 @@ Definition issigmacompact_detachable_subtype {A : Type} {P : A -> HProp}
 Proof.
   apply (issigmacompact_sigma cA); cbn beta.
   intro a.
-  destruct (equiv_decidable_hprop (P a)) as [e1|e2].
-  - apply (issigmacompact_equiv e1).
-    rapply issigmacompact_contr.
-  - apply (issigmacompact_equiv e2).
-    exact (fun P dP => inr proj1).
+  rapply issigmacompact_decidable_hprop.
 Defined.
 
 Section Uniform_Search.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -336,7 +336,7 @@ Proof.
   - by destruct a.
 Defined.
 
-(** Inductively, any type of the form [Fin n] is comapct. *)
+(** Inductively, any type of the form [Fin n] is compact. *)
 Definition issigmacompact_fin (n : nat)
   : IsSigmaCompact (Fin n).
 Proof.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -190,6 +190,20 @@ Definition issearchable_iff (A : Type) : IsSearchable A <-> A * (IsSigmaCompact 
   := (fun s => (inhabited_issearchable s, issigmacompact_issearchable s),
         fun c => issearchable_issigmacompact_inhabited (snd c) (fst c)).
 
+(** Since compactness implies decidability, a compact type is either empty or searchable. *)
+Definition issigmacompact_iff_not_or_issearchable (A : Type)
+  : IsSigmaCompact A <-> (~ A) + IsSearchable A.
+Proof.
+  constructor.
+  - intro c.
+    destruct (decidable_issigmacompact c) as [l|r].
+    + exact (inr (issearchable_issigmacompact_inhabited c l)).
+    + exact (inl r).
+  - intros [l|r].
+    + exact (fun P dP => inr (l o  pr1)).
+    + exact (issigmacompact_issearchable r).
+Defined.
+
 (** ** Examples of searchable and compact types, and closure properties *)
 
 (** Contractible types are compact. *)
@@ -223,20 +237,6 @@ Definition issigmacompact_bool : IsSigmaCompact Bool
 (** The empty type is trivially compact. *)
 Definition issigmacompact_empty : IsSigmaCompact Empty
   := fun P dP => inr pr1.
-
-(** Since compactness implies decidability, a compact type is either empty or searchable. *)
-Definition issigmacompact_iff_not_or_issearchable (A : Type)
-  : IsSigmaCompact A <-> (~ A) + IsSearchable A.
-Proof.
-  constructor.
-  - intro c.
-    destruct (decidable_issigmacompact c) as [l|r].
-    + exact (inr (issearchable_issigmacompact_inhabited c l)).
-    + exact (inl r).
-  - intros [l|r].
-    + exact (fun P dP => inr (l o  pr1)).
-    + exact (issigmacompact_issearchable r).
-Defined.
 
 (** Assuming univalence, the type of propositions is searchable. *)
 Definition issearchable_hprop `{Univalence} : IsSearchable HProp.
@@ -285,6 +285,18 @@ Definition issearchable_image `{Univalence} (A B : Type)
   : IsSearchable B
   := issearchable_issearchableprops (issearchableprops_image A B s f surj).
 
+(** Consequently, the same is true for compact types.  *)
+Definition issigmacompact_image `{Univalence} {A B : Type}
+  (c : IsSigmaCompact A)
+  (f : A -> B) (surj : IsSurjection f)
+  : IsSigmaCompact B.
+Proof.
+  apply issigmacompact_iff_not_or_issearchable.
+  destruct (fst (issigmacompact_iff_not_or_issearchable A) c) as [n|s].
+  - left; by rapply conn_map_elim.
+  - right; by rapply issearchable_image.
+Defined.
+
 (** Assuming univalence, every pointed, connected type is searchable. *)
 Definition issearchable_isconnected_ptype `{Univalence} (A : pType)
   (c : IsConnected 0 A)
@@ -302,17 +314,6 @@ Proof.
     1: exact (true; idpath).
     1: exact (false; idpath).
     intro x; by apply path_ishprop.
-Defined.
-
-Definition issigmacompact_image `{Univalence} {A B : Type}
-  (c : IsSigmaCompact A)
-  (f : A -> B) (surj : IsSurjection f)
-  : IsSigmaCompact B.
-Proof.
-  apply issigmacompact_iff_not_or_issearchable.
-  destruct ((fst (issigmacompact_iff_not_or_issearchable A)) c) as [n|s].
-  - left; by rapply conn_map_elim.
-  - right; by rapply issearchable_image.
 Defined.
 
 (** For any family of compact types over a compact type, the corresponding dependent sum type is compact. *)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -2,12 +2,12 @@
 
 From HoTT Require Import Basics Types.
 Require Import Truncations.Core Truncations.Connectedness.
-Require Import Spaces.Nat.Core.
+Require Import Spaces.Nat.Core Finite.Fin.
 Require Import Misc.UStructures.
 Require Import Spaces.NatSeq.Core Spaces.NatSeq.UStructure.
 Require Import Homotopy.Suspension.
 Require Import Pointed.Core.
-Require Import Universes.TruncType.
+Require Import Universes.TruncType HProp.
 Require Import Idempotents.
 
 Local Open Scope nat_scope.
@@ -312,6 +312,51 @@ Proof.
   destruct ((fst (issigmacompact_iff_not_or_issearchable A)) c) as [n|s].
   - left; by rapply conn_map_elim.
   - right; by rapply issearchable_image.
+Defined.
+
+(** For any family of compact types over a compact type, the corresponding dependent sum type is compact. *)
+Definition issigmacompact_sigma {A : Type} {P : A -> Type}
+  (cA : IsSigmaCompact A) (cP : forall (a : A), IsSigmaCompact (P a))
+  : IsSigmaCompact (sig P).
+Proof.
+  intros Q dQ.
+  apply (decidable_equiv _ (equiv_sigma_assoc P Q)).
+  apply cA; intro a.
+  by apply cP; intro p.
+Defined.
+
+Definition issigmacompact_sum {A B : Type}
+  (cA : IsSigmaCompact A) (cB : IsSigmaCompact B)
+  : IsSigmaCompact (A + B).
+Proof.
+  apply (issigmacompact_equiv (sig_of_sum A B)).
+  apply issigmacompact_sigma.
+  - exact issigmacompact_bool.
+  - by destruct a.
+Defined.
+
+(** Inductively, any type of the form [Fin n] is comapct. *)
+Definition issigmacompact_fin (n : nat)
+  : IsSigmaCompact (Fin n).
+Proof.
+  induction n.
+  - exact (fun P dP => inr proj1).
+  - apply (issigmacompact_sum IHn).
+    rapply issigmacompact_contr.
+Defined.
+
+(* A decidable subtype of a compact type is compact *)
+Definition issigmacompact_detachable_subtype {A : Type} {P : A -> HProp}
+  (cA : IsSigmaCompact A) (dP : forall (a : A), Decidable (P a))
+  : IsSigmaCompact (sig P).
+Proof.
+  apply (issigmacompact_sigma cA); cbn beta.
+  intro a.
+  destruct (equiv_decidable_hprop (P a)) as [e1|e2].
+  - apply (issigmacompact_equiv e1).
+    rapply issigmacompact_contr.
+  - apply (issigmacompact_equiv e2).
+    exact (fun P dP => inr proj1).
 Defined.
 
 Section Uniform_Search.

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -15,6 +15,47 @@ Local Open Scope pointed_scope.
 
 (** ** Basic definitions of compact types *)
 
+(** Another equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
+Definition IsSigmaCompact (A : Type)
+  := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
+
+(** Again, it is enough to consider [HProp]-valued families. *)
+Definition IsSigmaCompactProps (A : Type)
+  := forall P : A -> HProp,
+      (forall a : A, Decidable (P a)) -> Decidable (sig P).
+
+Definition issigmacompactprops_issigmacompact {A : Type}
+  (h : IsSigmaCompact A)
+  : IsSigmaCompactProps A
+  := fun P hP => h P hP.
+
+Definition issigmacompact_issigmacompactprops {A : Type}
+  (h : IsSigmaCompactProps A)
+  : IsSigmaCompact A.
+Proof.
+  intros P hP.
+  refine (decidable_iff _ (h (merely o P) _)).
+  apply iff_functor_sigma; intro a.
+  exact merely_inhabited_iff_inhabited_stable.
+Defined.
+
+(** A weaker definition: for any decidable family, the dependent function type is decidable. *)
+Definition IsPiCompact (A : Type)
+  := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
+      Decidable (forall a : A, P a).
+
+Definition ispicompact_issigmacompact {A : Type} (c : IsSigmaCompact A)
+  : IsPiCompact A.
+Proof.
+  intros P dP.
+  destruct (c (not o P) _) as [l|r].
+  - right; exact (fun f => l.2 (f l.1)).
+  - left.
+    intro a.
+    apply (stable_decidable (P a)).
+    exact (fun u => r (a; u)).
+Defined.
+
 (** A type [A] is compact if for every decidable predicate [P] on [A] we can either find an element of [A] making [P] false or we can show that [P a] always holds. *)
 Definition IsCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
@@ -61,10 +102,6 @@ Proof.
   all: intro a; by apply stable_decidable.
 Defined.
 
-(** Another equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
-Definition IsSigmaCompact (A : Type)
-  := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
-
 Definition equiv_iscompact'_issigmacompact {A : Type}
   : IsCompact' A <-> IsSigmaCompact A.
 Proof.
@@ -73,43 +110,6 @@ Proof.
   apply iff_equiv.
   apply (equiv_functor_sum' equiv_idmap).
   napply equiv_sig_ind.
-Defined.
-
-(** Again, it is enough to consider [HProp]-valued families. *)
-Definition IsSigmaCompactProps (A : Type)
-  := forall P : A -> HProp,
-      (forall a : A, Decidable (P a)) -> Decidable (sig P).
-
-Definition issigmacompactprops_issigmacompact {A : Type}
-  (h : IsSigmaCompact A)
-  : IsSigmaCompactProps A
-  := fun P hP => h P hP.
-
-Definition issigmacompact_issigmacompactprops {A : Type}
-  (h : IsSigmaCompactProps A)
-  : IsSigmaCompact A.
-Proof.
-  intros P hP.
-  refine (decidable_iff _ (h (merely o P) _)).
-  apply iff_functor_sigma; intro a.
-  exact merely_inhabited_iff_inhabited_stable.
-Defined.
-
-(** A weaker definition: for any decidable family, the dependent function type is decidable. *)
-Definition IsPiCompact (A : Type)
-  := forall (P : A -> Type) (dP : forall a : A, Decidable (P a)),
-      Decidable (forall a : A, P a).
-
-Definition ispicompact_issigmacompact {A : Type} (c : IsSigmaCompact A)
-  : IsPiCompact A.
-Proof.
-  intros P dP.
-  destruct (c (not o P) _) as [l|r].
-  - right; exact (fun f => l.2 (f l.1)).
-  - left.
-    intro a.
-    apply (stable_decidable (P a)).
-    exact (fun u => r (a; u)).
 Defined.
 
 (** Compact types are closed under retracts. *)
@@ -125,22 +125,6 @@ Definition iscompact_retract' {A R : Type} {f : A -> R} {g : R -> A}
   (s : f o g == idmap) (c : IsCompact A)
   : IsCompact R
   := iscompact_retract (Build_RetractOf A R f g s) c.
-
-(** Assuming the set truncation map has a section, a type is compact if and only if its set truncation is compact. *)
-Definition compact_set_trunc_compact `{Univalence} {A : Type}
-  (f : (Tr 0 A) -> A) (s : tr o f == idmap)
-  : IsCompact A <-> IsCompact (Tr 0 A).
-Proof.
-  constructor.
-  1: exact (iscompact_retract' s).
-  intro cpt; rapply iscompact_iscompactprops.
-  intros P dP.
-  destruct (cpt (Trunc_rec P)) as [l|r].
-  - intro a; strip_truncations.
-    exact (dP a).
-  - exact (inl (f l.1; fun x => l.2 (ap (Trunc_rec P) (s l.1) # x))).
-  - exact (inr (fun a => r (tr a))).
-Defined.
 
 (** ** Basic definitions of searchable types *)
 
@@ -238,6 +222,22 @@ Proof.
     rapply stable_decidable.
     by apply (not_not_constant_family_hprop P).
   - exact (Unit_hp; fun h => Empty_rec (f h)).
+Defined.
+
+(** Assuming the set truncation map has a section, a type is compact if and only if its set truncation is compact. *)
+Definition compact_set_trunc_compact `{Univalence} {A : Type}
+  (f : (Tr 0 A) -> A) (s : tr o f == idmap)
+  : IsCompact A <-> IsCompact (Tr 0 A).
+Proof.
+  constructor.
+  1: exact (iscompact_retract' s).
+  intro cpt; rapply iscompact_iscompactprops.
+  intros P dP.
+  destruct (cpt (Trunc_rec P)) as [l|r].
+  - intro a; strip_truncations.
+    exact (dP a).
+  - exact (inl (f l.1; fun x => l.2 (ap (Trunc_rec P) (s l.1) # x))).
+  - exact (inr (fun a => r (tr a))).
 Defined.
 
 (** Assuming univalence, if the domain of a surjective map is searchable, then so is its codomain. *)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -7,8 +7,7 @@ Require Import Misc.UStructures.
 Require Import Spaces.NatSeq.Core Spaces.NatSeq.UStructure.
 Require Import Homotopy.Suspension.
 Require Import Pointed.Core.
-Require Import Universes.TruncType HProp.
-Require Import Idempotents.
+Require Import Universes.TruncType Universes.HProp.
 
 Local Open Scope nat_scope.
 Local Open Scope pointed_scope.
@@ -27,7 +26,7 @@ Definition IsSigmaCompactProps (A : Type)
 Definition issigmacompactprops_issigmacompact {A : Type}
   (h : IsSigmaCompact A)
   : IsSigmaCompactProps A
-  := fun P hP => h P hP.
+  := h.
 
 Definition issigmacompact_issigmacompactprops {A : Type}
   (h : IsSigmaCompactProps A)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -190,15 +190,16 @@ Definition issearchable_iff (A : Type) : IsSearchable A <-> A * (IsSigmaCompact 
   := (fun s => (inhabited_issearchable s, issigmacompact_issearchable s),
         fun c => issearchable_issigmacompact_inhabited (snd c) (fst c)).
 
-(** ** Examples of searchable and compact types  *)
+(** ** Examples of searchable and compact types, and closure properties *)
 
-(** Contractible types are searchable. *)
+(** Contractible types are compact. *)
 Definition issigmacompact_contr {A} (c : Contr A) : IsSigmaCompact A.
 Proof.
   intros P dP.
   rapply (decidable_equiv _ (equiv_contr_sigma _)^-1).
 Defined.
 
+(** Contractible types are searchable. *)
 Definition issearchable_contr {A} (c : Contr A) : IsSearchable A.
 Proof.
   intros P dP.
@@ -215,6 +216,7 @@ Proof.
   all: by intros p' [].
 Defined.
 
+(** [Bool] is compact. *)
 Definition issigmacompact_bool : IsSigmaCompact Bool
   := issigmacompact_issearchable issearchable_Bool.
 
@@ -283,7 +285,7 @@ Definition issearchable_image `{Univalence} (A B : Type)
   : IsSearchable B
   := issearchable_issearchableprops (issearchableprops_image A B s f surj).
 
-(** Assuming univalence, every connected pointed type is searchable. *)
+(** Assuming univalence, every pointed, connected type is searchable. *)
 Definition issearchable_isconnected_ptype `{Univalence} (A : pType)
   (c : IsConnected 0 A)
   : IsSearchable A
@@ -344,7 +346,7 @@ Proof.
     rapply issigmacompact_contr.
 Defined.
 
-(* A decidable subtype of a compact type is compact *)
+(** A decidable subtype of a compact type is compact. *)
 Definition issigmacompact_detachable_subtype {A : Type} {P : A -> HProp}
   (cA : IsSigmaCompact A) (dP : forall (a : A), Decidable (P a))
   : IsSigmaCompact (sig P).

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -190,7 +190,7 @@ Definition issearchable_iff (A : Type) : IsSearchable A <-> A * (IsSigmaCompact 
   := (fun s => (inhabited_issearchable s, issigmacompact_issearchable s),
         fun c => issearchable_issigmacompact_inhabited (snd c) (fst c)).
 
-(** Since compactness implies decidability, a compact type is either empty or searchable. *)
+(** Since compactness implies decidability, a type is compact if and only if it is either empty or searchable. *)
 Definition issigmacompact_iff_not_or_issearchable (A : Type)
   : IsSigmaCompact A <-> (~ A) + IsSearchable A.
 Proof.
@@ -246,7 +246,7 @@ Proof.
   - apply (issigmacompact_equiv e1).
     rapply issigmacompact_contr.
   - apply (issigmacompact_equiv e2).
-    exact (fun P dP => inr proj1).
+    apply issigmacompact_empty.
 Defined.
 
 (** Assuming univalence, the type of propositions is searchable. *)

--- a/theories/Misc/CompactTypes.v
+++ b/theories/Misc/CompactTypes.v
@@ -15,11 +15,11 @@ Local Open Scope pointed_scope.
 
 (** ** Basic definitions of compact types *)
 
-(** Another equivalent definition of compactness: If a family over the type is decidable, then the Σ-type is decidable. *)
+(** A type [A] is compact if for every decidable family over [A], the Σ-type is decidable. *)
 Definition IsSigmaCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) -> Decidable (sig P).
 
-(** Again, it is enough to consider [HProp]-valued families. *)
+(** It is enough to consider [HProp]-valued families. *)
 Definition IsSigmaCompactProps (A : Type)
   := forall P : A -> HProp,
       (forall a : A, Decidable (P a)) -> Decidable (sig P).
@@ -56,18 +56,40 @@ Proof.
     exact (fun u => r (a; u)).
 Defined.
 
+(** Compact types are closed under retracts. *)
+Definition issigmacompact_retract {A R : Type} {f : A -> R} {g : R -> A}
+  (s : f o g == idmap) (c : IsSigmaCompact A)
+  : IsSigmaCompact R.
+Proof.
+  intros P dP; destruct (c (P o f) _) as [u|v].
+  1: left; exact (f u.1; u.2).
+  right; intros [r pr].
+  apply v.
+  exists (g r).
+  exact ((s r)^ # pr).
+Defined.
+
+Definition issigmacompact_equiv {A B : Type} (f : A -> B) `{!IsEquiv f}
+  (c : IsSigmaCompact B)
+  : IsSigmaCompact A
+  := issigmacompact_retract (eissect f) c.
+
+(** Any compact type is decidable. *)
+Definition decidable_issigmacompact {A : Type} (c : IsSigmaCompact A)
+  : Decidable A.
+Proof.
+  destruct (c (fun (_ : A) => Unit) _) as [c1|c2].
+  - exact (inl c1.1).
+  - right; intro a.
+    exact (c2 (a; pt)).
+Defined.
+
+(** ** Equivalent definitions *)
+
 (** A type [A] is compact if for every decidable predicate [P] on [A] we can either find an element of [A] making [P] false or we can show that [P a] always holds. *)
 Definition IsCompact (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
                               {a : A & ~ P a} + (forall a : A, P a).
-
-(** Any compact type is decidable. *)
-Definition decidable_iscompact {A : Type} (c : IsCompact A) : Decidable A.
-Proof.
-  destruct (c (fun (_ : A) => Empty) _) as [c1|c2].
-  - exact (inl c1.1).
-  - exact (inr c2).
-Defined.
 
 (** Compactness is equivalent to assuming the same for [HProp]-valued decidable predicates. *)
 Definition IsCompactProps (A : Type)
@@ -84,7 +106,7 @@ Proof.
     apply merely_inhabited_iff_inhabited_stable, r.
 Defined.
 
-(** Since decidable types are stable, it's also equivalent to negate [P] in the definition. *)
+(** Since decidable types are stable, it's also equivalent to negate [P] in the definition. We use this as an intermediate notion to show that [IsCompact] and [IsSigmaCompact] are logically equivalent. *)
 Definition IsCompact' (A : Type)
   := forall P : A -> Type, (forall a : A, Decidable (P a)) ->
                               {a : A & P a} + (forall a : A, ~ P a).
@@ -102,7 +124,7 @@ Proof.
   all: intro a; by apply stable_decidable.
 Defined.
 
-Definition equiv_iscompact'_issigmacompact {A : Type}
+Definition iff_iscompact'_issigmacompact (A : Type)
   : IsCompact' A <-> IsSigmaCompact A.
 Proof.
   apply iff_functor_forall; intro P.
@@ -112,19 +134,9 @@ Proof.
   napply equiv_sig_ind.
 Defined.
 
-(** Compact types are closed under retracts. *)
-Definition iscompact_retract {A : Type} (R : RetractOf A) (c : IsCompact A)
-  : IsCompact (retract_type R).
-Proof.
-  intros P dP; destruct (c (P o (retract_retr R)) _) as [l|r].
-  - exact (inl ((retract_retr R) l.1; l.2)).
-  - exact (inr (fun a =>  ((retract_issect R) a) # r ((retract_sect R) a))).
-Defined.
-
-Definition iscompact_retract' {A R : Type} {f : A -> R} {g : R -> A}
-  (s : f o g == idmap) (c : IsCompact A)
-  : IsCompact R
-  := iscompact_retract (Build_RetractOf A R f g s) c.
+Definition iff_iscompact_issigmacompact (A : Type)
+  : IsCompact A <-> IsSigmaCompact A
+  := iff_compose (iff_iscompact_iscompact' A) (iff_iscompact'_issigmacompact A).
 
 (** ** Basic definitions of searchable types *)
 
@@ -149,33 +161,44 @@ Defined.
 
 (** A type is searchable if and only if it is compact and inhabited. *)
 
-Definition issearchable_iscompact_inhabited {A : Type}
-  : IsCompact A -> A -> IsSearchable A.
+Definition issearchable_issigmacompact_inhabited {A : Type}
+  (c : IsSigmaCompact A)
+  : A -> IsSearchable A.
 Proof.
-  intros c a P dP.
-  induction (c P _) as [l|r].
+  intros a P dP.
+  destruct (c (fun x => ~ (P x)) _) as [l|r].
   - exists l.1.
     intro h; contradiction (l.2 h).
-  - exact (a; fun _ => r).
+  - exists a; intros _ x.
+    rapply stable_decidable.
+    exact (fun u => r (x; u)).
 Defined.
 
-Definition iscompact_issearchable {A : Type} : IsSearchable A -> IsCompact A.
+Definition issigmacompact_issearchable {A : Type} (s : IsSearchable A)
+  : IsSigmaCompact A.
 Proof.
-  intros h P dP.
-  set (w := (h P dP).1).
+  intros P dP.
+  destruct (s (fun x => ~ (P x)) _) as [w hw].
   destruct (dP w) as [x|y].
-  - exact (inr ((h P dP).2 x)).
-  - exact (inl (w; y)).
+  - exact (inl (w; x)).
+  - exact (inr (fun u => hw y u.1 u.2)).
 Defined.
 
-Definition inhabited_issearchable {A : Type} : IsSearchable A -> A
-  := fun s => (s (fun a => Unit) _).1.
+Definition inhabited_issearchable {A : Type} (s : IsSearchable A) : A
+  := (s (fun a => Unit) _).1.
 
-Definition searchable_iff {A : Type} : IsSearchable A <-> A * (IsCompact A)
-  := (fun s => (inhabited_issearchable s, iscompact_issearchable s),
-        fun c => issearchable_iscompact_inhabited (snd c) (fst c)).
+Definition issearchable_iff (A : Type) : IsSearchable A <-> A * (IsSigmaCompact A)
+  := (fun s => (inhabited_issearchable s, issigmacompact_issearchable s),
+        fun c => issearchable_issigmacompact_inhabited (snd c) (fst c)).
 
 (** ** Examples of searchable and compact types  *)
+
+(** Contractible types are searchable. *)
+Definition issigmacompact_contr {A} (c : Contr A) : IsSigmaCompact A.
+Proof.
+  intros P dP.
+  rapply (decidable_equiv _ (equiv_contr_sigma _)^-1).
+Defined.
 
 Definition issearchable_contr {A} (c : Contr A) : IsSearchable A.
 Proof.
@@ -185,6 +208,7 @@ Proof.
   by induction (contr a).
 Defined.
 
+(** [Bool] is searchable. *)
 Definition issearchable_Bool : IsSearchable Bool.
 Proof.
   intros P dP.
@@ -192,24 +216,25 @@ Proof.
   all: by intros p' [].
 Defined.
 
+Definition issigmacompact_bool : IsSigmaCompact Bool
+  := issigmacompact_issearchable issearchable_Bool.
+
 (** The empty type is trivially compact. *)
-Definition iscompact_empty : IsCompact Empty
-  := fun P dP => inr (fun a => Empty_rec a).
+Definition issigmacompact_empty : IsSigmaCompact Empty
+  := fun P dP => inr pr1.
 
-Definition iscompact_empty' {A : Type} (na : ~A) : IsCompact A
-  := fun p dP => inr (fun a => Empty_rec (na a)).
-
-Definition iscompact_iff_not_or_issearchable {A : Type} :
-  IsCompact A <-> (~ A) + IsSearchable A.
+(** Since compactness implies decidability, a compact type is either empty or searchable. *)
+Definition issigmacompact_iff_not_or_issearchable (A : Type)
+  : IsSigmaCompact A <-> (~ A) + IsSearchable A.
 Proof.
   constructor.
   - intro c.
-    destruct (decidable_iscompact c) as [l|r].
-    + exact (inr (issearchable_iscompact_inhabited c l)).
+    destruct (decidable_issigmacompact c) as [l|r].
+    + exact (inr (issearchable_issigmacompact_inhabited c l)).
     + exact (inl r).
   - intros [l|r].
-    + exact (iscompact_empty' l).
-    + exact (iscompact_issearchable r).
+    + exact (fun P dP => inr (l o  pr1)).
+    + exact (issigmacompact_issearchable r).
 Defined.
 
 (** Assuming univalence, the type of propositions is searchable. *)
@@ -225,19 +250,20 @@ Proof.
 Defined.
 
 (** Assuming the set truncation map has a section, a type is compact if and only if its set truncation is compact. *)
-Definition compact_set_trunc_compact `{Univalence} {A : Type}
+Definition issigmacompact_iff_issigmacompact_set_trunc `{Univalence} {A : Type}
   (f : (Tr 0 A) -> A) (s : tr o f == idmap)
-  : IsCompact A <-> IsCompact (Tr 0 A).
+  : IsSigmaCompact A <-> IsSigmaCompact (Tr 0 A).
 Proof.
   constructor.
-  1: exact (iscompact_retract' s).
-  intro cpt; rapply iscompact_iscompactprops.
+  1: exact (issigmacompact_retract s).
+  intro cpt; rapply issigmacompact_issigmacompactprops.
   intros P dP.
   destruct (cpt (Trunc_rec P)) as [l|r].
   - intro a; strip_truncations.
     exact (dP a).
-  - exact (inl (f l.1; fun x => l.2 (ap (Trunc_rec P) (s l.1) # x))).
-  - exact (inr (fun a => r (tr a))).
+  - left; exists (f l.1).
+    exact ((ap (Trunc_rec P) (s l.1))^ # l.2).
+  - right; refine (fun a => r (tr a.1; a.2)).
 Defined.
 
 (** Assuming univalence, if the domain of a surjective map is searchable, then so is its codomain. *)
@@ -277,13 +303,13 @@ Proof.
     intro x; by apply path_ishprop.
 Defined.
 
-Definition iscompact_image `{Univalence} (A B : Type)
-  (c : IsCompact A)
+Definition issigmacompact_image `{Univalence} {A B : Type}
+  (c : IsSigmaCompact A)
   (f : A -> B) (surj : IsSurjection f)
-  : IsCompact B.
+  : IsSigmaCompact B.
 Proof.
-  apply iscompact_iff_not_or_issearchable.
-  destruct ((fst iscompact_iff_not_or_issearchable) c) as [n|s].
+  apply issigmacompact_iff_not_or_issearchable.
+  destruct ((fst (issigmacompact_iff_not_or_issearchable A)) c) as [n|s].
   - left; by rapply conn_map_elim.
   - right; by rapply issearchable_image.
 Defined.


### PR DESCRIPTION
- We now use `IsSigmaCompact` as the definition of a compact type; proofs are modified accordingly.
- Added proof that for any family of compact types over a compact type the corresponding Σ-type is compact, together with some consequences of that lemma.