### PR TITLE
work on Eilenberg-Mac Lane spaces and related things

### DIFF
--- a/theories/Algebra/AbGroups/AbHom.v
+++ b/theories/Algebra/AbGroups/AbHom.v
@@ -58,7 +58,7 @@ Proof.
   snapply Build_GroupHomomorphism.
   1: exact (fun g => grp_homo_compose g f).
   intros phi psi.
-  by apply equiv_path_grouphomomorphism.
+  by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 Instance is1functor_ab_hom01 `{Funext} {A : Group^op}
@@ -69,9 +69,9 @@ Proof.
     apply equiv_path_grouphomomorphism; intro a; cbn.
     exact (p (phi a)).
   - intros B phi.
-    by apply equiv_path_grouphomomorphism.
+    by apply equiv_path_map_grouphomomorphism.
   - intros B C D f g phi.
-    by apply equiv_path_grouphomomorphism.
+    by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 Instance is1functor_ab_hom10 `{Funext} {B : AbGroup@{u}}
@@ -82,9 +82,9 @@ Proof.
     apply equiv_path_grouphomomorphism; intro a; cbn.
     exact (ap phi (p a)).
   - intros A phi.
-    by apply equiv_path_grouphomomorphism.
+    by apply equiv_path_map_grouphomomorphism.
   - intros A C D f g phi.
-    by apply equiv_path_grouphomomorphism.
+    by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 Instance is0bifunctor_ab_hom `{Funext}
@@ -97,7 +97,7 @@ Proof.
   napply Build_Is1Bifunctor''.
   1,2: exact _.
   intros A A' f B B' g phi; cbn.
-  by apply equiv_path_grouphomomorphism.
+  by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 (** ** [AbGroup] has a wild enrichment in wild abelian groups *)

--- a/theories/Algebra/AbGroups/AbelianGroup.v
+++ b/theories/Algebra/AbGroups/AbelianGroup.v
@@ -215,7 +215,7 @@ Lemma transport_abgrouphomomorphism_from_const `{Univalence} {A B B' : AbGroup}
     = grp_homo_compose (equiv_path_abgroup^-1 p) f.
 Proof.
   induction p.
-  by apply equiv_path_grouphomomorphism.
+  by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 Lemma transport_iso_abgrouphomomorphism_from_const `{Univalence} {A B B' : AbGroup}
@@ -233,7 +233,7 @@ Lemma transport_abgrouphomomorphism_to_const `{Univalence} {A A' B : AbGroup}
     = grp_homo_compose f (grp_iso_inverse (equiv_path_abgroup^-1 p)).
 Proof.
   induction p; cbn.
-  by apply equiv_path_grouphomomorphism.
+  by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 Lemma transport_iso_abgrouphomomorphism_to_const `{Univalence} {A A' B : AbGroup}

--- a/theories/Algebra/AbGroups/Biproduct.v
+++ b/theories/Algebra/AbGroups/Biproduct.v
@@ -254,7 +254,7 @@ Definition ab_diagonal {A : AbGroup} : A $-> ab_biprod A A
 Lemma ab_biprod_corec_diagonal `{Funext} {A B : AbGroup} (f g : B $-> A)
   : ab_biprod_corec f g = (functor_ab_biprod f g) $o ab_diagonal.
 Proof.
-  apply equiv_path_grouphomomorphism; reflexivity.
+  by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 (** Precomposing the codiagonal with the swap map has no effect. *)

--- a/theories/Algebra/AbSES/Core.v
+++ b/theories/Algebra/AbSES/Core.v
@@ -204,7 +204,7 @@ Proof.
     exact (fun _ => idmap).
   - intros [phi [p q]].
     apply path_sigma_hprop.
-    by apply equiv_path_groupisomorphism.
+    by apply equiv_path_map_groupisomorphism.
   - reflexivity.
 Defined.
 
@@ -314,8 +314,7 @@ Proof.
   apply (equiv_ap_inv' equiv_path_abses_iso).
   refine (eissect _ _ @ _).
   srapply path_sigma_hprop; simpl.
-  srapply equiv_path_groupisomorphism.
-  reflexivity.
+  by srapply equiv_path_map_groupisomorphism.
 Defined.
 
 Definition equiv_path_absesV_1 `{Univalence} {B A : AbGroup@{u}} {E : AbSES B A}
@@ -348,7 +347,7 @@ Proof.
   refine (equiv_path_abses_1^ @ _).
   apply (ap equiv_path_abses_iso).
   apply path_sigma_hprop.
-  by apply equiv_path_groupisomorphism.
+  by apply equiv_path_map_groupisomorphism.
 Defined.
 
 (** A second beta-principle where you start with path data instead of actual paths. *)

--- a/theories/Algebra/AbSES/Pullback.v
+++ b/theories/Algebra/AbSES/Pullback.v
@@ -74,7 +74,7 @@ Proof.
   srapply path_sigma_hprop.
   apply path_prod.
   1: apply path_prod.
-  all: by apply equiv_path_grouphomomorphism.
+  all: by apply equiv_path_map_grouphomomorphism.
 Defined.
 
 Definition abses_pullback_component1_id'

--- a/theories/Algebra/AbSES/Pushout.v
+++ b/theories/Algebra/AbSES/Pushout.v
@@ -102,8 +102,8 @@ Proof.
   srapply path_sigma_hprop.
   1: apply path_prod.
   1: apply path_prod.
-  all: apply equiv_path_grouphomomorphism; intro x; simpl.
-  1,3: reflexivity.
+  1,3: by apply equiv_path_map_grouphomomorphism.
+  apply equiv_path_grouphomomorphism; intro x; simpl.
   rewrite grp_homo_unit.
   exact (left_identity _)^.
 Defined.

--- a/theories/Algebra/Groups/Group.v
+++ b/theories/Algebra/Groups/Group.v
@@ -263,12 +263,18 @@ Coercion pmap_GroupHomomorphism : GroupHomomorphism >-> pForall.
 Definition issig_GroupHomomorphism (G H : Group) : _ <~> GroupHomomorphism G H
   := ltac:(issig).
 
+(** Equality of group homomorphisms is equivalent to equality of functions.  This uses [Funext] to know that [IsSemiGroupPreserving] is an hprop. *)
+Definition equiv_path_map_grouphomomorphism {F : Funext} {G H : Group}
+  {g h : GroupHomomorphism G H}
+  : (g = h :> (G -> H)) <~> g = h
+  := (equiv_ap (issig_GroupHomomorphism G H)^-1 _ _)^-1
+      oE equiv_path_sigma_hprop _ _.
+
 (** Function extensionality for group homomorphisms. *)
 Definition equiv_path_grouphomomorphism {F : Funext} {G H : Group}
   {g h : GroupHomomorphism G H} : g == h <~> g = h.
 Proof.
-  refine ((equiv_ap (issig_GroupHomomorphism G H)^-1 _ _)^-1 oE _).
-  refine (equiv_path_sigma_hprop _ _ oE _).
+  refine (equiv_path_map_grouphomomorphism oE _).
   apply equiv_path_forall.
 Defined.
 
@@ -277,7 +283,8 @@ Instance ishset_grouphomomorphism {F : Funext} {G H : Group}
   : IsHSet (GroupHomomorphism G H).
 Proof.
   apply istrunc_S.
-  intros f g; exact (istrunc_equiv_istrunc _ equiv_path_grouphomomorphism).
+  intros f g; exact (istrunc_equiv_istrunc _
+                       equiv_path_map_grouphomomorphism).
 Defined.
 
 (** Group homomorphisms preserve inverses. *)
@@ -342,22 +349,29 @@ Definition pequiv_groupisomorphism {A B : Group}
   := fun f => Build_pEquiv f _.
 Coercion pequiv_groupisomorphism : GroupIsomorphism >-> pEquiv.
 
-(** Funext for group isomorphisms. *)
-Definition equiv_path_groupisomorphism `{F : Funext} {G H : Group}
+(** Equality of group isomorphisms is equivalent to equality of functions.  This uses [Funext] to know that [IsEquiv] and [IsSemiGroupPreserving] are hprops. *)
+Definition equiv_path_map_groupisomorphism {F : Funext} {G H : Group}
   (f g : GroupIsomorphism G H)
-  : f == g <~> f = g.
+  : (f = g :> (G -> H)) <~> f = g.
 Proof.
   refine ((equiv_ap (issig_GroupIsomorphism G H)^-1 _ _)^-1 oE _).
   refine (equiv_path_sigma_hprop _ _ oE _).
-  exact equiv_path_grouphomomorphism.
+  exact equiv_path_map_grouphomomorphism.
 Defined.
+
+(** Funext for group isomorphisms. *)
+Definition equiv_path_groupisomorphism `{F : Funext} {G H : Group}
+  (f g : GroupIsomorphism G H)
+  : f == g <~> f = g
+  := equiv_path_map_groupisomorphism f g oE equiv_path_forall _ _.
 
 (** Group isomorphisms form a set. *)
 Definition ishset_groupisomorphism `{F : Funext} {G H : Group}
   : IsHSet (GroupIsomorphism G H).
 Proof.
   apply istrunc_S.
-  intros f g; exact (istrunc_equiv_istrunc _ (equiv_path_groupisomorphism _ _)).
+  intros f g; exact (istrunc_equiv_istrunc _
+                       (equiv_path_map_groupisomorphism _ _)).
 Defined.
 
 (** The identity map is an equivalence and therefore a group isomorphism. *)
@@ -804,7 +818,7 @@ Defined.
 Instance hasmorext_group `{Funext} : HasMorExt Group.
 Proof.
   intros A B f g; cbn in *.
-  snapply @isequiv_homotopic.
+  snapply isequiv_homotopic.
   1: exact (equiv_path_grouphomomorphism^-1%equiv).
   1: exact _.
   intros []; reflexivity. 
@@ -831,7 +845,7 @@ Defined.
 Instance is1cat_strong `{Funext} : Is1Cat_Strong Group.
 Proof.
   rapply Build_Is1Cat_Strong.
-  all: intros; apply equiv_path_grouphomomorphism; intro; reflexivity.
+  all: intros; apply equiv_path_map_grouphomomorphism; reflexivity.
 Defined.
 
 (** The [group_type] map is a 1-functor. *)
@@ -1101,7 +1115,7 @@ Proof.
   rapply equiv_path_grouphomomorphism.
   intros [].
   symmetry.
-  rapply grp_homo_unit.
+  napply grp_homo_unit.
 Defined.
 
 Instance isterminal_grp_trivial : IsTerminal grp_trivial.
@@ -1117,10 +1131,8 @@ Instance contr_grp_homo_trivial_target `{Funext} G
 Proof.
   snapply Build_Contr.
   1: exact (pr1 (isterminal_grp_trivial _)).
-  intros g.
-  rapply equiv_path_grouphomomorphism.
-  intros x.
-  apply path_contr.
+  intros f.
+  apply equiv_path_map_grouphomomorphism, path_contr.
 Defined.
 
 Instance ishprop_grp_iso_trivial `{Funext} (G : Group)

--- a/theories/Algebra/Groups/GrpPullback.v
+++ b/theories/Algebra/Groups/GrpPullback.v
@@ -213,7 +213,8 @@ Section IsEquivGrpPullbackCorec.
         (p : f o b == g o c)
     : grp_pullback_pr1 f g $o grp_pullback_corec f g b c p = b.
   Proof.
-    apply equiv_path_grouphomomorphism; reflexivity.
+    (* Here and below, the underlying functions are definitionally equal. *)
+    apply equiv_path_map_grouphomomorphism; reflexivity.
   Defined.
 
   Lemma grp_pullback_corec_pr2 {X : Group}
@@ -221,7 +222,7 @@ Section IsEquivGrpPullbackCorec.
         (p : f o b == g o c)
     : grp_pullback_pr2 f g $o grp_pullback_corec f g b c p = c.
   Proof.
-    apply equiv_path_grouphomomorphism; reflexivity.
+    apply equiv_path_map_grouphomomorphism; reflexivity.
   Defined.
 
   Theorem isequiv_grp_pullback_corec (X : Group)
@@ -232,7 +233,7 @@ Section IsEquivGrpPullbackCorec.
       refine (grp_pullback_pr1 f g $o phi; grp_pullback_pr2 f g $o phi; _).
       intro x; exact (pullback_commsq f g (phi x)).
     - intro phi.
-      apply equiv_path_grouphomomorphism; reflexivity.
+      apply equiv_path_map_grouphomomorphism; reflexivity.
     - intro bcp; simpl.
       srapply path_sigma.
       + simpl. apply grp_pullback_corec_pr1.

--- a/theories/Algebra/Groups/QuotientGroup.v
+++ b/theories/Algebra/Groups/QuotientGroup.v
@@ -233,7 +233,8 @@ Corollary grp_quotient_rec_beta `{F : Funext} {G : Group}
           (h : forall n:G, N n -> f n = mon_unit)
   : (grp_quotient_rec G N f h) $o grp_quotient_map = f.
 Proof.
-  apply equiv_path_grouphomomorphism; reflexivity.
+  (* The underlying functions are definitionally equal. *)
+  apply equiv_path_map_grouphomomorphism; reflexivity.
 Defined.
 
 (** Computation rule for [grp_quotient_rec]. *)
@@ -283,7 +284,7 @@ Proof.
     by apply grp_quotient_map_trivial.
   - intros f.
     rapply equiv_path_grouphomomorphism.
-      by srapply Quotient_ind_hprop.
+    by srapply Quotient_ind_hprop.
   - intros [f p].
     srapply path_sigma_hprop; simpl.
     exact (grp_quotient_rec_beta N H f p).

--- a/theories/Algebra/Groups/Subgroup.v
+++ b/theories/Algebra/Groups/Subgroup.v
@@ -272,10 +272,11 @@ Proof.
     intros x.
     exact (g x).2.
   - intros g.
-    by snapply equiv_path_grouphomomorphism.
+    (* The underlying functions are definitionally equal. *)
+    by snapply equiv_path_map_grouphomomorphism.
   - intros [f p].
     rapply path_sigma_hprop.
-    by snapply equiv_path_grouphomomorphism.
+    by snapply equiv_path_map_grouphomomorphism.
 Defined.
 
 (** Functoriality on subgroups. *)

--- a/theories/Basics/Trunc.v
+++ b/theories/Basics/Trunc.v
@@ -273,6 +273,10 @@ Proof.
   apply trunc_index_leq_add.
 Defined.
 
+Definition trunc_index_leq_add_nat@{} (n : trunc_index) (m : nat)
+  : n.+2 <= m +2+ n
+  := trunc_index_leq_add n m.-2.
+
 Fixpoint trunc_index_min@{} (n m : trunc_index)
   : trunc_index.
 Proof.

--- a/theories/Homotopy/ClassifyingSpace/Core.v
+++ b/theories/Homotopy/ClassifyingSpace/Core.v
@@ -404,6 +404,15 @@ Section EncodeDecode.
           (Build_IsSemiGroup _ _ _ concat_p_pp) concat_1p concat_p1)
         concat_Vp concat_pV).
 
+  (** For a pointed 1-type, the loop group and the fundamental group agree. *)
+  Definition grp_iso_loopgroup_pi1 (P : pType) `{IsTrunc 1 P}
+    : LoopGroup P $<~> Pi1 P.
+  Proof.
+    snapply Build_GroupIsomorphism'.
+    - rapply equiv_tr.
+    - intros x y; reflexivity.
+  Defined.
+
   Definition grp_iso_g_loopgroup_bg : GroupIsomorphism G (LoopGroup (B G)).
   Proof.
     snapply Build_GroupIsomorphism'.
@@ -412,13 +421,8 @@ Section EncodeDecode.
     apply bloop_pp.
   Defined.
 
-  Definition grp_iso_g_pi1_bg : GroupIsomorphism G (Pi1 (B G)).
-  Proof.
-    snapply (transitive_groupisomorphism _ _ _ grp_iso_g_loopgroup_bg).
-    snapply Build_GroupIsomorphism'.
-    - rapply equiv_tr.
-    - intros x y; reflexivity.
-  Defined.
+  Definition grp_iso_g_pi1_bg : GroupIsomorphism G (Pi1 (B G))
+    := grp_iso_loopgroup_pi1 (B G) $oE grp_iso_g_loopgroup_bg.
 
   (* We also record this fact. *)
   Definition grp_homo_loops {X Y : pType} `{IsTrunc 1 X} `{IsTrunc 1 Y}

--- a/theories/Homotopy/ClassifyingSpace/Core.v
+++ b/theories/Homotopy/ClassifyingSpace/Core.v
@@ -613,38 +613,17 @@ Proof.
   reflexivity.
 Defined.
 
-(** Interestingly, [fmap B] is an equivalence *)
+(** Interestingly, [fmap B] is an equivalence.  This is a corollary of the adjunction: transposing [fmap B u] gives [bloop o u] by [bloop_natural], so [fmap B] is the inverse of the adjunction composed with an isomorphism. *)
 Instance isequiv_fmap_pclassifyingspace `{U : Univalence} (G H : Group)
   : IsEquiv (fmap B (a := G) (b := H)).
 Proof.
-  snapply isequiv_adjointify.
-  { intros f.
-    refine (grp_homo_compose (grp_iso_inverse _) (grp_homo_compose _ _)).
-    1,3: exact grp_iso_g_loopgroup_bg.
-    exact (grp_homo_loops f). }
-  { intros f.
-    rapply equiv_path_pforall.
-    snapply Build_pHomotopy.
-    { snapply ClassifyingSpace_ind_hset.
-      1: exact _.
-      { cbn; symmetry.
-        rapply (point_eq f). }
-      { intro g.
-        rapply equiv_sq_dp^-1.
-        rewrite ClassifyingSpace_rec_beta_bloop.
-        simpl.
-        rapply sq_ccGc.
-        1: symmetry; rapply decode_encode.
-        apply equiv_sq_path.
-        rewrite concat_pp_p.
-        rewrite concat_pp_V.
-        reflexivity. } }
-      symmetry; apply concat_1p. }
-  intros f.
+  pose (e := equiv_postcompose_cat_equiv (x:=G) (grp_iso_g_loopgroup_bg (G:=H))).
+  rapply (isequiv_homotopic ((equiv_pmap_bg_loopgroup G (B H))^-1 oE e)).
+  intro phi.
+  apply moveR_equiv_V.
   rapply equiv_path_grouphomomorphism.
-  intro x.
-  rapply (moveR_equiv_V' equiv_g_loops_bg).
-  napply pClassifyingSpace_rec_beta_bloop.
+  change (bloop o phi == fmap loops (fmap B phi) o bloop).  (* For the reader. *)
+  symmetry; apply bloop_natural.
 Defined.
 
 (** Hence we have that group homomorphisms are equivalent to pointed maps between their deloopings. *)
@@ -671,26 +650,19 @@ Proof.
   rapply Build_NatEquiv.
 Defined.
 
-(** [B(Pi 1 X) <~>* X] for a 0-connected 1-truncated [X]. *)
+(** [B (Pi1 X) <~>* X] for a 0-connected 1-truncated [X].  The equivalence is the adjunct of the identity map [Pi1 X $-> Pi1 X]. *)
 Theorem pequiv_pclassifyingspace_pi1 `{Univalence}
   (X : pType) `{IsConnected 0 X} `{IsTrunc 1 X}
   : B (Pi1 X) <~>* X.
 Proof.
-  (** The pointed map [f] is the adjunct to the inverse of the natural map [loops X -> Pi1 X]. We define it first, to make the later goals easier to read. *)
-  transparent assert (f : (B (Pi1 X) ->* X)).
-  { snapply pClassifyingSpace_rec.
-    1: exact _.
-    1: exact (equiv_tr 0 _)^-1%equiv.
-    intros x y.
-    strip_truncations.
-    reflexivity. }
-  snapply (Build_pEquiv f).
-  (** [f] is an equivalence since [loops_functor f o bloop == tr^-1], and the other two maps are equivalences. *)
+  snapply (Build_pEquiv ((equiv_pmap_bg_pi1 _ X)^-1 grp_homo_id)).
+  1, 2: exact _.
+  (* Calling the map f, it is an equivalence since [fmap loops f o bloop == tr^-1], and the other two maps are equivalences. *)
   apply isequiv_is0connected_isequiv_loops.
   snapply (cancelR_isequiv bloop).
   1: exact _.
-  rapply isequiv_homotopic'; symmetry.
-  napply pClassifyingSpace_rec_beta_bloop.
+  rapply (isequiv_homotopic' (equiv_tr 0 _)^-1%equiv); symmetry.
+  intro g; napply pClassifyingSpace_rec_beta_bloop.
 Defined.
 
 (** The classifying space functor and the fundamental group functor form an adjunction ([pType] needs to be restricted to the subcategory of 0-connected pointed types). Note that the full adjunction should also be natural in [X], but this was not needed yet. *)

--- a/theories/Homotopy/ClassifyingSpace/Core.v
+++ b/theories/Homotopy/ClassifyingSpace/Core.v
@@ -299,7 +299,7 @@ Proof.
   exact bloop_id.
 Defined.
 
-(** This says that [B] is left adjoint to the loop space functor from pointed 1-types to groups. *)
+(** The pointed version of the recursion principle.  We will see in [equiv_pmap_bg_loopgroup] that this is an equivalence between group homomorphisms [G $-> LoopGroup P] and pointed maps [BG ->* P], giving an adjunction. *)
 Definition pClassifyingSpace_rec {G : Group} (P : pType) `{IsTrunc 1 P}
            (bloop' : G -> loops P)
            (bloop_pp' : forall x y : G, bloop' (x * y) = bloop' x @ bloop' y)
@@ -453,7 +453,7 @@ Proof.
   rapply isequiv_is0connected_isequiv_loops.
 Defined.
 
-(** Functoriality of B(-) *)
+(** ** Functoriality of B(-) *)
 
 Instance is0functor_pclassifyingspace : Is0Functor B.
 Proof.
@@ -563,6 +563,56 @@ Proof.
     reflexivity.
 Defined.
 
+(** ** The adjunction between [B] and the loop group *)
+
+(** [B] and [Pi1] are inverse equivalences between groups and 0-connected 1-truncated pointed types ([pequiv_pclassifyingspace_pi1] below and [grp_iso_g_pi1_bg] above).  This file contains two extensions of that equivalence to larger domains, which is why [B] appears below both as a left adjoint and as a right adjoint:
+
+  - Dropping the connectivity of the target, but keeping the source a classifying space, gives [B] as a left adjoint to the loop group functor on pointed 1-types.  This is [equiv_pmap_bg_loopgroup] just below, and [equiv_pmap_bg_pi1] is the same statement with [Pi1] in place of [LoopGroup], the two agreeing by [grp_iso_loopgroup_pi1].
+
+  - Dropping the truncatedness of the source, but keeping the target a classifying space, gives [B] as a right adjoint to [Pi1] on 0-connected pointed types.  That is [equiv_bg_pi1_adjoint], further below. *)
+
+(** The recursion principle [pClassifyingSpace_rec] says that [B] is left adjoint to the loop group functor on pointed 1-types.  Here we record that adjunction as an equivalence, with [pClassifyingSpace_rec] as the inverse map.  Note that no connectivity assumption on [P] is needed. *)
+Definition equiv_pmap_bg_loopgroup `{Univalence} (G : Group) (P : pType) `{IsTrunc 1 P}
+  : (B G $-> P) <~> (G $-> LoopGroup P).
+Proof.
+  snapply equiv_adjointify.
+  - intro f.
+    exact (grp_homo_compose (grp_homo_loops f) grp_iso_g_loopgroup_bg).
+  - intro phi.
+    exact (pClassifyingSpace_rec P phi (grp_homo_op phi)).
+  - intro phi.
+    rapply equiv_path_grouphomomorphism.
+    napply pClassifyingSpace_rec_beta_bloop.
+  - intro f.
+    rapply path_pforall.
+    snapply Build_pHomotopy.
+    + srapply ClassifyingSpace_ind_hset.
+      * cbn; symmetry; apply (point_eq f).
+      * intro g.
+        unfold DPath.
+        transport_paths FlFr.
+        lhs napply (whiskerR (ClassifyingSpace_rec_beta_bloop _ _ _ _ _)); cbn.
+        apply moveR_pV, concat_p_pp.
+    + cbn.
+      symmetry; napply concat_1p.
+Defined.
+
+(** The same adjunction, phrased using the fundamental group. *)
+Definition equiv_pmap_bg_pi1 `{Univalence} (G : Group) (P : pType) `{IsTrunc 1 P}
+  : (B G $-> P) <~> (G $-> Pi1 P)
+  := equiv_postcompose_cat_equiv (grp_iso_loopgroup_pi1 P)
+       oE equiv_pmap_bg_loopgroup G P.
+
+(** Unfolding the previous equivalence: it is [fmap Pi1] followed by restriction along [grp_iso_g_pi1_bg]. *)
+Definition equiv_pmap_bg_pi1_beta `{Univalence} (G : Group) (P : pType)
+  `{IsTrunc 1 P} (f : B G $-> P)
+  : equiv_pmap_bg_pi1 G P f = fmap Pi1 f $o grp_iso_g_pi1_bg.
+Proof.
+  (* The underlying functions are definitionally equal. *)
+  rapply equiv_path_map_grouphomomorphism.
+  reflexivity.
+Defined.
+
 (** Interestingly, [fmap B] is an equivalence *)
 Instance isequiv_fmap_pclassifyingspace `{U : Univalence} (G H : Group)
   : IsEquiv (fmap B (a := G) (b := H)).
@@ -605,6 +655,7 @@ Proof.
   2: apply isequiv_fmap_pclassifyingspace.
 Defined.
 
+(** This equivalence is natural in [H]. *)
 Instance is1natural_grp_homo_pmap_bg_r {U : Univalence} (G : Group)
   : Is1Natural (opyon G) (opyon (B G) o B) (equiv_grp_homo_pmap_bg G).
 Proof.

--- a/theories/Homotopy/ClassifyingSpace/Core.v
+++ b/theories/Homotopy/ClassifyingSpace/Core.v
@@ -721,6 +721,42 @@ Proof.
   rapply natequiv_map_bg.
 Defined.
 
+(** ** [Pi1] induces an equivalence on certain mapping types *)
+
+(** Our next goal is to prove that for pointed types [X] and [Y] with [X] 0-connected and [Y] 1-truncated, the map [fmap Pi1 (a:=X) (b:=Y)] is an equivalence.  We first prove this when [X] is also 1-truncated, using that [X] is then the classifying space of [Pi1 X], and then reduce the general case to that one by replacing [X] with [pTr 1 X]. *)
+
+(** For [X] a 0-connected 1-type and [Y] a pointed 1-type, [fmap Pi1] is an equivalence from pointed maps [X ->* Y] to group homomorphisms.  Since [X] is the classifying space of [Pi1 X], this follows from the adjunction [equiv_pmap_bg_pi1].  Note that [Y] is not assumed to be connected. *)
+Definition isequiv_fmap_pi1_pmap_dom_trunc `{Univalence} (X Y : pType)
+  `{IsConnected 0 X} `{IsTrunc 1 X} `{IsTrunc 1 Y}
+  : IsEquiv (fmap Pi1 (a:=X) (b:=Y)).
+Proof.
+  pose (e := pequiv_pclassifyingspace_pi1 X).
+  tapply (isequiv_homotopic (equiv_pmap_bg_pi1 _ Y oE equiv_precompose_cat_equiv (z:=Y) e)).
+  intro f.
+  lhs napply equiv_pmap_bg_pi1_beta.
+  apply path_hom.
+  intro x.
+  lhs exact (fmap_comp Pi1 e f (grp_iso_g_pi1_bg x)).
+  (* [fmap Pi1 e $o grp_iso_g_pi1_bg] is the identity, since [e] is the adjunct of the identity map. *)
+  exact (ap (fmap Pi1 f) (equiv_path_grouphomomorphism^-1
+    ((equiv_pmap_bg_pi1_beta _ X e)^ @ eisretr (equiv_pmap_bg_pi1 _ X) grp_homo_id) x)).
+Defined.
+
+(** For [X] 0-connected and [Y] a pointed 1-type, [fmap Pi1] is an equivalence from pointed maps [X ->* Y] to group homomorphisms.  Note that [Y] is not assumed to be connected. *)
+Definition isequiv_fmap_pi1_pmap `{Univalence} (X Y : pType)
+  `{IsConnected 0 X} `{IsTrunc 1 Y}
+  : IsEquiv (fmap Pi1 (a:=X) (b:=Y)).
+Proof.
+  (* Since [Y] is a 1-type, we can replace [X] by [pTr 1 X], which has the same [Pi1] and is a 0-connected 1-type.  The square commutes by functoriality of [Pi1]. *)
+  refine (isequiv_commsq (fmap Pi1 (a:=pTr 1 X) (b:=Y)) _
+    (fun g : pTr 1 X $-> Y => g $o ptr)
+    (equiv_precompose_cat_equiv (z:=Pi1 Y) (grp_iso_pi_Tr 0 X)) _).
+  - intro phi; symmetry.
+    apply path_hom; exact (fmap_comp Pi1 ptr phi).
+  - rapply isequiv_fmap_pi1_pmap_dom_trunc.
+  - exact (equiv_isequiv pequiv_ptr_rec).
+Defined.
+
 (** ** H-space structure on [B G] when [G] is abelian *)
 
 (** This will be used to prove that [B G] is an H-space when [G] is abelian, and has other uses as well. *)

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -40,7 +40,7 @@ Proof.
 Defined.
 
 (** For [X] [n]-connected and [Y] [n.+1]-truncated, [fmap (Pi n.+1)] is an equivalence from the pointed maps [X ->* Y] to the group homomorphisms [Pi n.+1 X $-> Pi n.+1 Y].  Neither connectivity of [Y] nor truncatedness of [X] is needed.  The induction is on [n]: the successor step is [isequiv_fmap_loops_pmap], which applies since [n.+2 <= n +2+ n], and the base case is [isequiv_fmap_pi1_pmap]. *)
-Definition isequiv_fmap_pi_pmap `{Univalence} (n : nat) (X Y : pType)
+Instance isequiv_fmap_pi_pmap `{Univalence} (n : nat) (X Y : pType)
   `{cX : IsConnected n X} `{tY : IsTrunc n.+1 Y}
   : IsEquiv (fmap (Pi n.+1) (a:=X) (b:=Y)).
 Proof.
@@ -266,6 +266,13 @@ Section EilenbergMacLane.
       exact (ap _ (IHn g)).
   Defined.
 
+  (** Equivalently, the composite is conjugation by the identifications [equiv_g_pi_n_em]. *)
+  Definition pi_em_fmap' {G G' : AbGroup}
+    (f : GroupHomomorphism G G') (n : nat)
+    : fmap (Pi n.+1) (fmap (K' n.+1) f)
+      == equiv_g_pi_n_em G' n o f o (equiv_g_pi_n_em G n)^-1
+    := cate_moveL_eV (A:=Group) _ _ (equiv_g_pi_n_em G' n $o f) (pi_em_fmap f n).
+
   (** Eilenberg-Mac Lane spaces of a contractible group are contractible. *)
   #[export] Instance contr_em_contr {G : Group} `{Contr G} (n : nat)
     : Contr K(G, n).
@@ -312,39 +319,18 @@ Section EilenbergMacLane.
                  (c _)).
   Defined.
 
-  (** [fmap (K' n.+1)] is an equivalence from group homomorphisms to pointed maps, extending [isequiv_fmap_pclassifyingspace] to all levels.  In particular, pointed maps between Eilenberg-Mac Lane spaces of the same level are determined by their effect on homotopy groups. *)
+  (** [fmap (K' n.+1)] is an equivalence from group homomorphisms to pointed maps.  Since [K(G, n.+1)] is [n]-connected and [K(G', n.+1)] is [n.+1]-truncated, [fmap (Pi n.+1)] is an equivalence from the pointed maps to the group homomorphisms [Pi n.+1 K(G, n.+1) $-> Pi n.+1 K(G', n.+1)], and by [pi_em_fmap'] the composite with [fmap (K' n.+1)] is conjugation by the identifications [equiv_g_pi_n_em], which is also an equivalence.  In particular, pointed maps between Eilenberg-Mac Lane spaces of the same level are determined by their effect on homotopy groups. *)
   #[export] Instance isequiv_em_fmap (G G' : AbGroup) (n : nat)
     : IsEquiv (fun f : GroupHomomorphism G G' => fmap (K' n.+1) f).
   Proof.
-    induction n as [|n IHn].
-    - exact (isequiv_fmap_pclassifyingspace G G').
-    - (* The ladder [pequiv_ptr_rec], [loop_susp_adjoint], postcomposition with [pequiv_loops_em_em], and the inductive hypothesis. *)
-      pose (L := ((Build_Equiv _ _ _ IHn)^-1%equiv)
-        oE (pequiv_pequiv_postcompose (pequiv_loops_em_em G' n.+1)^-1*
-            : (K(G, n.+1) ->** loops K(G', n.+2)) <~> _)
-        oE (loop_susp_adjoint K(G, n.+1) K(G', n.+2)
-            : (psusp K(G, n.+1) ->** _) <~> _)
-        oE (pequiv_ptr_rec
-            : (K(G, n.+2) ->** K(G', n.+2)) <~> _)).
-      napply (isequiv_homotopic' L^-1%equiv).
-      intro f.
-      apply moveR_equiv_V; symmetry.
-      unfold L; clear L.
-      apply moveR_equiv_V; unfold equiv_fun.
-      apply path_pforall.
-      lhs' refine (pmap_postwhisker _
-        (pmap_prewhisker _ (fmap2 loops (ptr_natural _ _)))).
-      lhs' refine (pmap_postwhisker _
-        (pmap_prewhisker _ (fmap_comp loops _ _))).
-      lhs' refine (pmap_postwhisker _ (pmap_compose_assoc _ _ _)).
-      lhs' refine (pmap_postwhisker _
-        (pmap_postwhisker _ (loop_susp_unit_natural _)^*)).
-      lhs' refine (pmap_postwhisker _ (pmap_compose_assoc _ _ _)^*).
-      lhs' refine (pmap_postwhisker _
-        (pmap_prewhisker _ (loops_em_em_ptr_unit G' n)^*)).
-      lhs_V' refine (pmap_compose_assoc _ _ _).
-      lhs' refine (pmap_prewhisker _ (peissect _)).
-      apply pmap_postcompose_idmap.
+    refine (isequiv_commsq' _
+              (equiv_precompose_cat_equiv (A:=Group)
+                 (grp_iso_inverse (equiv_g_pi_n_em G n)))
+              (equiv_postcompose_cat_equiv (A:=Group) (equiv_g_pi_n_em G' n))
+              (fmap (Pi n.+1)) _).
+    intro f.
+    apply equiv_path_grouphomomorphism; symmetry.
+    apply pi_em_fmap'.
   Defined.
 
   (** The equivalence between group homomorphisms and pointed maps of Eilenberg-Mac Lane spaces. *)

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -130,8 +130,8 @@ Section EilenbergMacLane.
   Proof.
     napply Build_Is1Functor.
     - intros G G' f g p.
-      exact (phomotopy_path (ap (fun h : G $-> G' => fmap (K' n) h)
-        (equiv_path_grouphomomorphism p))).
+      exact (phomotopy_path (ap (fmap (K' n))
+                               (equiv_path_grouphomomorphism p))).
     - intros G.
       induction n as [|[|m] IH].
       + rapply phomotopy_homotopy_hset.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -58,6 +58,17 @@ Definition equiv_fmap_pi_pmap `{Univalence} (n : nat) (X Y : pType)
   : (X ->* Y) <~> (Pi n.+1 X $-> Pi n.+1 Y)
   := Build_Equiv _ _ _ (isequiv_fmap_pi_pmap n X Y).
 
+(** Pointed maps from an [n]-connected type to an [n.+1]-truncated type which agree on [Pi n.+1] are equal. *)
+Definition path_pmap_pi_connected `{Univalence} (n : nat) {X Y : pType}
+  `{IsConnected n X} `{IsTrunc n.+1 Y}
+  (phi psi : X ->* Y)
+  (h : fmap (Pi n.+1) phi == fmap (Pi n.+1) psi)
+  : phi = psi.
+Proof.
+  tapply (equiv_inj (fmap (Pi n.+1) (a:=X) (b:=Y))).
+  exact (equiv_path_grouphomomorphism h).
+Defined.
+
 (** ** Definition and properties of Eilenberg-Mac Lane spaces *)
 
 (** The definition of the Eilenberg-Mac Lane spaces.  Note that while we allow [G] to be non-abelian for [n > 1], later results will need to assume that [G] is abelian. *)
@@ -338,22 +349,6 @@ Section EilenbergMacLane.
     : GroupHomomorphism G G' <~> (K(G, n.+1) ->* K(G', n.+1))
     := Build_Equiv _ _ _ (isequiv_em_fmap G G' n).
 
-  (** Pointed maps between Eilenberg-Mac Lane spaces of the same level which agree on homotopy groups are equal. *)
-  Definition path_em_pmap_pi {G G' : AbGroup} (n : nat)
-    (phi psi : K(G, n.+1) ->* K(G', n.+1))
-    (h : fmap (Pi n.+1) phi == fmap (Pi n.+1) psi)
-    : phi = psi.
-  Proof.
-    pose (e := equiv_em_fmap G G' n).
-    apply (equiv_inj e^-1).
-    apply equiv_path_grouphomomorphism; intro g.
-    apply (equiv_inj (equiv_g_pi_n_em G' n)).
-    refine ((pi_em_fmap _ n g)^ @ _ @ pi_em_fmap _ n g).
-    refine (ap (fun m => fmap (Pi n.+1) m _) (eisretr e phi) @ _).
-    refine (_ @ ap (fun m => fmap (Pi n.+1) m _) (eisretr e psi)^).
-    apply h.
-  Defined.
-
   (** Every pointed (n-1)-connected n-type is an Eilenberg-Mac Lane space. *)
   Definition pequiv_em_connected_truncated (X : pType)
     (n : nat) `{IsConnected n X} `{IsTrunc n.+1 X}
@@ -378,33 +373,6 @@ Section EilenbergMacLane.
     refine (emap (pTr n.+2 o psusp) _).
     refine ((IHn (loops X) _ _) o*E _).
     exact (emap (K' n.+1) (groupiso_pi_loops _ _)).
-  Defined.
-
-  (** Pointed maps between [n.+1]-connected [n.+2]-truncated types which agree on homotopy groups are equal. *)
-  Definition path_pmap_pi_connected (n : nat) {X Y : pType}
-    `{IsConnected n.+1 X} `{IsTrunc n.+2 X}
-    `{IsConnected n.+1 Y} `{IsTrunc n.+2 Y}
-    (phi psi : X ->* Y)
-    (h : fmap (Pi n.+2) phi == fmap (Pi n.+2) psi)
-    : phi = psi.
-  Proof.
-    apply (equiv_inj (pequiv_pequiv_precompose
-      (pequiv_em_connected_truncated X n.+1))).
-    change (phi o* pequiv_em_connected_truncated X n.+1
-            = psi o* pequiv_em_connected_truncated X n.+1).
-    apply (equiv_inj (pequiv_pequiv_postcompose
-      (pequiv_em_connected_truncated Y n.+1)^-1* )).
-    change ((pequiv_em_connected_truncated Y n.+1)^-1*
-              o* (phi o* pequiv_em_connected_truncated X n.+1)
-            = (pequiv_em_connected_truncated Y n.+1)^-1*
-              o* (psi o* pequiv_em_connected_truncated X n.+1)).
-    rapply (path_em_pmap_pi (G := Build_AbGroup (Pi n.+2 X) _)
-                            (G' := Build_AbGroup (Pi n.+2 Y) _)).
-    intro x.
-    refine (fmap_comp (Pi n.+2) _ _ x @ _ @ (fmap_comp (Pi n.+2) _ _ x)^).
-    refine (ap _ (fmap_comp (Pi n.+2) _ phi x) @ _
-            @ (ap _ (fmap_comp (Pi n.+2) _ psi x))^).
-    exact (ap _ (h _)).
   Defined.
 
 End EilenbergMacLane.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -69,6 +69,20 @@ Proof.
   exact (equiv_path_grouphomomorphism h).
 Defined.
 
+(** Two [n]-connected [n.+1]-truncated pointed types with isomorphic [Pi n.+1] are pointed equivalent. *)
+Definition pequiv_pi_connected_truncated `{Univalence} (n : nat) {X Y : pType}
+  `{IsConnected n X} `{IsTrunc n.+1 X} `{IsConnected n Y} `{IsTrunc n.+1 Y}
+  (phi : GroupIsomorphism (Pi n.+1 X) (Pi n.+1 Y))
+  : X <~>* Y
+  := cate_reflect_fmap (Pi n.+1) (x:=X) (y:=Y) phi.
+
+(** The equivalence induces the given isomorphism on [Pi n.+1]. *)
+Definition fmap_pi_pequiv_pi_connected_truncated `{Univalence} (n : nat) {X Y : pType}
+  `{IsConnected n X} `{IsTrunc n.+1 X} `{IsConnected n Y} `{IsTrunc n.+1 Y}
+  (phi : GroupIsomorphism (Pi n.+1 X) (Pi n.+1 Y))
+  : fmap (Pi n.+1) (pequiv_pi_connected_truncated n phi) == phi
+  := fmap_cate_reflect_fmap (Pi n.+1) (x:=X) (y:=Y) phi.
+
 (** ** Definition and properties of Eilenberg-Mac Lane spaces *)
 
 (** The definition of the Eilenberg-Mac Lane spaces.  Note that while we allow [G] to be non-abelian for [n > 1], later results will need to assume that [G] is abelian. *)
@@ -349,31 +363,27 @@ Section EilenbergMacLane.
     : GroupHomomorphism G G' <~> (K(G, n.+1) ->* K(G', n.+1))
     := Build_Equiv _ _ _ (isequiv_em_fmap G G' n).
 
+  (** The canonical identification of [Pi n.+1 K(Pi n.+1 X, n.+1)] with [Pi n.+1 X].  For [n = 0] this is [grp_iso_g_pi1_bg], and for positive [n] it is [equiv_g_pi_n_em] applied to the abelian group [Pi n.+1 X]. *)
+  Definition grp_iso_pi_em_pi (X : pType) (n : nat)
+    : GroupIsomorphism (Pi n.+1 K(Pi n.+1 X, n.+1)) (Pi n.+1 X).
+  Proof.
+    symmetry.
+    destruct n as [|m].
+    - exact grp_iso_g_pi1_bg.
+    - exact (equiv_g_pi_n_em (Build_AbGroup (Pi m.+2 X) _) m.+1).
+  Defined.
+
   (** Every pointed (n-1)-connected n-type is an Eilenberg-Mac Lane space. *)
   Definition pequiv_em_connected_truncated (X : pType)
     (n : nat) `{IsConnected n X} `{IsTrunc n.+1 X}
-    : K(Pi n.+1 X, n.+1) <~>* X.
-  Proof.
-    generalize dependent X; induction n; intros X isC isT.
-    1: rapply pequiv_pclassifyingspace_pi1.
-    (* The equivalence will be the composite
-<<
-      K( (Pi n.+2 X) n.+2)
-   <~>* K( (Pi n.+1 (loops X)), n.+2)
-   = pTr n.+2 (psusp K( (Pi n.+1 (loops X)), n.+1))  [by definition]
-   <~>* pTr n.+2 (psusp (loops X))                   [by induction]
-   <~>* pTr n.+2 X
-   <~>* X
->>
-    and we'll work from right to left.
-*)
-    refine ((pequiv_ptr (n:=n.+2))^-1* o*E _).
-    refine (pequiv_ptr_psusp_loops X n o*E _).
-    change (K(?G, n.+2)) with (pTr n.+2 (psusp K( G, n.+1 ))).
-    refine (emap (pTr n.+2 o psusp) _).
-    refine ((IHn (loops X) _ _) o*E _).
-    exact (emap (K' n.+1) (groupiso_pi_loops _ _)).
-  Defined.
+    : K(Pi n.+1 X, n.+1) <~>* X
+    := pequiv_pi_connected_truncated n (grp_iso_pi_em_pi X n).
+
+  (** It induces [grp_iso_pi_em_pi] on [Pi n.+1]. *)
+  Definition fmap_pi_pequiv_em_connected_truncated (X : pType)
+    (n : nat) `{IsConnected n X} `{IsTrunc n.+1 X}
+    : fmap (Pi n.+1) (pequiv_em_connected_truncated X n) == grp_iso_pi_em_pi X n
+    := fmap_pi_pequiv_pi_connected_truncated n (grp_iso_pi_em_pi X n).
 
 End EilenbergMacLane.
 

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -19,7 +19,7 @@ Local Open Scope mc_mult_scope.
 
 (** ** Maps from connected types to pointed types *)
 
-(** Before specializing to Eilenberg-Mac Lane spaces, we should that when [X] is [n]-connected and [Y] is [n.+1]-truncated, [fmap (Pi n.+1)] is an equivalence.  The case [n=1] is [isequiv_fmap_pi1_pmap], and the inductive step follows from [isequiv_fmap_loops_pmap]. *)
+(** Before specializing to Eilenberg-Mac Lane spaces, we show that when [X] is [n]-connected and [Y] is [n.+1]-truncated, [fmap (Pi n.+1)] is an equivalence.  The case [n=1] is [isequiv_fmap_pi1_pmap], and the inductive step follows from [isequiv_fmap_loops_pmap]. *)
 
 (** Part of the inductive step is factored out here. *)
 Local Definition isequiv_fmap_pi_pmap_succ `{Univalence} (n : nat) {X Y : pType}

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -1,7 +1,6 @@
 From HoTT Require Import Basics Types.
 From HoTT.WildCat Require Import Core Universe Equiv PointedCat Yoneda.
 Require Import Pointed.
-Require Import Cubical.DPath.
 Require Import Algebra.AbGroups.AbelianGroup.
 Require Import Homotopy.Suspension.
 Require Import Homotopy.ClassifyingSpace.Core.

--- a/theories/Homotopy/EMSpace.v
+++ b/theories/Homotopy/EMSpace.v
@@ -1,5 +1,5 @@
 From HoTT Require Import Basics Types.
-From HoTT.WildCat Require Import Core Universe Equiv PointedCat.
+From HoTT.WildCat Require Import Core Universe Equiv PointedCat Yoneda.
 Require Import Pointed.
 Require Import Cubical.DPath.
 Require Import Algebra.AbGroups.AbelianGroup.
@@ -17,6 +17,48 @@ Require Import Truncations.Core Truncations.Connectedness Truncations.SeparatedT
 Local Open Scope pointed_scope.
 Local Open Scope nat_scope.
 Local Open Scope mc_mult_scope.
+
+(** ** Maps from connected types to pointed types *)
+
+(** Before specializing to Eilenberg-Mac Lane spaces, we should that when [X] is [n]-connected and [Y] is [n.+1]-truncated, [fmap (Pi n.+1)] is an equivalence.  The case [n=1] is [isequiv_fmap_pi1_pmap], and the inductive step follows from [isequiv_fmap_loops_pmap]. *)
+
+(** Part of the inductive step is factored out here. *)
+Local Definition isequiv_fmap_pi_pmap_succ `{Univalence} (n : nat) {X Y : pType}
+  (el : IsEquiv (fmap loops (a:=X) (b:=Y)))
+  (e : IsEquiv (fmap (Pi n.+1) (a:=loops X) (b:=loops Y)))
+  : IsEquiv (fmap (Pi n.+2) (a:=X) (b:=Y)).
+Proof.
+  pose (a := groupiso_pi_loops n X).
+  pose (b := groupiso_pi_loops n Y).
+  pose (k := equiv_precompose_cat_equiv a
+              oE equiv_postcompose_cat_equiv (x:=Pi n.+1 (loops X)) b^-1$).
+  refine (isequiv_homotopic (k o fmap (Pi n.+1) o fmap loops (a:=X) (b:=Y)) _).
+  intro f.
+  rapply equiv_path_grouphomomorphism.
+  intro x.
+  exact (moveR_equiv_V (f:=b) _ _ (fmap_pi_loops n.+1 f x)^).
+Defined.
+
+(** For [X] [n]-connected and [Y] [n.+1]-truncated, [fmap (Pi n.+1)] is an equivalence from the pointed maps [X ->* Y] to the group homomorphisms [Pi n.+1 X $-> Pi n.+1 Y].  Neither connectivity of [Y] nor truncatedness of [X] is needed.  The induction is on [n]: the successor step is [isequiv_fmap_loops_pmap], which applies since [n.+2 <= n +2+ n], and the base case is [isequiv_fmap_pi1_pmap]. *)
+Definition isequiv_fmap_pi_pmap `{Univalence} (n : nat) (X Y : pType)
+  `{cX : IsConnected n X} `{tY : IsTrunc n.+1 Y}
+  : IsEquiv (fmap (Pi n.+1) (a:=X) (b:=Y)).
+Proof.
+  induction n in X, Y, cX, tY |- *.
+  1: exact (isequiv_fmap_pi1_pmap X Y).
+  napply isequiv_fmap_pi_pmap_succ.
+  - napply (isequiv_fmap_loops_pmap (n:=n)).
+    + exact _.
+    + apply (istrunc_leq (trunc_index_leq_add_nat n n)).
+  - rapply IHn.
+Defined.
+
+Definition equiv_fmap_pi_pmap `{Univalence} (n : nat) (X Y : pType)
+  `{IsConnected n X} `{IsTrunc n.+1 Y}
+  : (X ->* Y) <~> (Pi n.+1 X $-> Pi n.+1 Y)
+  := Build_Equiv _ _ _ (isequiv_fmap_pi_pmap n X Y).
+
+(** ** Definition and properties of Eilenberg-Mac Lane spaces *)
 
 (** The definition of the Eilenberg-Mac Lane spaces.  Note that while we allow [G] to be non-abelian for [n > 1], later results will need to assume that [G] is abelian. *)
 Fixpoint EilenbergMacLane@{u v | u <= v} (G : Group@{u}) (n : nat) : pType@{v}

--- a/theories/Homotopy/Hopf.v
+++ b/theories/Homotopy/Hopf.v
@@ -196,3 +196,30 @@ Proof.
   rewrite 2 trunc_index_add_succ.
   exact (conn_map_loop_susp_counit X).
 Defined.
+
+(** ** Looping is an equivalence on pointed mapping spaces in the metastable range *)
+
+(** When [X] is [n.+1]-connected and [Y] is [n +2+ n]-truncated, the loops functor from [X ->* Y] to [loops X ->* loops Y] is an equivalence. *)
+Definition isequiv_fmap_loops_pmap `{Univalence} {n : trunc_index} (X Y : pType)
+  `{IsConnected n.+1 X} `{IsTrunc (n +2+ n) Y}
+  : IsEquiv (fmap loops (a:=X) (b:=Y)).
+Proof.
+  (* We will show that [fmap loops] is homotopic to precomposition with the counit followed by the loop-suspension adjunction, both of which are equivalences. *)
+  rapply (isequiv_homotopic
+            (loop_susp_adjoint (loops X) Y
+               o*E pequiv_o_conn_map (n +2+ n) (loop_susp_counit X) Y)).
+  intro f.
+  apply path_pforall.
+  (* The left-hand side is definitionally of this form; the [change] is only to make the goal readable. *)
+  change (fmap loops (f o* loop_susp_counit X) o* loop_susp_unit (loops X)
+    ==* fmap loops f).
+  lhs' tapply (pmap_prewhisker _ (fmap_comp loops _ _)).
+  lhs' napply pmap_compose_assoc.
+  lhs' napply (pmap_postwhisker _ (loop_susp_triangle1 X)).
+  apply pmap_precompose_idmap.
+Defined.
+
+Definition pequiv_fmap_loops_pmap `{Univalence} {n : trunc_index} (X Y : pType)
+  `{IsConnected n.+1 X} `{IsTrunc (n +2+ n) Y}
+  : (X ->** Y) <~>* (loops X ->** loops Y)
+  := Build_pEquiv (pfmap loops) (isequiv_fmap_loops_pmap X Y).

--- a/theories/Pointed/pModality.v
+++ b/theories/Pointed/pModality.v
@@ -81,6 +81,24 @@ Proof.
     + exact (equiv_isequiv e).
 Defined.
 
+(** Precomposition with an [O]-connected pointed map is an equivalence on pointed mapping spaces into an [O]-local type.  This is a pointed version of [equiv_o_conn_map].  Note that it does not subsume [pequiv_o_pto_O], since [to O X] is only known to be [O]-connected when [O] is a modality. *)
+Definition pequiv_o_conn_map `{Funext} (O : ReflectiveSubuniverse)
+  {A B : pType} (f : A ->* B) `{IsConnMap O _ _ f} (Y : pType) `{In O Y}
+  : (B ->** Y) <~>* (A ->** Y).
+Proof.
+  snapply Build_pEquiv.
+  (* As in [pequiv_o_pto_O], we give the underlying map first so that Coq unfolds it to precomposition with [f]. *)
+  - exact (Build_pMap (fun g => g o* f) (path_pforall (postcompose_pconst f))).
+  - transparent assert (e : ((B ->* Y) <~> (A ->* Y))).
+    + refine (issig_pmap A Y oE _ oE (issig_pmap B Y)^-1%equiv).
+      snapply equiv_functor_sigma'.
+      * rapply (equiv_o_conn_map O f (fun _ => Y)).
+      * intro g; cbn.
+        (* This is the path that pointed composition inserts, so the underlying map agrees definitionally with precomposition by [f]. *)
+        exact (equiv_concat_l (ap g (point_eq f)) _).
+    + exact (equiv_isequiv e).
+Defined.
+
 (** ** Pointed functoriality *)
 
 Definition O_pfunctor `(O : ReflectiveSubuniverse) {X Y : pType}

--- a/theories/WildCat/Equiv.v
+++ b/theories/WildCat/Equiv.v
@@ -395,7 +395,7 @@ Definition cate_moveR_1V {A} `{HasEquivs A} {a b : A} {e : a $<~> b} (f : b $-> 
   : cate_fun e^-1$ $== f
   := cate_moveR_V1 (A:=A^op) (a:=b) (b:=a) f p.
 
-(** Lemmas about the underlying map of an equivalence. *)
+(** ** Lemmas about the underlying map of an equivalence *)
 
 Definition cate_inv2 {A} `{HasEquivs A} {a b : A} {e f : a $<~> b} (p : cate_fun e $== cate_fun f)
   : cate_fun e^-1$ $== cate_fun f^-1$.
@@ -424,6 +424,8 @@ Proof.
   apply cate_moveR_V1.
   symmetry; apply cate_issect.
 Defined.
+
+(** ** Behaviour of equivalences under functors *)
 
 (** Any sufficiently coherent functor preserves equivalences.  *)
 Instance iemap {A B : Type} `{HasEquivs A} `{HasEquivs B}
@@ -487,6 +489,33 @@ Definition emap_inv' {A B : Type} `{HasEquivs A} `{HasEquivs B}
   {a b : A} (e : a $<~> b)
   : cate_fun (emap F e)^-1$ $== fmap F e^-1$
   := emap_inv F e $@ cate_buildequiv_fun _.
+
+(** If [F] is fully faithful on the hom types among [x] and [y], in the sense that [fmap F] is an equivalence of types on each of them, then an equivalence [F x $<~> F y] lifts to an equivalence [x $<~> y].  We do not assume that [F] is globally fully faithful, since that is not always the case in applications.  Morphism extensionality in [B] is needed to convert [$==] into equality there, so that injectivity of [fmap F] on endomorphisms can be used. With a 0-groupoid version of being fully faithful, we wouldn't need this. *)
+Definition cate_reflect_fmap {A B : Type} `{HasEquivs A} `{HasEquivs B} `{!HasMorExt B}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F} {x y : A}
+  `{!IsEquiv (fmap F (a:=x) (b:=y))} `{!IsEquiv (fmap F (a:=y) (b:=x))}
+  `{!IsEquiv (fmap F (a:=x) (b:=x))} `{!IsEquiv (fmap F (a:=y) (b:=y))}
+  (phi : F x $<~> F y)
+  : x $<~> y.
+Proof.
+  rapply (cate_adjointify ((fmap F)^-1 phi) ((fmap F)^-1 phi^-1$)).
+  all: apply GpdHom_path, (equiv_inj (fmap F)), path_hom.
+  all: refine (fmap_comp F _ _ $@ _ $@ (fmap_id F _)^$).
+  all: lhs' rapply (GpdHom_path (eisretr (fmap F) _) $@@ GpdHom_path (eisretr (fmap F) _)).
+  - apply cate_isretr.
+  - apply cate_issect.
+Defined.
+
+(** The lifted equivalence induces the original one under [F]. *)
+Definition fmap_cate_reflect_fmap {A B : Type} `{HasEquivs A} `{HasEquivs B} `{!HasMorExt B}
+  (F : A -> B) `{!Is0Functor F, !Is1Functor F} {x y : A}
+  `{!IsEquiv (fmap F (a:=x) (b:=y))} `{!IsEquiv (fmap F (a:=y) (b:=x))}
+  `{!IsEquiv (fmap F (a:=x) (b:=x))} `{!IsEquiv (fmap F (a:=y) (b:=y))}
+  (phi : F x $<~> F y)
+  : fmap F (cate_reflect_fmap F phi) $== phi
+  := fmap2 F (cate_buildequiv_fun _) $@ GpdHom_path (eisretr (fmap F) phi).
+
+(** ** Univalent wild 1-categories *)
 
 (** When we have equivalences, we can define what it means for a category to be univalent. *)
 Definition cat_equiv_path {A : Type} `{HasEquivs A} (a b : A)


### PR DESCRIPTION
The goal of this PR is to give a better proof of `pequiv_em_connected_truncated`, which states that K(Pi n.+1 X, n.+1) is equivalent to X when X is n-connected and (n+1)-truncated.  The new proof follows from general principles and has the advantage that it induces the natural map on Pi n.+1.  Also, many of the results in this file no longer use the construction of K(G, n), instead only using their connectivity and truncatedness.  We now also have the general result that for X n-connected and Y (n+1)-truncated, fmap (Pi n.+1) induces an equivalence from X ->* Y to Pi n.+1 X $-> Pi n.+1 Y, and this is used to simplify many other results, so the file EMSpace.v is only five lines longer.

The base case of that is handled with new results in ClassifyingSpace/Core.v, and again, the new results allow some of the existing results to be simplified.

The inductive step is handled by new results in Hopf.f, mainly that when X is n-connected and Y is 2n-truncated, then the loops functor induces an equivalence from X ->* Y to loops X ->* loops Y.

This will be of interest to @CharlesCNorton for #2382 and to @thchatzidiamantis.   @CharlesCNorton , maybe you can rebase your work on this?  (I won't force push to it if there are changes during review.)  There will be one or two minor conflicts, but this work will avoid the need for the NormalizedEM material in your PR.

I was assisted by Claude Opus 5 and Fable 5.1, but most of the proofs were rewritten by me to be cleaner, and in all cases, I carefully reviewed them.

When reviewing, review one commit at a time, as some overlap in commits makes the larger diff harder to read.  The first and last commits are minor things not directly related to this PR, but which I noticed while working on it.