### PR TITLE
Pointed modalities, H-spaces

### DIFF
--- a/theories/Homotopy/HSpace/Pointwise.v
+++ b/theories/Homotopy/HSpace/Pointwise.v
@@ -6,10 +6,9 @@ Local Open Scope path_scope.
 
 (** * Pointwise H-space structures *)
 
-(** Whenever [X] is an H-space, so is the type of maps into [X]. *)
+(** Whenever [X] is an H-space, so is the type of maps into [X].  Note: When writing [f * g], Coq only finds this instance if [f] is explicitly in the pointed type [[Y -> X, const pt]]. *)
 Instance ishspace_map `{Funext} (X : pType) (Y : Type)
   `{IsHSpace X} : IsHSpace [Y -> X, const pt].
-(* Note: When writing [f * g], Coq only finds this instance if [f] is explicitly in the pointed type [[Y -> X, const pt]]. *)
 Proof.
   snapply Build_IsHSpace.
   - exact (fun f g y => (f y) * (g y)).
@@ -34,41 +33,55 @@ Instance isleftinvertible_hspace_map `{Funext} (X : pType) (Y : Type)
   : forall f : [Y -> X, const pt], IsEquiv (f *.).
 Proof.
   intro f; cbn.
-  (** Left multiplication by [f] unifies with [functor_forall]. *)
+  (* Left multiplication by [f] unifies with [functor_forall]. *)
   exact (isequiv_functor_forall (P:=const X) (f:=idmap)
            (g:=fun y gy => (f y) * gy)).
 Defined.
 
+(** The pointwise product of two pointed maps into an H-space. This is the operation underlying the H-space structure [ishspace_pmap] on [Y ->** X], but requires no coherence. *)
+Definition sgop_pmap {X Y : pType} `{IsHSpace X} (f g : Y ->* X) : Y ->* X.
+Proof.
+  snapply Build_pMap.
+  - exact (fun y => (f y) * (g y)).
+  - cbn beta.
+    lhs napply (ap _ (point_eq g)).
+    lhs napply (ap (.* pt) (point_eq f)).
+    apply hspace_left_identity.
+Defined.
+
+(** The constant map is a left unit for the pointwise product; this needs no coherence. *)
+Definition leftidentity_pmap {X Y : pType} `{IsHSpace X} (g : Y ->* X)
+  : sgop_pmap pconst g ==* g.
+Proof.
+  snapply Build_pHomotopy.
+  - intro y; cbn.
+    apply hspace_left_identity.
+  - cbn.
+    apply moveL_pV.
+    exact (1 @@ concat_1p _ @ concat_A1p _ _)^.
+Defined.
+
+(** The constant map is a right unit for the pointwise product; the base-point coherence forces [right_identity pt = left_identity pt], so this needs [X] coherent. *)
+Definition rightidentity_pmap {X Y : pType} `{IsCoherent X} (f : Y ->* X)
+  : sgop_pmap f pconst ==* f.
+Proof.
+  snapply Build_pHomotopy.
+  - intro y; cbn.
+    apply hspace_right_identity.
+  - pelim f; cbn.
+    symmetry.
+    lhs napply (concat_p1 _ @ concat_1p _ @ concat_1p _).
+    exact iscoherent.
+Defined.
 
 (** For the type of pointed maps [Y ->** X], coherence of [X] is needed even to get a non-coherent H-space structure on [Y ->** X]. *)
 Instance ishspace_pmap `{Funext} (X Y : pType) `{IsCoherent X}
   : IsHSpace (Y ->** X).
 Proof.
   snapply Build_IsHSpace.
-  - intros f g.
-    snapply Build_pMap.
-    + exact (fun y => hspace_op (f y) (g y)).
-    + cbn.
-      refine (ap _ (point_eq g) @ _); cbn.
-      refine (ap (.* pt) (point_eq f) @ _).
-      apply hspace_left_identity.
-  - intro g.
-    apply path_pforall.
-    snapply Build_pHomotopy.
-    + intro y; cbn.
-      apply hspace_left_identity.
-    + cbn.
-      apply moveL_pV.
-      exact (1 @@ concat_1p _ @ concat_A1p _ _)^.
-  - intro f.
-    apply path_pforall.
-    snapply Build_pHomotopy.
-    + intro y; cbn.
-      apply hspace_right_identity.
-    + pelim f; cbn.
-      symmetry.
-      lhs napply (concat_p1 _ @ concat_1p _ @ concat_1p _).
-      exact iscoherent.
+  - exact sgop_pmap.
+  - intro g; exact (path_pforall (leftidentity_pmap g)).
+  - intro f; exact (path_pforall (rightidentity_pmap f)).
 Defined.
 
 Instance iscoherent_hspace_pmap `{Funext} (X Y : pType) `{IsCoherent X}
@@ -85,11 +98,29 @@ Proof.
   - cbn.
     generalize iscoherent as isc.
     unfold left_identity, right_identity.
-    (* The next line is essentially the same as [generalize], but for some reason that tactic doesn't work here. *)
-    set (p := hspace_left_identity pt); clearbody p.
-    intros [].
-    induction p.
-    reflexivity.
+    generalize (hspace_left_identity pt).
+    intros p [].
+    by destruct p.
+Defined.
+
+(** Since [sgop_pmap] is defined pointwise, it commutes with precomposition. *)
+Definition sgop_pmap_precompose {X Y W : pType} `{IsHSpace X}
+  (f g : Y ->* X) (h : W ->* Y)
+  : sgop_pmap f g o* h ==* sgop_pmap (f o* h) (g o* h).
+Proof.
+  snapply Build_pHomotopy.
+  - reflexivity.
+  - pelim h f g; cbn.  symmetry; apply concat_pp_V.
+Defined.
+
+(** [sgop_pmap] respects pointed homotopy in each argument. *)
+Definition sgop_pmap_phomotopy {X Y : pType} `{IsHSpace X}
+  {f f' g g' : Y ->* X} (p : f ==* f') (q : g ==* g')
+  : sgop_pmap f g ==* sgop_pmap f' g'.
+Proof.
+  snapply Build_pHomotopy.
+  - intro y; exact (ap011 sg_op (p y) (q y)).
+  - pelim p f f' q g g'; cbn.  symmetry; apply concat_pV.
 Defined.
 
 (** If the H-space structure on [X] is left-invertible, so is the one induced on [Y ->** X]. *)

--- a/theories/Pointed/Core.v
+++ b/theories/Pointed/Core.v
@@ -91,6 +91,12 @@ Definition pmap_compose {A B C : pType} (g : B ->* C) (f : A ->* B)
 
 Infix "o*" := pmap_compose : pointed_scope.
 
+(** Precomposing a pointed type family with a pointed map. *)
+Definition pfam_precompose {A A' : pType} (B : pFam A')
+  (f : A ->* A')
+  : pFam A
+  := Build_pFam (B o f) ((point_eq f)^ # dpoint B).
+
 (** ** Pointed homotopies *)
 
 (** A pointed homotopy is a homotopy with a proof that the preservation paths agree. We define it instead as a special case of a [pForall]. This means that we can define pointed homotopies between pointed homotopies. *)

--- a/theories/Pointed/pMap.v
+++ b/theories/Pointed/pMap.v
@@ -139,6 +139,18 @@ Proof.
   pointed_reduce. reflexivity.
 Defined.
 
+(** The functorial action of [pForall A B] in [A]. *)
+Definition functor_pforall_left {A A' : pType} {B : pFam A'}
+  (g : pForall A' B) (f : A ->* A')
+  : pForall A (pfam_precompose B f).
+Proof.
+  snapply Build_pForall.
+  - exact (g o f).
+  - cbn.
+    tapply (moveL_equiv_V (f:=transport _ _)).
+    exact (apD g (point_eq f) @ dpoint_eq g).
+Defined.
+
 (* functorial action of [pForall A (pointed_fam B)] in [B]. *)
 Definition pmap_compose_ppforall {A : pType} {B B' : A -> pType}
   (g : forall a, B a ->* B' a) (f : ppforall a, B a) : ppforall a, B' a.

--- a/theories/Pointed/pModality.v
+++ b/theories/Pointed/pModality.v
@@ -1,10 +1,8 @@
-From HoTT Require Import Basics Types ReflectiveSubuniverse Pointed.Core.
+From HoTT Require Import Basics Types ReflectiveSubuniverse Modality Pointed.Core Pointed.pMap.
 
 Local Open Scope pointed_scope.
 
 (** * Modalities, reflective subuniverses and pointed types *)
-
-(** So far, everything is about general reflective subuniverses, but in the future results about modalities can be placed here as well. *)
 
 #[export] Instance ispointed_O `{O : ReflectiveSubuniverse} (X : Type)
   `{IsPointed X} : IsPointed (O X) := to O _ (point X).
@@ -31,6 +29,37 @@ Proof.
   cbn.
   apply moveL_pV.
   exact (concat_1p _)^.
+Defined.
+
+(** A pointed version of the induction principle for a modality. *)
+Definition pO_ind `{O : Modality} {X : pType} {Y : pFam [O X, _]}
+ `{forall x, In O (Y x)} (f : pForall X (pfam_precompose Y (pto O X)))
+  : pForall [O X, _] Y
+  := Build_pForall _ Y (O_ind Y f) (O_ind_beta Y f pt @ dpoint_eq f).
+
+Definition pO_ind_beta `{O : Modality} {X : pType} {Y : pFam [O X, _]}
+ `{forall x, In O (Y x)} (f : pForall X (pfam_precompose Y (pto O X)))
+  : functor_pforall_left (pO_ind f) (pto O X) ==* f.
+Proof.
+  srapply Build_pHomotopy.
+  1: napply O_ind_beta.
+  cbn; unfold moveL_equiv_V; cbn.
+  apply moveL_pV.
+  symmetry; lhs napply concat_1p.
+  lhs napply ap_idmap.
+  apply concat_1p.
+Defined.
+
+(** To show two pointed maps out of [O X] into an [O]-local type are pointed homotopic, it is enough to compare their precomposites with [pto O X]. Unlike passing through [pequiv_ptr_rec], this needs no [Funext]. And note that it goes through without assuming that [O] is a modality. *)
+Definition pO_indpaths `{O : ReflectiveSubuniverse} {X Y : pType} `{In O Y}
+  {f g : [O X, _] ->* Y} (h : f o* pto O X ==* g o* pto O X)
+  : f ==* g.
+Proof.
+  snapply Build_pHomotopy.
+  - exact (O_indpaths _ _ h).
+  - lhs napply O_indpaths_beta.
+    lhs napply (dpoint_eq h); cbn.
+    exact (concat_1p _ @@ inverse2 (concat_1p _)).
 Defined.
 
 (** A pointed version of the universal property. *)
@@ -65,10 +94,8 @@ Definition equiv_O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}
 
 (** Pointed naturality of [O_pfunctor]. *)
 Definition pto_O_natural `(O : ReflectiveSubuniverse) {X Y : pType}
-  (f : X ->* Y) : O_pfunctor O f o* pto O X ==* pto O Y o* f.
-Proof.
-  napply pO_rec_beta.
-Defined.
+  (f : X ->* Y) : O_pfunctor O f o* pto O X ==* pto O Y o* f
+  := pO_rec_beta _.
 
 Definition pequiv_O_inverts `(O : ReflectiveSubuniverse) {X Y : pType}
   (f : X ->* Y) `{O_inverts O f}

--- a/theories/Pointed/pTrunc.v
+++ b/theories/Pointed/pTrunc.v
@@ -1,5 +1,5 @@
 From HoTT Require Import Basics Types Truncations
-  Pointed.Core Pointed.pEquiv Pointed.Loops Pointed.pModality.
+  Pointed.Core Pointed.pMap Pointed.pEquiv Pointed.Loops Pointed.pModality.
 From HoTT.WildCat Require Import Core Equiv.
 
 Local Open Scope pointed_scope.
@@ -39,11 +39,28 @@ Definition pTr_rec_beta n {X Y : pType} `{IsTrunc n Y} (f : X ->* Y)
   : pTr_rec n f o* ptr ==* f
   := phomotopy_path (pTr_rec_beta_path n f).
 
-(** A pointed version of the induction principle. *)
+(** A pointed version of the induction principle. We could also use [pO_ind] here, but this version has a slightly simpler [pFam] because [ptr] is definitionally pointed. *)
 Definition pTr_ind n {X : pType} {Y : pFam (pTr n X)} `{forall x, IsTrunc n (Y x)}
   (f : pForall X (Build_pFam (Y o tr) (dpoint Y)))
   : pForall (pTr n X) Y
   := Build_pForall (pTr n X) Y (Trunc_ind Y f) (dpoint_eq f).
+
+(** For the beta rule, we use [functor_pforall_left] to compose the dependent function with [ptr].  This is more complicated than necessary, again because [ptr] is definitionally pointed, but is more awkward to avoid here. *)
+Definition pTr_ind_beta n {X : pType} {Y : pFam (pTr n X)} `{forall x, IsTrunc n (Y x)}
+  (f : pForall X (Build_pFam (Y o tr) (dpoint Y)))
+  : functor_pforall_left (pTr_ind n f) ptr ==* f.
+Proof.
+  (* The proof of [pO_ind_beta] applies, except for the difference in the pointedness. *)
+  rhs_V' rapply pO_ind_beta.
+  apply phomotopy_path.
+  exact (ap (fun p => functor_pforall_left (Build_pForall _ Y (Trunc_ind Y f) p) ptr) (concat_1p _)^).
+Defined.
+
+(** To show two pointed maps out of a truncation into a truncated type are pointed homotopic, it is enough to compare their precomposites with [ptr]. Unlike passing through [pequiv_ptr_rec], this needs no [Funext]. *)
+Definition pTr_indpaths {n : trunc_index} {X Y : pType} `{IsTrunc n Y}
+  {f g : pTr n X ->* Y} (h : f o* ptr ==* g o* ptr)
+  : f ==* g
+  := pO_indpaths h.
 
 Definition pequiv_ptr_rec `{Funext} {n} {X Y : pType} `{IsTrunc n Y}
   : (pTr n X ->** Y) <~>* (X ->** Y)


### PR DESCRIPTION
The first commit adds more about modalities and truncations to the Pointed library.

The second commit unpacks some of the components of the proof that `X ->* Y` is an H-space when `Y` is.  One advantage is that those components don't require Funext, and another is that some of them don't require that `Y` is coherent.  Also, some additional properties of the pointwise multiplication are proved.

The commits are independent, and the library builds after each one.  (They are together here just because some other work needs both of these.)