### PR TITLE
Decidable paths updates, speed improvements

### DIFF
--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -50,7 +50,7 @@ Proof.
       change (ab_pushout_inl (b + - f (- a)) = bc').  (* Just to guide the reader. *)
       refine (_ @ q).
       symmetry.
-      apply path_ab_pushout; cbn.
+      napply path_ab_pushout; cbn.
       refine (tr (-a; _)).
       apply path_prod; cbn.
       * apply grp_moveL_Mg.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -55,6 +55,9 @@ Arguments group_assoc_opp {_}.
 (** We should never need to unfold the proof that something is a group. *)
 Global Opaque group_isgroup.
 
+(** While this can be found by typeclass search, it is sometimes slow, so we add it as an instance. *)
+Instance ishset_group (G : Group) : IsHSet G := _.
+
 Definition issig_group : _ <~> Group
   := ltac:(issig).
 

--- a/theories/Algebra/Rings/KroneckerDelta.v
+++ b/theories/Algebra/Rings/KroneckerDelta.v
@@ -23,7 +23,7 @@ Section AssumeDecidable.
   Proof.
     unfold kronecker_delta.
     generalize (dec (i = i)).
-    by rapply decidable_paths_refl.
+    by rapply decidablepaths_refl.
   Defined.
 
   (** Kronecker delta with differing indices is 0. *)

--- a/theories/Basics/Decidable.v
+++ b/theories/Basics/Decidable.v
@@ -270,15 +270,11 @@ Proof.
   intros x y; apply collapsible_hprop; exact _.
 Defined.
 
-(** Hedberg's Theorem *)
-Corollary hset_decpaths (A : Type) `{DecidablePaths A}
-: IsHSet A.
-Proof.
-  exact _.
-Defined.
+(** Hedberg's Theorem.  Note that this is found by typeclass search, so it does not need to be added as an instance. *)
+Definition hset_decpaths (A : Type) `{DecidablePaths A} : IsHSet A := _.
 
-(** We can use Hedberg's Theorem to simplify a goal of the form [forall (d : Decidable (x = x :> A)), P d] when [A] has decidable paths. *)
-Definition decidable_paths_refl (A : Type) `{DecidablePaths A}
+(** When [A] is an [HSet], to prove [forall (d : Decidable (x = x :> A)), P d] it is enough to prove [P] on [idpath]. In particular, by Hedberg's Theorem, this applies when [A] has decidable paths. *)
+Definition decidablepaths_refl (A : Type) `{IsHSet A}
   (x : A)
   (P : forall (d : Decidable (x = x)), Type)
   (Px : P (inl idpath))
@@ -286,8 +282,8 @@ Definition decidable_paths_refl (A : Type) `{DecidablePaths A}
 Proof.
   rapply (decidable_true idpath).
   intro p.
-  (** We cannot eliminate [p : x = x] with path induction, but we can use Hedberg's theorem to replace this with [idpath]. *)
-  assert (r : (idpath = p)) by apply path_ishprop.
+  (* We cannot eliminate [p : x = x] with path induction, but we can use that [A] is an [HSet] to replace this with [idpath]. *)
+  assert (r : idpath = p) by apply path_ishprop.
   by destruct r.
 Defined.
 

--- a/theories/Spaces/List/Paths.v
+++ b/theories/Spaces/List/Paths.v
@@ -1,4 +1,4 @@
-Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Trunc.
+Require Import Basics.Overture Basics.Tactics Basics.PathGroupoids Basics.Trunc Basics.Decidable.
 Require Import Basics.Equivalences Types.Empty Types.Unit Types.Prod.
 Require Import Modalities.ReflectiveSubuniverse Truncations.Core.
 Require Import Spaces.List.Core.
@@ -99,5 +99,16 @@ Section PathList.
   Definition equiv_path_list {l1 l2}
     : ListEq l1 l2 <~> l1 = l2
     := equiv_adjointify decode encode decode_encode encode_decode.
+
+  #[export] Instance decidablepaths_list `{DecidablePaths A}
+    : DecidablePaths (list A).
+  Proof.
+    intros l1 l2.
+    apply (decidable_equiv _ equiv_path_list).
+    revert l2; induction l1 as [|a1 l1];
+    intros [|a2 l2]; cbn.
+    1, 2, 3: exact _.
+    apply decidable_prod.
+  Defined.
 
 End PathList.

--- a/theories/Spaces/Nat/Core.v
+++ b/theories/Spaces/Nat/Core.v
@@ -243,7 +243,7 @@ Defined.
 (** ** Truncatedness of natural numbers *)
 
 (** [nat] has decidable paths. *)
-Instance decidable_paths_nat@{} : DecidablePaths nat.
+Instance decidablepaths_nat@{} : DecidablePaths nat.
 Proof.
   intros n m.
   induction n as [|n IHn] in m |- *; destruct m.

--- a/theories/Types/Bool.v
+++ b/theories/Types/Bool.v
@@ -59,7 +59,7 @@ Section BoolDecidable.
   Definition true_ne_false : ~ (true = false)
     := fun H => false_ne_true (symmetry _ _ H).
 
-  #[export] Instance decidable_paths_bool : DecidablePaths Bool
+  #[export] Instance decidablepaths_bool : DecidablePaths Bool
     := fun x y => match x as x, y as y return ((x = y) + ~(x = y)) with
                     | true, true => inl idpath
                     | false, false => inl idpath

--- a/theories/WildCat/Biproducts.v
+++ b/theories/WildCat/Biproducts.v
@@ -138,7 +138,7 @@ Section HomotopyConstructor.
     refine (cat_hbiprod_pr_in i i $@ _).
     unfold cat_coprod_prod_component.
     generalize (dec_paths i i).
-    by napply decidable_paths_refl.
+    by rapply decidablepaths_refl.
   Defined.
 
   (** An inclusion followed by a projection of a different index is zero. *)
@@ -206,7 +206,7 @@ Section EquivConstructor.
     refine (cat_biprod_pr_in i i $@ _).
     unfold cat_coprod_prod_component.
     generalize (dec_paths i i).
-    by napply decidable_paths_refl.
+    by rapply decidablepaths_refl.
   Defined.
 
   Definition cat_biprod_pr_in_ne (i j : I) (p : i <> j)


### PR DESCRIPTION
These are just things that were in my HIT integers branch but were stripped out of that PR to make it cleaner.

The first commit just makes some naming consistent, using `decidablepaths` everywhere instead of sometimes using `decidable_paths`.  It also slightly generalizes one result.

The second adds that `list A` has decidable paths when `A` does.  This means that equality vectors and matrices over a ring with decidable equality can be decided.  This can be used for their tests, but in the end using `int_reduce` was faster, so this wasn't needed.  Still, it's worth having.

The last commit is completely independent, but it speeds up the build of the library by 1.0s.